### PR TITLE
fix(codeql): Add actions language to resolve configuration errors

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript' ]
+        language: [ 'javascript-typescript', 'actions' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Problem
PRs were still blocked with CodeQL configuration error:
> Warning: Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on refs/heads/main was not found: Default setup
> ❓ /language:actions

## Solution
Added `actions` language to the CodeQL matrix to enable GitHub Actions workflow scanning.

## Changes
- **`.github/workflows/codeql.yml`**: Added `'actions'` to the language matrix alongside `'javascript-typescript'`

## Why This Fixes It
According to GitHub's CodeQL documentation, the `actions` language enables security analysis of GitHub Actions workflow files. The error message `/language:actions` indicates this language was expected but missing from our configuration.

## Testing
- CodeQL workflow will now analyze both JavaScript/TypeScript code and GitHub Actions workflows
- This should resolve the "configuration not found" errors blocking PRs