### PR TITLE
fix: ensure Playwright tests run headless by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ npm run debug:lint      # Detailed lint output
 
 # Testing
 npm run test:coverage
+npm run test:e2e         # E2E tests (headless - no browser windows)
+# AVOID: test:e2e:headed, test:e2e:ui (these show browser windows)
 
 # TypeScript Error Filtering
 npm run typecheck                                 # Check entire project (recommended)
@@ -307,6 +309,7 @@ For detailed guidance beyond these essentials:
 ## Development Practices
 
 - **ESLint Disabling**: NEVER add an eslint-disable unless you have exhausted all other options and confirmed with the user that it is the correct thing to do.
+- **E2E Testing**: Use `npm run test:e2e` (headless). NEVER use `test:e2e:headed` or `test:e2e:ui` as they show browser windows and interrupt the user's workflow.
 
 ## Key Lessons Learned (Non-Obvious Insights)
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --headed=false",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "_comment_validation": "========== Validation & Pre-commit ==========",


### PR DESCRIPTION
## Summary

• Add explicit `--headed=false` flag to `test:e2e` script to prevent browser popups
• Add clear documentation about which E2E scripts agents should avoid
• Prevent workflow interruption from accidental headed test runs

## Test plan

- [x] Verify `npm run test:e2e` runs headless (no browser windows)
- [x] Confirm documentation clearly warns against headed variants
- [x] Check CLAUDE.md guidance prevents future agent mistakes

🤖 Generated with [Claude Code](https://claude.ai/code)