### PR TITLE
📚 docs: add server status check guidance and fix Playwright config fo…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,7 @@ For detailed guidance beyond these essentials:
 
 ## Development Practices
 
+- **Server Status Checks**: ALWAYS use `npm run dev:bg:status` to check if the development server is running. NEVER use curl commands for server status checks.
 - **ESLint Disabling**: NEVER add an eslint-disable unless you have exhausted all other options and confirmed with the user that it is the correct thing to do.
 - **E2E Testing**: Use `npm run test:e2e` (headless). NEVER use `test:e2e:headed` or `test:e2e:ui` as they show browser windows and interrupt the user's workflow.
 - **Prisma Studio**: AVOID launching Prisma Studio (`npm run db:studio`) unless absolutely necessary for debugging complex data issues. Use direct SQL queries, schema file reading, or existing component inspection instead.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   // Shared settings for all the projects below
   use: {
     // Base URL to use in actions like `await page.goto('/')`
-    baseURL: "http://localhost:3000",
+    baseURL: `http://localhost:${process.env["PORT"] ?? "3000"}`,
 
     // Collect trace when retrying the failed test
     trace: "on-first-retry",
@@ -55,7 +55,7 @@ export default defineConfig({
   // Automatically start dev server for tests
   webServer: {
     command: "npm run dev",
-    url: "http://localhost:3000",
+    url: `http://localhost:${process.env["PORT"] ?? "3000"}`,
     reuseExistingServer: !process.env["CI"],
     timeout: 120000,
   },


### PR DESCRIPTION
…r multi-worktree

- Add development practice: use npm run dev:bg:status instead of curl commands
- Update Playwright config to respect PORT environment variable for worktree environments

🤖 Generated with [Claude Code](https://claude.ai/code)