### PR TITLE
Fix: Eliminate DATABASE_URL dependency for Supabase integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,10 @@ AUTH_SECRET=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
-# Prisma
-# https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DATABASE_URL="postgresql://postgres:password@localhost:5432/pinpoint"
+# Supabase Database Connection (provided by Vercel integration)
+# https://supabase.com/docs/guides/integrations/vercel
+POSTGRES_PRISMA_URL="postgres://postgres.PROJECT-REF:[PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
+POSTGRES_URL_NON_POOLING="postgres://postgres.PROJECT-REF:[PASSWORD]@aws-0-[REGION].pooler.supabase.com:5432/postgres"
 
 # OPDB.org token
 OPDB_API_TOKEN=""

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("POSTGRES_PRISMA_URL")
+  directUrl = env("POSTGRES_URL_NON_POOLING")
 }
 
 // =================================

--- a/src/env.js
+++ b/src/env.js
@@ -26,7 +26,11 @@ export const env = createEnv({
       getEnvironmentType() === "production"
         ? z.string()
         : z.string().optional(),
-    DATABASE_URL:
+    POSTGRES_PRISMA_URL:
+      getEnvironmentType() === "test"
+        ? z.string().url().optional()
+        : z.string().url(),
+    POSTGRES_URL_NON_POOLING:
       getEnvironmentType() === "test"
         ? z.string().url().optional()
         : z.string().url(),
@@ -75,7 +79,8 @@ export const env = createEnv({
    */
   runtimeEnv: {
     AUTH_SECRET: process.env["AUTH_SECRET"],
-    DATABASE_URL: process.env["DATABASE_URL"],
+    POSTGRES_PRISMA_URL: process.env["POSTGRES_PRISMA_URL"],
+    POSTGRES_URL_NON_POOLING: process.env["POSTGRES_URL_NON_POOLING"],
     NODE_ENV: process.env["NODE_ENV"],
     GOOGLE_CLIENT_ID: process.env["GOOGLE_CLIENT_ID"],
     GOOGLE_CLIENT_SECRET: process.env["GOOGLE_CLIENT_SECRET"],


### PR DESCRIPTION
## Summary
- Completely eliminates DATABASE_URL dependency in favor of Supabase's native environment variables
- Updates Prisma schema to use POSTGRES_PRISMA_URL (pooled) and POSTGRES_URL_NON_POOLING (direct)
- Fixes build failures in both local development and preview deployments
- Updates documentation to reflect new Supabase variable format

## Technical Changes
- **Prisma Schema**: Now uses `POSTGRES_PRISMA_URL` and `POSTGRES_URL_NON_POOLING` for optimal connection pooling
- **Environment Validation**: Removed `DATABASE_URL` from `src/env.js` validation and added Supabase variables
- **Documentation**: Updated `.env.example` to show proper Supabase connection string format

## Testing
- ✅ `npm run build` now succeeds
- ✅ Pre-push validation passes
- ✅ Uses environment variables automatically provided by Vercel + Supabase integration

## Context
This completes the Supabase migration cleanup after Issue #218. Preview deployments were failing because Supabase doesn't provide DATABASE_URL - it provides POSTGRES_PRISMA_URL and POSTGRES_URL_NON_POOLING instead. This change aligns with Supabase/Vercel integration standards.

🤖 Generated with [Claude Code](https://claude.ai/code)