### PR TITLE
🔒 Block dangerous find commands and document safe alternatives

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,6 @@
       "Bash(npx tsc:*)",
       "Bash(npx prisma db seed:*)",
       "Bash(ls:*)",
-      "Bash(find:*)",
       "Bash(grep:*)",
       "Bash(gitleaks detect:*)",
       "Bash(git add:*)",
@@ -62,6 +61,6 @@
       "mcp__context7__resolve-library-id",
       "mcp__context7__get-library-docs"
     ],
-    "deny": []
+    "deny": ["Bash(find:*)"]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,14 @@
 - Your training ended in 2024. It's July 2025 now. Don't hesitate to look up the latest documentation if you suspect you're out of date
 - We use husky for precommits and preuploads
 - We run shellcheck against our scripts
+
+## Command Line Tools
+
+- **NEVER use the `find` command** - it's dangerous due to the `-exec` flag which can execute arbitrary commands
+- Use safe alternatives instead:
+  - **ripgrep (rg)** - for content searching and file discovery: `rg --files | rg "pattern"`, `rg -l "content" --type js`
+  - **fd/fdfind** - for file system traversal: `fd "*.js"`, `fd --type f --changed-within 1day`
+  - **git ls-files** - for git repositories: `git ls-files | grep "\.js$"`
+  - **Enhanced ls** - for basic directory listing with tools like `exa` or `lsd`
+- Prefer rg (ripgrep) to find or grep
+- If trying to use a tool that is not installed, suggest installation of the tool with `brew` (preferred) or `apt`


### PR DESCRIPTION
## Summary
- Adds `find` command to `.claude/settings.json` deny list to prevent dangerous `-exec` usage
- Documents safe alternatives in `CLAUDE.md` (ripgrep, fd, git ls-files, enhanced ls)

## Why This Matters
The `find -exec` combination can execute arbitrary commands on found files, making it a security risk. This change:
- **Prevents accidental dangerous usage** via Claude Code's permission system  
- **Documents better alternatives** that are safer and often faster
- **Maintains development velocity** while improving security posture

## Safe Alternatives Added
- **ripgrep (rg)** - for content searching and file discovery
- **fd/fdfind** - for modern file system traversal  
- **git ls-files** - for git repository file operations
- **Enhanced ls tools** - like exa and lsd for better directory listing

## Testing
- ✅ All quality checks pass
- ✅ Pre-commit hooks pass
- ✅ Only meta/config changes (no source code impact)

🤖 Generated with [Claude Code](https://claude.ai/code) via Ship It\! 🚀