### PR TITLE
🔧 Block stream redirection in npm test commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,6 @@
       "mcp__context7__resolve-library-id",
       "mcp__context7__get-library-docs"
     ],
-    "deny": ["Bash(find:*)"]
+    "deny": ["Bash(find:*)", "Bash(npm*test*&2>1*)", "Bash(npm*test*2>&1*)"]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,6 @@
       "mcp__context7__resolve-library-id",
       "mcp__context7__get-library-docs"
     ],
-    "deny": ["Bash(find:*)", "Bash(npm*test*&2>1*)", "Bash(npm*test*2>&1*)"]
+    "deny": ["Bash(find:*)", "Bash(npm*test*2>&1*)"]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,12 @@
 ## Command Line Tools
 
 - **NEVER use the `find` command** - it's dangerous due to the `-exec` flag which can execute arbitrary commands
+- **NEVER use stream redirection with npm test commands** - redirection like `2>&1` gets passed as arguments to Vitest, causing it to interpret them as test filters instead of shell redirection
 - Use safe alternatives instead:
   - **ripgrep (rg)** - for content searching and file discovery: `rg --files | rg "pattern"`, `rg -l "content" --type js`
   - **fd/fdfind** - for file system traversal: `fd "*.js"`, `fd --type f --changed-within 1day`
   - **git ls-files** - for git repositories: `git ls-files | grep "\.js$"`
   - **Enhanced ls** - for basic directory listing with tools like `exa` or `lsd`
+- For test output control, use the existing npm scripts: `test:brief`, `test:quiet`, `test:verbose`
 - Prefer rg (ripgrep) to find or grep
 - If trying to use a tool that is not installed, suggest installation of the tool with `brew` (preferred) or `apt`


### PR DESCRIPTION
## Summary
Prevents npm test commands with `2>&1` redirection from being passed as arguments to Vitest, which interprets them as test filters instead of shell redirection.

## Changes
- 🚫 Block `Bash(npm*test*2>&1*)` pattern in `.claude/settings.json`
- 📚 Add command line guidance to `CLAUDE.md` about stream redirection issues
- 🎯 Documents the proper alternatives (using existing npm scripts like `test:brief`, `test:quiet`)

## Why This Matters
When Claude tried to use proper bash redirection like `npm run test 2>&1`, Vitest would interpret the `2>&1` as a test name filter, causing confusion and test failures. This change prevents that pattern while documenting the correct alternatives.

## Risk Assessment
- ✅ **EXTREMELY LOW RISK** - Pure configuration and documentation
- ✅ **NO CODE CHANGES** - Only meta files affected
- ✅ **BACKWARDS COMPATIBLE** - No breaking changes

## Auto-Ship Criteria Met
- [x] No source code changes
- [x] No test changes  
- [x] No schema changes
- [x] TypeScript checks pass
- [x] Pre-commit hooks pass
- [x] File sizes reasonable (< 2KB each)

---
🤖 Generated with [Claude Code](https://claude.ai/code) via Ship It\! auto-shipper