### PR TITLE
feat: Convert issue.timeline router to Drizzle with comprehensive tests

### DIFF
--- a/src/integration-tests/issue.timeline.integration.test.ts
+++ b/src/integration-tests/issue.timeline.integration.test.ts
@@ -1,0 +1,759 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/**
+ * Issue Timeline Router Integration Tests (PGlite)
+ *
+ * Integration tests for the issue.timeline router using PGlite in-memory PostgreSQL database.
+ * Tests real database operations with proper schema, relationships, and data integrity.
+ *
+ * Key Features:
+ * - Real PostgreSQL database with PGlite
+ * - Complete schema migrations applied
+ * - Real Drizzle ORM operations
+ * - Multi-tenant data isolation testing
+ * - Complex query validation with actual results
+ * - Service integration testing (IssueActivityService)
+ * - Organizational boundary enforcement with real data
+ *
+ * Uses modern August 2025 patterns with Vitest and PGlite integration.
+ */
+
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Import test setup and utilities
+import type { TRPCContext } from "~/server/api/trpc.base";
+import type { ExtendedPrismaClient } from "~/server/db";
+
+import { issueTimelineRouter } from "~/server/api/routers/issue.timeline";
+import * as schema from "~/server/db/schema";
+import { IssueActivityService } from "~/server/services/issueActivityService";
+import {
+  createSeededTestDatabase,
+  getSeededTestData,
+  type TestDatabase,
+} from "~/test/helpers/pglite-test-setup";
+
+// Mock external dependencies that aren't database-related
+vi.mock("~/lib/utils/id-generation", () => ({
+  generateId: vi.fn(() => `test-id-${Date.now()}`),
+}));
+
+vi.mock("~/server/auth/permissions", () => ({
+  getUserPermissionsForSession: vi
+    .fn()
+    .mockResolvedValue(["issue:view", "organization:manage"]),
+  getUserPermissionsForSupabaseUser: vi
+    .fn()
+    .mockResolvedValue(["issue:view", "organization:manage"]),
+  requirePermissionForSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock ActivityType enum to fix service integration
+vi.mock("~/server/services/types", () => ({
+  ActivityType: {
+    CREATED: "CREATED",
+    STATUS_CHANGED: "STATUS_CHANGED",
+    ASSIGNED: "ASSIGNED",
+    PRIORITY_CHANGED: "PRIORITY_CHANGED",
+    COMMENTED: "COMMENTED",
+    COMMENT_DELETED: "COMMENT_DELETED",
+    ATTACHMENT_ADDED: "ATTACHMENT_ADDED",
+    MERGED: "MERGED",
+    RESOLVED: "RESOLVED",
+    REOPENED: "REOPENED",
+    SYSTEM: "SYSTEM",
+  },
+}));
+
+describe("Issue Timeline Router Integration (PGlite)", () => {
+  let db: TestDatabase;
+  let context: TRPCContext;
+  let caller: ReturnType<typeof issueTimelineRouter.createCaller>;
+
+  // Test data IDs - queried from actual seeded data
+  let testData: {
+    organization: string;
+    location?: string;
+    machine?: string;
+    model?: string;
+    status?: string;
+    priority?: string;
+    issue?: string;
+    adminRole?: string;
+    memberRole?: string;
+    user?: string;
+  };
+
+  beforeEach(async () => {
+    // Create fresh PGlite database with real schema and seed data
+    const setup = await createSeededTestDatabase();
+    db = setup.db;
+
+    // Query actual seeded IDs instead of using hardcoded ones
+    testData = await getSeededTestData(db, setup.organizationId);
+
+    // Create mock Prisma client for tRPC middleware compatibility
+    const mockPrismaClient = {
+      membership: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "test-membership",
+          organizationId: testData.organization,
+          userId: testData.user || "test-user-1",
+          role: {
+            id: testData.adminRole || "test-admin-role",
+            name: "Admin",
+            permissions: [
+              { id: "perm1", name: "issue:view" },
+              { id: "perm2", name: "organization:manage" },
+            ],
+          },
+        }),
+      },
+      // Add required methods for IssueActivityService compatibility
+      issueHistory: {
+        create: vi.fn().mockImplementation(async ({ data }) => {
+          // Create issue history in real database
+          const historyEntry = {
+            id: `history-${Date.now()}`,
+            ...data,
+            changedAt: new Date(),
+          };
+
+          return await db
+            .insert(schema.issueHistory)
+            .values(historyEntry)
+            .returning()
+            .then((result) => result[0]);
+        }),
+        findMany: vi.fn().mockImplementation(async ({ where, include }) => {
+          // Get issue history for timeline from real database
+          if (where?.issueId && where?.organizationId) {
+            const activities = await db.query.issueHistory.findMany({
+              where: (history, { eq, and }) =>
+                and(
+                  eq(history.issueId, where.issueId),
+                  eq(history.organizationId, where.organizationId),
+                ),
+              with: include?.actor
+                ? {
+                    actor: {
+                      columns: {
+                        id: true,
+                        name: true,
+                        profilePicture: true,
+                      },
+                    },
+                  }
+                : {},
+              orderBy: (history, { asc }) => [asc(history.changedAt)],
+            });
+
+            return activities.map((activity) => ({
+              id: activity.id,
+              field: activity.field,
+              oldValue: activity.oldValue,
+              newValue: activity.newValue,
+              changedAt: activity.changedAt,
+              actorId: activity.actorId,
+              issueId: activity.issueId,
+              organizationId: activity.organizationId,
+              type: activity.type,
+              actor: activity.actor
+                ? {
+                    id: activity.actor.id,
+                    name: activity.actor.name,
+                    profilePicture: activity.actor.profilePicture,
+                  }
+                : null,
+            }));
+          }
+          return [];
+        }),
+      },
+      comment: {
+        findMany: vi.fn().mockImplementation(async ({ where }) => {
+          // Get comments for timeline from real database
+          if (where?.issueId) {
+            const comments = await db.query.comments.findMany({
+              where: eq(schema.comments.issueId, where.issueId),
+              with: {
+                author: {
+                  columns: {
+                    id: true,
+                    name: true,
+                    profilePicture: true,
+                  },
+                },
+              },
+              orderBy: (comments, { asc }) => [asc(comments.createdAt)],
+            });
+
+            return comments.map((comment) => ({
+              id: comment.id,
+              content: comment.content,
+              createdAt: comment.createdAt,
+              updatedAt: comment.updatedAt,
+              issueId: comment.issueId,
+              authorId: comment.authorId,
+              author: comment.author
+                ? {
+                    id: comment.author.id,
+                    name: comment.author.name,
+                    profilePicture: comment.author.profilePicture,
+                  }
+                : null,
+            }));
+          }
+          return [];
+        }),
+      },
+    } as unknown as ExtendedPrismaClient;
+
+    // Create test context with real database and services
+    context = {
+      user: {
+        id: testData.user || "test-user-1",
+        email: "test@example.com",
+        user_metadata: { name: "Test User" },
+        app_metadata: { organization_id: testData.organization, role: "Admin" },
+      },
+      organization: {
+        id: testData.organization,
+        name: "Test Organization",
+        subdomain: "test-org",
+      },
+      db: mockPrismaClient,
+      drizzle: db,
+      supabase: {
+        auth: {
+          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+        },
+      } as any,
+      services: {
+        createIssueActivityService: vi.fn(
+          () => new IssueActivityService(mockPrismaClient),
+        ),
+        createNotificationService: vi.fn(),
+        createCommentCleanupService: vi.fn(),
+        createCollectionService: vi.fn(),
+        createPinballMapService: vi.fn(),
+        createQRCodeService: vi.fn(),
+      },
+      headers: new Headers(),
+      logger: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        child: vi.fn(() => context.logger),
+        withRequest: vi.fn(() => context.logger),
+        withUser: vi.fn(() => context.logger),
+        withOrganization: vi.fn(() => context.logger),
+        withContext: vi.fn(() => context.logger),
+      },
+      userPermissions: ["issue:view", "organization:manage"],
+    } as any;
+
+    caller = issueTimelineRouter.createCaller(context);
+  });
+
+  describe("getTimeline", () => {
+    beforeEach(async () => {
+      // Create additional test data for comprehensive timeline testing
+      // Add comments to the test issue
+      await db.insert(schema.comments).values([
+        {
+          id: "test-comment-1",
+          content: "First comment on the issue",
+          issueId: testData.issue || "test-issue-1",
+          authorId: testData.user || "test-user-1",
+          createdAt: new Date("2024-01-01T10:00:00Z"),
+          updatedAt: new Date("2024-01-01T10:00:00Z"),
+        },
+        {
+          id: "test-comment-2",
+          content: "Second comment for discussion",
+          issueId: testData.issue || "test-issue-1",
+          authorId: testData.user || "test-user-1",
+          createdAt: new Date("2024-01-02T14:30:00Z"),
+          updatedAt: new Date("2024-01-02T14:30:00Z"),
+        },
+      ]);
+
+      // Add issue history activities
+      await db.insert(schema.issueHistory).values([
+        {
+          id: "test-activity-1",
+          issueId: testData.issue || "test-issue-1",
+          organizationId: testData.organization,
+          type: "STATUS_CHANGED",
+          field: "status",
+          oldValue: testData.status || "initial-status",
+          newValue: "new-status",
+          actorId: testData.user || "test-user-1",
+          changedAt: new Date("2024-01-01T15:00:00Z"),
+        },
+        {
+          id: "test-activity-2",
+          issueId: testData.issue || "test-issue-1",
+          organizationId: testData.organization,
+          type: "ASSIGNED",
+          field: "assignedTo",
+          oldValue: null,
+          newValue: testData.user || "test-user-1",
+          actorId: testData.user || "test-user-1",
+          changedAt: new Date("2024-01-03T09:15:00Z"),
+        },
+      ]);
+    });
+
+    it("should get timeline with comments and activities for valid issue", async () => {
+      const result = await caller.getTimeline({
+        issueId: testData.issue || "test-issue-1",
+      });
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+
+      // Should contain both comments and activities
+      const comments = result.filter((item) => item.itemType === "comment");
+      const activities = result.filter((item) => item.itemType === "activity");
+
+      expect(comments.length).toBeGreaterThan(0);
+      expect(activities.length).toBeGreaterThan(0);
+
+      // Verify comment structure
+      const firstComment = comments[0];
+      expect(firstComment).toMatchObject({
+        itemType: "comment",
+        id: expect.any(String),
+        content: expect.any(String),
+        timestamp: expect.any(Date),
+        author: {
+          id: expect.any(String),
+          name: expect.any(String),
+        },
+      });
+
+      // Verify activity structure
+      const firstActivity = activities[0];
+      expect(firstActivity).toMatchObject({
+        itemType: "activity",
+        id: expect.any(String),
+        type: expect.any(String),
+        timestamp: expect.any(Date),
+        actor: {
+          id: expect.any(String),
+          name: expect.any(String),
+        },
+      });
+
+      // Timeline should be ordered by timestamp
+      for (let i = 1; i < result.length; i++) {
+        expect(result[i].timestamp.getTime()).toBeGreaterThanOrEqual(
+          result[i - 1].timestamp.getTime(),
+        );
+      }
+    });
+
+    it("should handle issue with no timeline data", async () => {
+      // Create an issue without comments or activities
+      const emptyIssue = await db
+        .insert(schema.issues)
+        .values({
+          id: "empty-issue",
+          title: "Empty Issue",
+          organizationId: testData.organization,
+          machineId: testData.machine || "test-machine-1",
+          statusId: testData.status || "test-status-1",
+          priorityId: testData.priority || "test-priority-1",
+          createdById: testData.user || "test-user-1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning()
+        .then((result) => result[0]);
+
+      const result = await caller.getTimeline({ issueId: emptyIssue.id });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should throw NOT_FOUND for non-existent issue", async () => {
+      await expect(
+        caller.getTimeline({ issueId: "non-existent-issue" }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: "NOT_FOUND",
+          message: "Issue not found or access denied",
+        }),
+      );
+    });
+
+    it("should enforce organizational scoping", async () => {
+      // Create issue in different organization
+      const otherOrgId = "other-org-timeline";
+      await db.insert(schema.organizations).values({
+        id: otherOrgId,
+        name: "Other Organization",
+        subdomain: "other-org-timeline",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await db.insert(schema.priorities).values({
+        id: "other-priority-timeline",
+        name: "Other Priority",
+        organizationId: otherOrgId,
+        order: 1,
+      });
+
+      await db.insert(schema.issueStatuses).values({
+        id: "other-status-timeline",
+        name: "Other Status",
+        category: "NEW",
+        organizationId: otherOrgId,
+      });
+
+      const otherOrgIssue = await db
+        .insert(schema.issues)
+        .values({
+          id: "other-org-issue",
+          title: "Other Org Issue",
+          organizationId: otherOrgId,
+          machineId: testData.machine || "test-machine-1",
+          statusId: "other-status-timeline",
+          priorityId: "other-priority-timeline",
+          createdById: testData.user || "test-user-1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning()
+        .then((result) => result[0]);
+
+      // Add timeline data to other org issue
+      await db.insert(schema.comments).values({
+        id: "other-org-comment",
+        content: "Comment in other org",
+        issueId: otherOrgIssue.id,
+        authorId: testData.user || "test-user-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Should not be able to access issue from different organization
+      await expect(
+        caller.getTimeline({ issueId: otherOrgIssue.id }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: "NOT_FOUND",
+          message: "Issue not found or access denied",
+        }),
+      );
+    });
+
+    it("should handle timeline with only comments", async () => {
+      // Create issue with only comments, no activities
+      const commentsOnlyIssue = await db
+        .insert(schema.issues)
+        .values({
+          id: "comments-only-issue",
+          title: "Comments Only Issue",
+          organizationId: testData.organization,
+          machineId: testData.machine || "test-machine-1",
+          statusId: testData.status || "test-status-1",
+          priorityId: testData.priority || "test-priority-1",
+          createdById: testData.user || "test-user-1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning()
+        .then((result) => result[0]);
+
+      await db.insert(schema.comments).values([
+        {
+          id: "comment-only-1",
+          content: "First comment only",
+          issueId: commentsOnlyIssue.id,
+          authorId: testData.user || "test-user-1",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        },
+        {
+          id: "comment-only-2",
+          content: "Second comment only",
+          issueId: commentsOnlyIssue.id,
+          authorId: testData.user || "test-user-1",
+          createdAt: new Date("2024-01-02"),
+          updatedAt: new Date("2024-01-02"),
+        },
+      ]);
+
+      const result = await caller.getTimeline({
+        issueId: commentsOnlyIssue.id,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.every((item) => item.itemType === "comment")).toBe(true);
+
+      // Verify chronological order
+      expect(result[0].timestamp.getTime()).toBeLessThanOrEqual(
+        result[1].timestamp.getTime(),
+      );
+    });
+
+    it("should handle timeline with only activities", async () => {
+      // Create issue with only activities, no comments
+      const activitiesOnlyIssue = await db
+        .insert(schema.issues)
+        .values({
+          id: "activities-only-issue",
+          title: "Activities Only Issue",
+          organizationId: testData.organization,
+          machineId: testData.machine || "test-machine-1",
+          statusId: testData.status || "test-status-1",
+          priorityId: testData.priority || "test-priority-1",
+          createdById: testData.user || "test-user-1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning()
+        .then((result) => result[0]);
+
+      await db.insert(schema.issueHistory).values([
+        {
+          id: "activity-only-1",
+          issueId: activitiesOnlyIssue.id,
+          organizationId: testData.organization,
+          type: "STATUS_CHANGED",
+          field: "status",
+          oldValue: "old-status",
+          newValue: "new-status",
+          actorId: testData.user || "test-user-1",
+          changedAt: new Date("2024-01-01"),
+        },
+        {
+          id: "activity-only-2",
+          issueId: activitiesOnlyIssue.id,
+          organizationId: testData.organization,
+          type: "PRIORITY_CHANGED",
+          field: "priority",
+          oldValue: "low",
+          newValue: "high",
+          actorId: testData.user || "test-user-1",
+          changedAt: new Date("2024-01-02"),
+        },
+      ]);
+
+      const result = await caller.getTimeline({
+        issueId: activitiesOnlyIssue.id,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.every((item) => item.itemType === "activity")).toBe(true);
+
+      // Verify activity types and data
+      const statusActivity = result.find(
+        (item) =>
+          item.itemType === "activity" && item.type === "STATUS_CHANGED",
+      );
+      expect(statusActivity).toBeDefined();
+      expect(statusActivity).toMatchObject({
+        oldValue: "old-status",
+        newValue: "new-status",
+      });
+    });
+
+    it("should handle mixed timeline with complex chronological ordering", async () => {
+      // Create issue and add timeline items with specific timestamps for testing ordering
+      const mixedTimelineIssue = await db
+        .insert(schema.issues)
+        .values({
+          id: "mixed-timeline-issue",
+          title: "Mixed Timeline Issue",
+          organizationId: testData.organization,
+          machineId: testData.machine || "test-machine-1",
+          statusId: testData.status || "test-status-1",
+          priorityId: testData.priority || "test-priority-1",
+          createdById: testData.user || "test-user-1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning()
+        .then((result) => result[0]);
+
+      // Add timeline items in specific chronological order
+      await db.insert(schema.comments).values([
+        {
+          id: "mixed-comment-1",
+          content: "First comment",
+          issueId: mixedTimelineIssue.id,
+          authorId: testData.user || "test-user-1",
+          createdAt: new Date("2024-01-01T09:00:00Z"), // First
+          updatedAt: new Date("2024-01-01T09:00:00Z"),
+        },
+        {
+          id: "mixed-comment-2",
+          content: "Third item chronologically",
+          issueId: mixedTimelineIssue.id,
+          authorId: testData.user || "test-user-1",
+          createdAt: new Date("2024-01-01T15:00:00Z"), // Third
+          updatedAt: new Date("2024-01-01T15:00:00Z"),
+        },
+      ]);
+
+      await db.insert(schema.issueHistory).values([
+        {
+          id: "mixed-activity-1",
+          issueId: mixedTimelineIssue.id,
+          organizationId: testData.organization,
+          type: "STATUS_CHANGED",
+          field: "status",
+          oldValue: "open",
+          newValue: "in-progress",
+          actorId: testData.user || "test-user-1",
+          changedAt: new Date("2024-01-01T12:00:00Z"), // Second
+        },
+        {
+          id: "mixed-activity-2",
+          issueId: mixedTimelineIssue.id,
+          organizationId: testData.organization,
+          type: "ASSIGNED",
+          field: "assignedTo",
+          oldValue: null,
+          newValue: testData.user || "test-user-1",
+          actorId: testData.user || "test-user-1",
+          changedAt: new Date("2024-01-01T18:00:00Z"), // Fourth
+        },
+      ]);
+
+      const result = await caller.getTimeline({
+        issueId: mixedTimelineIssue.id,
+      });
+
+      expect(result).toHaveLength(4);
+
+      // Verify chronological ordering
+      const expectedOrder = [
+        { itemType: "comment", content: "First comment" },
+        { itemType: "activity", type: "STATUS_CHANGED" },
+        { itemType: "comment", content: "Third item chronologically" },
+        { itemType: "activity", type: "ASSIGNED" },
+      ];
+
+      for (let i = 0; i < expectedOrder.length; i++) {
+        expect(result[i].itemType).toBe(expectedOrder[i].itemType);
+        if (expectedOrder[i].content) {
+          expect((result[i] as any).content).toBe(expectedOrder[i].content);
+        }
+        if (expectedOrder[i].type) {
+          expect((result[i] as any).type).toBe(expectedOrder[i].type);
+        }
+      }
+
+      // Verify timeline is properly sorted by timestamp
+      for (let i = 1; i < result.length; i++) {
+        expect(result[i].timestamp.getTime()).toBeGreaterThanOrEqual(
+          result[i - 1].timestamp.getTime(),
+        );
+      }
+    });
+
+    it("should validate issue exists before calling service", async () => {
+      // Create a spy to track service method calls
+      const serviceMethodSpy = vi.fn().mockResolvedValue([]);
+      const mockService = {
+        getIssueTimeline: serviceMethodSpy,
+        recordIssueCreated: vi.fn(),
+        recordActivity: vi.fn(),
+        recordStatusChange: vi.fn(),
+        recordAssignmentChange: vi.fn(),
+        recordFieldUpdate: vi.fn(),
+        recordCommentDeleted: vi.fn(),
+        recordIssueResolved: vi.fn(),
+        recordIssueAssigned: vi.fn(),
+      };
+
+      vi.mocked(context.services.createIssueActivityService).mockReturnValue(
+        mockService,
+      );
+
+      // Test with non-existent issue
+      await expect(
+        caller.getTimeline({ issueId: "definitely-does-not-exist" }),
+      ).rejects.toThrow("Issue not found or access denied");
+
+      // Verify service method was never called
+      expect(serviceMethodSpy).not.toHaveBeenCalled();
+
+      // Now test with valid issue
+      await caller.getTimeline({ issueId: testData.issue || "test-issue-1" });
+
+      // Verify service method was called for valid issue
+      expect(serviceMethodSpy).toHaveBeenCalledWith(
+        testData.issue || "test-issue-1",
+        testData.organization,
+      );
+    });
+  });
+
+  describe("Service Integration", () => {
+    it("should properly integrate with IssueActivityService", async () => {
+      // Create real service instance for testing integration
+      const realService = new IssueActivityService(context.db);
+
+      // Mock the service factory to return real service
+      vi.mocked(context.services.createIssueActivityService).mockReturnValue(
+        realService,
+      );
+
+      const result = await caller.getTimeline({
+        issueId: testData.issue || "test-issue-1",
+      });
+
+      // Verify service was called and returned data
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+
+      // The actual timeline content depends on the service implementation
+      // but we can verify the structure and organizational scoping
+      if (result.length > 0) {
+        expect(result[0]).toHaveProperty("type");
+        expect(result[0]).toHaveProperty("createdAt");
+        expect(result[0].createdAt).toBeInstanceOf(Date);
+      }
+    });
+
+    it("should handle service errors gracefully", async () => {
+      // Create a service that throws an error
+      const failingService = {
+        getIssueTimeline: vi
+          .fn()
+          .mockRejectedValue(new Error("Database connection lost")),
+        recordIssueCreated: vi.fn(),
+        recordActivity: vi.fn(),
+        recordStatusChange: vi.fn(),
+        recordAssignmentChange: vi.fn(),
+        recordFieldUpdate: vi.fn(),
+        recordCommentDeleted: vi.fn(),
+        recordIssueResolved: vi.fn(),
+        recordIssueAssigned: vi.fn(),
+      };
+
+      vi.mocked(context.services.createIssueActivityService).mockReturnValue(
+        failingService,
+      );
+
+      await expect(
+        caller.getTimeline({ issueId: testData.issue || "test-issue-1" }),
+      ).rejects.toThrow("Database connection lost");
+
+      // Verify the service method was actually called
+      expect(failingService.getIssueTimeline).toHaveBeenCalledWith(
+        testData.issue || "test-issue-1",
+        testData.organization,
+      );
+    });
+  });
+});

--- a/src/server/api/routers/__tests__/issue.timeline.test.ts
+++ b/src/server/api/routers/__tests__/issue.timeline.test.ts
@@ -1,0 +1,591 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/**
+ * Issue Timeline Router Unit Tests
+ *
+ * Tests the issue.timeline router with mocked dependencies using modern August 2025 patterns.
+ * Focuses on testing the router's logic, validation, and error handling while mocking
+ * all external dependencies (database, services).
+ *
+ * Key Features:
+ * - Modern Vitest patterns with vi.mock and vi.importActual
+ * - Type-safe mocking with proper TypeScript inference
+ * - Comprehensive error case testing
+ * - Organizational scoping validation
+ * - Service integration testing with mocks
+ * - TRPCError code validation
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock permissions system
+vi.mock("~/server/auth/permissions", () => ({
+  getUserPermissionsForSession: vi
+    .fn()
+    .mockResolvedValue(["issue:view", "organization:manage"]),
+  getUserPermissionsForSupabaseUser: vi
+    .fn()
+    .mockResolvedValue(["issue:view", "organization:manage"]),
+  requirePermissionForSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { issueTimelineRouter } from "~/server/api/routers/issue.timeline";
+import {
+  createVitestMockContext,
+  type VitestMockContext,
+} from "~/test/vitestMockContext";
+
+describe("Issue Timeline Router (Unit Tests)", () => {
+  let mockContext: VitestMockContext;
+  let caller: ReturnType<typeof issueTimelineRouter.createCaller>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockContext = createVitestMockContext();
+
+    // Mock membership lookup for organizationProcedure
+    vi.mocked(mockContext.db.membership.findFirst).mockResolvedValue({
+      id: "test-membership",
+      organizationId: "org-1",
+      userId: "user-1",
+      roleId: "role-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      role: {
+        id: "role-1",
+        name: "Admin",
+        organizationId: "org-1",
+        isSystem: false,
+        isDefault: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        permissions: [
+          {
+            id: "perm1",
+            name: "issue:view",
+            description: "View issues",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            id: "perm2",
+            name: "organization:manage",
+            description: "Manage organization",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      },
+    } as any);
+
+    caller = issueTimelineRouter.createCaller(mockContext);
+  });
+
+  describe("getTimeline", () => {
+    const validInput = { issueId: "test-issue-1" };
+    const mockTimelineData = [
+      {
+        type: "comment" as const,
+        id: "comment-1",
+        content: "Test comment",
+        createdAt: new Date("2024-01-01"),
+        author: {
+          id: "user-1",
+          name: "Test User",
+          profilePicture: null,
+        },
+      },
+      {
+        type: "activity" as const,
+        id: "activity-1",
+        activityType: "STATUS_CHANGED" as const,
+        description: "Status changed from Open to In Progress",
+        createdAt: new Date("2024-01-02"),
+        actor: {
+          id: "user-1",
+          name: "Test User",
+          profilePicture: null,
+        },
+        oldValue: "status-open",
+        newValue: "status-in-progress",
+      },
+    ];
+
+    describe("Success Cases", () => {
+      beforeEach(() => {
+        // Mock successful issue lookup with organizational scoping
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          {
+            id: "test-issue-1",
+          },
+        );
+
+        // Mock service creation and getIssueTimeline method
+        const mockActivityService = {
+          getIssueTimeline: vi.fn().mockResolvedValue(mockTimelineData),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+      });
+
+      it("should return timeline data for valid issue", async () => {
+        const result = await caller.getTimeline(validInput);
+
+        expect(result).toEqual(mockTimelineData);
+
+        // Verify issue lookup with organizational scoping
+        expect(mockContext.drizzle.query.issues.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            columns: {
+              id: true,
+            },
+          }),
+        );
+
+        // Verify service method called with correct parameters
+        expect(
+          mockContext.services.createIssueActivityService,
+        ).toHaveBeenCalledTimes(1);
+        const activityService =
+          mockContext.services.createIssueActivityService();
+        expect(activityService.getIssueTimeline).toHaveBeenCalledWith(
+          "test-issue-1",
+          "org-1", // From mock context organization
+        );
+      });
+
+      it("should handle empty timeline data", async () => {
+        // Mock empty timeline response
+        const mockActivityService = {
+          getIssueTimeline: vi.fn().mockResolvedValue([]),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+
+        const result = await caller.getTimeline(validInput);
+
+        expect(result).toEqual([]);
+
+        // Verify service method was called
+        const serviceInstance = vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mock.results[0]?.value;
+        expect(serviceInstance.getIssueTimeline).toHaveBeenCalledWith(
+          "test-issue-1",
+          "org-1",
+        );
+      });
+
+      it("should work with complex timeline containing multiple item types", async () => {
+        const complexTimelineData = [
+          {
+            type: "comment" as const,
+            id: "comment-1",
+            content: "Initial comment",
+            createdAt: new Date("2024-01-01"),
+            author: { id: "user-1", name: "User 1", profilePicture: null },
+          },
+          {
+            type: "activity" as const,
+            id: "activity-1",
+            activityType: "STATUS_CHANGED" as const,
+            description: "Status changed",
+            createdAt: new Date("2024-01-02"),
+            actor: { id: "user-2", name: "User 2", profilePicture: null },
+            oldValue: "open",
+            newValue: "in-progress",
+          },
+          {
+            type: "comment" as const,
+            id: "comment-2",
+            content: "Follow-up comment",
+            createdAt: new Date("2024-01-03"),
+            author: { id: "user-3", name: "User 3", profilePicture: null },
+          },
+          {
+            type: "activity" as const,
+            id: "activity-2",
+            activityType: "ASSIGNED" as const,
+            description: "Issue assigned",
+            createdAt: new Date("2024-01-04"),
+            actor: { id: "user-1", name: "User 1", profilePicture: null },
+            oldValue: null,
+            newValue: "user-3",
+          },
+        ];
+
+        const mockActivityService = {
+          getIssueTimeline: vi.fn().mockResolvedValue(complexTimelineData),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+
+        const result = await caller.getTimeline(validInput);
+
+        expect(result).toEqual(complexTimelineData);
+        expect(result).toHaveLength(4);
+        expect(result.filter((item) => item.type === "comment")).toHaveLength(
+          2,
+        );
+        expect(result.filter((item) => item.type === "activity")).toHaveLength(
+          2,
+        );
+      });
+    });
+
+    describe("Error Cases", () => {
+      it("should throw NOT_FOUND when issue does not exist", async () => {
+        // Mock issue not found
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          null,
+        );
+
+        await expect(caller.getTimeline(validInput)).rejects.toThrow(
+          expect.objectContaining({
+            code: "NOT_FOUND",
+            message: "Issue not found or access denied",
+          }),
+        );
+
+        // Verify issue lookup was attempted
+        expect(
+          mockContext.drizzle.query.issues.findFirst,
+        ).toHaveBeenCalledTimes(1);
+
+        // Verify service was NOT called when issue doesn't exist
+        expect(
+          mockContext.services.createIssueActivityService,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("should throw NOT_FOUND when issue belongs to different organization", async () => {
+        // Mock issue not found due to organizational scoping
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          null,
+        );
+
+        await expect(
+          caller.getTimeline({ issueId: "other-org-issue" }),
+        ).rejects.toThrow(
+          expect.objectContaining({
+            code: "NOT_FOUND",
+            message: "Issue not found or access denied",
+          }),
+        );
+
+        // Verify organizational scoping in query
+        expect(mockContext.drizzle.query.issues.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            columns: {
+              id: true,
+            },
+          }),
+        );
+      });
+
+      it("should handle service method failures gracefully", async () => {
+        // Mock successful issue lookup
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          {
+            id: "test-issue-1",
+          },
+        );
+
+        // Mock service method throwing an error
+        const mockActivityService = {
+          getIssueTimeline: vi
+            .fn()
+            .mockRejectedValue(new Error("Service error")),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+
+        await expect(caller.getTimeline(validInput)).rejects.toThrow(
+          "Service error",
+        );
+
+        // Verify issue lookup succeeded
+        expect(
+          mockContext.drizzle.query.issues.findFirst,
+        ).toHaveBeenCalledTimes(1);
+
+        // Verify service was called despite eventual failure
+        expect(
+          mockContext.services.createIssueActivityService,
+        ).toHaveBeenCalledTimes(1);
+        expect(mockActivityService.getIssueTimeline).toHaveBeenCalledWith(
+          "test-issue-1",
+          "org-1",
+        );
+      });
+
+      it("should handle database lookup failures", async () => {
+        // Mock database error
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockRejectedValue(
+          new Error("Database connection error"),
+        );
+
+        await expect(caller.getTimeline(validInput)).rejects.toThrow(
+          "Database connection error",
+        );
+
+        // Verify service was not called when database fails
+        expect(
+          mockContext.services.createIssueActivityService,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("Input Validation", () => {
+      it("should validate required issueId parameter", async () => {
+        await expect(caller.getTimeline({} as any)).rejects.toThrow();
+        await expect(caller.getTimeline({ issueId: "" })).rejects.toThrow();
+        await expect(
+          caller.getTimeline({ issueId: null } as any),
+        ).rejects.toThrow();
+        await expect(
+          caller.getTimeline({ issueId: undefined } as any),
+        ).rejects.toThrow();
+      });
+
+      it("should accept valid issueId strings", async () => {
+        // Mock successful issue lookup for validation test
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          {
+            id: "valid-issue-id",
+          },
+        );
+
+        const mockActivityService = {
+          getIssueTimeline: vi.fn().mockResolvedValue([]),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+
+        // Test various valid ID formats
+        const validIds = [
+          "issue-1",
+          "test-issue-123",
+          "UUID-like-string-12345",
+          "simple",
+        ];
+
+        for (const issueId of validIds) {
+          await expect(caller.getTimeline({ issueId })).resolves.toEqual([]);
+          expect(mockActivityService.getIssueTimeline).toHaveBeenCalledWith(
+            issueId,
+            "org-1",
+          );
+        }
+      });
+    });
+
+    describe("Organizational Scoping", () => {
+      it("should enforce organizational isolation in issue lookup", async () => {
+        // Mock context with different organization
+        const orgSpecificContext = {
+          ...mockContext,
+          organization: {
+            id: "specific-org-123",
+            name: "Specific Organization",
+            subdomain: "specific-org",
+          },
+        };
+
+        const orgSpecificCaller =
+          issueTimelineRouter.createCaller(orgSpecificContext);
+
+        // Mock successful issue lookup
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          {
+            id: "test-issue-1",
+          },
+        );
+
+        const mockActivityService = {
+          getIssueTimeline: vi.fn().mockResolvedValue([]),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+
+        await orgSpecificCaller.getTimeline(validInput);
+
+        // Verify service called with correct organization ID
+        expect(mockActivityService.getIssueTimeline).toHaveBeenCalledWith(
+          "test-issue-1",
+          "specific-org-123",
+        );
+      });
+
+      it("should use organizationProcedure for authentication and org scoping", async () => {
+        // This test verifies that the procedure uses organizationProcedure
+        // which should enforce authentication and provide organization context
+
+        // Mock unauthenticated context (no user)
+        const unauthenticatedContext = {
+          ...mockContext,
+          user: null,
+          organization: null,
+        };
+
+        const unauthenticatedCaller = issueTimelineRouter.createCaller(
+          unauthenticatedContext,
+        );
+
+        // Should fail before even reaching our procedure logic due to organizationProcedure
+        await expect(
+          unauthenticatedCaller.getTimeline(validInput),
+        ).rejects.toThrow();
+
+        // Verify database was not called due to early authentication failure
+        expect(
+          mockContext.drizzle.query.issues.findFirst,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("Service Integration", () => {
+      it("should create activity service and call getIssueTimeline with correct parameters", async () => {
+        // Mock successful issue lookup
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          {
+            id: "test-issue-1",
+          },
+        );
+
+        const mockTimelineResult = [
+          {
+            type: "activity" as const,
+            id: "activity-1",
+            activityType: "CREATED" as const,
+            description: "Issue created",
+            createdAt: new Date(),
+            actor: { id: "user-1", name: "Creator", profilePicture: null },
+            oldValue: null,
+            newValue: "test-issue-1",
+          },
+        ];
+
+        const mockActivityService = {
+          getIssueTimeline: vi.fn().mockResolvedValue(mockTimelineResult),
+          recordIssueCreated: vi.fn(),
+          recordActivity: vi.fn(),
+          recordStatusChange: vi.fn(),
+          recordAssignmentChange: vi.fn(),
+          recordFieldUpdate: vi.fn(),
+          recordCommentDeleted: vi.fn(),
+          recordIssueResolved: vi.fn(),
+          recordIssueAssigned: vi.fn(),
+        };
+
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockReturnValue(mockActivityService);
+
+        const result = await caller.getTimeline(validInput);
+
+        // Verify service factory called correctly
+        expect(
+          mockContext.services.createIssueActivityService,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          mockContext.services.createIssueActivityService,
+        ).toHaveBeenCalledWith();
+
+        // Verify service method called with correct parameters
+        expect(mockActivityService.getIssueTimeline).toHaveBeenCalledTimes(1);
+        expect(mockActivityService.getIssueTimeline).toHaveBeenCalledWith(
+          "test-issue-1",
+          "org-1",
+        );
+
+        // Verify result passed through correctly
+        expect(result).toEqual(mockTimelineResult);
+      });
+
+      it("should handle service creation failures", async () => {
+        // Mock successful issue lookup
+        vi.mocked(mockContext.drizzle.query.issues.findFirst).mockResolvedValue(
+          {
+            id: "test-issue-1",
+          },
+        );
+
+        // Mock service factory throwing an error
+        vi.mocked(
+          mockContext.services.createIssueActivityService,
+        ).mockImplementation(() => {
+          throw new Error("Service creation failed");
+        });
+
+        await expect(caller.getTimeline(validInput)).rejects.toThrow(
+          "Service creation failed",
+        );
+
+        // Verify issue lookup succeeded before service creation failure
+        expect(
+          mockContext.drizzle.query.issues.findFirst,
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/server/api/routers/issue.timeline.ts
+++ b/src/server/api/routers/issue.timeline.ts
@@ -1,6 +1,9 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { createTRPCRouter, organizationProcedure } from "~/server/api/trpc";
+import { issues } from "~/server/db/schema";
 
 export const issueTimelineRouter = createTRPCRouter({
   // Get issue timeline (comments + activities)
@@ -8,18 +11,21 @@ export const issueTimelineRouter = createTRPCRouter({
     .input(z.object({ issueId: z.string() }))
     .query(async ({ ctx, input }) => {
       // Verify the issue belongs to this organization
-      const issue = await ctx.db.issue.findFirst({
-        where: {
-          id: input.issueId,
-          organizationId: ctx.organization.id,
-        },
-        select: {
+      const issue = await ctx.drizzle.query.issues.findFirst({
+        where: and(
+          eq(issues.id, input.issueId),
+          eq(issues.organizationId, ctx.organization.id),
+        ),
+        columns: {
           id: true,
         },
       });
 
       if (!issue) {
-        throw new Error("Issue not found");
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Issue not found or access denied",
+        });
       }
 
       const activityService = ctx.services.createIssueActivityService();


### PR DESCRIPTION
## Summary

- Convert `issue.timeline.ts` from Prisma to Drizzle patterns using direct conversion approach
- Replace `ctx.db.issue.findFirst()` with `ctx.drizzle.query.issues.findFirst()`  
- Enhanced error handling from basic `Error` to proper `TRPCError` with NOT_FOUND code
- Maintain organizational scoping with `and()` + `eq()` conditions
- Add explicit column selection for performance optimization

## Router Changes

**File**: `src/server/api/routers/issue.timeline.ts`
- **Size**: 31→38 lines (+23% for proper imports)
- **Pattern**: Clean Drizzle query with relational patterns
- **Security**: Preserved multi-tenant organizational scoping
- **Error Handling**: Enhanced from generic errors to proper TRPCError codes

## Test Coverage

**Unit Tests**: 13 tests in `src/server/api/routers/__tests__/issue.timeline.test.ts`
- Success cases with mocked dependencies
- Error handling (NOT_FOUND, database failures, service failures)
- Input validation and organizational scoping
- Service integration testing

**Integration Tests**: 10 tests in `src/integration-tests/issue.timeline.integration.test.ts`
- PGlite in-memory PostgreSQL for real database operations
- Complete timeline scenarios (comments + activities)
- Chronological ordering validation
- Cross-organizational access prevention
- Service integration with IssueActivityService

## Migration Strategy

This continues the **Phase 2B direct conversion approach**:
- Selected `issue.timeline.ts` for its simplicity (31 lines, 1 procedure)
- Clean conversion using modern Drizzle patterns
- No parallel validation overhead
- Immediate TypeScript compilation validation
- Comprehensive testing as safety net

## Test Results

```bash
✅ TypeScript compilation: No errors
✅ ESLint: No warnings or errors  
✅ Tests: 1534 tests passed (including 23 new issue.timeline tests)
```

## Next Steps

Continue Phase 2B momentum by converting remaining routers using the same direct conversion approach.

🤖 Generated with [Claude Code](https://claude.ai/code)