### PR TITLE
fix(auth): hide admin login button in production

### DIFF
--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -10,7 +10,13 @@ import { loginAction, type LoginResult } from "~/app/(auth)/actions";
 import { cn } from "~/lib/utils";
 import { TestAdminButton } from "./TestAdminButton";
 
-export function LoginForm(): React.JSX.Element {
+interface LoginFormProps {
+  enableTestAdmin?: boolean;
+}
+
+export function LoginForm({
+  enableTestAdmin = false,
+}: LoginFormProps): React.JSX.Element {
   const [state, formAction] = useActionState<LoginResult | undefined, FormData>(
     loginAction,
     undefined
@@ -100,10 +106,12 @@ export function LoginForm(): React.JSX.Element {
         </Button>
       </form>
 
-      {/* Test Admin Login Button */}
-      <div className="space-y-2">
-        <TestAdminButton />
-      </div>
+      {/* Test Admin Login Button (Dev/Preview only) */}
+      {enableTestAdmin && (
+        <div className="space-y-2">
+          <TestAdminButton />
+        </div>
+      )}
 
       {/* Signup link */}
       <div className="text-center text-sm text-muted-foreground">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -33,7 +33,10 @@ export default async function LoginPage(): Promise<React.JSX.Element> {
       </CardHeader>
 
       <CardContent className="space-y-6">
-        <LoginForm />
+        {/* Only enable test admin button in non-production environments */}
+        <LoginForm
+          enableTestAdmin={process.env["VERCEL_ENV"] !== "production"}
+        />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Overview
Hides the "Login with Admin User" button in production environments by checking `process.env.VERCEL_ENV`.

## Changes
- Conditionally renders `TestAdminButton` in `src/app/(auth)/login/page.tsx` based on `VERCEL_ENV`.
- Passes filtering logic down to `LoginForm`.

## Verification
- Verified with `npm run typecheck`.
- Manual verification required in Vercel Preview/Production.