### PR TITLE
fix: Mobile sidebar cleanup and polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7969,7 +7969,6 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
       "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -14047,6 +14046,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
       "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.0.7",
         "@swc/helpers": "0.5.15",

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -40,7 +40,11 @@ export function MobileNav({
             Main navigation menu for accessing dashboard, issues, and machines.
           </SheetDescription>
         </div>
-        <Sidebar role={role} onNavigate={() => setOpen(false)} />
+        <Sidebar
+          role={role}
+          onNavigate={() => setOpen(false)}
+          isMobile={true}
+        />
       </SheetContent>
     </Sheet>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -47,20 +47,23 @@ const sidebarItems = [
 export function Sidebar({
   role,
   onNavigate,
+  isMobile = false,
 }: {
   role?: "guest" | "member" | "admin" | undefined;
   onNavigate?: () => void;
+  isMobile?: boolean;
 }): React.JSX.Element {
   const [collapsed, setCollapsed] = useState(false);
   const pathname = usePathname();
 
   // Load state from localStorage on mount
   useEffect(() => {
+    if (isMobile) return; // Don't load/save collapse state on mobile
     const savedState = window.localStorage.getItem("sidebar-collapsed");
     if (savedState) {
       setCollapsed(JSON.parse(savedState) as boolean);
     }
-  }, []);
+  }, [isMobile]);
 
   const toggleSidebar = (): void => {
     const newState = !collapsed;
@@ -129,7 +132,8 @@ export function Sidebar({
         data-testid="sidebar"
         className={cn(
           "flex h-full flex-col border-r border-primary/50 bg-card text-card-foreground shadow-[0_0_15px_rgba(74,222,128,0.15)] transition-all duration-300 ease-in-out overflow-x-hidden",
-          collapsed ? "w-[64px]" : "w-64"
+          collapsed ? "w-[64px]" : "w-64",
+          isMobile && "w-full border-r-0 shadow-none" // Full width and no border/shadow on mobile sheet
         )}
       >
         {/* Logo Area */}
@@ -141,6 +145,7 @@ export function Sidebar({
         >
           <Link
             href="/dashboard"
+            {...(onNavigate ? { onClick: onNavigate } : {})}
             className="flex size-full items-center justify-center"
           >
             {collapsed ? (
@@ -201,24 +206,26 @@ export function Sidebar({
             />
           </div>
 
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={toggleSidebar}
-            className="w-full h-10 hover:bg-primary/10 hover:text-primary"
-            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          >
-            {collapsed ? (
-              <ChevronRight className="size-4" />
-            ) : (
-              <div className="flex items-center gap-2">
-                <ChevronLeft className="size-4" />
-                <span className="text-xs uppercase font-semibold">
-                  Collapse
-                </span>
-              </div>
-            )}
-          </Button>
+          {!isMobile && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={toggleSidebar}
+              className="w-full h-10 hover:bg-primary/10 hover:text-primary"
+              aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            >
+              {collapsed ? (
+                <ChevronRight className="size-4" />
+              ) : (
+                <div className="flex items-center gap-2">
+                  <ChevronLeft className="size-4" />
+                  <span className="text-xs uppercase font-semibold">
+                    Collapse
+                  </span>
+                </div>
+              )}
+            </Button>
+          )}
         </div>
       </div>
     </TooltipProvider>


### PR DESCRIPTION
This PR applies the final polish fixes for the mobile sidebar that were missed in the previous merge due to a process error.

### Fixes
- **Collapse Button:** Hides the collapse button when the sidebar is rendered in the mobile sheet.
- **State Persistence:** Prevents the mobile sidebar from reading/writing the 'collapsed' state to local storage (mobile sidebar should always be full width).
- **Styling:** Ensures the sidebar takes full width and removes borders/shadows when in the sheet.