### PR TITLE
fix: exempt Jules bot from CHANGELOG requirement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ Referencing `TASKS.md` PR order:
 ## Copilot Review Priorities
 
 1. **GitHub Staging Files**: Any files in `.github-staging/` directory MUST be manually reviewed before moving to `.github/`. Never automatically move or activate these files. See `.github-staging/README.md` for review process.
-2. **Release Notes**: Verify `CHANGELOG.md` has been updated with a brief description of changes for user-facing or significant technical updates. Skip only for CI, refactoring, or test-only changes.
+2. **Release Notes**: Verify `CHANGELOG.md` has been updated with a brief description of changes for user-facing or significant technical updates. Skip only for CI plumbing, refactoring, test-only changes, and bot PRs (dependabot, Jules).
 3. Security & Data Integrity: Input validation, single-tenant assumptions honored, issue-machine relationship enforced.
 4. Server-First Compliance: Avoid unnecessary `"use client"`.
 5. Type Safety: No forbidden escapes; proper narrowing.

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,7 +10,7 @@ jobs:
   changelog:
     name: Ensure CHANGELOG updated
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'jules[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -30,7 +30,7 @@ trigger: always_on
 10. Forms work without JavaScript (progressive enhancement)
 11. Use Drizzle migrations for schema changes (no ad-hoc `push` to production/preview)
 12. Keep auth host consistent: use `localhost` everywhere (Supabase site_url, Next dev, Playwright baseURL) to prevent cookie host mismatches
-13. Update `CHANGELOG.md` for every PR (skip only for CI plumbing/test-only changes); release-notes workflow will block otherwise
+13. Update `CHANGELOG.md` for every PR (skip only for CI plumbing/test-only changes and bot PRs like dependabot/Jules); release-notes workflow will block otherwise
 
 ---
 


### PR DESCRIPTION
Prevents Jules bot PRs from failing on missing CHANGELOG entries.

This PR updates:
- `.github/workflows/release-notes.yml` - Adds jules[bot] to exemption list
- `.github/copilot-instructions.md` - Documents bot exemption policy
- `docs/NON_NEGOTIABLES.md` - Clarifies bot PR exemption in quick start

**Why**: Jules bot PRs were causing CHANGELOG merge conflicts. By exempting bots from the requirement, we eliminate this friction while maintaining CHANGELOG discipline for human contributors.

**Impact**: Future Jules bot PRs will bypass the CHANGELOG check, allowing them to merge cleanly without manual changelog updates.