### PR TITLE
feat: add Desktop Firefox to E2E test suite

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -153,6 +153,10 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
       name: "Mobile Chrome",
       use: { ...devices["Pixel 5"] },
     },


### PR DESCRIPTION
This PR adds Desktop Firefox to the E2E test suite. All tests (smoke and full) have been verified locally and pass. Auto-merge is requested.