### PR TITLE
feat: Google Sheets to PinPoint sync (Closes #sheets-sync)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,7 @@ RESEND_API_KEY=re_xxxxxxxxxxxx
 # UPSTASH_REDIS_REST_TOKEN = ${KV_REST_API_TOKEN}
 UPSTASH_REDIS_REST_URL=https://your-redis-instance.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your_redis_rest_token_here
+
+# Maintenance Spreadsheet Sync
+MAINTENANCE_SPREADSHEET_ID=1hMQ0rE-ietdI365PqbRozVA8gGy02Qm8oPRnijzxwrw
+GOOGLE_APPLICATION_CREDENTIALS=/home/froeht/.sheets-api-key.json

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ __pycache__/
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Sheets Sync Cache
+.sheets-sync-cache.json

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.1",
+    "google-auth-library": "^10.5.0",
+    "google-spreadsheet": "^5.0.2",
     "lucide-react": "^0.562.0",
     "next": "^16.1.1",
     "nodemailer": "^7.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,12 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@electric-sql/pglite@0.3.14)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(@upstash/redis@1.36.0)(postgres@3.4.7)
+      google-auth-library:
+        specifier: ^10.5.0
+        version: 10.5.0
+      google-spreadsheet:
+        specifier: ^5.0.2
+        version: 5.0.2(google-auth-library@10.5.0)
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -3269,6 +3275,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
     hasBin: true
@@ -3279,6 +3288,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -3306,6 +3318,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3440,6 +3455,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@6.0.0:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
@@ -3646,6 +3665,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   electron-to-chromium@1.5.249:
     resolution: {integrity: sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==}
 
@@ -3725,6 +3747,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.44.0:
+    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
   es6-promise@4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
@@ -3929,6 +3954,9 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
 
@@ -3970,6 +3998,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -4004,6 +4036,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
@@ -4026,6 +4062,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -4089,12 +4133,32 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  google-spreadsheet@5.0.2:
+    resolution: {integrity: sha512-8ugGYGsy6BLl6d4z2zwllEv8hFB2IVcCNAUYT/seo4DU7Pk6m79qv+qRxE2cE8bxbf4S13T5fzrjcPhbk2ogsw==}
+    peerDependencies:
+      google-auth-library: '>=8.8.0'
+    peerDependenciesMeta:
+      google-auth-library:
+        optional: true
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -4397,6 +4461,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4428,8 +4495,18 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  ky@1.14.2:
+    resolution: {integrity: sha512-q3RBbsO5A5zrPhB6CaCS8ZUv+NWCXv6JJT4Em0i264G9W0fdPB8YRfnnEi7Dm7X7omAkBIPojzYJ2D1oHTHqug==}
+    engines: {node: '>=18'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -4695,6 +4772,11 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -4703,6 +4785,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -5135,6 +5221,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rollup@4.55.1:
     resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
@@ -5727,6 +5817,10 @@ packages:
   watchpack@2.5.0:
     resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
     engines: {node: '>=10.13.0'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -9171,6 +9265,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.11: {}
 
   baseline-browser-mapping@2.9.14: {}
@@ -9178,6 +9274,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -9211,6 +9309,8 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -9349,6 +9449,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@6.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -9464,6 +9566,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.249: {}
 
@@ -9658,6 +9764,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.44.0: {}
 
   es6-promise@4.2.8: {}
 
@@ -10000,6 +10108,8 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  extend@3.0.2: {}
+
   fast-copy@4.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -10033,6 +10143,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fflate@0.8.2: {}
 
@@ -10070,6 +10185,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded-parse@2.1.2: {}
 
   fsevents@2.3.2:
@@ -10090,6 +10209,23 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -10157,9 +10293,37 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  google-spreadsheet@5.0.2(google-auth-library@10.5.0):
+    dependencies:
+      es-toolkit: 1.44.0
+      ky: 1.14.2
+    optionalDependencies:
+      google-auth-library: 10.5.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   has-bigints@1.1.0: {}
 
@@ -10493,6 +10657,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-better-errors@1.0.2: {}
@@ -10518,9 +10686,22 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  ky@1.14.2: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -10749,9 +10930,17 @@ snapshots:
 
   nice-try@1.0.5: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.27: {}
 
@@ -11187,6 +11376,10 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   rollup@4.55.1:
     dependencies:
@@ -11881,6 +12074,8 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/scripts/force-db-reset.mjs
+++ b/scripts/force-db-reset.mjs
@@ -24,6 +24,7 @@ const tables = [
   "issues",
   "machines",
   "user_profiles",
+  "invited_users",
   "unconfirmed_users",
 ];
 

--- a/scripts/sheets-sync/README.md
+++ b/scripts/sheets-sync/README.md
@@ -1,0 +1,43 @@
+# PinPoint Google Sheets Sync Setup
+
+This script allows two-way synchronization between the APC Maintenance Spreadsheet and the PinPoint database.
+
+## Prerequisites
+
+1. **Google Service Account**:
+   - Go to the [Google Cloud Console](https://console.cloud.google.com/).
+   - Create a new project (or use an existing one).
+   - Enable the **Google Sheets API**.
+   - Create a **Service Account** under "IAM & Admin" > "Service Accounts".
+   - Create and download a **JSON Key** for the service account.
+   - Rename this file to `credentials.json` and place it in `scripts/sheets-sync/`.
+
+2. **Spreadsheet Access**:
+   - Open your copy of the spreadsheet.
+   - Click "Share".
+   - Add the service account's email address (found in your `credentials.json`) with "Editor" access.
+
+## Usage
+
+### Dry Run (Recommended)
+
+This will fetch data and show what changes would be made without modifying anything.
+
+```bash
+npx tsx scripts/sheets-sync/sync.ts
+```
+
+### Execute Sync
+
+This will apply changes to both the sheet and the database.
+
+```bash
+npx tsx scripts/sheets-sync/sync.ts --execute
+```
+
+## How it works
+
+1. **New Issues**: Rows in the sheet without a "PinPoint" ID are treated as new issues and created in the database.
+2. **Existing Issues**: Matched using the UUID in the "PinPoint" column.
+3. **Conflicts**: If both the sheet and database have changed since the last sync, the script will bail out for that row and ask for manual resolution.
+4. **New Machines**: If a game name in the sheet doesn't match a machine initials in PinPoint, the script will skip it and notify you to create the machine first.

--- a/scripts/sheets-sync/field-mappings.ts
+++ b/scripts/sheets-sync/field-mappings.ts
@@ -1,0 +1,129 @@
+import {
+  type IssueConsistency,
+  type IssueSeverity,
+  type IssueStatus,
+  type SheetRow,
+  type SyncIssue,
+} from "./types";
+
+// Note: This will need to be populated from the database in the main script
+export let machineMap: Record<string, string> = {};
+
+export function setMachineMap(map: Record<string, string>) {
+  machineMap = map;
+}
+
+export function mapSheetSeverity(value: string): IssueSeverity {
+  const v = value.toLowerCase().trim();
+  if (v.includes("major")) return "major";
+  if (v.includes("severe") || v.includes("unplayable")) return "unplayable";
+  if (v.includes("cosmetic")) return "cosmetic";
+  return "minor"; // default
+}
+
+export function mapSheetConsistency(value: string): IssueConsistency {
+  const v = value.toLowerCase().trim();
+  if (v.includes("always") || v.includes("every game")) return "constant";
+  if (v.includes("frequent")) return "frequent";
+  return "intermittent"; // default
+}
+
+export function mapSheetStatus(value: string): IssueStatus {
+  const v = value.toLowerCase().trim();
+  if (v.includes("fixed")) return "fixed";
+  if (v.includes("not a bug") || v.includes("intended")) return "wai";
+  if (v.includes("owner")) return "wait_owner";
+  if (v.includes("parts")) return "need_parts";
+  if (v.includes("progress")) return "in_progress";
+  if (v.includes("help") || v.includes("expert")) return "need_help";
+  return "new"; // default
+}
+
+export function parseSheetRow(
+  row: Record<string, string | undefined>,
+  rowIndex: number
+): SheetRow {
+  return {
+    timestamp: row["Timestamp"] ?? "",
+    email: row["Email Address"] ?? "",
+    game: row["Game"] ?? "",
+    pinpointId: row["PinPoint"] ?? "",
+    severity: row["Severity"] ?? "",
+    consistency: row["Consistency"] ?? "",
+    fixStatus: row["Fix Status"] ?? "",
+    description: row["Description"] ?? "",
+    workLog: row["Work Log"] ?? "",
+    lastSynced: row["Last Synced"] ?? "",
+    rowIndex,
+  };
+}
+
+// Normalizes a string for comparison (lowercase, alphanumeric only, removes "The " prefix)
+function normalize(str: string): string {
+  let s = str.toLowerCase().trim();
+  if (s.startsWith("the ")) s = s.substring(4);
+  return s.replace(/[^a-z0-9]/g, "");
+}
+
+export function mapRowToIssue(row: SheetRow): SyncIssue | null {
+  // Try exact match first
+  let initials = machineMap[row.game];
+
+  // Try normalized match
+  if (!initials) {
+    const normalizedGame = normalize(row.game);
+    const match = Object.entries(machineMap).find(
+      ([name]) => normalize(name) === normalizedGame
+    );
+    if (match) initials = match[1];
+  }
+
+  // Fuzzy match (substring)
+  if (!initials) {
+    const normalizedGame = normalize(row.game);
+    if (normalizedGame.length >= 3) {
+      const matches = Object.entries(machineMap).filter(([name]) => {
+        const normName = normalize(name);
+        return (
+          normName.includes(normalizedGame) || normalizedGame.includes(normName)
+        );
+      });
+      // Only use fuzzy match if there's exactly one candidate to avoid false positives
+      if (matches.length === 1) {
+        initials = matches[0]?.[1];
+      }
+    }
+  }
+
+  // Handle specific common aliases/mismatches
+  if (!initials) {
+    const raw = row.game.trim().toUpperCase();
+    if (raw.includes("IRON MAIDEN") || raw === "MAIDEN")
+      initials = machineMap["Iron Maiden"];
+    if (raw === "TNA") initials = machineMap["Total Nuclear Ann."];
+    if (raw === "LOTR") initials = machineMap["Lord of the Rings"];
+    if (raw === "F-14" || raw === "F14") initials = machineMap["F14 Tomcat"];
+    if (raw === "X MEN" || raw === "X-MEN")
+      initials = machineMap["X-Men Wolverine"];
+  }
+
+  if (!initials) return null;
+
+  // Split description into title and description
+  const lines = row.description.split("\n");
+  const title = (lines[0] ?? "").substring(0, 100);
+  const description = lines.length > 1 ? lines.slice(1).join("\n") : lines[0];
+
+  return {
+    id: row.pinpointId?.match(/[0-9a-f-]{36}/)?.[0], // Extract UUID if present
+    machineInitials: initials,
+    title,
+    description: description ?? "",
+    status: mapSheetStatus(row.fixStatus),
+    severity: mapSheetSeverity(row.severity),
+    consistency: mapSheetConsistency(row.consistency),
+    reporterEmail: row.email,
+    updatedAt: new Date(), // Will be updated by comparison logic
+    createdAt: new Date(row.timestamp),
+  };
+}

--- a/scripts/sheets-sync/sheets-client.ts
+++ b/scripts/sheets-sync/sheets-client.ts
@@ -1,0 +1,55 @@
+import { GoogleSpreadsheet } from "google-spreadsheet";
+import { JWT } from "google-auth-library";
+import { type SheetRow } from "./types";
+import { parseSheetRow } from "./field-mappings";
+import fs from "node:fs/promises";
+
+export class SheetsClient {
+  private doc!: GoogleSpreadsheet;
+
+  constructor(spreadsheetId: string, credentialsPath: string) {
+    this.spreadsheetId = spreadsheetId;
+    this.credentialsPath = credentialsPath;
+  }
+
+  private spreadsheetId: string;
+  private credentialsPath: string;
+
+  async load() {
+    const credsRaw = await fs.readFile(this.credentialsPath, "utf-8");
+    const creds = JSON.parse(credsRaw) as {
+      client_email: string;
+      private_key: string;
+    };
+    const auth = new JWT({
+      email: creds.client_email,
+      key: creds.private_key,
+      scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+    });
+    this.doc = new GoogleSpreadsheet(this.spreadsheetId, auth);
+    await this.doc.loadInfo();
+  }
+
+  async getRows(sheetName: string): Promise<SheetRow[]> {
+    const sheet = this.doc.sheetsByTitle[sheetName];
+    if (!sheet) throw new Error(`Sheet "${sheetName}" not found`);
+
+    const rows = await sheet.getRows();
+    return rows.map((row, index) => parseSheetRow(row.toObject(), index + 2)); // +2 for 1-based index and header
+  }
+
+  async updatePinPointId(
+    sheetName: string,
+    rowIndex: number,
+    pinpointId: string
+  ): Promise<void> {
+    const sheet = this.doc.sheetsByTitle[sheetName];
+    if (!sheet) return;
+
+    const rows = await sheet.getRows({ offset: rowIndex - 2, limit: 1 });
+    if (rows[0]) {
+      rows[0].set("PinPoint", pinpointId);
+      await rows[0].save();
+    }
+  }
+}

--- a/scripts/sheets-sync/sync-engine.ts
+++ b/scripts/sheets-sync/sync-engine.ts
@@ -1,0 +1,125 @@
+import { type SyncIssue, type SheetRow } from "./types";
+import { issues, issueComments } from "../../src/server/db/schema";
+import { eq } from "drizzle-orm";
+import { type PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import * as schema from "../../src/server/db/schema";
+
+export interface SyncAction {
+  type: "create_in_db" | "update_db" | "update_sheet" | "conflict" | "none";
+  row: SheetRow;
+  issue: SyncIssue;
+  reason?: string;
+  changes?: Record<string, { from: string; to: string }>;
+}
+
+export class SyncEngine {
+  constructor(private db: PostgresJsDatabase<typeof schema>) {}
+
+  determineAction(
+    row: SheetRow,
+    issue: SyncIssue,
+    dbIssue: typeof issues.$inferSelect | null,
+    lastCachedRow: SheetRow | null
+  ): SyncAction {
+    if (!dbIssue) {
+      return { type: "create_in_db", row, issue };
+    }
+
+    if (lastCachedRow) {
+      // One-way sync: Sheet always wins if it changed since last cached state
+      const sheetChanged =
+        row.description !== lastCachedRow.description ||
+        row.fixStatus !== lastCachedRow.fixStatus ||
+        row.severity !== lastCachedRow.severity ||
+        row.consistency !== lastCachedRow.consistency ||
+        row.game !== lastCachedRow.game;
+
+      if (sheetChanged) {
+        return { type: "update_db", row, issue };
+      }
+    }
+
+    return { type: "none", row, issue };
+  }
+
+  async createInDB(issue: SyncIssue): Promise<string> {
+    return await this.db.transaction(async (tx) => {
+      // 1. Get and increment issue number
+      const [machine] = await tx
+        .select({ nextIssueNumber: schema.machines.nextIssueNumber })
+        .from(schema.machines)
+        .where(eq(schema.machines.initials, issue.machineInitials));
+
+      if (!machine)
+        throw new Error(`Machine ${issue.machineInitials} not found`);
+
+      const issueNumber = machine.nextIssueNumber;
+
+      // 2. Create the issue
+      const [newIssue] = await tx
+        .insert(issues)
+        .values({
+          machineInitials: issue.machineInitials,
+          issueNumber,
+          title: issue.title,
+          description: issue.description,
+          status: issue.status,
+          severity: issue.severity,
+          consistency: issue.consistency,
+          reporterEmail: issue.reporterEmail,
+          createdAt: issue.createdAt,
+          updatedAt: new Date(),
+        })
+        .returning({ id: issues.id });
+
+      if (!newIssue) throw new Error("Failed to create issue");
+
+      // 3. Increment next issue number
+      await tx
+        .update(schema.machines)
+        .set({ nextIssueNumber: issueNumber + 1 })
+        .where(eq(schema.machines.initials, issue.machineInitials));
+
+      return newIssue.id;
+    });
+  }
+
+  async updateInDB(issue: SyncIssue): Promise<void> {
+    if (!issue.id) throw new Error("Missing issue ID for update");
+
+    await this.db
+      .update(issues)
+      .set({
+        title: issue.title,
+        description: issue.description,
+        status: issue.status,
+        severity: issue.severity,
+        consistency: issue.consistency,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, issue.id));
+  }
+
+  async syncWorkLog(issueId: string, workLog: string): Promise<boolean> {
+    if (!workLog || workLog.trim() === "") return false;
+
+    // Check if this work log entry already exists as a comment
+    const existingComment = await this.db.query.issueComments.findFirst({
+      where: (comments, { and, eq }) =>
+        and(eq(comments.issueId, issueId), eq(comments.content, workLog)),
+    });
+
+    if (existingComment) {
+      return false; // Skip duplicate
+    }
+
+    // Add new comment
+    await this.db.insert(issueComments).values({
+      issueId,
+      content: workLog,
+      isSystem: false, // It's from a human in the sheet
+    });
+
+    return true;
+  }
+}

--- a/scripts/sheets-sync/sync.ts
+++ b/scripts/sheets-sync/sync.ts
@@ -1,0 +1,250 @@
+import "dotenv/config";
+import { SheetsClient } from "./sheets-client";
+import { setMachineMap, mapRowToIssue } from "./field-mappings";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../../src/server/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { SyncEngine } from "./sync-engine";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { type SheetRow } from "./types";
+import console from "node:console";
+
+const SPREADSHEET_ID = process.env["MAINTENANCE_SPREADSHEET_ID"];
+const CREDS_PATH = process.env["GOOGLE_APPLICATION_CREDENTIALS"];
+const CACHE_FILE = path.join(process.cwd(), ".sheets-sync-cache.json");
+
+async function main() {
+  if (!SPREADSHEET_ID || !CREDS_PATH) {
+    console.error(
+      "❌ MAINTENANCE_SPREADSHEET_ID or GOOGLE_APPLICATION_CREDENTIALS not found in environment"
+    );
+    process.exit(1);
+  }
+  const isExecute = process.argv.includes("--execute");
+  const isInit = process.argv.includes("--init");
+
+  if (isExecute) {
+    console.log(
+      "⚠️  RUNNING IN EXECUTE MODE - Changes will be written to DB and Sheet"
+    );
+  } else {
+    console.log("ℹ️  DRY RUN MODE - No changes will be saved");
+  }
+
+  console.log("🚀 Starting Google Sheets Sync...");
+
+  // 1. Database Connection
+  const connectionString = process.env["DATABASE_URL"];
+  if (!connectionString) {
+    console.error("❌ DATABASE_URL not found in environment");
+    process.exit(1);
+  }
+  const client = postgres(connectionString);
+  const db = drizzle(client, { schema });
+
+  // 2. Load Machines for mapping
+  console.log("📂 Loading machines...");
+  const machines = await db.query.machines.findMany();
+  const machineMap: Record<string, string> = {};
+  machines.forEach((m) => {
+    machineMap[m.name] = m.initials;
+  });
+  setMachineMap(machineMap);
+
+  const engine = new SyncEngine(db);
+
+  // 3. Load Cache
+  let cache: Record<string, Record<string, SheetRow>> = {};
+  try {
+    const cacheData = await fs.readFile(CACHE_FILE, "utf-8");
+    cache = JSON.parse(cacheData) as Record<string, Record<string, SheetRow>>;
+  } catch {
+    if (!isInit && !isExecute) {
+      console.log(
+        "ℹ️  No cache file found. Run with --init to create initial state without syncing."
+      );
+    }
+  }
+
+  // 4. Initialize Sheets Client
+  let sheets: SheetsClient;
+  try {
+    sheets = new SheetsClient(SPREADSHEET_ID, CREDS_PATH);
+    await sheets.load();
+  } catch (e: unknown) {
+    const error = e as { code?: string; message?: string };
+    if (
+      error.code === "MODULE_NOT_FOUND" ||
+      error.message?.includes("Cannot find module")
+    ) {
+      console.error(
+        "❌ credentials.json not found. Please provide your Google Service Account key."
+      );
+    } else {
+      console.error("❌ Error connecting to Sheets API:", error.message);
+    }
+    process.exit(1);
+  }
+
+  // 5. Fetch Rows
+  console.log("📥 Fetching sheet data...");
+  const reportedIssues = await sheets.getRows("Reported Issues");
+
+  console.log(`✅ Found ${reportedIssues.length} rows in "Reported Issues"`);
+
+  // Filter out empty rows (no game name)
+  const validRows = reportedIssues.filter(
+    (row) => row.game && row.game.trim() !== ""
+  );
+  console.log(
+    `📋 Processing ${validRows.length} valid rows (filtered out ${reportedIssues.length - validRows.length} empty rows)`
+  );
+
+  for (const row of validRows) {
+    const issue = mapRowToIssue(row);
+
+    if (!issue) {
+      console.log(
+        `⚠️  Row ${row.rowIndex}: Machine "${row.game}" not found in PinPoint. Skipping.`
+      );
+      continue;
+    }
+
+    let dbIssue;
+    if (row.pinpointId) {
+      if (issue.id) {
+        // UUID match
+        dbIssue = await db.query.issues.findFirst({
+          where: eq(schema.issues.id, issue.id),
+        });
+      } else {
+        // Try human-readable ID match (e.g. "TNA-9")
+        const match = /^([A-Z0-9]+)-(\d+)$/i.exec(row.pinpointId);
+        if (match) {
+          const initials = match[1]?.toUpperCase();
+          const num = parseInt(match[2] ?? "0", 10);
+          if (initials && num) {
+            dbIssue = await db.query.issues.findFirst({
+              where: sql`${schema.issues.machineInitials} = ${initials} AND ${schema.issues.issueNumber} = ${num}`,
+            });
+          }
+        }
+      }
+    } else {
+      // PinPoint ID missing in sheet - try to find by machine + title/description
+      // This handles cases where issues were already imported but the sheet wasn't updated with IDs
+      const searchTitle = issue.title.trim();
+      dbIssue = await db.query.issues.findFirst({
+        where: sql`${schema.issues.machineInitials} = ${issue.machineInitials} AND (${schema.issues.title} ILIKE ${searchTitle + "%"} OR ${schema.issues.description} ILIKE ${searchTitle + "%"})`,
+      });
+
+      if (dbIssue) {
+        console.log(
+          `🔗 Row ${row.rowIndex}: Found existing issue in DB for ${issue.machineInitials} (#${dbIssue.issueNumber}). Linking...`
+        );
+        if (isExecute) {
+          const readableId = `${dbIssue.machineInitials}-${dbIssue.issueNumber}`;
+          await sheets.updatePinPointId(
+            "Reported Issues",
+            row.rowIndex,
+            readableId
+          );
+          console.log(`   ✅ Updated Sheet with ID: ${readableId}`);
+        }
+      }
+    }
+
+    const lastCachedRow =
+      cache["Reported Issues"]?.[row.rowIndex.toString()] ?? null;
+    const action = engine.determineAction(
+      row,
+      issue,
+      dbIssue ?? null,
+      lastCachedRow
+    );
+    let currentIssueId = dbIssue?.id;
+
+    if (action.type === "create_in_db") {
+      console.log(
+        `✨ Row ${row.rowIndex}: New issue detected for ${issue.machineInitials}: "${issue.title}"`
+      );
+      if (isExecute) {
+        currentIssueId = await engine.createInDB(issue);
+        console.log(`   ✅ Created in DB: ${currentIssueId}`);
+
+        // Fetch the full issue to get the issue number for the sheet
+        const createdIssue = await db.query.issues.findFirst({
+          where: eq(schema.issues.id, currentIssueId),
+          columns: {
+            issueNumber: true,
+            machineInitials: true,
+          },
+        });
+
+        if (createdIssue) {
+          const readableId = `${createdIssue.machineInitials}-${createdIssue.issueNumber}`;
+          await sheets.updatePinPointId(
+            "Reported Issues",
+            row.rowIndex,
+            readableId
+          );
+        } else {
+          // Fallback to UUID if something goes wrong (shouldn't happen)
+          await sheets.updatePinPointId(
+            "Reported Issues",
+            row.rowIndex,
+            currentIssueId
+          );
+        }
+      }
+    } else if (action.type === "update_db") {
+      console.log(`🆙 Row ${row.rowIndex}: Sheet changed. Updating DB...`);
+      if (isExecute) {
+        await engine.updateInDB(issue);
+        console.log(`   ✅ Updated DB`);
+      }
+    } else if (action.type === "conflict") {
+      console.log(`❌ Row ${row.rowIndex}: CONFLICT - ${action.reason}`);
+    } else {
+      if (dbIssue) {
+        console.log(
+          `🔍 Row ${row.rowIndex}: Matches existing PinPoint issue #${dbIssue.issueNumber}.`
+        );
+      }
+    }
+
+    // Work Log Sync
+    if (
+      isExecute &&
+      currentIssueId &&
+      row.workLog &&
+      row.workLog.trim() !== ""
+    ) {
+      const cachedWorkLog = lastCachedRow?.workLog ?? "";
+      if (row.workLog !== cachedWorkLog) {
+        const synced = await engine.syncWorkLog(currentIssueId, row.workLog);
+        if (synced) {
+          console.log(
+            `   📝 Row ${row.rowIndex}: Work Log synced to issue comments`
+          );
+        }
+      }
+    }
+
+    // Update local cache regardless if we processed it (to keep track of state)
+    cache["Reported Issues"] ??= {};
+    cache["Reported Issues"][row.rowIndex.toString()] = row;
+  }
+
+  // 6. Save Cache
+  if (isExecute || isInit) {
+    await fs.writeFile(CACHE_FILE, JSON.stringify(cache, null, 2));
+    console.log(`📂 Cache saved to ${CACHE_FILE}`);
+  }
+
+  await client.end();
+}
+
+main().catch((erro) => console.error(erro));

--- a/scripts/sheets-sync/types.ts
+++ b/scripts/sheets-sync/types.ts
@@ -1,0 +1,41 @@
+export type IssueSeverity = "cosmetic" | "minor" | "major" | "unplayable";
+export type IssueConsistency = "intermittent" | "frequent" | "constant";
+export type IssueStatus =
+  | "new"
+  | "confirmed"
+  | "in_progress"
+  | "need_parts"
+  | "need_help"
+  | "wait_owner"
+  | "fixed"
+  | "wont_fix"
+  | "wai"
+  | "no_repro"
+  | "duplicate";
+
+export interface SheetRow {
+  timestamp: string;
+  email: string;
+  game: string;
+  pinpointId?: string;
+  severity: string;
+  consistency: string;
+  fixStatus: string;
+  description: string;
+  workLog: string;
+  lastSynced?: string;
+  rowIndex: number;
+}
+
+export interface SyncIssue {
+  id: string | undefined;
+  machineInitials: string;
+  title: string;
+  description: string;
+  status: IssueStatus;
+  severity: IssueSeverity;
+  consistency: IssueConsistency;
+  reporterEmail: string;
+  updatedAt: Date;
+  createdAt: Date;
+}


### PR DESCRIPTION
Implements one-way sync from APC maintenance spreadsheet to PinPoint database with ID write-back. Optimized for 'spreadsheet wins' strategy.