### PR TITLE
fix: clear drizzle migration tracking in preview db reset script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ __pycache__/
 
 # Auto-generated test schema
 src/test/setup/schema.sql
+supabase/migrations/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 ## 2. Critical Non-Negotiables (The "10 Commandments")
 
 1. **Escape parentheses** in paths (e.g., `src/app/\(app\)/page.tsx`).
-2. **Migrations ONLY**: Never use `drizzle-kit push`. Use `db:generate` + `db:migrate`.
+2. **Drizzle Migrations**: We use Drizzle ORM, NOT Supabase migrations. Never use `drizzle-kit push`. Use `db:generate` + `db:migrate`. Supabase migration config is disabled (`db.migrations.enabled = false`).
 3. **Worker-Scoped PGlite**: No per-test DB instances (causes lockups). Use shared worker.
 4. **Server Components Default**: "use client" only for interaction leaves.
 5. **Progressive Enhancement**: `<form action={serverAction}>`. No inline handlers.

--- a/scripts/db-reset-preview.sh
+++ b/scripts/db-reset-preview.sh
@@ -97,6 +97,10 @@ if [ "$TABLE_COUNT" -ne 0 ]; then
 fi
 echo "✅ Schema reset"
 
+# Clear drizzle migration tracking (survives schema drop since it's in drizzle schema)
+echo "   Clearing drizzle migration tracking..."
+psql "$DATABASE_URL" -c "DELETE FROM drizzle.__drizzle_migrations;" 2>&1 | grep -v "^NOTICE:" | grep -v "^DETAIL:" || true
+
 echo ""
 echo "2️⃣  Applying schema with drizzle-kit migrations..."
 # Uses DIRECT_URL from env (Session Mode pooler, IPv4-compatible)


### PR DESCRIPTION
## Summary

Fixes a bug in the preview database reset script where drizzle-kit would skip migrations, resulting in 0 tables created after schema reset.

## Root Cause

When `DROP SCHEMA public CASCADE` runs during preview DB reset:
1. ✅ Deletes all tables in public schema
2. ❌ `drizzle.__drizzle_migrations` tracking table **survives** (it's in drizzle schema, not public)
3. ❌ drizzle-kit checks tracking, sees migrations "already applied", skips execution
4. ❌ Result: Tracking exists but no tables

## Fix

Clear drizzle migration tracking **after** schema drop:
```bash
psql "$DATABASE_URL" -c "DELETE FROM drizzle.__drizzle_migrations;"
```

This forces drizzle-kit to re-execute all migrations.

## Changes

- **scripts/db-reset-preview.sh**: Add `DELETE FROM drizzle.__drizzle_migrations` after schema drop
- **AGENTS.md**: Clarify we use Drizzle ORM for migrations (not Supabase migrations)
- **.gitignore**: Ignore `supabase/migrations/` directory (auto-generated, not used)

## Testing

- ✅ Manually tested preview DB reset - all 10 tables now created successfully
- ✅ All local checks pass (typecheck, lint, tests, format)

## Discovery

Found via systematic debugging during preview database troubleshooting after PR #871 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)