### PR TITLE
fix: Include assignedTo field in issue detail query (Closes #853)

### DIFF
--- a/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
@@ -129,6 +129,9 @@ export default async function IssueDetailPage({
         issueNumber: true,
         machineInitials: true,
         reporterName: true,
+        assignedTo: true,
+        reportedBy: true,
+        invitedReportedBy: true,
       },
     }),
     // Fetch all members/admins for assignment dropdown (Restrict to actual users)


### PR DESCRIPTION
## Summary
Fixes the bug where issue assignee was not reflected on the Issue Detail page after update.

## Problem
The issue detail page query used an explicit `columns` filter that excluded the `assignedTo`, `reportedBy`, and `invitedReportedBy` fields. Without these foreign key fields, Drizzle couldn't populate the related `assignedToUser`, `reportedByUser`, and `invitedReporter` relations, causing the assignee dropdown to always show "Unassigned".

## Solution
Added `assignedTo`, `reportedBy`, and `invitedReportedBy` to the columns object in `/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx` to match the working pattern used in the issues list page.

## Changes
- Added three fields to the columns filter in the issue detail query
- No other code changes needed - components already expected these fields

## Testing
- ✅ `pnpm run check` passes (types, lint, format, unit tests)
- Manual testing plan created for verification

## Closes
Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)