### PR TITLE
docs: Add E2E interaction coverage non-negotiable (CORE-TEST-005)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 8. **Path Aliases**: Always use `~/` (e.g., `~/lib/utils`).
 9. **Preflight**: Must run `pnpm run preflight` before commit.
 10. **Code Cleanliness**: Follow Rule of Three. DRY up code only after 3rd duplication.
+11. **E2E Interaction Coverage**: If you add a clickable UI element, you must click it in an E2E test.
 
 ## 3. Agent Skills (Progressive Disclosure)
 

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -30,6 +30,7 @@ trigger: always_on
 10. Forms work without JavaScript (progressive enhancement)
 11. Use Drizzle migrations for schema changes (no ad-hoc `push` to production/preview)
 12. Keep auth host consistent: use `localhost` everywhere (Supabase site_url, Next dev, Playwright baseURL) to prevent cookie host mismatches
+13. E2E interaction coverage: if you add a clickable element, click it in a test
 
 ---
 
@@ -222,6 +223,13 @@ trigger: always_on
 - **Do:** Use integration tests (with PGlite) for service layer logic that primarily interacts with the database
 - **Don't:** Write unit tests that require extensive mocking of `db.query`, `db.transaction`, or method chains
 
+**CORE-TEST-005:** E2E Interaction Coverage for Clickable Elements
+
+- **Severity:** Required
+- **Why:** Tests that verify element existence without clicking miss broken handlers (PR #894 pattern)
+- **Do:** If you add a clickable element (button, link, icon), write an E2E test that clicks it and verifies the outcome
+- **Don't:** Only assert `toBeVisible()` without testing the actual interaction
+
 ---
 
 ## Architecture
@@ -365,7 +373,7 @@ If all Yes → ship it. Perfect is the enemy of done.
 - CORE‑SSR‑001..006: Supabase SSR and auth
 - CORE‑SEC‑001..004: Security
 - CORE‑PERF‑001..002: Performance
-- CORE‑TEST‑001..003: Testing
+- CORE‑TEST‑001..005: Testing
 - CORE‑ARCH‑001..007: Architecture
 
 **Cross-References:**


### PR DESCRIPTION
## Summary
- Adds CORE-TEST-005: Clickable UI elements must have E2E tests that actually click them
- Prevents PR #894 pattern where buttons pass visibility tests but handlers are broken
- Added to AGENTS.md (11th commandment) and NON_NEGOTIABLES.md

## Context
Audit of recent merged PRs revealed systematic gap: tests verify elements exist but don't test interactions. This rule ensures new clickable elements get click tests.

## Test plan
- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)