### PR TITLE
test(e2e): Add non-admin machine create access test

### DIFF
--- a/e2e/smoke/machines-crud.spec.ts
+++ b/e2e/smoke/machines-crud.spec.ts
@@ -62,6 +62,27 @@ test.describe("Machines CRUD", () => {
     });
   });
 
+  test("non-admin cannot access /m/new page", async ({ page }) => {
+    // Default login is member (non-admin) from beforeEach
+
+    // Verify "Add Machine" button is NOT visible to non-admin on /m page
+    await page.goto("/m");
+    await expect(page.getByRole("heading", { name: "Machines" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Add Machine/i })
+    ).not.toBeVisible();
+
+    // Attempt direct navigation to /m/new - should redirect to /m
+    await page.goto("/m/new");
+    await expect(page).toHaveURL("/m");
+
+    // Verify we're back on machines list, not the create form
+    await expect(page.getByRole("heading", { name: "Machines" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Add New Machine" })
+    ).not.toBeVisible();
+  });
+
   test("should display seeded test machines with correct statuses", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Adds E2E test verifying non-admin users cannot access the machine creation page.

## Changes

- Add new test `non-admin cannot access /m/new page` in `e2e/smoke/machines-crud.spec.ts`
- Tests both UI visibility (button hidden) and server-side redirect (direct URL blocked)

## Testing

- ✅ Unit tests: passing (386 tests)
- ✅ All checks: `pnpm run check` passes
- ✅ E2E: All 15 machines-crud tests pass (5 tests × 3 browsers)

## Related Issues

Closes #875

🤖 Generated with [Claude Code](https://claude.ai/code)