### PR TITLE
test(e2e): Add settings page email display verification

### DIFF
--- a/e2e/full/profile-settings.spec.ts
+++ b/e2e/full/profile-settings.spec.ts
@@ -3,6 +3,19 @@ import { loginAs } from "../support/actions";
 import { TEST_USERS } from "../support/constants";
 
 test.describe("Profile Settings", () => {
+  test("should display user email in settings", async ({ page }, testInfo) => {
+    await loginAs(page, testInfo, TEST_USERS.member);
+    await page.goto("/settings");
+
+    const profileForm = page.getByTestId("profile-form");
+    const emailInput = profileForm.getByLabel("Email");
+
+    // Verify the email field displays the logged-in user's email
+    await expect(emailInput).toHaveValue(TEST_USERS.member.email);
+    // Verify it's disabled (read-only)
+    await expect(emailInput).toBeDisabled();
+  });
+
   test("should update profile and handle cancel", async ({
     page,
   }, testInfo) => {


### PR DESCRIPTION
## Summary
- Add E2E test verifying that users see their email address displayed in the settings page
- Verify the email field is disabled (read-only) as expected

## Test plan
- [x] New test `should display user email in settings` passes locally
- [x] Existing `should update profile and handle cancel` test still passes
- [x] `pnpm run check` passes

Closes beads issue `PinPoint-up5`

---
Generated with [Claude Code](https://claude.com/claude-code)