### PR TITLE
test(e2e): Add ownership transfer test for invited user signup

### DIFF
--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -77,6 +77,7 @@ export function OwnerSelect({
           id="ownerId"
           className="border-outline bg-surface text-on-surface"
           aria-describedby="owner-help"
+          data-testid="owner-select"
         >
           <SelectValue placeholder="Select an owner" />
         </SelectTrigger>


### PR DESCRIPTION
## Summary
- Adds E2E test verifying invited user → machine owner → signup flow correctly transfers ownership
- Test verifies the "(Invited)" suffix is removed after user completes signup
- Fixes cleanup API FK constraint issue when deleting users who own machines

## Changes
- Added `data-testid="owner-select"` to OwnerSelect component for test targeting
- Fixed cleanup API to clear machine ownership references before deleting users
- Added ownership transfer test in `e2e/full/invite-signup.spec.ts`

## Test plan
- [x] Test passes on all browsers (chromium, firefox, mobile chrome)
- [x] All existing invite-signup tests still pass
- [x] `pnpm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes beads-2ig