### PR TITLE
fix(e2e): resolve parallel test race condition in issues-crud

### DIFF
--- a/e2e/smoke/issues-crud.spec.ts
+++ b/e2e/smoke/issues-crud.spec.ts
@@ -181,15 +181,31 @@ test.describe("Issues System", () => {
   });
 
   test.describe("Issue Detail Display", () => {
+    let issueUrl: string;
+    let issueTitle: string;
+
+    test.beforeEach(async ({ page }) => {
+      // Create a fresh issue for this worker to avoid parallel test conflicts
+      const machineInitials = seededMachines.humptyDumpty.initials;
+      issueTitle = `Assignee Test ${Date.now()}`;
+      await page.goto(`/report?machine=${machineInitials}`);
+      await fillReportForm(page, { title: issueTitle, priority: "medium" });
+      await page.getByRole("button", { name: "Submit Issue Report" }).click();
+
+      await expect(page).toHaveURL(/\/m\/[A-Z0-9]{2,6}\/i\/[0-9]+/);
+      issueUrl = page.url();
+      rememberIssueId(page);
+    });
+
     test("should display assignee on issue detail page", async ({ page }) => {
-      // Navigate to HD-02 (reported by member, so member has permission)
-      await page.goto("/m/HD/i/2");
+      // Navigate to the freshly created issue
+      await page.goto(issueUrl);
 
       // Verify we're on the issue detail page
       await expect(
         page.getByRole("heading", {
           level: 1,
-          name: /Scoring reels sticking/,
+          name: new RegExp(issueTitle),
         })
       ).toBeVisible();
 


### PR DESCRIPTION
## Summary

Fixed the `should display assignee on issue detail page` E2E test that was failing when run with multiple Playwright workers due to shared database state.

## Root Cause

The test navigated to a hardcoded seeded issue (`/m/HD/i/2`) and modified its assignee. When parallel workers ran simultaneously, they competed for the same database row - the first worker would assign "Member User", causing subsequent workers to fail their "Unassigned" assertion.

## Solution

Applied the established pattern from "Issue Detail and Updates" test block: create a fresh issue in `beforeEach` for each test run, ensuring complete isolation between parallel workers.

## Changes

- Added `beforeEach` hook to "Issue Detail Display" test block that creates a fresh issue
- Updated test to use the dynamically created issue URL instead of hardcoded `/m/HD/i/2`
- Leveraged existing `rememberIssueId()` for automatic cleanup in `afterEach`

## Testing

- ✅ Unit tests: 386 passed
- ✅ Integration tests: 140 passed  
- ✅ E2E tests: 12/12 passed with `--workers=3` (chromium, firefox, Mobile Chrome)
- ✅ Stability test: 24/24 passed with `--repeat-each=2`
- ✅ Pre-commit hooks: passed

## Closes

Fixes: PinPoint-6c9 (beads issue)

---

🤖 Generated with [Claude Code](https://claude.ai/code)