### PR TITLE
chore(issues): remove dead createIssueSchema and createIssueAction

### DIFF
--- a/src/app/(app)/issues/schemas.ts
+++ b/src/app/(app)/issues/schemas.ts
@@ -16,38 +16,6 @@ const uuidish = z
   );
 
 /**
- * Schema for creating a new issue
- *
- * Validates:
- * - title: Required, trimmed, 1-200 characters
- * - description: Nullish (can be null, undefined, or string), trimmed
- * - machineInitials: Required (Plan: Machine Initials)
- * - severity: Enum of 'minor' | 'playable' | 'unplayable'
- */
-export const createIssueSchema = z.object({
-  title: z
-    .string()
-    .min(1, "Title is required")
-    .max(200, "Title must be less than 200 characters")
-    .trim(),
-  description: z.string().trim().max(5000, "Description is too long").nullish(),
-  machineInitials: z
-    .string()
-    .min(2, "Machine initials invalid")
-    .max(6, "Machine initials invalid")
-    .regex(/^[A-Z0-9]+$/, "Machine initials invalid"),
-  severity: z.enum(["cosmetic", "minor", "major", "unplayable"], {
-    message: "Invalid severity level",
-  }),
-  priority: z.enum(["low", "medium", "high"], {
-    message: "Invalid priority level",
-  }),
-  frequency: z.enum(["intermittent", "frequent", "constant"], {
-    message: "Invalid frequency level",
-  }),
-});
-
-/**
  * Schema for updating issue status
  * Based on _issue-status-redesign/README.md - Final design with 11 statuses
  * Status values imported from single source of truth

--- a/src/test/unit/issue-schemas.test.ts
+++ b/src/test/unit/issue-schemas.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  createIssueSchema,
   updateIssueStatusSchema,
   updateIssueSeveritySchema,
   updateIssuePrioritySchema,
@@ -9,109 +8,6 @@ import {
 
 describe("Issue Validation Schemas", () => {
   const validUuid = "123e4567-e89b-12d3-a456-426614174000";
-  const validInitials = "MM";
-
-  describe("createIssueSchema", () => {
-    it("should validate a valid issue", () => {
-      const result = createIssueSchema.safeParse({
-        title: "Test Issue",
-        description: "Test Description",
-        machineInitials: validInitials,
-        severity: "minor",
-        priority: "low",
-        frequency: "intermittent",
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it("should validate a valid issue without description", () => {
-      const result = createIssueSchema.safeParse({
-        title: "Test Issue",
-        machineInitials: validInitials,
-        severity: "cosmetic",
-        priority: "medium",
-        frequency: "constant",
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it("should reject missing title", () => {
-      const result = createIssueSchema.safeParse({
-        description: "Test Description",
-        machineInitials: validInitials,
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject empty title", () => {
-      const result = createIssueSchema.safeParse({
-        title: "",
-        machineInitials: validInitials,
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject long title", () => {
-      const result = createIssueSchema.safeParse({
-        title: "a".repeat(201),
-        machineInitials: validInitials,
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject long description", () => {
-      const result = createIssueSchema.safeParse({
-        title: "Test Issue",
-        description: "a".repeat(5001),
-        machineInitials: validInitials,
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject invalid machineInitials", () => {
-      const result = createIssueSchema.safeParse({
-        title: "Test Issue",
-        machineInitials: "A", // too short
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result.success).toBe(false);
-
-      const result2 = createIssueSchema.safeParse({
-        title: "Test Issue",
-        machineInitials: "TOOLONG", // too long
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result2.success).toBe(false);
-
-      const result3 = createIssueSchema.safeParse({
-        title: "Test Issue",
-        machineInitials: "A!", // invalid char
-        severity: "minor",
-        priority: "low",
-      });
-      expect(result3.success).toBe(false);
-    });
-
-    it("should reject invalid severity", () => {
-      const result = createIssueSchema.safeParse({
-        title: "Test Issue",
-        machineInitials: validInitials,
-        severity: "critical", // invalid
-        priority: "low",
-      });
-      expect(result.success).toBe(false);
-    });
-  });
 
   describe("updateIssueStatusSchema", () => {
     it("should validate valid status update", () => {


### PR DESCRIPTION
## Summary

Removes ~230 lines of dead code identified in PR #872 review. The `createIssueSchema` and `createIssueAction` were superseded by `submitPublicIssueAction` but never cleaned up.

## Changes

- Delete unused `createIssueSchema` from `schemas.ts`
- Delete unused `createIssueAction` from `actions.ts`
- Remove orphaned unit tests that tested the dead code
- Clean up unused imports (`redirect`, `createIssue`)

## Testing

- ✅ Unit tests: 378 passed
- ✅ Integration tests: 140 passed
- ✅ Build: successful
- ⚠️ E2E smoke: 62/70 passed (6 pre-existing flaky failures unrelated to changes)

## Verification

Confirmed dead code via grep - `createIssueAction` had zero imports outside its definition file.

🤖 Generated with [Claude Code](https://claude.ai/code)