### PR TITLE
feat(issues): add owner link on issue detail page

### DIFF
--- a/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
@@ -9,7 +9,7 @@ import { PageShell } from "~/components/layout/PageShell";
 import { IssueTimeline } from "~/components/issues/IssueTimeline";
 import { IssueSidebar } from "~/components/issues/IssueSidebar";
 import { IssueBadgeGrid } from "~/components/issues/IssueBadgeGrid";
-import { getMachineOwnerName } from "~/lib/issues/owner";
+import { getMachineOwnerName, getMachineOwnerId } from "~/lib/issues/owner";
 import { formatIssueId } from "~/lib/issues/utils";
 import { ImageGallery } from "~/components/images/ImageGallery";
 import type { Issue, IssueWithAllRelations } from "~/lib/types";
@@ -160,6 +160,7 @@ export default async function IssueDetailPage({
   // Cast issue to IssueWithAllRelations for type safety
   const issueWithRelations = issue as unknown as IssueWithAllRelations;
   const ownerName = getMachineOwnerName(issueWithRelations);
+  const ownerId = getMachineOwnerId(issueWithRelations);
 
   return (
     <PageShell className="space-y-8" size="wide">
@@ -182,7 +183,16 @@ export default async function IssueDetailPage({
             <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
               <span>•</span>
               <span>Game Owner:</span>
-              <span className="font-medium text-foreground">{ownerName}</span>
+              {ownerId ? (
+                <Link
+                  href={`/issues?owner=${ownerId}`}
+                  className="font-medium text-foreground transition-colors hover:text-primary"
+                >
+                  {ownerName}
+                </Link>
+              ) : (
+                <span className="font-medium text-foreground">{ownerName}</span>
+              )}
             </div>
           )}
         </div>

--- a/src/lib/issues/owner.ts
+++ b/src/lib/issues/owner.ts
@@ -33,3 +33,13 @@ export function getMachineOwnerName(
 ): string | null {
   return issue.machine.owner?.name ?? issue.machine.invitedOwner?.name ?? null;
 }
+
+/**
+ * Gets the machine owner's ID
+ *
+ * @param issue - The issue with machine owner information
+ * @returns The owner's ID or null if no owner
+ */
+export function getMachineOwnerId(issue: IssueWithAllRelations): string | null {
+  return issue.machine.owner?.id ?? issue.machine.invitedOwner?.id ?? null;
+}


### PR DESCRIPTION
## Summary
- Add `getMachineOwnerId` helper function to `src/lib/issues/owner.ts`
- Wrap owner name in Link component that filters issues by owner (`/issues?owner={ownerId}`)
- Machine link to `/m/{initials}` already existed (lines 175-180)

## Test plan
- [ ] Navigate to an issue detail page for a machine with an owner
- [ ] Verify owner name is now clickable
- [ ] Click owner name and verify it navigates to `/issues?owner={ownerId}`
- [ ] Verify issues list filters correctly by that owner

Closes PinPoint-tdq

🤖 Generated with [Claude Code](https://claude.com/claude-code)