### PR TITLE
fix(landing): Improve logo glow and add APC links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function LandingPage(): React.JSX.Element {
               href="https://austinpinballcollective.org"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary font-medium hover:underline"
+              className="text-link font-medium"
             >
               Austin Pinball Collective
             </a>


### PR DESCRIPTION
## Summary

Improves the landing page with better logo styling and adds links to the Austin Pinball Collective website.

## Changes

- **Logo glow fix**: Changed from `glow-primary` (box-shadow) to `drop-shadow` filter so the glow follows the actual shape of the APC logo instead of glowing around the rectangular box
- **Clickable logo**: Made the APC logo clickable, linking to austinpinballcollective.org
- **Updated text**: Changed to "the Austin Pinball Collective" and made it a link to the APC website
- **Security & accessibility**: Added proper `target="_blank"`, `rel="noopener noreferrer"` for external links and `aria-label` for the logo link

## Testing

- Visual verification of logo glow effect
- Click logo and text link to verify they open APC website in new tab