### PR TITLE
chore: add beads workflow instructions and gitignore .bv/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ __pycache__/
 # Auto-generated test schema
 src/test/setup/schema.sql
 supabase/migrations/
+
+# bv (beads viewer) local config and caches
+.bv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,3 +226,66 @@ See `pinpoint-orchestrator` skill for the full workflow.
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
+
+<!-- bv-agent-instructions-v1 -->
+
+---
+
+## Beads Workflow Integration
+
+This project uses [beads_viewer](https://github.com/Dicklesworthstone/beads_viewer) for issue tracking. Issues are stored in `.beads/` and tracked in git.
+
+### Essential Commands
+
+```bash
+# View issues (launches TUI - avoid in automated sessions)
+bv
+
+# CLI commands for agents (use these instead)
+bd ready              # Show issues ready to work (no blockers)
+bd list --status=open # All open issues
+bd show <id>          # Full issue details with dependencies
+bd create --title="..." --type=task --priority=2
+bd update <id> --status=in_progress
+bd close <id> --reason="Completed"
+bd close <id1> <id2>  # Close multiple issues at once
+bd sync               # Commit and push changes
+```
+
+### Workflow Pattern
+
+1. **Start**: Run `bd ready` to find actionable work
+2. **Claim**: Use `bd update <id> --status=in_progress`
+3. **Work**: Implement the task
+4. **Complete**: Use `bd close <id>`
+5. **Sync**: Always run `bd sync` at session end
+
+### Key Concepts
+
+- **Dependencies**: Issues can block other issues. `bd ready` shows only unblocked work.
+- **Priority**: P0=critical, P1=high, P2=medium, P3=low, P4=backlog (use numbers, not words)
+- **Types**: task, bug, feature, epic, question, docs
+- **Blocking**: `bd dep add <issue> <depends-on>` to add dependencies
+
+### Session Protocol
+
+**Before ending any session, run this checklist:**
+
+```bash
+git status              # Check what changed
+git add <files>         # Stage code changes
+bd sync                 # Commit beads changes
+git commit -m "..."     # Commit code
+bd sync                 # Commit any new beads changes
+git push                # Push to remote
+```
+
+### Best Practices
+
+- Check `bd ready` at session start to find available work
+- Update status as you work (in_progress → closed)
+- Create new issues with `bd create` when you discover tasks
+- Use descriptive titles and set appropriate priority/type
+- Always `bd sync` before ending session
+
+<!-- end-bv-agent-instructions -->


### PR DESCRIPTION
## Summary
- Add beads_viewer (`bd`) agent instructions to `AGENTS.md` covering essential commands, workflow patterns, session protocol, and best practices
- Add `.bv/` to `.gitignore` to exclude beads viewer local config and caches

## Test plan
- [ ] Verify `.bv/` directory is properly ignored by git
- [ ] Confirm AGENTS.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)