### PR TITLE
feat(errors): add root error boundary for graceful error handling

### DIFF
--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import ErrorPage from "./error";
+
+// Mock Sentry to avoid side effects in tests
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("ErrorPage", () => {
+  const baseError = Object.assign(new Error("Test failure"), {
+    digest: undefined as string | undefined,
+  });
+
+  it("renders 500 heading and description", () => {
+    render(<ErrorPage error={baseError} reset={vi.fn()} />);
+
+    expect(screen.getByText("500")).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "An unexpected error occurred. Please try again or return to the home page."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("calls reset when Try Again is clicked", async () => {
+    const reset = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ErrorPage error={baseError} reset={reset} />);
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it("renders Go Home link", () => {
+    render(<ErrorPage error={baseError} reset={vi.fn()} />);
+
+    const homeLink = screen.getByRole("link", { name: /go home/i });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  it("shows digest when provided", () => {
+    const errorWithDigest = Object.assign(new Error("Server error"), {
+      digest: "abc123",
+    });
+
+    render(<ErrorPage error={errorWithDigest} reset={vi.fn()} />);
+
+    expect(screen.getByText("Error ID: abc123")).toBeInTheDocument();
+  });
+
+  it("does not show digest section when digest is absent", () => {
+    render(<ErrorPage error={baseError} reset={vi.fn()} />);
+
+    expect(screen.queryByText(/Error ID:/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type React from "react";
+import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
+import type React from "react";
 import { useEffect } from "react";
 
 import { Button } from "~/components/ui/button";
@@ -22,8 +23,16 @@ export default function ErrorPage({
   reset,
 }: ErrorPageProps): React.JSX.Element {
   useEffect(() => {
-    // Log to console for development; Sentry captures automatically via integration
-    console.error("Unhandled error:", error);
+    // Capture to Sentry (matches global-error.tsx pattern)
+    Sentry.captureException(error);
+
+    // Log full error details only in development to avoid leaking stack traces
+    // in production DevTools. In production, log digest only for correlation.
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Unhandled error:", error);
+    } else if (error.digest) {
+      console.error("Unhandled error (digest only):", error.digest);
+    }
   }, [error]);
 
   return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import NextError from "next/error";
-import { useEffect } from "react";
 import type React from "react";
+import { useEffect } from "react";
 
+/**
+ * Global error boundary — catches errors that escape the root layout.
+ *
+ * Because this replaces the entire <html>, it cannot use the app's theme
+ * provider or component library. Styles are inlined for reliability.
+ */
 export default function GlobalError({
   error,
 }: {
@@ -17,11 +22,69 @@ export default function GlobalError({
   return (
     <html>
       <body>
-        {/* `NextError` is the default Next.js error page component. Its type
-        definition requires a `statusCode` prop. However, since the App Router
-        does not expose status codes for errors, we simply pass 0 to render a
-        generic error message. */}
-        <NextError statusCode={0} />
+        <div
+          style={{
+            display: "flex",
+            minHeight: "100vh",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "0 1rem",
+            fontFamily: "system-ui, sans-serif",
+          }}
+        >
+          <div style={{ textAlign: "center" }}>
+            <h1
+              style={{
+                fontSize: "8rem",
+                fontWeight: 700,
+                color: "rgba(0,0,0,0.1)",
+                margin: 0,
+              }}
+            >
+              500
+            </h1>
+            <h2 style={{ marginTop: "1rem", fontSize: "1.5rem" }}>
+              Something went wrong
+            </h2>
+            <p style={{ marginTop: "0.5rem", color: "#666" }}>
+              A critical error occurred. Please refresh the page or return to
+              the home page.
+            </p>
+            <div
+              style={{
+                marginTop: "2rem",
+                display: "flex",
+                gap: "1rem",
+                justifyContent: "center",
+              }}
+            >
+              <a
+                href="/"
+                style={{
+                  padding: "0.5rem 1rem",
+                  background: "#000",
+                  color: "#fff",
+                  borderRadius: "0.375rem",
+                  textDecoration: "none",
+                }}
+              >
+                Go Home
+              </a>
+            </div>
+            {error.digest && (
+              <p
+                style={{
+                  marginTop: "2rem",
+                  fontSize: "0.75rem",
+                  color: "rgba(0,0,0,0.3)",
+                }}
+              >
+                Error ID: {error.digest}
+              </p>
+            )}
+          </div>
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Adds `src/app/error.tsx` as the Next.js root error boundary
- Shows a user-friendly error page with "Try Again" (calls `reset()`) and "Go Home" (links to `/`) actions
- Displays only the error digest for support purposes — no technical details exposed to users
- Matches existing error page styling from `Forbidden.tsx` (centered layout, muted foreground colors, Button components)

## Test plan
- [ ] Verify `pnpm run check` passes (types, lint, format, unit tests)
- [ ] Manually trigger an error in a route to confirm the error boundary renders
- [ ] Confirm "Try Again" button re-renders the errored segment
- [ ] Confirm "Go Home" link navigates to `/`

Closes PinPoint-vrg

🤖 Generated with [Claude Code](https://claude.com/claude-code)