### PR TITLE
fix(scripts): harden workflow scripts per Copilot feedback

### DIFF
--- a/scripts/workflow/copilot-comments.sh
+++ b/scripts/workflow/copilot-comments.sh
@@ -22,6 +22,10 @@ if [ $# -lt 1 ]; then
 fi
 
 PR=$1
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number must be numeric (e.g. '945'); received '$PR'."
+    exit 1
+fi
 MODE="${2:-}"
 
 case "$MODE" in

--- a/scripts/workflow/pr-dashboard.sh
+++ b/scripts/workflow/pr-dashboard.sh
@@ -25,6 +25,11 @@ printf "%-6s %-40s %-12s %-10s %-8s %s\n" "PR" "Title" "CI" "Copilot" "Draft" "B
 printf "%-6s %-40s %-12s %-10s %-8s %s\n" "------" "----------------------------------------" "------------" "----------" "--------" "-------------------"
 
 for pr in $PRS; do
+    if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
+        echo "Error: PR number must be numeric (e.g. '945'); received '$pr'."
+        exit 1
+    fi
+
     # Get PR metadata
     pr_data=$(gh pr view "$pr" --json title,headRefName,isDraft 2>/dev/null) || continue
     title=$(echo "$pr_data" | jq -r '.title' | cut -c1-40)

--- a/scripts/workflow/resolve-copilot-threads.sh
+++ b/scripts/workflow/resolve-copilot-threads.sh
@@ -21,6 +21,10 @@ if [ $# -lt 1 ]; then
 fi
 
 PR=$1
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number must be numeric (e.g. '945'); received '$PR'."
+    exit 1
+fi
 MODE="${2:-}"
 
 case "$MODE" in
@@ -110,7 +114,12 @@ echo "$unresolved" | jq -c '.[]' | while read -r thread; do
     line=$(echo "$thread" | jq -r '.line')
     body=$(echo "$thread" | jq -r '.body')
 
-    echo "  ${path}:${line} — ${body}..."
+    display_line="${line}"
+    if [ "$display_line" = "null" ]; then
+        display_line="N/A"
+    fi
+
+    echo "  ${path}:${display_line} — ${body}..."
 
     if [ "$MODE" = "--dry-run" ]; then
         echo "    → Would resolve (dry-run)"

--- a/scripts/workflow/respond-to-copilot.sh
+++ b/scripts/workflow/respond-to-copilot.sh
@@ -30,6 +30,10 @@ if [ $# -lt 3 ]; then
 fi
 
 PR=$1
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number must be numeric (e.g. '945'); received '$PR'."
+    exit 1
+fi
 PATH_LINE=$2
 MESSAGE="${*:3}"
 
@@ -106,7 +110,7 @@ fi
 
 if [ -z "$match" ] || [ "$match" = "" ]; then
     echo "No unresolved Copilot thread found at ${PATH_LINE}. It may already be resolved."
-    exit 0
+    exit 1
 fi
 
 THREAD_ID=$(echo "$match" | jq -r '.threadId')


### PR DESCRIPTION
## Summary
- **PR number validation**: All 5 workflow scripts (`copilot-comments.sh`, `respond-to-copilot.sh`, `resolve-copilot-threads.sh`, `pr-dashboard.sh`, `label-ready.sh`) now reject non-numeric PR input (e.g. `#918`) with a clear error message.
- **Non-zero exit on no match**: `respond-to-copilot.sh` now exits 1 when no matching unresolved thread is found, so automation can detect typos or already-resolved threads.
- **CI terminal state handling**: `label-ready.sh` now treats all non-SUCCESS terminal states (ERROR, CANCELLED, TIMED_OUT, STALE, STARTUP_FAILURE) as failures, not just FAILURE. Codecov and pending states are still excluded.
- **Normalize `null` to `N/A`**: `resolve-copilot-threads.sh` now displays `N/A` instead of `null` for line numbers, consistent with `copilot-comments.sh`.
- **Fail closed on `gh pr checks`**: `label-ready.sh` now fails with a clear error when the `gh pr checks` API call fails, instead of silently falling back to an empty array.

## Test plan
- [ ] Run `copilot-comments.sh '#123'` and verify it rejects with a clear error
- [ ] Run `respond-to-copilot.sh 999 "fake:1" "test"` on a PR with no matching thread and verify exit code is 1
- [ ] Run `label-ready.sh` on a PR with a cancelled CI check and verify it reports the failure
- [ ] Run `resolve-copilot-threads.sh` and verify null lines display as N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)