### PR TITLE
chore: update copilot-instructions.md for post-launch status

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,8 +37,8 @@
 ## Quality Gates
 
 ```bash
-pnpm run check       # Fast: types + lint + format + unit tests
-pnpm run preflight   # Full: check + build + integration (run before commit)
+pnpm run check       # Fast: types + lint + format:fix + unit tests (may modify files)
+pnpm run preflight   # Full: check + build + DB reset + integration + smoke/e2e (pre-commit)
 ```
 
 Conventional commit messages required.


### PR DESCRIPTION
## Summary
- Updated `.github/copilot-instructions.md` to reflect current project status: soft-launched beta with active users at Austin Pinball Collective
- Removed outdated references to "v2 rewrite", "greenfield", "pre-beta", "0 production users", and PR sequence guidance
- Added safety emphasis for destructive operations since real users depend on the data
- Trimmed from 126 lines to 67 lines for better Copilot context window utilization

## Test plan
- [x] `pnpm run check` passes (types, lint, format, unit tests)
- [ ] Verify Copilot picks up the updated instructions in code reviews

Closes PinPoint-5t6

🤖 Generated with [Claude Code](https://claude.com/claude-code)