### PR TITLE
fix(tooling): stop deleting local branches on worktree remove

### DIFF
--- a/pinpoint-wt.py
+++ b/pinpoint-wt.py
@@ -437,7 +437,7 @@ def cmd_remove(args: argparse.Namespace) -> int:
 
     print()
     print("✅ Worktree removed successfully!")
-    print(f"   Branch '{branch}' preserved (delete manually with: git branch -d {branch})")
+    print(f"   Branch '{branch}' preserved (delete manually with: git branch -d -- '{branch}' (or: git branch -D -- '{branch}' to force))")
     print()
 
     return 0


### PR DESCRIPTION
## Summary

- Remove the `git branch -D` step from `pinpoint-wt.py remove`
- Worktree infra (Supabase, Docker volumes, git worktree) is still fully cleaned up
- Local branch is preserved with a hint on how to delete manually

## Context

`pinpoint-wt.py remove` was force-deleting the local branch as part of cleanup. This is destructive when the branch has an open PR or is still needed for testing. The worktree is the resource being cleaned up, not the branch.

## Test plan

- [x] `ruff check pinpoint-wt.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)