### PR TITLE
docs(security): add email privacy non-negotiable (CORE-SEC-007)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 9. **Preflight**: Must run `pnpm run preflight` before commit.
 10. **Code Cleanliness**: Follow Rule of Three. DRY up code only after 3rd duplication.
 11. **E2E Interaction Coverage**: If you add a clickable UI element, you must click it in an E2E test.
+12. **Email Privacy**: User email addresses must NEVER be displayed outside of admin views and the user's own settings page. Use names, "Anonymous", or role labels instead. This applies to UI, seed data, timeline events, and any client-facing serialization.
 
 ## 3. Agent Skills (Progressive Disclosure)
 

--- a/NON_NEGOTIABLES.md
+++ b/NON_NEGOTIABLES.md
@@ -2,6 +2,41 @@
 
 This document contains strict rules that must always be followed in the PinPoint codebase to prevent bugs and maintain consistency.
 
+## Privacy: Email Address Visibility
+
+**Rule:** User email addresses must NEVER be displayed outside of admin views and the user's own settings page.
+
+**Why:** Email addresses are PII. Displaying them to non-admin users violates user privacy expectations. Anonymous reporters who provide an email for follow-up do not consent to public display.
+
+**Applies to:**
+
+- Issue timeline events and comments
+- Reporter display names (sidebar, cards, lists)
+- Notification content
+- Seed data and test fixtures
+- Any client-serialized data
+
+**Use instead:**
+
+- User's display name (from `userProfiles.name`)
+- Invited user's name (from `invitedUsers.name`)
+- `reporterName` field (guest-provided name)
+- `"Anonymous"` as final fallback
+
+**Examples:**
+
+```typescript
+// ✅ Correct - uses name hierarchy with Anonymous fallback
+const name =
+  issue.reportedByUser?.name ??
+  issue.invitedReporter?.name ??
+  issue.reporterName ??
+  "Anonymous";
+
+// ❌ Wrong - leaks email to non-admin UI
+const name = issue.reporterName ?? issue.reporterEmail ?? "Guest";
+```
+
 ## Network: localhost Domain Standard
 
 **Rule:** Always use `localhost` (not `127.0.0.1`) for local development URLs.

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -32,6 +32,7 @@ trigger: always_on
 12. Use Drizzle migrations for schema changes (no ad-hoc `push` to production/preview)
 13. Keep auth host consistent: use `localhost` everywhere (Supabase site_url, Next dev, Playwright baseURL) to prevent cookie host mismatches
 14. E2E interaction coverage: if you add a clickable element, click it in a test
+15. Email addresses never displayed outside admin views and user's own settings page
 
 ---
 
@@ -180,6 +181,13 @@ trigger: always_on
 - **Why:** RSC payload is visible in page source; full domain objects leak sensitive fields (emails, roles, internal IDs) even on authenticated pages
 - **Do:** Map data to a minimal shape before passing to Client Components — only include fields the component actually uses
 - **Don't:** Pass full ORM/domain objects (UnifiedUser, full profile records, etc.) as props to "use client" components
+
+**CORE-SEC-007:** Email addresses never displayed outside admin/settings
+
+- **Severity:** Critical
+- **Why:** Email addresses are PII; anonymous reporters providing email for follow-up do not consent to public display
+- **Do:** Use name hierarchy: `reportedByUser.name` → `invitedReporter.name` → `reporterName` → `"Anonymous"`
+- **Don't:** Fall back to `reporterEmail` in any UI, timeline event, seed data, or client-serialized response
 
 ---
 
@@ -349,6 +357,7 @@ trigger: always_on
 - **Playwright arbitrary waits**: No `page.waitForTimeout()` in tests; assert on real UI state (add `data-testid` hooks if needed)
 - **Direct auth.users queries**: Never query Supabase's internal `auth.users` table in application code (use `user_profiles` instead)
 - **Over-serialization to client**: Don't pass full domain objects to Client Components; map to minimal shapes at the server→client boundary (especially user/account data)
+- **Email display outside admin**: Never display `reporterEmail` in non-admin UI, timeline text, or seed data (use names or "Anonymous")
 
 ---
 
@@ -380,7 +389,7 @@ If all Yes → ship it. Perfect is the enemy of done.
 
 - CORE‑TS‑001..006: Type system
 - CORE‑SSR‑001..006: Supabase SSR and auth
-- CORE‑SEC‑001..006: Security
+- CORE‑SEC‑001..007: Security
 - CORE‑PERF‑001..002: Performance
 - CORE‑TEST‑001..005: Testing
 - CORE‑ARCH‑001..007: Architecture

--- a/supabase/seed-users.mjs
+++ b/supabase/seed-users.mjs
@@ -462,7 +462,7 @@ async function seedUsersAndData() {
       `;
 
       // Add "Issue reported by..." system comment to match service logic
-      let reporterDesc = issue.reporterName ?? issue.reporterEmail ?? "Guest";
+      let reporterDesc = issue.reporterName ?? "Anonymous";
 
       if (issue.reportedBy) {
         // In real app, we fetch the user name. Here we can check the user map.


### PR DESCRIPTION
## Summary
- Add **CORE-SEC-007** email privacy rule: email addresses must never be displayed outside admin views and user's own settings page
- Added to all 3 rule locations: `AGENTS.md` (rule #12), `NON_NEGOTIABLES.md`, `docs/NON_NEGOTIABLES.md`
- Fix seed data email leak: `seed-users.mjs` was using `reporterEmail` as fallback display name in timeline events — now falls back to "Anonymous"

## Test plan
- [x] `pnpm run check` passes (492 tests)
- [x] No code behavior changes — documentation and seed data only
- [x] Verified `resolveIssueReporter()` already uses correct name hierarchy (no production code change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)