### PR TITLE
fix(auth): remove login barriers from public routes

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -118,7 +118,10 @@ export async function updateSession(
     path.startsWith("/report") ||
     path.startsWith("/dashboard") ||
     path.startsWith("/help") ||
-    path.startsWith("/api");
+    path.startsWith("/api") ||
+    path === "/privacy" ||
+    path === "/terms" ||
+    path === "/roadmap";
 
   if (!user && !isPublic) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## Summary

- Add `/privacy`, `/terms`, and `/roadmap` to middleware public path list so unauthenticated visitors are not redirected to `/login`
- Remove page-level auth guard from issue detail page (`/m/[initials]/i/[issueNumber]`) — the middleware already marks `/m/*` as public and the permissions matrix allows `issues.view` for unauthenticated users
- Issue detail page now works in read-only mode for unauthenticated users (no sidebar edit controls, empty userId for timeline)

## Route Access Audit

| Route | Access Level | Middleware Public | Page Auth Guard | Status |
|:------|:-------------|:-----------------|:----------------|:-------|
| `/` | Public | Yes | None | OK |
| `/login` | Public | Yes | None | OK |
| `/signup` | Public | Yes | None | OK |
| `/forgot-password` | Public | Yes | None | OK |
| `/reset-password` | Public | Yes | None | OK |
| `/auth/*` | Public | Yes | None | OK |
| `/api/*` | Public | Yes | None | OK |
| `/report` | Public | Yes | None | OK |
| `/report/success` | Public | Yes (via `/report` prefix) | None | OK |
| `/dashboard` | Public | Yes | None (user optional) | OK |
| `/help` | Public | Yes | None | OK |
| `/help/permissions` | Public | Yes (via `/help` prefix) | None | OK |
| `/m` | Public | Yes | None (user optional) | OK |
| `/m/[initials]` | Public | Yes | None (user optional) | OK |
| `/m/[initials]/i` | Public redirect | Yes | Redirects to `/issues` | OK (redirect only) |
| `/m/[initials]/i/[num]` | Public | Yes | ~~Redirect to /login~~ **FIXED** | Was broken |
| `/privacy` | Public | ~~No~~ **FIXED** | None | Was blocked by middleware |
| `/terms` | Public | ~~No~~ **FIXED** | None | Was blocked by middleware |
| `/roadmap` | Public | ~~No~~ **FIXED** | None | Was blocked by middleware |
| `/debug/badges` | Internal | No | None | Middleware blocks (intentional) |
| `/issues` | Auth required | No | Redirect to `/login` | OK |
| `/settings` | Auth required | No | Redirect to `/login` | OK |
| `/m/new` | Auth + Admin | No | Redirect to `/login` + 403 | OK |
| `/admin/*` | Auth + Admin | No | Layout redirect to `/login` + 403 | OK |

## Test plan

- [ ] Visit `/privacy` while logged out — page should render
- [ ] Visit `/terms` while logged out — page should render
- [ ] Visit `/roadmap` while logged out — page should render
- [ ] Visit `/m/[initials]/i/[num]` while logged out — issue detail should render in read-only mode
- [ ] Visit `/settings` while logged out — should redirect to `/login`
- [ ] Visit `/admin/users` while logged out — should redirect to `/login`
- [ ] Visit `/m/new` while logged out — should redirect to `/login`

Closes PinPoint-kh6

🤖 Generated with [Claude Code](https://claude.com/claude-code)