### PR TITLE
chore: improve worktree docs and clean up settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -221,11 +221,7 @@
       "mcp__supabase__search_docs",
       "mcp__github__add_issue_comment",
       "WebFetch(domain:www.npmjs.com)",
-      "WebFetch(domain:vercel.com)",
-      "Read(//home/froeht/Code/pinpoint-worktrees/**)",
-      "Glob(//home/froeht/Code/pinpoint-worktrees/**)",
-      "Edit(//home/froeht/Code/pinpoint-worktrees/**)",
-      "Write(//home/froeht/Code/pinpoint-worktrees/**)"
+      "WebFetch(domain:vercel.com)"
     ],
     "deny": [
       "Bash(find:*)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ We use git worktrees for parallel environments. There are two types:
 
 Created with `./pinpoint-wt.py` for quick PR reviews or parallel development. Ports are hash-allocated to avoid conflicts.
 
+**Worktree Path Resolution**: Branch names with slashes (e.g., `feat/my-feature`) create nested directories. **Always use `git worktree list`** to find the actual path — never guess it. Example: branch `feat/f3r-rename-env-vars` lives at `/home/froeht/Code/pinpoint-worktrees/feat/f3r-rename-env-vars`, NOT `.../f3r-rename-env-vars`.
+
 **Commands**:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add worktree path resolution guidance to AGENTS.md — agents should always use `git worktree list` instead of guessing nested directories from branch names with slashes
- Remove machine-specific worktree permissions from project `.claude/settings.json` (moved to global `~/.claude/settings.json` where they belong)

## Test plan
- [ ] Verify AGENTS.md renders correctly
- [ ] Verify `.claude/settings.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)