### PR TITLE
fix: ignore cancelled/skipped CI in label-ready script

### DIFF
--- a/.claude/skills/pinpoint-orchestrator/SKILL.md
+++ b/.claude/skills/pinpoint-orchestrator/SKILL.md
@@ -191,13 +191,14 @@ gh run rerun <run-id> --failed
 
 ### 4.4 Label Ready PRs
 
-When a PR passes CI and has 0 Copilot comments:
+**PROACTIVE**: Label PRs as soon as CI goes green and Copilot comments are resolved. Do NOT wait for the user to ask — this is part of the orchestrator's job.
 
 ```bash
+bash scripts/workflow/label-ready.sh <PR>               # Label (keeps worktree)
 bash scripts/workflow/label-ready.sh <PR> --cleanup     # Label + remove worktree
 ```
 
-The script checks: all CI passed, 0 Copilot comments, not draft. `--cleanup` frees the branch for the review tool (git won't allow two worktrees on the same branch).
+The script checks: all CI passed (cancelled/skipped runs are ignored), 0 Copilot comments, not draft. Use `--cleanup` only when explicitly asked — worktrees may be needed for follow-up work.
 
 ### 4.5 Review Feedback Loop
 

--- a/scripts/workflow/label-ready.sh
+++ b/scripts/workflow/label-ready.sh
@@ -52,7 +52,7 @@ fi
 # Check CI
 checks=$(gh pr checks "$PR" --json name,state 2>&1) || { echo "FAIL: Could not fetch CI checks for PR #${PR}."; exit 1; }
 total=$(echo "$checks" | jq 'length')
-failed=$(echo "$checks" | jq '[.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.name | startswith("codecov/") | not))] | length')
+failed=$(echo "$checks" | jq '[.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.state != "CANCELLED") and (.state != "SKIPPED") and (.name | startswith("codecov/") | not))] | length')
 pending=$(echo "$checks" | jq '[.[] | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING")] | length')
 
 if [ "$total" -eq 0 ]; then
@@ -66,7 +66,7 @@ if [ "$pending" -gt 0 ]; then
 fi
 
 if [ "$failed" -gt 0 ]; then
-    failed_names=$(echo "$checks" | jq -r '.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.name | startswith("codecov/") | not)) | "\(.name) (\(.state))"' | paste -sd ", ")
+    failed_names=$(echo "$checks" | jq -r '.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.state != "CANCELLED") and (.state != "SKIPPED") and (.name | startswith("codecov/") | not)) | "\(.name) (\(.state))"' | paste -sd ", ")
     echo "FAIL: ${failed} checks failed: ${failed_names}"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- `label-ready.sh` now treats `CANCELLED` and `SKIPPED` CI check states as neutral instead of failures, fixing false negatives from superseded runs
- Orchestrator skill docs updated: labeling PRs is proactive, `--cleanup` only when explicitly requested

## Test plan
- [ ] Run `bash scripts/workflow/label-ready.sh <PR>` on a PR with cancelled/skipped checks and verify it no longer reports false failures
- [ ] Verify the script still correctly fails on genuinely failed checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)