### PR TITLE
test: docs-only change to verify CI path filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/froeht/PinPoint/actions/workflows/ci.yml/badge.svg)](https://github.com/froeht/PinPoint/actions/workflows/ci.yml)
 
-PinPoint is an issue tracker built for the **Austin Pinball Collective**.
+PinPoint is an issue tracker built for the **Austin Pinball Collective**. <!-- CI path-filter test -->
 It helps keep games playable by making it easy to report problems, see what’s broken, and coordinate repairs.
 
 ---


### PR DESCRIPTION
## Purpose

Test PR to verify the CI path filtering from #1031. This PR only changes `README.md` (a non-code file).

## Expected behavior

Only these jobs should run:
- `changes` (Detect Changes)
- `linters` (Fast Linters)  
- `gitleaks` (Gitleaks Secret Scan)

All other jobs (setup, typecheck, lint, format, tests, build, E2E, screenshots) should be **skipped**.

## After verification

Close this PR without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)