### PR TITLE
feat(worktree): add beads redirect to pinpoint-wt create and sync

### DIFF
--- a/pinpoint-wt.py
+++ b/pinpoint-wt.py
@@ -18,6 +18,7 @@ Port Allocation:
 
 import argparse
 import hashlib
+import os
 import re
 import stat
 import subprocess
@@ -363,6 +364,14 @@ def cmd_create(args: argparse.Namespace) -> int:
     if result.returncode != 0:
         print(f"  ⚠️  Warning: pnpm install failed: {result.stderr[:200]}")
 
+    # Set up beads redirect (so `bd` commands work from this worktree)
+    beads_dir = worktree_dir / ".beads"
+    beads_dir.mkdir(exist_ok=True)
+    main_beads = repo_root / ".beads"
+    rel_path = os.path.relpath(main_beads, worktree_dir)
+    (beads_dir / "redirect").write_text(rel_path + "\n")
+    print("  📋 Beads redirect configured")
+
     print()
     print("✅ Ephemeral worktree created successfully!")
     print()
@@ -573,6 +582,17 @@ def cmd_sync(args: argparse.Namespace) -> int:
             )
         except Exception as e:
             print(f"    ❌ .env.local: {e}")
+
+        # Ensure beads redirect exists for non-main worktrees
+        main_beads = Path.cwd() / ".beads"
+        wt_beads = path / ".beads"
+        if main_beads.is_dir() and not (wt_beads / "dolt").exists():
+            wt_beads.mkdir(exist_ok=True)
+            redirect_file = wt_beads / "redirect"
+            if not redirect_file.exists():
+                rel_path = os.path.relpath(main_beads, path)
+                redirect_file.write_text(rel_path + "\n")
+                print("    📋 Beads redirect configured")
 
     print()
     print("✅ Sync complete!")


### PR DESCRIPTION
## Summary
- `pinpoint-wt.py create` now automatically creates a `.beads/redirect` file in new ephemeral worktrees, pointing back to the main repo's beads database
- `pinpoint-wt.py sync` retroactively creates missing redirects for existing worktrees (idempotent — won't overwrite existing redirects)
- Enables `bd` commands (list, show, create, close) to work from any worktree without a full database copy

## Test plan
- [x] Verified `bd list` works from PinPoint-Secondary, PinPoint-AntiGravity, and ephemeral worktrees
- [x] Verified `bd doctor` shows 0 errors across all worktrees
- [x] Python syntax check passes
- [ ] Manual: run `pinpoint-wt.py create test/branch` and verify `.beads/redirect` is created
- [ ] Manual: run `pinpoint-wt.py sync --all` and verify missing redirects are filled in

🤖 Generated with [Claude Code](https://claude.com/claude-code)