### PR TITLE
feat(admin): add Remove button for pending invited users

### DIFF
--- a/e2e/full/admin-remove-invited-user.spec.ts
+++ b/e2e/full/admin-remove-invited-user.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../support/actions.js";
+import {
+  createTestUser,
+  updateUserRole,
+  createInvitedUser,
+} from "../support/supabase-admin.js";
+
+test.describe("Admin Remove Invited User", () => {
+  let adminEmail: string;
+  let adminId: string;
+
+  test.beforeAll(async () => {
+    const ts = Date.now();
+    adminEmail = `admin_remove_${ts}@example.com`;
+    const adminUser = await createTestUser(adminEmail);
+    adminId = adminUser.id;
+    await updateUserRole(adminId, "admin");
+  });
+
+  test("admin can remove a pending invited user", async ({
+    page,
+  }, testInfo) => {
+    const inviteEmail = `invited_remove_${Date.now()}@example.com`;
+    await createInvitedUser(inviteEmail, "Chip", "S");
+
+    await loginAs(page, testInfo, {
+      email: adminEmail,
+      password: "TestPassword123",
+    });
+
+    await page.goto("/admin/users");
+    await expect(
+      page.getByRole("heading", { name: "User Management" })
+    ).toBeVisible();
+
+    // The invited user row should be visible
+    const row = page.getByRole("row").filter({ hasText: inviteEmail });
+    await expect(row).toBeVisible();
+
+    // The Remove button should be present on the invited row
+    const removeButton = row.getByRole("button", { name: /remove/i });
+    await expect(removeButton).toBeVisible();
+    await removeButton.click();
+
+    // AlertDialog should appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Remove invitation?")).toBeVisible();
+    await expect(dialog.getByText("Chip S")).toBeVisible();
+
+    // Confirm removal
+    await dialog.getByRole("button", { name: "Remove" }).click();
+
+    // Toast success message
+    await expect(
+      page.getByText("Invitation removed successfully")
+    ).toBeVisible();
+
+    // The row should be gone from the table
+    await expect(
+      page.getByRole("row").filter({ hasText: inviteEmail })
+    ).not.toBeVisible();
+  });
+
+  test("Remove button is not shown for active users", async ({
+    page,
+  }, testInfo) => {
+    await loginAs(page, testInfo, {
+      email: adminEmail,
+      password: "TestPassword123",
+    });
+
+    await page.goto("/admin/users");
+
+    // The admin's own row (active user) should not have a Remove button
+    const row = page.getByRole("row").filter({ hasText: adminEmail });
+    await expect(row).toBeVisible();
+    await expect(
+      row.getByRole("button", { name: /remove/i })
+    ).not.toBeVisible();
+  });
+});

--- a/src/app/(app)/admin/users/page.tsx
+++ b/src/app/(app)/admin/users/page.tsx
@@ -14,6 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { UserManagementHeader } from "./user-management-header";
 import { Badge } from "~/components/ui/badge";
 import { ResendInviteButton } from "./resend-invite-button";
+import { RemoveInvitedUserButton } from "./remove-invited-user-button";
 import type { UnifiedUser } from "~/lib/types";
 
 function UserRow({
@@ -77,7 +78,10 @@ function UserRow({
       </TableCell>
       <TableCell className="text-right">
         {user.status === "invited" && (
-          <ResendInviteButton userId={user.id} userName={user.name} />
+          <div className="flex justify-end gap-2">
+            <ResendInviteButton userId={user.id} userName={user.name} />
+            <RemoveInvitedUserButton userId={user.id} userName={user.name} />
+          </div>
         )}
       </TableCell>
     </TableRow>

--- a/src/app/(app)/admin/users/remove-invited-user-button.tsx
+++ b/src/app/(app)/admin/users/remove-invited-user-button.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type * as React from "react";
+import { useTransition } from "react";
+import { Button } from "~/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import { UserX } from "lucide-react";
+import { removeInvitedUser } from "./actions";
+import { toast } from "sonner";
+
+interface RemoveInvitedUserButtonProps {
+  userId: string;
+  userName: string;
+}
+
+export function RemoveInvitedUserButton({
+  userId,
+  userName,
+}: RemoveInvitedUserButtonProps): React.JSX.Element {
+  const [isPending, startTransition] = useTransition();
+
+  function handleRemove(): void {
+    startTransition(async () => {
+      try {
+        await removeInvitedUser(userId);
+        toast.success("Invitation removed successfully");
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to remove invitation"
+        );
+      }
+    });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-xs"
+          aria-label={`Remove invitation for ${userName}`}
+        >
+          <UserX className="mr-2 size-3" />
+          Remove
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove invitation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will cancel {userName}&apos;s pending invitation. This cannot
+            be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleRemove}
+            disabled={isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isPending ? "Removing..." : "Remove"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a **Remove** button to each invited-user row in `/admin/users`
- Clicking opens an `AlertDialog` asking for confirmation (no text entry required — admin-only, low-stakes action)
- Server action `removeInvitedUser` runs a DB transaction: nulls `machines.invited_owner_id` and `issues.invited_reported_by` FKs before deleting the `invited_users` row (necessary because both FKs default to RESTRICT)
- Follows the exact same `useTransition` + toast pattern as `ResendInviteButton`

## Test plan

- [x] `pnpm run check` passes (only pre-existing `blob/client.ts` TS error unrelated to this PR)
- [x] E2E test: `e2e/full/admin-remove-invited-user.spec.ts`
  - Admin can click Remove → confirm AlertDialog → invited user disappears from table + success toast
  - Remove button is NOT shown on active user rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)