### PR TITLE
fix(ui): tighten PageShell mobile padding

### DIFF
--- a/src/components/layout/PageShell.tsx
+++ b/src/components/layout/PageShell.tsx
@@ -26,7 +26,7 @@ export function PageShell({
     <div
       className={cn(
         "mx-auto w-full",
-        padded && "px-6 py-10 sm:px-8 lg:px-10",
+        padded && "px-4 py-6 sm:px-6 sm:py-10 lg:px-10",
         sizeClassName[size],
         className
       )}


### PR DESCRIPTION
## Summary

- Fixes PageShell padded variant: changes horizontal padding from px-6 (24px) to px-4 (16px) on mobile, matching the px-4 sm:px-6 responsive pattern used throughout the app
- Tightens vertical padding on mobile from py-10 to py-6 for better density on small screens
- Affects the about, whats-new, and help pages which use PageShell with the default padded=true
- Pages using padded=false are unaffected

Before: px-6 py-10 sm:px-8 lg:px-10
After: px-4 py-6 sm:px-6 sm:py-10 lg:px-10

## Test plan

- [x] pnpm run check passes (705 tests, types, lint, format all clean)
- [ ] Visually verify about, whats-new, and help pages at 375px viewport width show correct 16px side padding

Generated with Claude Code