### PR TITLE
fix(workflow): fix Claude review action posting + add manual trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,12 @@ on:
       - "src/**/*.tsx"
       - "src/**/*.js"
       - "src/**/*.jsx"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,10 +21,11 @@ concurrency:
 
 jobs:
   claude-review:
-    # Only run when the 'claude-review' label is present
+    # Run when 'claude-review' label is present (PR event) or manual dispatch
     if: |
-      contains(github.event.pull_request.labels.*.name, 'claude-review') &&
-      github.event.pull_request.head.repo.fork == false
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'claude-review') &&
+       github.event.pull_request.head.repo.fork == false)
 
     runs-on: ubuntu-latest
     permissions:
@@ -38,6 +45,20 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}'
+
+      - name: Post clean-review marker if no issues found
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          existing=$(gh pr view "$PR_NUMBER" --json comments \
+            --jq '[.comments[] | select(.author.login == "github-actions[bot]" and (.body | contains("Claude Code Review")))] | length')
+          if [ "$existing" -eq 0 ]; then
+            gh pr comment "$PR_NUMBER" --body "<!-- claude-review: clean -->
+          **Claude Code Review**: No issues found."
+          fi


### PR DESCRIPTION
## Summary
- Fix Claude Code Review silently failing to post comments by adding explicit `github_token` (anthropics/claude-code-action#891)
- Add `workflow_dispatch` trigger so reviews can be manually triggered by PR number
- Add clean-review marker step that posts when review finds no issues

## Context
Without explicit `github_token`, the OAuth-exchanged token replaces GITHUB_TOKEN but lacks `pull-requests:write`, so Claude runs its review but silently fails to post.

The clean-review marker ensures our workflow scripts can distinguish "reviewed and clean" from "review didn't run."

## Test plan
- [ ] Merge this PR, then push to a `claude-review`-labeled PR and verify Claude posts comments
- [ ] If clean review, verify "No issues found" marker comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)