### PR TITLE
feat(skills): add pinpoint-briefing session health review skill

### DIFF
--- a/.agent/skills/pinpoint-briefing/SKILL.md
+++ b/.agent/skills/pinpoint-briefing/SKILL.md
@@ -29,8 +29,9 @@ Covers: open PRs (CI + Copilot + merge), worktree health, beads ready/in-progres
 ### Group B: Security Audit
 
 ```bash
+bash -c 'set -o pipefail
 pnpm audit --audit-level=moderate 2>&1 | tail -20
-pnpm outdated 2>&1 | head -30
+pnpm outdated 2>&1 | head -30'
 ```
 
 `pnpm audit` catches CVEs not yet in Dependabot. `pnpm outdated` flags major bumps worth a scheduled update.
@@ -38,8 +39,8 @@ pnpm outdated 2>&1 | head -30
 ### Group C: Main Branch CI
 
 ```bash
-gh run list --branch main --limit 10 --json status,conclusion,name,createdAt,url \
-  --jq '[.[] | select(.status == "completed")] | .[0:5]'
+gh run list --branch main --status completed --limit 5 \
+  --json status,conclusion,name,createdAt,url
 ```
 
 Shows the last 5 completed runs on main. Flag any `conclusion == "failure"`.

--- a/.agent/skills/pinpoint-briefing/SKILL.md
+++ b/.agent/skills/pinpoint-briefing/SKILL.md
@@ -47,9 +47,9 @@ Shows the last 5 completed runs on main. Flag any `conclusion == "failure"`.
 ### Group D: New GitHub Issues (last 5 days)
 
 ```bash
-gh issue list --state open --sort created --limit 20 \
-  --json number,title,createdAt,body \
-  --jq '[.[] | select(.createdAt > (now - 432000 | todate))]'
+gh issue list --state open --limit 20 \
+  --json number,title,createdAt \
+  --jq '[.[] | select(.createdAt > ((now - 432000) | todate))] | .[] | "#\(.number) \(.title) (\(.createdAt | split("T")[0]))"'
 ```
 
 User-reported bugs and feature requests. Cross-reference with beads — flag any not yet tracked.

--- a/.agent/skills/pinpoint-briefing/SKILL.md
+++ b/.agent/skills/pinpoint-briefing/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: pinpoint-briefing
+description: Run a full project health review at session start or on demand. Answers "what should I work on?" before the orchestrator answers "how do I work on it?". Use when starting a new session, when user asks for a briefing, or before deciding what to pick up next.
+---
+
+# PinPoint Session Briefing
+
+Run this skill at the start of every session or when asked for a project status check.
+Goal: answer "what's broken, what shipped, what needs attention" before picking up any work.
+
+## How to Run
+
+Run all data-gathering steps **in parallel** (one Bash call per logical group). Then synthesize into a structured briefing output.
+
+---
+
+## Step 1 — Parallel Data Gathering
+
+Launch these five groups simultaneously:
+
+### Group A: Orchestration Baseline
+
+```bash
+./scripts/workflow/orchestration-status.sh
+```
+
+Covers: open PRs (CI + Copilot + merge), worktree health, beads ready/in-progress, Dependabot alerts.
+
+### Group B: Security Audit
+
+```bash
+pnpm audit --audit-level=moderate 2>&1 | tail -20
+pnpm outdated 2>&1 | head -30
+```
+
+`pnpm audit` catches CVEs not yet in Dependabot. `pnpm outdated` flags major bumps worth a scheduled update.
+
+### Group C: Main Branch CI
+
+```bash
+gh run list --branch main --limit 10 --json status,conclusion,name,createdAt,url \
+  --jq '[.[] | select(.status == "completed")] | .[0:5]'
+```
+
+Shows the last 5 completed runs on main. Flag any `conclusion == "failure"`.
+
+### Group D: New GitHub Issues (last 5 days)
+
+```bash
+gh issue list --state open --sort created --limit 20 \
+  --json number,title,createdAt,body \
+  --jq '[.[] | select(.createdAt > (now - 432000 | todate))]'
+```
+
+User-reported bugs and feature requests. Cross-reference with beads — flag any not yet tracked.
+
+### Group E: Sentry — New Errors
+
+Use the Sentry MCP tools:
+
+1. `mcp__plugin_sentry_sentry__find_organizations` — get org slug
+2. `mcp__plugin_sentry_sentry__search_issues` with `query: "is:unresolved firstSeen:>-5d"` and `limit: 10`
+
+Flag issues with high event counts or new regressions.
+
+---
+
+## Step 2 — Structured Briefing Output
+
+Synthesize all gathered data into this format:
+
+```
+╔══════════════════════════════════════════════════════╗
+║              PINPOINT SESSION BRIEFING               ║
+╚══════════════════════════════════════════════════════╝
+
+📅 Date: [today]
+
+## 🚨 Needs Immediate Attention
+[Anything failing on main, critical security alerts, P0 bugs]
+
+## 🔐 Security
+pnpm audit:    [X vulns (critical/high/moderate)] or ✅ clean
+Dependabot:    [X open alerts] — link to any mergeable PRs
+pnpm outdated: [notable major bumps] or ✅ up to date
+
+## 📋 Open PRs
+[Table from pr-dashboard.sh: PR# | Title | CI | Copilot | Merge Ready]
+Highlight: any with unresolved Copilot comments, failing CI, or stale > 7 days
+
+## 🏗️ Main Branch Health
+[Last 5 post-submit runs: pass/fail summary]
+[Flag any failures with link]
+
+## 🐛 New GitHub Issues (last 5 days)
+[List: #NNN Title (created X days ago) — [in beads / NOT TRACKED]]
+
+## ⚠️ Sentry — New Errors
+[List: Error message | First seen | Event count | URL]
+Or: ✅ No new errors in last 5 days
+
+## 📦 Beads State
+Ready to pick up: [top 5 from `bd ready`]
+In progress:     [from `bd list --status=in_progress`]
+Newly unblocked: [blockers resolved — check `bd blocked` for items whose blocker PRs just merged]
+Recently closed: [from `bd list --status=closed --limit 5`]
+
+## 🌿 Worktree Health
+[From stale-worktrees.sh: any stale/dirty worktrees]
+
+## 🚀 Recommended Next Actions
+1. [Highest impact / most urgent item]
+2. [Second priority]
+3. [Third priority]
+```
+
+---
+
+## Step 3 — Propose Next Work
+
+After the briefing, propose one specific bead to pick up (from `bd ready`, prioritized by P-level and
+relation to open PRs). Reference bead ID and title. Wait for user confirmation before claiming.
+
+---
+
+## Relationship to Other Skills
+
+| Skill                      | When to Use                                                     |
+| -------------------------- | --------------------------------------------------------------- |
+| `pinpoint-briefing`        | Start of session — situational awareness and triage             |
+| `pinpoint-orchestrator`    | After briefing — dispatching parallel subagents for chosen work |
+| `pinpoint-github-monitor`  | During work — watching a specific PR's CI until green           |
+| `pinpoint-ready-to-review` | End of work — getting a PR merged                               |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ If your tool does not support skills, read the file path directly.
 | **Testing**    | `pinpoint-e2e`                   | `.agent/skills/pinpoint-e2e/SKILL.md`                   | E2E tests, worker isolation, stability patterns.                                              |
 | **Security**   | `pinpoint-security`              | `.agent/skills/pinpoint-security/SKILL.md`              | Auth flows, CSP, Zod validation, Supabase SSR.                                                |
 | **Patterns**   | `pinpoint-patterns`              | `.agent/skills/pinpoint-patterns/SKILL.md`              | Server Actions, architecture, data fetching.                                                  |
+| **Workflow**   | `pinpoint-briefing`              | `.agent/skills/pinpoint-briefing/SKILL.md`              | Session start health review: Sentry, PRs, main CI, new issues, audit, beads triage.           |
 | **Workflow**   | `pinpoint-commit`                | `.agent/skills/pinpoint-commit/SKILL.md`                | Intelligent commit-to-PR workflow and CI monitoring.                                          |
 | **Workflow**   | `pinpoint-ready-to-review`       | `.agent/skills/pinpoint-ready-to-review/SKILL.md`       | CI green + Copilot comments addressed + label applied. Use standalone when PR already exists. |
 | **Workflow**   | `pinpoint-github-monitor`        | `.agent/skills/pinpoint-github-monitor/SKILL.md`        | Monitoring GitHub Actions and build status.                                                   |


### PR DESCRIPTION
## Summary

- Adds `.agent/skills/pinpoint-briefing/SKILL.md` — a session-start skill that runs 5 parallel data-gathering groups and synthesizes a structured triage briefing
- Registers the skill in AGENTS.md skill table

## What the skill checks

| Group | What | Tool |
|---|---|---|
| A | PRs, worktrees, beads, Dependabot | `orchestration-status.sh` |
| B | CVEs + major version bumps | `pnpm audit` + `pnpm outdated` |
| C | Post-submit failures on `main` | `gh run list --branch main` |
| D | New GitHub issues (last 5 days) | `gh issue list` |
| E | New Sentry errors (last 5 days) | Sentry MCP tools |

Output is a structured briefing with a "Recommended Next Actions" section. Designed to run before the orchestrator — answers "what should I work on?" before "how do I parallelize it?"

## Test plan

- [x] Ran the skill live in the session that created it — all 5 groups returned correct data
- [x] Fixed `gh issue list --sort` flag bug caught during live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)