### PR TITLE
fix(issues): bottom pagination visible on out-of-range page

### DIFF
--- a/e2e/smoke/issue-list.spec.ts
+++ b/e2e/smoke/issue-list.spec.ts
@@ -187,7 +187,9 @@ test.describe("Issue List Features", () => {
 
     // The page is empty (no issues on page 999), but totalCount > 0 in seeded data.
     // Both top and bottom pagination controls must be visible so the user can navigate back.
-    await expect(page.getByTestId("bottom-prev-page").first()).toBeVisible();
+    const bottomPrevPage = page.getByTestId("bottom-prev-page");
+    await expect(bottomPrevPage).toHaveCount(1);
+    await expect(bottomPrevPage).toBeVisible();
   });
 
   test("should export issues to CSV", async ({ page }) => {

--- a/e2e/smoke/issue-list.spec.ts
+++ b/e2e/smoke/issue-list.spec.ts
@@ -178,6 +178,18 @@ test.describe("Issue List Features", () => {
     expect(machineParam).toContain("MM");
   });
 
+  test("should show bottom pagination on out-of-range page", async ({
+    page,
+  }) => {
+    // Regression test for PP-o9g: bottom pagination used issues.length > 0 instead of
+    // totalCount > 0, hiding navigation controls when landing on an empty out-of-range page.
+    await page.goto("/issues?page=999");
+
+    // The page is empty (no issues on page 999), but totalCount > 0 in seeded data.
+    // Both top and bottom pagination controls must be visible so the user can navigate back.
+    await expect(page.getByTestId("bottom-prev-page").first()).toBeVisible();
+  });
+
   test("should export issues to CSV", async ({ page }) => {
     await page.goto("/issues");
 

--- a/src/components/issues/IssueList.tsx
+++ b/src/components/issues/IssueList.tsx
@@ -617,7 +617,7 @@ export function IssueList({
         </div>
       )}
 
-      {issues.length > 0 && (
+      {totalCount > 0 && (
         <div className="flex items-center justify-end gap-3 pt-2">
           <div className="flex items-center gap-3 text-xs font-medium text-muted-foreground">
             <span>


### PR DESCRIPTION
## Summary

- Fixes PP-o9g: the bottom pagination in `IssueList` was guarded on `issues.length > 0` instead of `totalCount > 0`
- When a user landed on an out-of-range page (e.g. `?page=999`), the page was empty but issues existed — the bottom navigation was hidden, trapping the user with no way to navigate back
- Changed the guard to `totalCount > 0` to match the existing top pagination behavior

## Test plan

- [ ] Regression test added: `e2e/smoke/issue-list.spec.ts` — navigates to `?page=999` and asserts `bottom-prev-page` is visible
- [ ] `pnpm run check` passes (848 unit tests green)
- [ ] CI E2E covers the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)