### PR TITLE
refactor(ui): hoist TooltipProvider to root layout

### DIFF
--- a/src/app/(app)/m/[initials]/edit-button-tooltip.tsx
+++ b/src/app/(app)/m/[initials]/edit-button-tooltip.tsx
@@ -5,7 +5,6 @@ import { Button } from "~/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { Pencil } from "lucide-react";
@@ -16,26 +15,24 @@ export function EditButtonWithTooltip({
   reason: string;
 }): React.JSX.Element {
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span tabIndex={0} className="inline-block w-full">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled
-              className="w-full border-outline text-on-surface-variant"
-              data-testid="edit-machine-button-disabled"
-            >
-              <Pencil className="mr-2 size-4" />
-              Edit Machine
-            </Button>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>{reason}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0} className="inline-block w-full">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled
+            className="w-full border-outline text-on-surface-variant"
+            data-testid="edit-machine-button-disabled"
+          >
+            <Pencil className="mr-2 size-4" />
+            Edit Machine
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{reason}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/assign-issue-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/assign-issue-form.tsx
@@ -16,7 +16,6 @@ import { type AccessLevel } from "~/lib/permissions/matrix";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 
@@ -95,12 +94,10 @@ export function AssignIssueForm({
       {permissionState.allowed ? (
         picker
       ) : (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>{picker}</TooltipTrigger>
-            <TooltipContent>{deniedReason}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{picker}</TooltipTrigger>
+          <TooltipContent>{deniedReason}</TooltipContent>
+        </Tooltip>
       )}
       {state && !state.ok && (
         <p className="text-sm text-destructive">{state.message}</p>

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-frequency-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-frequency-form.tsx
@@ -26,7 +26,6 @@ import { type AccessLevel } from "~/lib/permissions/matrix";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
@@ -169,14 +168,12 @@ export function UpdateIssueFrequencyForm({
         {permissionState.allowed ? (
           control
         ) : (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {compact ? <span className="block">{control}</span> : control}
-              </TooltipTrigger>
-              <TooltipContent>{deniedReason}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {compact ? <span className="block">{control}</span> : control}
+            </TooltipTrigger>
+            <TooltipContent>{deniedReason}</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </form>

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-priority-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-priority-form.tsx
@@ -26,7 +26,6 @@ import { type AccessLevel } from "~/lib/permissions/matrix";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
@@ -166,14 +165,12 @@ export function UpdateIssuePriorityForm({
         {permissionState.allowed ? (
           control
         ) : (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {compact ? <span className="block">{control}</span> : control}
-              </TooltipTrigger>
-              <TooltipContent>{deniedReason}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {compact ? <span className="block">{control}</span> : control}
+            </TooltipTrigger>
+            <TooltipContent>{deniedReason}</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </form>

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-severity-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-severity-form.tsx
@@ -26,7 +26,6 @@ import { type AccessLevel } from "~/lib/permissions/matrix";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
@@ -167,14 +166,12 @@ export function UpdateIssueSeverityForm({
         {permissionState.allowed ? (
           control
         ) : (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {compact ? <span className="block">{control}</span> : control}
-              </TooltipTrigger>
-              <TooltipContent>{deniedReason}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {compact ? <span className="block">{control}</span> : control}
+            </TooltipTrigger>
+            <TooltipContent>{deniedReason}</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </form>

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-status-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-status-form.tsx
@@ -26,7 +26,6 @@ import { type AccessLevel } from "~/lib/permissions/matrix";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
@@ -164,14 +163,12 @@ export function UpdateIssueStatusForm({
         {permissionState.allowed ? (
           control
         ) : (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {compact ? <span className="block">{control}</span> : control}
-              </TooltipTrigger>
-              <TooltipContent>{deniedReason}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {compact ? <span className="block">{control}</span> : control}
+            </TooltipTrigger>
+            <TooltipContent>{deniedReason}</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </form>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ClientLogger } from "~/components/dev/client-logger";
 
 import { CookieConsentBanner } from "~/components/CookieConsentBanner";
 import { SentryInitializer } from "~/components/SentryInitializer";
+import { ClientProviders } from "~/components/layout/ClientProviders";
 import { DEV_SHOW_COOKIE_BANNER_KEY } from "~/lib/cookies/constants";
 
 export const metadata: Metadata = {
@@ -41,11 +42,13 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="flex flex-col h-screen overflow-hidden">
-        <SentryInitializer />
-        {isDevelopment && <ClientLogger />}
-        <div className="flex-1 overflow-hidden">{children}</div>
-        <Toaster />
-        {showCookieBanner && <CookieConsentBanner />}
+        <ClientProviders>
+          <SentryInitializer />
+          {isDevelopment && <ClientLogger />}
+          <div className="flex-1 overflow-hidden">{children}</div>
+          <Toaster />
+          {showCookieBanner && <CookieConsentBanner />}
+        </ClientProviders>
       </body>
     </html>
   );

--- a/src/components/issues/ExportButton.tsx
+++ b/src/components/issues/ExportButton.tsx
@@ -6,7 +6,6 @@ import { Button } from "~/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { toast } from "sonner";
@@ -63,29 +62,27 @@ export function ExportButton({
   }
 
   return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 w-8 p-0 shadow-sm"
-            onClick={handleExport}
-            disabled={isExporting}
-            aria-label="Export to CSV"
-            data-testid="export-csv-button"
-          >
-            {isExporting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Download className="h-3.5 w-3.5" />
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>Export to CSV</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 w-8 p-0 shadow-sm"
+          onClick={handleExport}
+          disabled={isExporting}
+          aria-label="Export to CSV"
+          data-testid="export-csv-button"
+        >
+          {isExporting ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Download className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Export to CSV</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/issues/IssueBadge.tsx
+++ b/src/components/issues/IssueBadge.tsx
@@ -26,7 +26,6 @@ import { cn } from "~/lib/utils";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 
@@ -111,14 +110,12 @@ export function IssueBadge({
   if (!showTooltip) return badgeElement;
 
   return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{badgeElement}</TooltipTrigger>
-        <TooltipContent side="top" className="text-[10px] py-1 px-2">
-          <span className="font-semibold capitalize">{type}:</span>{" "}
-          <span className="capitalize">{label}</span>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>{badgeElement}</TooltipTrigger>
+      <TooltipContent side="top" className="text-[10px] py-1 px-2">
+        <span className="font-semibold capitalize">{type}:</span>{" "}
+        <span className="capitalize">{label}</span>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/issues/IssueFilters.tsx
+++ b/src/components/issues/IssueFilters.tsx
@@ -31,7 +31,6 @@ import type { UserStatus } from "~/lib/types";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 
@@ -479,30 +478,28 @@ export function IssueFilters({
           >
             <Search className="h-4 w-4 text-muted-foreground shrink-0" />
             <div className="flex-1 min-w-0 relative h-full flex items-center">
-              <TooltipProvider delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <input
-                      ref={inputRef}
-                      placeholder="Search issues..."
-                      data-testid="issue-search"
-                      className="flex-1 bg-transparent border-0 text-sm focus:outline-none placeholder:text-muted-foreground relative z-10 w-full"
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="bottom"
-                    align="start"
-                    className="max-w-[300px] p-3"
-                  >
-                    <p className="text-xs leading-relaxed text-muted-foreground">
-                      Search across titles, descriptions, IDs (e.g., AFM-101),
-                      machine names, assignees, reporters, and comments.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <input
+                    ref={inputRef}
+                    placeholder="Search issues..."
+                    data-testid="issue-search"
+                    className="flex-1 bg-transparent border-0 text-sm focus:outline-none placeholder:text-muted-foreground relative z-10 w-full"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                  />
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  align="start"
+                  className="max-w-[300px] p-3"
+                >
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    Search across titles, descriptions, IDs (e.g., AFM-101),
+                    machine names, assignees, reporters, and comments.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
 
               <div
                 data-testid="filter-bar"

--- a/src/components/issues/fields/SelectFields.test.tsx
+++ b/src/components/issues/fields/SelectFields.test.tsx
@@ -5,6 +5,7 @@ import { StatusSelect } from "./StatusSelect";
 import { PrioritySelect } from "./PrioritySelect";
 import { FrequencySelect } from "./FrequencySelect";
 import React from "react";
+import { TooltipProvider } from "~/components/ui/tooltip";
 
 // Mock ResizeObserver for Radix UI
 globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -26,7 +27,11 @@ describe("Issue Field Selects Accessibility", () => {
 
   it("StatusSelect has dynamic accessible name", () => {
     const onValueChange = vi.fn();
-    render(<StatusSelect value="in_progress" onValueChange={onValueChange} />);
+    render(
+      <TooltipProvider>
+        <StatusSelect value="in_progress" onValueChange={onValueChange} />
+      </TooltipProvider>
+    );
     const trigger = screen.getByRole("combobox");
     expect(trigger).toHaveAttribute("aria-label", "Status: In Progress");
   });

--- a/src/components/issues/fields/StatusSelect.tsx
+++ b/src/components/issues/fields/StatusSelect.tsx
@@ -13,7 +13,6 @@ import {
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import {
@@ -93,22 +92,20 @@ export function StatusSelect({
             const config = STATUS_CONFIG[status];
             const Icon = config.icon;
             return (
-              <TooltipProvider key={status} delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <SelectItem
-                      value={status}
-                      data-testid={`status-option-${status}`}
-                    >
-                      <Icon className={`size-4 ${config.iconColor}`} />
-                      <span>{config.label}</span>
-                    </SelectItem>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" className="text-xs">
-                    {config.description}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip key={status}>
+                <TooltipTrigger asChild>
+                  <SelectItem
+                    value={status}
+                    data-testid={`status-option-${status}`}
+                  >
+                    <Icon className={`size-4 ${config.iconColor}`} />
+                    <span>{config.label}</span>
+                  </SelectItem>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="text-xs">
+                  {config.description}
+                </TooltipContent>
+              </Tooltip>
             );
           })}
         </SelectGroup>
@@ -124,22 +121,20 @@ export function StatusSelect({
             const config = STATUS_CONFIG[status];
             const Icon = config.icon;
             return (
-              <TooltipProvider key={status} delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <SelectItem
-                      value={status}
-                      data-testid={`status-option-${status}`}
-                    >
-                      <Icon className={`size-4 ${config.iconColor}`} />
-                      <span>{config.label}</span>
-                    </SelectItem>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" className="text-xs">
-                    {config.description}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip key={status}>
+                <TooltipTrigger asChild>
+                  <SelectItem
+                    value={status}
+                    data-testid={`status-option-${status}`}
+                  >
+                    <Icon className={`size-4 ${config.iconColor}`} />
+                    <span>{config.label}</span>
+                  </SelectItem>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="text-xs">
+                  {config.description}
+                </TooltipContent>
+              </Tooltip>
             );
           })}
         </SelectGroup>
@@ -155,22 +150,20 @@ export function StatusSelect({
             const config = STATUS_CONFIG[status];
             const Icon = config.icon;
             return (
-              <TooltipProvider key={status} delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <SelectItem
-                      value={status}
-                      data-testid={`status-option-${status}`}
-                    >
-                      <Icon className={`size-4 ${config.iconColor}`} />
-                      <span>{config.label}</span>
-                    </SelectItem>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" className="text-xs">
-                    {config.description}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip key={status}>
+                <TooltipTrigger asChild>
+                  <SelectItem
+                    value={status}
+                    data-testid={`status-option-${status}`}
+                  >
+                    <Icon className={`size-4 ${config.iconColor}`} />
+                    <span>{config.label}</span>
+                  </SelectItem>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="text-xs">
+                  {config.description}
+                </TooltipContent>
+              </Tooltip>
             );
           })}
         </SelectGroup>

--- a/src/components/layout/ClientProviders.tsx
+++ b/src/components/layout/ClientProviders.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import type React from "react";
+import { TooltipProvider } from "~/components/ui/tooltip";
+
+/**
+ * Global client-side providers wrapper.
+ *
+ * TooltipProvider is placed here (rather than in individual components) so:
+ * 1. There is a single provider in the tree, preventing "missing provider" crashes.
+ * 2. delayDuration={300} is enforced consistently across all tooltips.
+ *
+ * Exception: CopyButton keeps its own local <TooltipProvider delayDuration={0}>
+ * so that the "Copied!" tooltip appears instantly after a click.
+ */
+export function ClientProviders({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return <TooltipProvider delayDuration={300}>{children}</TooltipProvider>;
+}

--- a/src/components/machines/WatchMachineButton.tsx
+++ b/src/components/machines/WatchMachineButton.tsx
@@ -15,7 +15,6 @@ import {
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { Bell, BellRing, BellOff, Loader2 } from "lucide-react";
@@ -84,25 +83,23 @@ export function WatchMachineButton({
 
   if (!isWatching) {
     return (
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={isPending}
-              onClick={handleToggleWatch}
-              className="text-on-surface-variant hover:bg-surface-variant"
-            >
-              {icon}
-              Watch
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Get notified when new issues are reported on this machine</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={isPending}
+            onClick={handleToggleWatch}
+            className="text-on-surface-variant hover:bg-surface-variant"
+          >
+            {icon}
+            Watch
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Get notified when new issues are reported on this machine</p>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/src/test/unit/components/issues/IssueFilters.test.tsx
+++ b/src/test/unit/components/issues/IssueFilters.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+import type { ReactElement } from "react";
 import { IssueFilters } from "~/components/issues/IssueFilters";
 import { STATUS_GROUPS, OPEN_STATUSES } from "~/lib/issues/status";
 import type { IssueStatus } from "~/lib/types";
@@ -10,7 +10,7 @@ import { TooltipProvider } from "~/components/ui/tooltip";
 
 // Wrap renders in TooltipProvider since the global provider lives in the root
 // layout (ClientProviders) which is not rendered in unit tests.
-function renderWithProviders(ui: React.ReactElement) {
+function renderWithProviders(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
 

--- a/src/test/unit/components/issues/IssueFilters.test.tsx
+++ b/src/test/unit/components/issues/IssueFilters.test.tsx
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import { IssueFilters } from "~/components/issues/IssueFilters";
 import { STATUS_GROUPS, OPEN_STATUSES } from "~/lib/issues/status";
 import type { IssueStatus } from "~/lib/types";
 import "@testing-library/jest-dom/vitest";
+import { TooltipProvider } from "~/components/ui/tooltip";
+
+// Wrap renders in TooltipProvider since the global provider lives in the root
+// layout (ClientProviders) which is not rendered in unit tests.
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 // Mock next/navigation
 const pushMock = vi.fn();
@@ -47,7 +55,7 @@ describe("IssueFilters", () => {
   };
 
   it("shows status badges on landing (default state)", async () => {
-    render(<IssueFilters {...defaultProps} />);
+    renderWithProviders(<IssueFilters {...defaultProps} />);
     // Wait for layout effect
     await new Promise((resolve) => setTimeout(resolve, 0));
     // Default state: Open statuses are selected, so badges should be visible
@@ -56,7 +64,7 @@ describe("IssueFilters", () => {
   });
 
   it("clears 'Open' group statuses when X is clicked", async () => {
-    render(
+    renderWithProviders(
       <IssueFilters
         {...defaultProps}
         filters={{ status: [...OPEN_STATUSES] }}
@@ -92,7 +100,9 @@ describe("IssueFilters", () => {
 
   it("clears individual status when X is clicked", async () => {
     // Setup filter with just "fixed" status (closed group)
-    render(<IssueFilters {...defaultProps} filters={{ status: ["fixed"] }} />);
+    renderWithProviders(
+      <IssueFilters {...defaultProps} filters={{ status: ["fixed"] }} />
+    );
 
     const fixedBadge = await screen.findByText("Fixed");
     const badgeElement = fixedBadge.closest('[data-testid="filter-badge"]');
@@ -126,7 +136,7 @@ describe("IssueFilters - My machines quick-select", () => {
 
   it('shows "My machines" toggle when ownedMachineInitials is non-empty', async () => {
     const user = userEvent.setup();
-    render(
+    renderWithProviders(
       <IssueFilters
         machines={machines}
         users={[]}
@@ -141,7 +151,7 @@ describe("IssueFilters - My machines quick-select", () => {
 
   it('does not show "My machines" toggle when ownedMachineInitials is empty', async () => {
     const user = userEvent.setup();
-    render(
+    renderWithProviders(
       <IssueFilters
         machines={machines}
         users={[]}
@@ -156,7 +166,9 @@ describe("IssueFilters - My machines quick-select", () => {
 
   it('does not show "My machines" toggle when ownedMachineInitials is undefined', async () => {
     const user = userEvent.setup();
-    render(<IssueFilters machines={machines} users={[]} filters={{}} />);
+    renderWithProviders(
+      <IssueFilters machines={machines} users={[]} filters={{}} />
+    );
 
     await user.click(screen.getByTestId("filter-machine"));
     expect(screen.queryByText("My machines")).not.toBeInTheDocument();
@@ -164,7 +176,7 @@ describe("IssueFilters - My machines quick-select", () => {
 
   it('clicking "My machines" selects all owned machine initials (AFM and MM)', async () => {
     const user = userEvent.setup();
-    render(
+    renderWithProviders(
       <IssueFilters
         machines={machines}
         users={[]}
@@ -184,7 +196,7 @@ describe("IssueFilters - My machines quick-select", () => {
 
   it('clicking "My machines" when all owned selected deselects only owned machines', async () => {
     const user = userEvent.setup();
-    render(
+    renderWithProviders(
       <IssueFilters
         machines={machines}
         users={[]}

--- a/src/test/unit/components/issues/issue-detail-permissions.test.tsx
+++ b/src/test/unit/components/issues/issue-detail-permissions.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import React from "react";
+import type { ReactElement } from "react";
 import type { IssueWithAllRelations } from "~/lib/types";
 import type { ProseMirrorDoc } from "~/lib/tiptap/types";
 import { UpdateIssueStatusForm } from "~/app/(app)/m/[initials]/i/[issueNumber]/update-issue-status-form";
@@ -10,7 +10,7 @@ import { TooltipProvider } from "~/components/ui/tooltip";
 
 // Wrap renders in TooltipProvider since the global provider lives in the root
 // layout (ClientProviders) which is not rendered in unit tests.
-function renderWithProviders(ui: React.ReactElement) {
+function renderWithProviders(ui: ReactElement) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
 

--- a/src/test/unit/components/issues/issue-detail-permissions.test.tsx
+++ b/src/test/unit/components/issues/issue-detail-permissions.test.tsx
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import type { IssueWithAllRelations } from "~/lib/types";
 import type { ProseMirrorDoc } from "~/lib/tiptap/types";
 import { UpdateIssueStatusForm } from "~/app/(app)/m/[initials]/i/[issueNumber]/update-issue-status-form";
 import { IssueTimeline } from "~/components/issues/IssueTimeline";
 import { IssueSidebar } from "~/components/issues/IssueSidebar";
+import { TooltipProvider } from "~/components/ui/tooltip";
+
+// Wrap renders in TooltipProvider since the global provider lives in the root
+// layout (ClientProviders) which is not rendered in unit tests.
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 vi.mock("~/app/(app)/issues/actions", () => ({
   assignIssueAction: vi.fn(),
@@ -74,7 +82,7 @@ function createIssue(
 
 describe("Issue detail permission-aware UI", () => {
   it("renders status as read-only badge for unauthenticated users", () => {
-    render(
+    renderWithProviders(
       <UpdateIssueStatusForm
         issueId="issue-1"
         currentStatus="new"
@@ -88,7 +96,7 @@ describe("Issue detail permission-aware UI", () => {
   });
 
   it("disables status control for guest users on others' issues", () => {
-    render(
+    renderWithProviders(
       <UpdateIssueStatusForm
         issueId="issue-1"
         currentStatus="new"
@@ -107,7 +115,7 @@ describe("Issue detail permission-aware UI", () => {
   it("shows a login prompt instead of the add-comment form when unauthenticated", () => {
     const issue = createIssue();
 
-    render(
+    renderWithProviders(
       <IssueTimeline
         issue={issue}
         currentUserId={null}
@@ -125,7 +133,7 @@ describe("Issue detail permission-aware UI", () => {
   it("hides the watch button in the sidebar for unauthenticated users", () => {
     const issue = createIssue();
 
-    render(
+    renderWithProviders(
       <IssueSidebar
         issue={issue}
         allUsers={[]}


### PR DESCRIPTION
## Summary

Resolves PP-nsy.

- Add a single global `<TooltipProvider delayDuration={300}>` in a new `ClientProviders` component (`src/components/layout/ClientProviders.tsx`), wrapping the root layout body
- Remove the local `TooltipProvider` wrappers from **11 files** (listed below), preventing redundant providers and ensuring consistent 300ms delay everywhere
- Update 3 unit test files to wrap renders with `TooltipProvider` (since the global provider lives in the root layout, which is not rendered in unit tests)

## Files that lost their local TooltipProvider

1. `src/app/(app)/m/[initials]/edit-button-tooltip.tsx` — default props (no delay set)
2. `src/app/(app)/m/[initials]/i/[issueNumber]/assign-issue-form.tsx` — default props
3. `src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-frequency-form.tsx` — default props
4. `src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-priority-form.tsx` — default props
5. `src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-severity-form.tsx` — default props
6. `src/app/(app)/m/[initials]/i/[issueNumber]/update-issue-status-form.tsx` — default props
7. `src/components/machines/WatchMachineButton.tsx` — was `delayDuration={300}` (matches global)
8. `src/components/issues/ExportButton.tsx` — was `delayDuration={300}` (matches global)
9. `src/components/issues/IssueBadge.tsx` — was `delayDuration={300}` (matches global)
10. `src/components/issues/fields/StatusSelect.tsx` — was `delayDuration={300}` × 3 instances (matches global)
11. `src/components/issues/IssueFilters.tsx` — was `delayDuration={300}` (matches global)

## delayDuration={300} choice

Files 7–11 already used `300ms` explicitly. Files 1–6 used the Radix default of `700ms`. The global `300ms` is a slight speedup for the form-level permission tooltips, which is an acceptable behavior improvement (faster feedback on disabled controls).

## Files that kept their local TooltipProvider

- `src/components/ui/copy-button.tsx` — retains `<TooltipProvider delayDuration={0}>` intentionally. The "Copied!" tooltip must appear instantly after a click; a 300ms delay would feel broken for this specific UX.

## Test plan

- [x] `pnpm run check` — 848 tests pass, types clean, lint clean
- [x] 3 unit test files updated to wrap renders in `TooltipProvider` (avoids "must be used within TooltipProvider" runtime error in jsdom)
- [ ] CI E2E runs `machines-crud.spec.ts` which already asserts the disabled edit button (rendered by `EditButtonWithTooltip`) is visible — verifies the global provider is in effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)