### PR TITLE
fix(e2e): replace networkidle in auth helpers; serialize auth-setup

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -42,14 +42,14 @@ async function loginAndSave(
   await page.getByLabel("Password", { exact: true }).fill(password);
   await page.getByRole("button", { name: "Sign In" }).click();
 
-  await page.waitForLoadState("networkidle");
+  await page.waitForLoadState("domcontentloaded");
   await expect(page).toHaveURL("/dashboard", { timeout: 15000 });
   await expect(page.getByTestId("app-header")).toBeVisible();
   await expect(page.getByTestId("user-menu-button")).toBeVisible();
 
   // Force a full server round-trip to settle Supabase cookie rotation.
   // See the comment in loginAs() in actions.ts for the full explanation.
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "domcontentloaded" });
   await expect(page).toHaveURL("/dashboard", { timeout: 10000 });
 
   await page.context().storageState({ path });

--- a/e2e/support/actions.ts
+++ b/e2e/support/actions.ts
@@ -52,7 +52,7 @@ export async function loginAs(
   await page.getByRole("button", { name: "Sign In" }).click();
 
   // Wait for initial dashboard load
-  await page.waitForLoadState("networkidle");
+  await page.waitForLoadState("domcontentloaded");
   await expect(page).toHaveURL("/dashboard", { timeout: 15000 });
 
   // AppHeader is always rendered (mobile and desktop) — just verify it's visible
@@ -66,7 +66,7 @@ export async function loginAs(
   // (refresh token exchange) may not be fully committed by the time the NEXT
   // navigation fires. Reloading the dashboard forces the browser to send the
   // auth cookie back to the server, completing the rotation cycle.
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "domcontentloaded" });
 
   // Confirm the reload kept us on /dashboard (not redirected to /login by middleware).
   await expect(page).toHaveURL("/dashboard", { timeout: 10000 });

--- a/playwright.config.smoke.ts
+++ b/playwright.config.smoke.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       name: "auth-setup",
       testDir: "./e2e",
       testMatch: "auth.setup.ts",
+      fullyParallel: false, // Serialize to prevent Supabase cookie rotation races
       use: { ...devices["Desktop Chrome"] },
     },
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
       name: "auth-setup",
       testDir: "./e2e",
       testMatch: "auth.setup.ts",
+      fullyParallel: false, // Serialize to prevent Supabase cookie rotation races
       use: { ...devices["Desktop Chrome"] },
     },
     {


### PR DESCRIPTION
## Summary

- Replace `waitForLoadState("networkidle")` and `reload({ waitUntil: "networkidle" })` with `domcontentloaded` in `e2e/auth.setup.ts` and `e2e/support/actions.ts` — the Turnstile CAPTCHA widget holds a persistent connection that prevents `networkidle` from ever firing on the login page
- Add `fullyParallel: false` to the `auth-setup` project in both `playwright.config.ts` and `playwright.config.smoke.ts` to prevent Supabase cookie rotation races when admin/member/technician setup runs concurrently

The subsequent semantic assertions (`toHaveURL("/dashboard")`, `toBeVisible()` for the user menu) already serve as the real readiness gate. The `networkidle` waits were redundant and hazardous.

This is Phase 3 of the CI hardening series (Phase 1 + 2 shipped in #1180 and #1181).

## Test plan

- [ ] E2E smoke passes with 3 workers (auth-setup now serialized)
- [ ] E2E full passes — login helpers no longer hang on Turnstile persistent connection
- [ ] `auth.setup.ts` cookie files written correctly for all 3 roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)