### PR TITLE
refactor(ui): migrate hand-rolled alerts to shadcn <Alert> (PP-aag)

### DIFF
--- a/src/app/(app)/report/unified-report-form.tsx
+++ b/src/app/(app)/report/unified-report-form.tsx
@@ -12,6 +12,7 @@ import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { useSearchParams } from "next/navigation";
 import { cn } from "~/lib/utils";
 import {
@@ -272,12 +273,9 @@ export function UnifiedReportForm({
         {/* Main Form Column */}
         <div className="lg:col-span-7 space-y-3 md:space-y-4">
           {(initialError ?? state.error) && (
-            <div
-              role="alert"
-              className="rounded-md border border-red-900/50 bg-red-900/20 px-4 py-2 text-sm text-red-300"
-            >
-              {initialError ?? state.error}
-            </div>
+            <Alert variant="destructive">
+              <AlertDescription>{initialError ?? state.error}</AlertDescription>
+            </Alert>
           )}
 
           <form action={formAction} className="space-y-3 md:space-y-4">

--- a/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -4,6 +4,7 @@ import React, { useActionState, useState, useCallback } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { forgotPasswordAction } from "~/app/(auth)/actions";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
 
@@ -24,21 +25,21 @@ export function ForgotPasswordForm(): React.JSX.Element {
     <form action={formAction} className="space-y-4">
       {/* Message */}
       {state && !state.ok && (
-        <div
-          className="rounded-lg bg-error-container px-4 py-3 text-sm text-on-error-container"
-          role="alert"
-        >
-          {state.message}
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
       )}
       {state && state.ok && (
-        <div
-          className="rounded-lg px-4 py-3 text-sm bg-primary-container text-on-primary-container"
-          role="alert"
-        >
-          If an account exists with that email, you will receive a password
-          reset link shortly.
-        </div>
+        // Success alert: migrated from bg-primary-container (deprecated MD token)
+        // to default Alert variant. Original used primary-container colors, not
+        // destructive — default variant is closest semantic match in the shadcn
+        // Alert component (no dedicated success variant exists).
+        <Alert>
+          <AlertDescription>
+            If an account exists with that email, you will receive a password
+            reset link shortly.
+          </AlertDescription>
+        </Alert>
       )}
 
       {/* Email */}

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -8,8 +8,8 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { PasswordInput } from "~/components/ui/password-input";
 import { Label } from "~/components/ui/label";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { loginAction, type LoginResult } from "~/app/(auth)/actions";
-import { cn } from "~/lib/utils";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
 
 // Lazily load TestAdminButton to prevent including test credentials in the production bundle
@@ -42,15 +42,9 @@ export function LoginForm({
     <>
       {/* Flash message */}
       {state && !state.ok && (
-        <div
-          className={cn(
-            "rounded-lg px-4 py-3 text-sm",
-            "border border-destructive/30 bg-destructive/10 text-destructive"
-          )}
-          role="alert"
-        >
-          {state.message}
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
       )}
 
       {/* Login form */}

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -5,6 +5,7 @@ import { useActionState, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
 import { PasswordInput } from "~/components/ui/password-input";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { PasswordMismatch } from "~/components/password-mismatch";
 import { PasswordStrength } from "~/components/password-strength";
 import {
@@ -24,12 +25,9 @@ export function ResetPasswordForm(): React.JSX.Element {
     <form action={formAction} className="space-y-4">
       {/* Message */}
       {state && !state.ok && (
-        <div
-          className="rounded-lg bg-error-container px-4 py-3 text-sm text-on-error-container"
-          role="alert"
-        >
-          {state.message}
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
       )}
 
       {/* New Password */}

--- a/src/app/(auth)/signup/signup-form.tsx
+++ b/src/app/(auth)/signup/signup-form.tsx
@@ -8,6 +8,7 @@ import { PasswordInput } from "~/components/ui/password-input";
 import { PasswordMismatch } from "~/components/password-mismatch";
 import { Label } from "~/components/ui/label";
 import { Checkbox } from "~/components/ui/checkbox";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { PasswordStrength } from "~/components/password-strength";
 import { signupAction, type SignupResult } from "~/app/(auth)/actions";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
@@ -78,12 +79,9 @@ export function SignupForm({
     <form action={formAction} className="space-y-4">
       {/* Error Message */}
       {state && !state.ok && (
-        <div
-          className="rounded-lg bg-error-container px-4 py-3 text-sm text-on-error-container"
-          role="alert"
-        >
-          {state.message}
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
       )}
 
       <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
Migrated all hand-rolled form-level destructive alerts across auth + report forms to the shadcn `<Alert variant="destructive">` component. One success alert (forgot-password) migrated to the default Alert variant.

## Plan
/Users/froeht/.claude/plans/pure-hatching-swing.md (Wave 2b detail, lines 173-187)

## Beads
PP-aag

## Migrated Files (5 sites across 5 files)
- `src/app/(auth)/login/login-form.tsx` — destructive (was `border-destructive/30 bg-destructive/10`)
- `src/app/(app)/report/unified-report-form.tsx` — destructive (was `border-red-900/50 bg-red-900/20`)
- `src/app/(auth)/signup/signup-form.tsx` — destructive (was `bg-error-container`, deprecated MD token)
- `src/app/(auth)/reset-password/reset-password-form.tsx` — destructive (was `bg-error-container`, deprecated MD token)
- `src/app/(auth)/forgot-password/forgot-password-form.tsx` — **two alerts**:
  - Error alert (destructive, was `bg-error-container`)
  - Success alert (default Alert variant, was `bg-primary-container`). No dedicated success variant exists in `src/components/ui/alert.tsx` — default variant is the closest semantic match. Inline code comment added explaining the choice.

## Notes
- The deprecated Material Design `error-container` / `primary-container` / `on-*-container` tokens are replaced by the Alert component's internal tokens, aligning with design bible §18.
- No new components created — pure mechanical migration.

## Test plan
- [x] `pnpm run check` (types, lint, 851 unit tests) passes
- [ ] Manual: trigger validation errors on `/login`, `/signup`, `/reset-password`, `/forgot-password`, `/report` and confirm red alert renders
- [ ] Manual: trigger forgot-password success path and confirm default-variant alert renders