### PR TITLE
feat(ui): extract <EmptyState> and migrate inline empty states (PP-yxw.5)

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -28,6 +28,7 @@ import { IssueCard } from "~/components/issues/IssueCard";
 import { OrganizationBanner } from "~/components/dashboard/OrganizationBanner";
 import { PageContainer } from "~/components/layout/PageContainer";
 import { PageHeader } from "~/components/layout/PageHeader";
+import { EmptyState } from "~/components/ui/empty-state";
 
 /**
  * Cached dashboard data fetcher (CORE-PERF-001)
@@ -367,12 +368,11 @@ export default async function DashboardPage(): Promise<React.JSX.Element> {
             Newest Games
           </h2>
           {newestMachines.length === 0 ? (
-            <Card className="border-border bg-card">
-              <CardContent className="py-12 text-center">
-                <Sparkles className="mx-auto mb-4 size-12 text-muted-foreground" />
-                <p className="text-lg text-muted-foreground">No machines yet</p>
-              </CardContent>
-            </Card>
+            <EmptyState
+              icon={Sparkles}
+              title="No machines yet"
+              description="Machines will appear here once they are added to the collection."
+            />
           ) : (
             <div
               className="grid grid-cols-1 md:grid-cols-3 gap-4"
@@ -410,14 +410,11 @@ export default async function DashboardPage(): Promise<React.JSX.Element> {
             Recently Fixed Games
           </h2>
           {recentlyFixedMachines.length === 0 ? (
-            <Card className="border-border bg-card">
-              <CardContent className="py-12 text-center">
-                <CheckCircle2 className="mx-auto mb-4 size-12 text-muted-foreground" />
-                <p className="text-lg text-muted-foreground">
-                  No recently fixed machines
-                </p>
-              </CardContent>
-            </Card>
+            <EmptyState
+              icon={CheckCircle2}
+              title="No recently fixed machines"
+              description="Machines will appear here once major or unplayable issues are resolved."
+            />
           ) : (
             <div
               className="grid grid-cols-1 md:grid-cols-3 gap-4"
@@ -454,14 +451,11 @@ export default async function DashboardPage(): Promise<React.JSX.Element> {
               Issues Assigned to Me
             </h2>
             {assignedIssues.length === 0 ? (
-              <Card className="border-border bg-card">
-                <CardContent className="py-12 text-center">
-                  <CheckCircle2 className="mx-auto mb-4 size-12 text-muted-foreground" />
-                  <p className="text-lg text-muted-foreground">
-                    No issues assigned to you
-                  </p>
-                </CardContent>
-              </Card>
+              <EmptyState
+                icon={CheckCircle2}
+                title="No issues assigned to you"
+                description="Issues assigned to you will appear here."
+              />
             ) : (
               <div
                 className="grid grid-cols-1 md:grid-cols-2 gap-3"
@@ -487,14 +481,11 @@ export default async function DashboardPage(): Promise<React.JSX.Element> {
             Recently Reported Issues
           </h2>
           {recentIssues.length === 0 ? (
-            <Card className="border-border bg-card">
-              <CardContent className="py-12 text-center">
-                <Clock className="mx-auto mb-4 size-12 text-muted-foreground" />
-                <p className="text-lg text-muted-foreground">
-                  No issues reported yet
-                </p>
-              </CardContent>
-            </Card>
+            <EmptyState
+              icon={Clock}
+              title="No issues reported yet"
+              description="Issues will appear here once they are reported."
+            />
           ) : (
             <div
               className="grid grid-cols-1 md:grid-cols-2 gap-3"

--- a/src/app/(app)/m/page.tsx
+++ b/src/app/(app)/m/page.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Badge } from "~/components/ui/badge";
 import { Plus, SearchX } from "lucide-react";
+import { EmptyState } from "~/components/ui/empty-state";
 import { cn } from "~/lib/utils";
 import {
   parseMachineFilters,
@@ -179,49 +180,36 @@ export default async function MachinesPage({
       {/* Content */}
       <div>
         {sortedMachines.length === 0 ? (
-          // Empty state
-          <Card className="border-outline-variant border-dashed bg-transparent">
-            <CardContent className="py-16 text-center">
-              <div className="flex flex-col items-center gap-4">
-                {hasFilters ? (
-                  <>
-                    <div className="rounded-full bg-surface-container-highest p-4">
-                      <SearchX className="size-8 text-on-surface-variant" />
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xl font-semibold text-on-surface">
-                        No matches found
-                      </p>
-                      <p className="text-on-surface-variant">
-                        Try adjusting your filters to find what you're looking
-                        for.
-                      </p>
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <p className="text-xl font-semibold text-on-surface">
-                      No machines yet
-                    </p>
-                    <p className="text-on-surface-variant mb-4">
-                      {accessLevel === "admin" || accessLevel === "technician"
-                        ? "Get started by adding your first machine to the collection."
-                        : "No machines have been added to the collection yet."}
-                    </p>
-                    {(accessLevel === "admin" ||
-                      accessLevel === "technician") && (
-                      <Link href="/m/new">
-                        <Button className="bg-primary text-on-primary hover:bg-primary/90">
-                          <Plus className="mr-2 size-4" />
-                          Add Your First Machine
-                        </Button>
-                      </Link>
-                    )}
-                  </>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          hasFilters ? (
+            <EmptyState
+              icon={SearchX}
+              title="No matches found"
+              description="Try adjusting your filters to find what you're looking for."
+            />
+          ) : (
+            <EmptyState
+              icon={Plus}
+              title="No machines yet"
+              description={
+                accessLevel === "admin" || accessLevel === "technician"
+                  ? "Get started by adding your first machine to the collection."
+                  : "No machines have been added to the collection yet."
+              }
+              action={
+                accessLevel === "admin" || accessLevel === "technician" ? (
+                  <Button
+                    asChild
+                    className="bg-primary text-on-primary hover:bg-primary/90"
+                  >
+                    <Link href="/m/new">
+                      <Plus className="mr-2 size-4" />
+                      Add Your First Machine
+                    </Link>
+                  </Button>
+                ) : undefined
+              }
+            />
+          )
         ) : (
           // Machine grid (responsive: 1 col on mobile, 2 on tablet, 3 on desktop)
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/app/(app)/m/page.tsx
+++ b/src/app/(app)/m/page.tsx
@@ -185,6 +185,11 @@ export default async function MachinesPage({
               icon={SearchX}
               title="No matches found"
               description="Try adjusting your filters to find what you're looking for."
+              action={
+                <Button variant="outline" asChild>
+                  <Link href="/m">Clear filters</Link>
+                </Button>
+              }
             />
           ) : (
             <EmptyState

--- a/src/app/(dev)/dev/design-system/page.tsx
+++ b/src/app/(dev)/dev/design-system/page.tsx
@@ -8,6 +8,8 @@ import type { IssueSeverity, IssuePriority, IssueFrequency } from "~/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Separator } from "~/components/ui/separator";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Inbox, SearchX, Plus } from "lucide-react";
 
 /**
  * Design System / Style Guide
@@ -1202,22 +1204,68 @@ function PageArchetypesSection(): React.JSX.Element {
    ──────────────────────────────────────────────────────────── */
 
 function UIStatesSection(): React.JSX.Element {
-  // Filled in by PP-yxw.5 (EmptyState) and PP-aag (Alert migration).
-  // Should render:
-  //   - EmptyState variants: card (default) and bare, with/without action
-  //   - Loading: Skeleton shapes at common sizes (row, card, hero)
-  //   - Error: Alert variant="destructive" with AlertTitle + AlertDescription
-  // See pinpoint-design-bible SKILL.md §13 for canonical patterns.
   return (
     <section className="space-y-6">
       <SectionHeading
         title="UI States"
-        description="Canonical empty, loading, and error patterns. Filled in by PP-yxw.5 (EmptyState) and PP-aag (Alert migration) — see design bible §13."
+        description="Canonical empty, loading, and error patterns — see design bible §13. Alert migration (Wave 2b / PP-aag) still pending."
       />
+
+      {/* EmptyState: card variant (default) */}
+      <div className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">
+          EmptyState — <code>variant=&quot;card&quot;</code> (default)
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">Without action</p>
+            <EmptyState
+              icon={Inbox}
+              title="No items yet"
+              description="Items will appear here once they are added."
+            />
+          </div>
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">With action</p>
+            <EmptyState
+              icon={Plus}
+              title="No machines yet"
+              description="Get started by adding your first machine."
+              action={
+                <Button variant="outline" size="sm">
+                  Add Machine
+                </Button>
+              }
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* EmptyState: bare variant */}
+      <div className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">
+          EmptyState — <code>variant=&quot;bare&quot;</code> (use inside an
+          existing card)
+        </p>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="mb-2 text-xs font-medium text-muted-foreground">
+              Existing card wrapper
+            </p>
+            <EmptyState
+              variant="bare"
+              icon={SearchX}
+              title="No matches found"
+              description="Try adjusting your filters to see more results."
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Alert showcase reserved for Wave 2b */}
       <div className="rounded-lg border border-dashed border-outline-variant bg-card p-8 text-center">
         <p className="text-sm text-muted-foreground">
-          Reserved for EmptyState / Skeleton / Alert showcases. Filled by Wave
-          2a (PP-yxw.5) and Wave 2b (PP-aag).
+          Alert / error state showcase reserved for Wave 2b (PP-aag).
         </p>
       </div>
     </section>

--- a/src/components/issues/IssueList.tsx
+++ b/src/components/issues/IssueList.tsx
@@ -604,11 +604,15 @@ export function IssueList({
               : "Issues will appear here once they are reported."
           }
           action={
-            !hasActiveIssueFilters(searchParams) ? (
+            hasActiveIssueFilters(searchParams) ? (
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/issues">Clear filters</Link>
+              </Button>
+            ) : (
               <Button variant="outline" size="sm" asChild>
                 <Link href="/report">Report an Issue</Link>
               </Button>
-            ) : undefined
+            )
           }
         />
       )}

--- a/src/components/issues/IssueList.tsx
+++ b/src/components/issues/IssueList.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   SlidersHorizontal,
 } from "lucide-react";
+import { EmptyState } from "~/components/ui/empty-state";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
 import { formatDistanceToNow } from "date-fns";
@@ -590,31 +591,26 @@ export function IssueList({
       </div>
 
       {issues.length === 0 && (
-        <div className="p-12 flex flex-col items-center justify-center text-center rounded-lg border border-dashed border-border/60 bg-muted/20">
-          <div className="h-12 w-12 rounded-full bg-muted flex items-center justify-center mb-4">
-            <AlertCircle className="h-6 w-6 text-muted-foreground" />
-          </div>
-          <p className="text-base font-semibold text-foreground">
-            {hasActiveIssueFilters(searchParams)
+        <EmptyState
+          icon={AlertCircle}
+          title={
+            hasActiveIssueFilters(searchParams)
               ? "No issues found"
-              : "No issues yet. Report your first issue!"}
-          </p>
-          <p className="text-sm text-muted-foreground mt-1 max-w-[250px] mx-auto">
-            {hasActiveIssueFilters(searchParams)
+              : "No issues yet"
+          }
+          description={
+            hasActiveIssueFilters(searchParams)
               ? "Adjust your filters to see more issues."
-              : "Issues will appear here once they are reported."}
-          </p>
-          {!hasActiveIssueFilters(searchParams) && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-4 shadow-sm"
-              asChild
-            >
-              <Link href="/report">Report an Issue</Link>
-            </Button>
-          )}
-        </div>
+              : "Issues will appear here once they are reported."
+          }
+          action={
+            !hasActiveIssueFilters(searchParams) ? (
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/report">Report an Issue</Link>
+              </Button>
+            ) : undefined
+          }
+        />
       )}
 
       {totalCount > 0 && (

--- a/src/components/machines/MachineEmptyState.tsx
+++ b/src/components/machines/MachineEmptyState.tsx
@@ -1,31 +1,38 @@
 import type React from "react";
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Button } from "~/components/ui/button";
 
 interface MachineEmptyStateProps {
   machineInitials: string;
 }
 
+/**
+ * MachineEmptyState — pre-configured empty state for the "game is operational" case.
+ *
+ * Shown on machine detail pages when there are no open issues.
+ * Thin wrapper around <EmptyState> with icon/copy pre-set.
+ */
 export function MachineEmptyState({
   machineInitials,
 }: MachineEmptyStateProps): React.JSX.Element {
   return (
-    <div className="py-16 text-center">
-      <Link
-        href={`/report?machine=${machineInitials}`}
-        className="group inline-flex flex-col items-center"
-        aria-label="Report a new issue"
-      >
-        <div className="inline-flex size-12 items-center justify-center rounded-full bg-surface-variant mb-4 group-hover:bg-primary/10 transition-colors duration-200">
-          <Plus className="size-6 text-on-surface-variant group-hover:text-primary transition-colors duration-200" />
-        </div>
-        <p className="text-lg font-medium text-on-surface mb-1 group-hover:text-primary transition-colors duration-200">
-          No open issues
-        </p>
-      </Link>
-      <p className="text-sm text-on-surface-variant mt-1">
-        The game is operational. Great job!
-      </p>
-    </div>
+    <EmptyState
+      variant="bare"
+      icon={CheckCircle2}
+      title="No open issues"
+      description="The game is operational. Great job!"
+      action={
+        <Button variant="outline" size="sm" asChild>
+          <Link
+            href={`/report?machine=${machineInitials}`}
+            aria-label="Report a new issue"
+          >
+            Report an Issue
+          </Link>
+        </Button>
+      }
+    />
   );
 }

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -34,9 +34,11 @@ export function EmptyState({
       <div className="mb-4 inline-flex size-24 items-center justify-center rounded-full bg-muted">
         <Icon className="size-12 text-muted-foreground" />
       </div>
-      <p className="text-base font-semibold text-foreground">{title}</p>
+      <p className="text-base font-semibold text-balance text-foreground">
+        {title}
+      </p>
       {description ? (
-        <p className="mt-1 max-w-xs text-sm text-muted-foreground">
+        <p className="mt-1 max-w-sm text-sm text-pretty text-muted-foreground">
           {description}
         </p>
       ) : null}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -30,7 +30,7 @@ export function EmptyState({
   variant = "card",
 }: EmptyStateProps): React.JSX.Element {
   const content = (
-    <div className="flex flex-col items-center py-12 text-center">
+    <div className="flex flex-col items-center px-6 py-12 text-center">
       <div className="mb-4 inline-flex size-24 items-center justify-center rounded-full bg-muted">
         <Icon className="size-12 text-muted-foreground" />
       </div>

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,52 @@
+import type React from "react";
+import type { LucideIcon } from "lucide-react";
+import { Card } from "~/components/ui/card";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  variant?: "card" | "bare";
+}
+
+/**
+ * EmptyState — canonical pattern for zero-item lists and sections.
+ *
+ * Design bible §13: icon-in-circle + heading + optional body + optional CTA.
+ * - `variant="card"` (default) wraps content in a <Card> with py-12 text-center.
+ * - `variant="bare"` renders the content directly — use when the parent is already a Card.
+ *
+ * Rules:
+ * - Icon must be a single lucide-react icon rendered at size-12 in a muted circle.
+ * - Keep title under 40 characters. Use description for more detail.
+ * - Provide an action only if the user can take a productive next step.
+ */
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  variant = "card",
+}: EmptyStateProps): React.JSX.Element {
+  const content = (
+    <div className="flex flex-col items-center py-12 text-center">
+      <div className="mb-4 inline-flex size-24 items-center justify-center rounded-full bg-muted">
+        <Icon className="size-12 text-muted-foreground" />
+      </div>
+      <p className="text-base font-semibold text-foreground">{title}</p>
+      {description ? (
+        <p className="mt-1 max-w-xs text-sm text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+      {action ? <div className="mt-4">{action}</div> : null}
+    </div>
+  );
+
+  if (variant === "bare") {
+    return content;
+  }
+
+  return <Card>{content}</Card>;
+}


### PR DESCRIPTION
## Summary

- Implements the canonical `<EmptyState>` component at `src/components/ui/empty-state.tsx` per design bible §13 (props: `icon: LucideIcon`, `title: string`, `description?: string`, `action?: ReactNode`, `variant?: "card" | "bare"`).
- Migrates all inline empty states to use the new component.
- Fills in the pre-seeded `UIStatesSection` in the design system page.

## Plan reference

Plan: `/Users/froeht/.claude/plans/pure-hatching-swing.md` §"Wave 2 detail → 2a" (lines 154–171)
Beads issue: **PP-yxw.5**

## Migrated call sites

| File | Notes |
|---|---|
| `src/app/(app)/dashboard/page.tsx` | 4 variants: Newest Games, Recently Fixed, Assigned Issues, Recently Reported |
| `src/components/issues/IssueList.tsx` | ~lines 592–618; two conditional title/description paths (filters active vs. empty) |
| `src/app/(app)/m/page.tsx` | Two variants: filter no-match (`SearchX` icon) and no-machines-yet (`Plus` icon with optional CTA for admin/technician) |
| `src/components/machines/MachineEmptyState.tsx` | Rewritten as thin wrapper that pre-configures icon/copy for the "game operational" case; `variant="bare"` since it renders inside a bordered details element |
| `src/app/(dev)/dev/design-system/page.tsx` | `UIStatesSection` filled in with `variant="card"` and `variant="bare"` showcase rows |

## `report/success/page.tsx` decision — stays bespoke

`src/app/(app)/report/success/page.tsx` is a full-page post-submission confirmation screen, not an embedded list empty state. It uses a large branded `CheckCircle` icon (size-16, primary color), a 3xl bold heading, and a conditional "Join PinPoint" upsell card — none of which map to the generic `<EmptyState>` slot. Forcing it into the component would require adding one-off props (icon color, heading size) that would bloat the API and leak page-specific concerns into the shared component. Decision: **stays bespoke**.

## Verification

- `pnpm run check` — all 97 test files / 851 tests passed; lint, types, format clean.
- Playwright `e2e/smoke/responsive-overflow.spec.ts --project=chromium` — 13/13 passed at both 375px and 1024px viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)