### PR TITLE
fix(ui): ghost button variant uses surface tokens natively (PP-zsa)

### DIFF
--- a/src/app/(app)/report/success/page.tsx
+++ b/src/app/(app)/report/success/page.tsx
@@ -89,7 +89,7 @@ export default async function ReportSuccessPage({
             <Button
               asChild
               variant="ghost"
-              className="text-on-surface hover:text-on-surface-variant"
+              className="hover:text-muted-foreground"
             >
               <Link href="/">Return to Dashboard</Link>
             </Button>

--- a/src/components/machines/WatchMachineButton.tsx
+++ b/src/components/machines/WatchMachineButton.tsx
@@ -90,7 +90,7 @@ export function WatchMachineButton({
             size="sm"
             disabled={isPending}
             onClick={handleToggleWatch}
-            className="text-on-surface-variant hover:bg-surface-variant"
+            className="text-muted-foreground"
           >
             {icon}
             Watch
@@ -106,12 +106,7 @@ export function WatchMachineButton({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          disabled={isPending}
-          className="text-on-surface hover:bg-surface-variant"
-        >
+        <Button variant="ghost" size="sm" disabled={isPending}>
           {icon}
           Watching
         </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "text-foreground hover:bg-muted hover:text-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
## Summary

- Updated `ghost` variant in `src/components/ui/button.tsx` to include `text-foreground hover:bg-muted` base classes, aligning it with the bible §18 surface-on-surface canonical token pattern
- Removed redundant `className` overrides at 3 sites where the variant now provides the correct defaults:
  - `src/components/machines/WatchMachineButton.tsx` — "Watching" state: dropped `text-on-surface hover:bg-surface-variant` entirely (now covered by variant); "Watch" state: dropped `hover:bg-surface-variant`, migrated `text-on-surface-variant` → `text-muted-foreground` (intentionally muted text preserved)
  - `src/app/(app)/report/success/page.tsx` — dropped `text-on-surface` (now variant default), migrated `hover:text-on-surface-variant` → `hover:text-muted-foreground`

## Token mapping (bible §18)

| Removed (MD-era) | Replaced by |
|---|---|
| `text-on-surface` | `text-foreground` (now ghost variant default) |
| `text-on-surface-variant` | `text-muted-foreground` |
| `hover:bg-surface-variant` | `hover:bg-muted` (now ghost variant default) |

`muted` and `accent` share the same CSS value (`#27272a`) on PinPoint's theme, so pixel output is unchanged. The change is semantic correctness, not visual change.

## Verification

- `pnpm run check` — 869 tests pass, types and lint clean
- `pnpm exec playwright test e2e/smoke/responsive-overflow.spec.ts --project=chromium` — 13 tests pass

Closes PP-zsa

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>