### PR TITLE
refactor(ui): extract MachineStatusBadge + MachinePresenceBadge (PP-4c3)

### DIFF
--- a/src/app/(app)/m/[initials]/page.tsx
+++ b/src/app/(app)/m/[initials]/page.tsx
@@ -1,27 +1,19 @@
 import type React from "react";
 import { notFound } from "next/navigation";
 import { getUnifiedUsers } from "~/lib/users/queries";
-import { cn } from "~/lib/utils";
 import Link from "next/link";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
 import { machines, issues, userProfiles } from "~/server/db/schema";
 import { eq, notInArray, sql } from "drizzle-orm";
-import {
-  deriveMachineStatus,
-  getMachineStatusLabel,
-  getMachineStatusStyles,
-} from "~/lib/machines/status";
-import {
-  getMachinePresenceLabel,
-  getMachinePresenceStyles,
-  isOnTheFloor,
-} from "~/lib/machines/presence";
+import { deriveMachineStatus } from "~/lib/machines/status";
+import { getMachinePresenceLabel, isOnTheFloor } from "~/lib/machines/presence";
 import { CLOSED_STATUSES } from "~/lib/issues/status";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
-import { Badge } from "~/components/ui/badge";
 import { Calendar, Plus } from "lucide-react";
+import { MachineStatusBadge } from "~/components/machines/MachineStatusBadge";
+import { MachinePresenceBadge } from "~/components/machines/MachinePresenceBadge";
 import { PageContainer } from "~/components/layout/PageContainer";
 import { formatDate } from "~/lib/dates";
 import { PageHeader } from "~/components/layout/PageHeader";
@@ -213,14 +205,7 @@ export default async function MachineDetailPage({
   const watchMode = currentUserWatch?.watchMode ?? "notify";
 
   const presenceBadge = !isOnTheFloor(machine.presenceStatus) ? (
-    <Badge
-      className={cn(
-        getMachinePresenceStyles(machine.presenceStatus),
-        "border px-3 py-1 text-sm font-semibold"
-      )}
-    >
-      {getMachinePresenceLabel(machine.presenceStatus)}
-    </Badge>
+    <MachinePresenceBadge status={machine.presenceStatus} size="md" />
   ) : null;
 
   const watchButton = canWatch ? (
@@ -305,14 +290,7 @@ export default async function MachineDetailPage({
                       <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-on-surface-variant">
                         Status
                       </p>
-                      <Badge
-                        className={cn(
-                          getMachineStatusStyles(machineStatus),
-                          "border px-2 py-0.5 text-[10px] font-bold"
-                        )}
-                      >
-                        {getMachineStatusLabel(machineStatus)}
-                      </Badge>
+                      <MachineStatusBadge status={machineStatus} size="xs" />
                     </div>
 
                     <div data-testid="detail-open-issues">

--- a/src/app/(app)/m/page.tsx
+++ b/src/app/(app)/m/page.tsx
@@ -7,22 +7,17 @@ import { getUnifiedUsers } from "~/lib/users/queries";
 import { desc, eq } from "drizzle-orm";
 import {
   deriveMachineStatus,
-  getMachineStatusLabel,
-  getMachineStatusStyles,
   type IssueForStatus,
 } from "~/lib/machines/status";
-import {
-  getMachinePresenceLabel,
-  getMachinePresenceStyles,
-  isOnTheFloor,
-} from "~/lib/machines/presence";
+import { isOnTheFloor } from "~/lib/machines/presence";
 import { CLOSED_STATUSES } from "~/lib/issues/status";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
-import { Badge } from "~/components/ui/badge";
 import { Plus, SearchX } from "lucide-react";
 import { EmptyState } from "~/components/ui/empty-state";
 import { cn } from "~/lib/utils";
+import { MachineStatusBadge } from "~/components/machines/MachineStatusBadge";
+import { MachinePresenceBadge } from "~/components/machines/MachinePresenceBadge";
 import {
   parseMachineFilters,
   hasActiveMachineFilters,
@@ -232,24 +227,16 @@ export default async function MachinesPage({
                         {machine.name}
                       </CardTitle>
                       <div className="flex flex-col items-end gap-1.5">
-                        <Badge
+                        <MachineStatusBadge
                           data-testid="machine-status-badge"
-                          className={cn(
-                            getMachineStatusStyles(machine.status),
-                            "border px-2.5 py-0.5 text-xs font-semibold rounded-full"
-                          )}
-                        >
-                          {getMachineStatusLabel(machine.status)}
-                        </Badge>
+                          status={machine.status}
+                          size="sm"
+                        />
                         {!isOnTheFloor(machine.presenceStatus) && (
-                          <Badge
-                            className={cn(
-                              getMachinePresenceStyles(machine.presenceStatus),
-                              "border px-2.5 py-0.5 text-xs font-semibold rounded-full"
-                            )}
-                          >
-                            {getMachinePresenceLabel(machine.presenceStatus)}
-                          </Badge>
+                          <MachinePresenceBadge
+                            status={machine.presenceStatus}
+                            size="sm"
+                          />
                         )}
                       </div>
                     </div>

--- a/src/components/machines/MachinePresenceBadge.tsx
+++ b/src/components/machines/MachinePresenceBadge.tsx
@@ -1,0 +1,59 @@
+import type React from "react";
+import { Badge } from "~/components/ui/badge";
+import {
+  getMachinePresenceStyles,
+  getMachinePresenceLabel,
+  type MachinePresenceStatus,
+} from "~/lib/machines/presence";
+import { cn } from "~/lib/utils";
+
+interface MachinePresenceBadgeProps {
+  status: MachinePresenceStatus;
+  /**
+   * xs — info-grid / very dense contexts (px-2 py-0.5 text-[10px])
+   * sm — card listings and dense rows (px-2.5 py-0.5 text-xs)
+   * md — page headers and prominent placements (px-3 py-1 text-sm)
+   */
+  size?: "xs" | "sm" | "md";
+  className?: string;
+  "data-testid"?: string;
+}
+
+const sizeClasses: Record<"xs" | "sm" | "md", string> = {
+  xs: "px-2 py-0.5 text-[10px] font-bold",
+  sm: "px-2.5 py-0.5 text-xs font-semibold",
+  md: "px-3 py-1 text-sm font-semibold",
+};
+
+/**
+ * MachinePresenceBadge — physical location / presence status for a machine.
+ *
+ * Encapsulates the `getMachinePresenceStyles` helper + canonical badge padding
+ * so call sites only pass `status` (and optionally `size`).
+ *
+ * Only render this when `!isOnTheFloor(status)` — "on the floor" is the
+ * default state and typically not badged.
+ *
+ * Design bible §18: badge tokens come from the MD colour system defined in
+ * globals.css (`bg-tertiary-container`, `bg-secondary-container`, etc.).
+ */
+export function MachinePresenceBadge({
+  status,
+  size = "md",
+  className,
+  "data-testid": testId,
+}: MachinePresenceBadgeProps): React.JSX.Element {
+  return (
+    <Badge
+      data-testid={testId}
+      className={cn(
+        getMachinePresenceStyles(status),
+        "border",
+        sizeClasses[size],
+        className
+      )}
+    >
+      {getMachinePresenceLabel(status)}
+    </Badge>
+  );
+}

--- a/src/components/machines/MachineStatusBadge.tsx
+++ b/src/components/machines/MachineStatusBadge.tsx
@@ -1,0 +1,57 @@
+import type React from "react";
+import { Badge } from "~/components/ui/badge";
+import {
+  getMachineStatusStyles,
+  getMachineStatusLabel,
+  type MachineStatus,
+} from "~/lib/machines/status";
+import { cn } from "~/lib/utils";
+
+interface MachineStatusBadgeProps {
+  status: MachineStatus;
+  /**
+   * xs — info-grid / very dense contexts (px-2 py-0.5 text-[10px])
+   * sm — card listings and dense rows (px-2.5 py-0.5 text-xs)
+   * md — page headers and prominent placements (px-3 py-1 text-sm)
+   */
+  size?: "xs" | "sm" | "md";
+  className?: string;
+  /** Override the label. Defaults to the canonical status label. */
+  "data-testid"?: string;
+}
+
+const sizeClasses: Record<"xs" | "sm" | "md", string> = {
+  xs: "px-2 py-0.5 text-[10px] font-bold",
+  sm: "px-2.5 py-0.5 text-xs font-semibold",
+  md: "px-3 py-1 text-sm font-semibold",
+};
+
+/**
+ * MachineStatusBadge — derived health status for a machine.
+ *
+ * Encapsulates the `getMachineStatusStyles` helper + canonical badge padding
+ * so call sites only pass `status` (and optionally `size`).
+ *
+ * Design bible §18: badge tokens come from the MD colour system defined in
+ * globals.css (`bg-success-container`, `bg-warning-container`, etc.).
+ */
+export function MachineStatusBadge({
+  status,
+  size = "md",
+  className,
+  "data-testid": testId,
+}: MachineStatusBadgeProps): React.JSX.Element {
+  return (
+    <Badge
+      data-testid={testId}
+      className={cn(
+        getMachineStatusStyles(status),
+        "border",
+        sizeClasses[size],
+        className
+      )}
+    >
+      {getMachineStatusLabel(status)}
+    </Badge>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts `MachineStatusBadge` and `MachinePresenceBadge` as pure presentational components in `src/components/machines/`
- Both components wrap the existing `<Badge>` primitive and encapsulate the `getMachineStatusStyles` / `getMachinePresenceStyles` helpers plus canonical border + padding
- Adds a `size` prop with three values: `"xs"` (info grid), `"sm"` (card listings), `"md"` (page headers/default)

## Call sites migrated

| File | Usage | Size |
|------|-------|------|
| `src/app/(app)/m/page.tsx` | Status badge on each machine card | `sm` |
| `src/app/(app)/m/page.tsx` | Presence badge on each machine card | `sm` |
| `src/app/(app)/m/[initials]/page.tsx` | Presence badge in `PageHeader` `titleAdornment` | `md` |
| `src/app/(app)/m/[initials]/page.tsx` | Status badge in Machine Information card info grid | `xs` |

Call sites no longer import `Badge`, `cn`, `getMachineStatusStyles`, `getMachinePresenceStyles`, `getMachineStatusLabel`, or `getMachinePresenceLabel` for badge rendering. The detail page still imports `getMachinePresenceLabel` for the non-badge prose banner ("This machine is currently off the floor.").

## Design bible reference

Design bible §18 (Token Canonical Form): badge colour tokens come from the MD colour system defined in `globals.css` (`bg-success-container`, `bg-warning-container`, etc.). These are preserved as-is — the status/presence colour system is intentional and separate from the deprecated `text-on-surface*` tokens being swept in Wave 3b.

## Verification

- `pnpm run check` — 869 unit tests pass, types clean, lint clean
- Playwright `e2e/smoke/responsive-overflow.spec.ts` — 13/13 pass (covers `/m` list and `/m/TAF` detail)

Closes PP-4c3

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>