### PR TITLE
refactor(machines): share BadgeSize map + drop stray JSDoc

### DIFF
--- a/src/components/machines/MachinePresenceBadge.tsx
+++ b/src/components/machines/MachinePresenceBadge.tsx
@@ -6,24 +6,14 @@ import {
   type MachinePresenceStatus,
 } from "~/lib/machines/presence";
 import { cn } from "~/lib/utils";
+import { badgeSizeClasses, type BadgeSize } from "./badge-size";
 
 interface MachinePresenceBadgeProps {
   status: MachinePresenceStatus;
-  /**
-   * xs — info-grid / very dense contexts (px-2 py-0.5 text-[10px])
-   * sm — card listings and dense rows (px-2.5 py-0.5 text-xs)
-   * md — page headers and prominent placements (px-3 py-1 text-sm)
-   */
-  size?: "xs" | "sm" | "md";
+  size?: BadgeSize;
   className?: string;
   "data-testid"?: string;
 }
-
-const sizeClasses: Record<"xs" | "sm" | "md", string> = {
-  xs: "px-2 py-0.5 text-[10px] font-bold",
-  sm: "px-2.5 py-0.5 text-xs font-semibold",
-  md: "px-3 py-1 text-sm font-semibold",
-};
 
 /**
  * MachinePresenceBadge — physical location / presence status for a machine.
@@ -49,7 +39,7 @@ export function MachinePresenceBadge({
       className={cn(
         getMachinePresenceStyles(status),
         "border",
-        sizeClasses[size],
+        badgeSizeClasses[size],
         className
       )}
     >

--- a/src/components/machines/MachineStatusBadge.tsx
+++ b/src/components/machines/MachineStatusBadge.tsx
@@ -6,25 +6,14 @@ import {
   type MachineStatus,
 } from "~/lib/machines/status";
 import { cn } from "~/lib/utils";
+import { badgeSizeClasses, type BadgeSize } from "./badge-size";
 
 interface MachineStatusBadgeProps {
   status: MachineStatus;
-  /**
-   * xs — info-grid / very dense contexts (px-2 py-0.5 text-[10px])
-   * sm — card listings and dense rows (px-2.5 py-0.5 text-xs)
-   * md — page headers and prominent placements (px-3 py-1 text-sm)
-   */
-  size?: "xs" | "sm" | "md";
+  size?: BadgeSize;
   className?: string;
-  /** Override the label. Defaults to the canonical status label. */
   "data-testid"?: string;
 }
-
-const sizeClasses: Record<"xs" | "sm" | "md", string> = {
-  xs: "px-2 py-0.5 text-[10px] font-bold",
-  sm: "px-2.5 py-0.5 text-xs font-semibold",
-  md: "px-3 py-1 text-sm font-semibold",
-};
 
 /**
  * MachineStatusBadge — derived health status for a machine.
@@ -47,7 +36,7 @@ export function MachineStatusBadge({
       className={cn(
         getMachineStatusStyles(status),
         "border",
-        sizeClasses[size],
+        badgeSizeClasses[size],
         className
       )}
     >

--- a/src/components/machines/badge-size.ts
+++ b/src/components/machines/badge-size.ts
@@ -1,0 +1,13 @@
+export type BadgeSize = "xs" | "sm" | "md";
+
+/**
+ * Canonical badge padding/type-size per visual density tier.
+ * - xs: info grids, very dense contexts
+ * - sm: card listings and dense rows
+ * - md: page headers and prominent placements
+ */
+export const badgeSizeClasses: Record<BadgeSize, string> = {
+  xs: "px-2 py-0.5 text-[10px] font-bold",
+  sm: "px-2.5 py-0.5 text-xs font-semibold",
+  md: "px-3 py-1 text-sm font-semibold",
+};


### PR DESCRIPTION
Follow-up to #1196 addressing two Copilot review comments that landed after auto-merge.

## Summary

- Extract `badgeSizeClasses` + `BadgeSize` type into `src/components/machines/badge-size.ts` so MachineStatusBadge and MachinePresenceBadge both reference one source of truth (previously duplicated verbatim).
- Remove a stray JSDoc block from MachineStatusBadge that described a `label` override prop that never existed.

## Test plan

- [x] `pnpm run check` — 869/869 pass locally
- [ ] CI green
- [ ] Visual spot-check unchanged (pure refactor, identical class output)