### PR TITLE
chore(ui): conformance drift cleanup — Button overrides, size-4, checkbox, admin badges, MD tokens (PP-fhc)

### DIFF
--- a/src/app/(app)/admin/users/page.tsx
+++ b/src/app/(app)/admin/users/page.tsx
@@ -48,18 +48,12 @@ function UserRow({
       </TableCell>
       <TableCell className="w-[150px]">
         {user.status === "active" ? (
-          <Badge
-            variant="secondary"
-            className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-          >
+          <Badge className="bg-success-container text-on-success-container">
             Active
           </Badge>
         ) : (
           <div className="flex flex-col gap-1">
-            <Badge
-              variant="outline"
-              className="w-fit border-amber-600/30 text-amber-600"
-            >
+            <Badge className="bg-warning-container text-on-warning-container">
               Invited
             </Badge>
             {user.inviteSentAt && (

--- a/src/app/(app)/m/[initials]/edit-button-tooltip.tsx
+++ b/src/app/(app)/m/[initials]/edit-button-tooltip.tsx
@@ -22,7 +22,7 @@ export function EditButtonWithTooltip({
             variant="outline"
             size="sm"
             disabled
-            className="w-full border-outline text-on-surface-variant"
+            className="w-full border-outline text-muted-foreground"
             data-testid="edit-machine-button-disabled"
           >
             <Pencil className="mr-2 size-4" />

--- a/src/app/(app)/m/[initials]/issues-expando.tsx
+++ b/src/app/(app)/m/[initials]/issues-expando.tsx
@@ -33,7 +33,7 @@ export function IssuesExpando({
       data-testid="issues-expando"
     >
       <summary
-        className="flex cursor-pointer list-none items-center gap-2 px-6 py-4 text-on-surface hover:bg-surface-variant/30"
+        className="flex cursor-pointer list-none items-center gap-2 px-6 py-4 text-foreground hover:bg-surface-variant/30"
         data-testid="issues-expando-trigger"
       >
         <ChevronRight
@@ -46,7 +46,7 @@ export function IssuesExpando({
           Open Issues ({issues.length})
         </span>
         {totalIssuesCount > issues.length && (
-          <span className="text-sm text-on-surface-variant">
+          <span className="text-sm text-muted-foreground">
             of {totalIssuesCount} total
           </span>
         )}

--- a/src/app/(app)/m/[initials]/machine-info-display.tsx
+++ b/src/app/(app)/m/[initials]/machine-info-display.tsx
@@ -33,40 +33,40 @@ export function MachineInfoDisplay({
     <div className="space-y-4">
       {/* Machine Name */}
       <div className="space-y-1">
-        <p className="text-[10px] font-bold text-on-surface-variant uppercase tracking-wider">
+        <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
           Name
         </p>
-        <p className="text-sm font-medium text-on-surface">{machine.name}</p>
+        <p className="text-sm font-medium text-foreground">{machine.name}</p>
       </div>
 
       {/* Initials */}
       <div className="space-y-1">
-        <p className="text-[10px] font-bold text-on-surface-variant uppercase tracking-wider">
+        <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
           Initials
         </p>
-        <p className="text-sm font-medium text-on-surface">
+        <p className="text-sm font-medium text-foreground">
           {machine.initials}
         </p>
       </div>
 
       {/* Owner */}
       <div className="space-y-1" data-testid="owner-display">
-        <p className="text-[10px] font-bold text-on-surface-variant uppercase tracking-wider">
+        <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
           Machine Owner
         </p>
         {machine.owner || machine.invitedOwner ? (
           <div className="flex items-center gap-2">
-            <p className="text-sm font-medium text-on-surface">
+            <p className="text-sm font-medium text-foreground">
               {machine.owner?.name ?? machine.invitedOwner?.name}
             </p>
             {machine.invitedOwner && !machine.owner && (
-              <span className="text-[10px] font-medium uppercase tracking-wider text-on-surface-variant/70">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
                 (Invited)
               </span>
             )}
           </div>
         ) : (
-          <p className="text-sm text-on-surface-variant">No owner assigned</p>
+          <p className="text-sm text-muted-foreground">No owner assigned</p>
         )}
       </div>
 

--- a/src/app/(app)/m/[initials]/page.tsx
+++ b/src/app/(app)/m/[initials]/page.tsx
@@ -239,7 +239,7 @@ export default async function MachineDetailPage({
       {/* Content */}
       <div className="space-y-6">
         {!isOnTheFloor(machine.presenceStatus) && (
-          <div className="rounded-md border border-outline-variant bg-surface-container px-4 py-2 text-sm text-on-surface-variant">
+          <div className="rounded-md border border-outline-variant bg-surface-container px-4 py-2 text-sm text-muted-foreground">
             This machine is currently{" "}
             <strong>
               {getMachinePresenceLabel(machine.presenceStatus).toLowerCase()}
@@ -251,7 +251,7 @@ export default async function MachineDetailPage({
         {/* Full-width Details Card */}
         <Card className="border-outline-variant bg-surface">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-7">
-            <CardTitle className="text-xl text-on-surface">
+            <CardTitle className="text-xl text-foreground">
               Machine Information
             </CardTitle>
             <QrCodeDialog
@@ -287,18 +287,18 @@ export default async function MachineDetailPage({
                   {/* Status & Issues Count Row */}
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-on-surface-variant">
+                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                         Status
                       </p>
                       <MachineStatusBadge status={machineStatus} size="xs" />
                     </div>
 
                     <div data-testid="detail-open-issues">
-                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-on-surface-variant">
+                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                         Open Issues
                       </p>
                       <p
-                        className="text-xl font-bold text-on-surface"
+                        className="text-xl font-bold text-foreground"
                         data-testid="detail-open-issues-count"
                       >
                         {openIssues.length}
@@ -309,10 +309,10 @@ export default async function MachineDetailPage({
                   {/* Date & Total Row */}
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-on-surface-variant">
+                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                         Added Date
                       </p>
-                      <div className="flex items-center gap-1.5 text-on-surface-variant">
+                      <div className="flex items-center gap-1.5 text-muted-foreground">
                         <Calendar className="size-3" />
                         <p className="text-xs font-medium">
                           {formatDate(machine.createdAt)}
@@ -321,10 +321,10 @@ export default async function MachineDetailPage({
                     </div>
 
                     <div>
-                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-on-surface-variant">
+                      <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                         Total Issues
                       </p>
-                      <p className="text-xl font-bold text-on-surface">
+                      <p className="text-xl font-bold text-foreground">
                         {totalIssuesCount}
                       </p>
                     </div>

--- a/src/app/(app)/m/[initials]/qr-code-dialog.tsx
+++ b/src/app/(app)/m/[initials]/qr-code-dialog.tsx
@@ -67,12 +67,12 @@ export function QrCodeDialog({
             <div className="flex gap-2">
               <div className="relative flex-1">
                 <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none">
-                  <Printer className="size-4 text-on-surface-variant/50" />
+                  <Printer className="size-4 text-muted-foreground/50" />
                 </div>
                 <CopyButton
                   value={reportUrl}
                   variant="outline"
-                  className="w-full justify-start pl-10 pr-2 font-mono text-xs text-on-surface-variant hover:text-on-surface border-dashed"
+                  className="w-full justify-start pl-10 pr-2 font-mono text-xs text-muted-foreground hover:text-foreground border-dashed"
                 />
               </div>
               <Button
@@ -89,7 +89,7 @@ export function QrCodeDialog({
               </Button>
             </div>
 
-            <p className="text-[10px] text-center text-on-surface-variant/70 pt-2">
+            <p className="text-[10px] text-center text-muted-foreground/70 pt-2">
               Optimized for standard 2&quot;x2&quot; or larger label printers.
             </p>
           </div>

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -143,7 +143,7 @@ export function EditMachineDialog({
           <Button
             variant="outline"
             size="sm"
-            className="w-full border-outline text-on-surface hover:bg-surface-variant"
+            className="w-full border-outline text-foreground hover:bg-surface-variant"
             data-testid="edit-machine-button"
           >
             <Pencil className="mr-2 size-4" />
@@ -180,23 +180,23 @@ export function EditMachineDialog({
 
             {/* Machine Initials (Read Only) */}
             <div className="space-y-2">
-              <Label htmlFor="edit-initials" className="text-on-surface">
+              <Label htmlFor="edit-initials" className="text-foreground">
                 Initials
               </Label>
               <Input
                 id="edit-initials"
                 value={machine.initials}
                 disabled
-                className="border-outline bg-surface-variant text-on-surface-variant"
+                className="border-outline bg-surface-variant text-muted-foreground"
               />
-              <p className="text-xs text-on-surface-variant">
+              <p className="text-xs text-muted-foreground">
                 Machine initials cannot be changed
               </p>
             </div>
 
             {/* Machine Name */}
             <div className="space-y-2">
-              <Label htmlFor="edit-name" className="text-on-surface">
+              <Label htmlFor="edit-name" className="text-foreground">
                 Machine Name *
               </Label>
               <Input
@@ -206,16 +206,16 @@ export function EditMachineDialog({
                 required
                 defaultValue={machine.name}
                 placeholder="e.g., Medieval Madness"
-                className="border-outline bg-surface text-on-surface placeholder:text-on-surface-variant"
+                className="border-outline bg-surface text-foreground placeholder:text-muted-foreground"
               />
-              <p className="text-xs text-on-surface-variant">
+              <p className="text-xs text-muted-foreground">
                 Enter the full name of the pinball machine
               </p>
             </div>
 
             {/* Availability */}
             <div className="space-y-2">
-              <Label htmlFor="edit-presence" className="text-on-surface">
+              <Label htmlFor="edit-presence" className="text-foreground">
                 Availability
               </Label>
               <Select
@@ -224,7 +224,7 @@ export function EditMachineDialog({
               >
                 <SelectTrigger
                   id="edit-presence"
-                  className="border-outline bg-surface text-on-surface"
+                  className="border-outline bg-surface text-foreground"
                 >
                   <SelectValue />
                 </SelectTrigger>
@@ -236,7 +236,7 @@ export function EditMachineDialog({
                   ))}
                 </SelectContent>
               </Select>
-              <p className="text-xs text-on-surface-variant">
+              <p className="text-xs text-muted-foreground">
                 Whether this machine is currently available on the floor
               </p>
             </div>
@@ -250,28 +250,28 @@ export function EditMachineDialog({
               />
             ) : (
               <div className="space-y-2" data-testid="owner-display">
-                <span className="text-sm font-semibold text-on-surface">
+                <span className="text-sm font-semibold text-foreground">
                   Machine Owner
                 </span>
                 <div className="rounded-md border border-outline bg-surface px-3 py-2">
                   {machine.owner || machine.invitedOwner ? (
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-on-surface">
+                      <span className="text-sm text-foreground">
                         {machine.owner?.name ?? machine.invitedOwner?.name}
                       </span>
                       {machine.invitedOwner && !machine.owner && (
-                        <span className="text-[10px] font-medium uppercase tracking-wider text-on-surface-variant/70">
+                        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
                           (Invited)
                         </span>
                       )}
                     </div>
                   ) : (
-                    <span className="text-sm text-on-surface-variant">
+                    <span className="text-sm text-muted-foreground">
                       No owner assigned
                     </span>
                   )}
                 </div>
-                <p className="text-xs text-on-surface-variant">
+                <p className="text-xs text-muted-foreground">
                   The owner receives notifications for new issues on this
                   machine.
                 </p>

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -51,7 +51,7 @@ export function CreateMachineForm({
       <form action={formAction} className="space-y-6">
         {/* Machine Name */}
         <div className="space-y-2">
-          <Label htmlFor="name" className="text-on-surface">
+          <Label htmlFor="name" className="text-foreground">
             Machine Name *
           </Label>
           <Input
@@ -60,17 +60,17 @@ export function CreateMachineForm({
             type="text"
             required
             placeholder="e.g., Medieval Madness"
-            className="border-outline bg-surface text-on-surface placeholder:text-on-surface-variant"
+            className="border-outline bg-surface text-foreground placeholder:text-muted-foreground"
             autoFocus
           />
-          <p className="text-xs text-on-surface-variant">
+          <p className="text-xs text-muted-foreground">
             Enter the full name of the pinball machine
           </p>
         </div>
 
         {/* Machine Initials */}
         <div className="space-y-2">
-          <Label htmlFor="initials" className="text-on-surface">
+          <Label htmlFor="initials" className="text-foreground">
             Initials *
           </Label>
           <Input
@@ -81,14 +81,14 @@ export function CreateMachineForm({
             minLength={2}
             maxLength={6}
             placeholder="e.g., MM"
-            className="border-outline bg-surface text-on-surface placeholder:text-on-surface-variant uppercase"
+            className="border-outline bg-surface text-foreground placeholder:text-muted-foreground uppercase"
             onChange={(e) => {
               e.target.value = e.target.value
                 .toUpperCase()
                 .replace(/[^A-Z0-9]/g, "");
             }}
           />
-          <p className="text-xs text-on-surface-variant">
+          <p className="text-xs text-muted-foreground">
             2-6 characters. Permanent unique identifier.
           </p>
         </div>
@@ -111,7 +111,7 @@ export function CreateMachineForm({
             <Button
               type="button"
               variant="outline"
-              className="w-full border-outline text-on-surface hover:bg-surface-variant"
+              className="w-full border-outline text-foreground hover:bg-surface-variant"
             >
               Cancel
             </Button>

--- a/src/app/(app)/m/new/page.tsx
+++ b/src/app/(app)/m/new/page.tsx
@@ -61,7 +61,7 @@ export default async function NewMachinePage(): Promise<React.JSX.Element> {
       {/* Form */}
       <Card className="max-w-2xl border-outline-variant">
         <CardHeader>
-          <CardTitle className="text-2xl text-on-surface">
+          <CardTitle className="text-2xl text-foreground">
             Machine Details
           </CardTitle>
         </CardHeader>

--- a/src/app/(app)/m/page.tsx
+++ b/src/app/(app)/m/page.tsx
@@ -223,7 +223,7 @@ export default async function MachinesPage({
                 <Card className="h-full border-outline-variant hover:border-primary transition-all cursor-pointer hover:shadow-md bg-surface-container-low group">
                   <CardHeader className="pb-3">
                     <div className="flex items-start justify-between gap-2">
-                      <CardTitle className="text-xl text-on-surface group-hover:text-primary transition-colors">
+                      <CardTitle className="text-xl text-foreground group-hover:text-primary transition-colors">
                         {machine.name}
                       </CardTitle>
                       <div className="flex flex-col items-end gap-1.5">
@@ -246,7 +246,7 @@ export default async function MachinesPage({
                       {/* Issue count */}
                       <div className="flex items-center gap-2 text-sm">
                         <span
-                          className="text-on-surface-variant"
+                          className="text-muted-foreground"
                           data-testid="machine-open-issues-label"
                         >
                           Open Issues:
@@ -258,7 +258,7 @@ export default async function MachinesPage({
                               ? "text-error"
                               : machine.status === "needs_service"
                                 ? "text-warning"
-                                : "text-on-surface-variant"
+                                : "text-muted-foreground"
                           )}
                           data-testid={`machine-open-issues-count-${machine.id}`}
                         >
@@ -269,10 +269,10 @@ export default async function MachinesPage({
                       <div className="h-px bg-outline-variant w-full" />
 
                       {/* Created date */}
-                      <div className="text-xs text-on-surface-variant flex items-center justify-between">
+                      <div className="text-xs text-muted-foreground flex items-center justify-between">
                         <span>
                           initials:{" "}
-                          <span className="font-mono text-on-surface">
+                          <span className="font-mono text-foreground">
                             {machine.initials}
                           </span>
                         </span>

--- a/src/app/(app)/report/success/page.tsx
+++ b/src/app/(app)/report/success/page.tsx
@@ -44,16 +44,16 @@ export default async function ReportSuccessPage({
             className="mx-auto size-16 text-primary"
             strokeWidth={2.5}
           />
-          <CardTitle className="text-3xl font-bold text-on-surface">
+          <CardTitle className="text-3xl font-bold text-foreground">
             Issue Sent!
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="space-y-3">
-            <p className="text-lg text-on-surface">
+            <p className="text-lg text-foreground">
               Thank you for reporting this issue.
             </p>
-            <p className="text-sm text-on-surface-variant leading-relaxed">
+            <p className="text-sm text-muted-foreground leading-relaxed">
               Our maintenance team has been notified. We appreciate your help
               keeping these machines running smoothly for everyone.
             </p>
@@ -64,7 +64,7 @@ export default async function ReportSuccessPage({
               <h4 className="text-sm font-semibold text-primary mb-1">
                 Want to track your reports?
               </h4>
-              <p className="text-xs text-on-surface-variant mb-3">
+              <p className="text-xs text-muted-foreground mb-3">
                 We&apos;ve saved your details. Create a full account to see
                 status updates and manage all your reports in one place.
               </p>
@@ -82,7 +82,7 @@ export default async function ReportSuccessPage({
             <Button
               asChild
               variant="outline"
-              className="border-outline-variant text-on-surface"
+              className="border-outline-variant text-foreground"
             >
               <Link href="/report">Report Another Issue</Link>
             </Button>

--- a/src/app/(app)/report/unified-report-form.tsx
+++ b/src/app/(app)/report/unified-report-form.tsx
@@ -265,7 +265,7 @@ export function UnifiedReportForm({
 
   return (
     <div className="w-full">
-      <p className="text-sm text-on-surface-variant mb-6">
+      <p className="text-sm text-muted-foreground mb-6">
         Tell us what&apos;s going on and the maintenance crew will take it from
         here.
       </p>
@@ -288,7 +288,7 @@ export function UnifiedReportForm({
               autoComplete="off"
             />
             <div className="space-y-1.5">
-              <Label htmlFor="machineId" className="text-on-surface">
+              <Label htmlFor="machineId" className="text-foreground">
                 Machine *
               </Label>
               <select
@@ -313,7 +313,7 @@ export function UnifiedReportForm({
                     );
                   }
                 }}
-                className="w-full rounded-md border border-outline-variant bg-surface px-3 h-9 text-sm text-on-surface focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                className="w-full rounded-md border border-outline-variant bg-surface px-3 h-9 text-sm text-foreground focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
               >
                 <option value="" disabled>
                   Select a machine...
@@ -341,7 +341,7 @@ export function UnifiedReportForm({
 
             <div className="space-y-1.5">
               <div className="flex items-center justify-between">
-                <Label htmlFor="title" className="text-on-surface">
+                <Label htmlFor="title" className="text-foreground">
                   Issue Title *
                 </Label>
                 <span
@@ -362,12 +362,12 @@ export function UnifiedReportForm({
                 placeholder="e.g., Left flipper not responding"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="h-9 border-outline-variant bg-surface text-on-surface focus:border-primary"
+                className="h-9 border-outline-variant bg-surface text-foreground focus:border-primary"
               />
             </div>
 
             <div className="space-y-1.5">
-              <Label className="text-on-surface">Description</Label>
+              <Label className="text-foreground">Description</Label>
               <RichTextEditor
                 content={description}
                 onChange={setDescription}
@@ -386,7 +386,7 @@ export function UnifiedReportForm({
             {/* Severity + Frequency: always side-by-side */}
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
-                <Label htmlFor="severity" className="text-on-surface">
+                <Label htmlFor="severity" className="text-foreground">
                   Severity *
                 </Label>
                 <input type="hidden" name="severity" value={severity} />
@@ -394,7 +394,7 @@ export function UnifiedReportForm({
               </div>
 
               <div className="space-y-1.5">
-                <Label htmlFor="frequency" className="text-on-surface">
+                <Label htmlFor="frequency" className="text-foreground">
                   Frequency *
                 </Label>
                 <input type="hidden" name="frequency" value={frequency} />
@@ -410,7 +410,7 @@ export function UnifiedReportForm({
             {canSetWorkflowFields && (
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
-                  <Label htmlFor="priority" className="text-on-surface">
+                  <Label htmlFor="priority" className="text-foreground">
                     Priority *
                   </Label>
                   <input type="hidden" name="priority" value={priority} />
@@ -420,7 +420,7 @@ export function UnifiedReportForm({
                   />
                 </div>
                 <div className="space-y-1.5">
-                  <Label htmlFor="status" className="text-on-surface">
+                  <Label htmlFor="status" className="text-foreground">
                     Status *
                   </Label>
                   <input type="hidden" name="status" value={status} />
@@ -432,7 +432,7 @@ export function UnifiedReportForm({
             {/* Assign To: full-width */}
             {canSetWorkflowFields && assignees.length > 0 && (
               <div className="space-y-1.5">
-                <Label htmlFor="assignedTo" className="text-on-surface">
+                <Label htmlFor="assignedTo" className="text-foreground">
                   Assign To
                 </Label>
                 <select
@@ -441,7 +441,7 @@ export function UnifiedReportForm({
                   data-testid="assigned-to-select"
                   value={assignedTo}
                   onChange={(e) => setAssignedTo(e.target.value)}
-                  className="w-full rounded-md border border-outline-variant bg-surface px-3 h-9 text-sm text-on-surface focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  className="w-full rounded-md border border-outline-variant bg-surface px-3 h-9 text-sm text-foreground focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
                 >
                   <option value="">Unassigned</option>
                   {assignees.map((assignee) => (
@@ -491,7 +491,7 @@ export function UnifiedReportForm({
             {!userAuthenticated && (
               <div className="space-y-2 pt-2">
                 <div className="space-y-1">
-                  <h3 className="text-sm font-semibold text-on-surface">
+                  <h3 className="text-sm font-semibold text-foreground">
                     Your Information (Optional)
                   </h3>
                 </div>
@@ -500,46 +500,46 @@ export function UnifiedReportForm({
                     <div className="space-y-1.5">
                       <Label
                         htmlFor="firstName"
-                        className="text-xs text-on-surface"
+                        className="text-xs text-foreground"
                       >
                         First Name
                       </Label>
                       <Input
                         id="firstName"
                         name="firstName"
-                        className="h-8 border-outline-variant bg-surface text-sm text-on-surface"
+                        className="h-8 border-outline-variant bg-surface text-sm text-foreground"
                       />
                     </div>
                     <div className="space-y-1.5">
                       <Label
                         htmlFor="lastName"
-                        className="text-xs text-on-surface"
+                        className="text-xs text-foreground"
                       >
                         Last Name
                       </Label>
                       <Input
                         id="lastName"
                         name="lastName"
-                        className="h-8 border-outline-variant bg-surface text-sm text-on-surface"
+                        className="h-8 border-outline-variant bg-surface text-sm text-foreground"
                       />
                     </div>
                   </div>
                   <div className="space-y-1.5">
-                    <Label htmlFor="email" className="text-xs text-on-surface">
+                    <Label htmlFor="email" className="text-xs text-foreground">
                       Email Address
                     </Label>
                     <Input
                       id="email"
                       name="email"
                       type="email"
-                      className="h-8 border-outline-variant bg-surface text-sm text-on-surface"
+                      className="h-8 border-outline-variant bg-surface text-sm text-foreground"
                     />
-                    <p className="text-[10px] text-on-surface-variant leading-none">
+                    <p className="text-[10px] text-muted-foreground leading-none">
                       Verified emails link to your profile.
                     </p>
                   </div>
                 </div>
-                <p className="text-sm text-on-surface-variant pb-1">
+                <p className="text-sm text-muted-foreground pb-1">
                   Already have an account?{" "}
                   <Link
                     href={getLoginUrl(
@@ -566,11 +566,11 @@ export function UnifiedReportForm({
                 <div className="space-y-0.5">
                   <Label
                     htmlFor="watchIssue"
-                    className="text-sm font-medium text-on-surface cursor-pointer"
+                    className="text-sm font-medium text-foreground cursor-pointer"
                   >
                     Watch this issue
                   </Label>
-                  <p className="text-xs text-on-surface-variant">
+                  <p className="text-xs text-muted-foreground">
                     Get updates when status or comments change.
                   </p>
                 </div>

--- a/src/app/(auth)/auth/callback-loading/CallbackLoadingClient.tsx
+++ b/src/app/(auth)/auth/callback-loading/CallbackLoadingClient.tsx
@@ -49,9 +49,9 @@ export function CallbackLoadingClient({
   return (
     <main className="flex min-h-screen items-center justify-center bg-surface px-4">
       <div className="rounded-lg border border-outline-variant bg-surface shadow-md">
-        <div className="px-6 py-4 text-center text-on-surface">
+        <div className="px-6 py-4 text-center text-foreground">
           <p className="text-sm font-medium">Finalizing sign-in…</p>
-          <p className="text-xs text-on-surface-variant">
+          <p className="text-xs text-muted-foreground">
             One moment while we finish securing your session.
           </p>
         </div>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -25,10 +25,10 @@ export default async function ForgotPasswordPage(): Promise<React.JSX.Element> {
   return (
     <Card className="border-outline-variant bg-surface shadow-xl">
       <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl font-bold text-on-surface">
+        <CardTitle className="text-2xl font-bold text-foreground">
           Reset Password
         </CardTitle>
-        <p className="text-sm text-on-surface-variant">
+        <p className="text-sm text-muted-foreground">
           Enter your email address and we'll send you a link to reset your
           password
         </p>
@@ -39,7 +39,7 @@ export default async function ForgotPasswordPage(): Promise<React.JSX.Element> {
         <ForgotPasswordForm />
 
         {/* Back to login link */}
-        <div className="text-center text-sm text-on-surface-variant">
+        <div className="text-center text-sm text-muted-foreground">
           Remember your password?{" "}
           <Link
             href="/login"

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -8,6 +8,7 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { PasswordInput } from "~/components/ui/password-input";
 import { Label } from "~/components/ui/label";
+import { Checkbox } from "~/components/ui/checkbox";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { loginAction, type LoginResult } from "~/app/(auth)/actions";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
@@ -90,13 +91,7 @@ export function LoginForm({
 
         {/* Remember Me */}
         <div className="flex items-center space-x-2">
-          <input
-            id="rememberMe"
-            name="rememberMe"
-            type="checkbox"
-            className="size-4 rounded border-border text-primary focus:ring-2 focus:ring-ring bg-input"
-            defaultChecked
-          />
+          <Checkbox id="rememberMe" name="rememberMe" defaultChecked />
           <Label
             htmlFor="rememberMe"
             className="text-sm font-normal cursor-pointer"
@@ -114,7 +109,7 @@ export function LoginForm({
         {/* Submit button */}
         <Button
           type="submit"
-          className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+          className="w-full"
           size="lg"
           loading={isPending}
           disabled={isPending || (enforceCaptcha && !turnstileToken)}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -48,10 +48,10 @@ export default async function ResetPasswordPage({
   return (
     <Card className="border-outline-variant bg-surface shadow-xl">
       <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl font-bold text-on-surface">
+        <CardTitle className="text-2xl font-bold text-foreground">
           Set New Password
         </CardTitle>
-        <p className="text-sm text-on-surface-variant">
+        <p className="text-sm text-muted-foreground">
           Enter your new password below
         </p>
       </CardHeader>
@@ -60,7 +60,7 @@ export default async function ResetPasswordPage({
         <ResetPasswordForm />
 
         {/* Back to login link */}
-        <div className="text-center text-sm text-on-surface-variant">
+        <div className="text-center text-sm text-muted-foreground">
           Remember your password?{" "}
           <Link
             href="/login"

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -44,7 +44,7 @@ export function ResetPasswordForm(): React.JSX.Element {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <p className="text-xs text-on-surface-variant">
+        <p className="text-xs text-muted-foreground">
           Must be at least 8 characters
         </p>
         <PasswordStrength password={password} />
@@ -71,12 +71,7 @@ export function ResetPasswordForm(): React.JSX.Element {
       </div>
 
       {/* Submit button */}
-      <Button
-        type="submit"
-        className="w-full bg-primary text-on-primary hover:bg-primary-container hover:text-on-primary-container"
-        size="lg"
-        loading={isPending}
-      >
+      <Button type="submit" className="w-full" size="lg" loading={isPending}>
         Update Password
       </Button>
     </form>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -69,10 +69,10 @@ export default async function SignupPage({
   return (
     <Card className="border-outline-variant bg-surface shadow-xl">
       <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl font-bold text-on-surface">
+        <CardTitle className="text-2xl font-bold text-foreground">
           Create Account
         </CardTitle>
-        <p className="text-sm text-on-surface-variant">
+        <p className="text-sm text-muted-foreground">
           Join PinPoint to report and track issues
         </p>
       </CardHeader>
@@ -82,7 +82,7 @@ export default async function SignupPage({
         <SignupForm initialData={initialData} />
 
         {/* Login link */}
-        <div className="text-center text-sm text-on-surface-variant">
+        <div className="text-center text-sm text-muted-foreground">
           Already have an account?{" "}
           <Link href="/login" className="text-link font-medium">
             Sign in

--- a/src/app/(auth)/signup/signup-form.tsx
+++ b/src/app/(auth)/signup/signup-form.tsx
@@ -60,10 +60,10 @@ export function SignupForm({
           </svg>
         </div>
         <div className="space-y-2">
-          <h3 className="text-xl font-semibold text-on-surface">
+          <h3 className="text-xl font-semibold text-foreground">
             Check your email
           </h3>
-          <p className="text-on-surface-variant text-sm text-balance">
+          <p className="text-muted-foreground text-sm text-balance">
             We sent a confirmation link to your email address. Please click the
             link to verify your account.
           </p>
@@ -145,7 +145,7 @@ export function SignupForm({
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <p className="text-xs text-on-surface-variant">Minimum 8 characters</p>
+        <p className="text-xs text-muted-foreground">Minimum 8 characters</p>
 
         {/* Password strength indicator */}
         <PasswordStrength password={password} />
@@ -179,7 +179,7 @@ export function SignupForm({
         />
         <Label
           htmlFor="termsAccepted"
-          className="text-sm text-on-surface-variant leading-relaxed cursor-pointer"
+          className="text-sm text-muted-foreground leading-relaxed cursor-pointer"
         >
           I agree to the{" "}
           <Link
@@ -201,7 +201,7 @@ export function SignupForm({
 
       <Button
         type="submit"
-        className="w-full bg-primary text-on-primary hover:bg-primary-container hover:text-on-primary-container"
+        className="w-full"
         size="lg"
         loading={isPending}
         disabled={isPending || (enforceCaptcha && !turnstileToken)}

--- a/src/components/inline-editable-field.tsx
+++ b/src/components/inline-editable-field.tsx
@@ -103,7 +103,7 @@ export function InlineEditableField({
 
   return (
     <div data-testid={testId} className="space-y-1.5">
-      <p className="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant">
+      <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
         {label}
       </p>
 
@@ -173,7 +173,7 @@ export function InlineEditableField({
           data-testid={testId ? `${testId}-display` : undefined}
         >
           {isEmpty ? (
-            <p className="py-1 text-sm italic text-on-surface-variant/60">
+            <p className="py-1 text-sm italic text-muted-foreground/60">
               {placeholder ?? `Add ${label.toLowerCase()}...`}
             </p>
           ) : (
@@ -181,7 +181,7 @@ export function InlineEditableField({
           )}
           {canEdit && (
             <Pencil
-              className="absolute right-2 top-1 size-3.5 text-on-surface-variant opacity-0 transition-opacity group-hover:opacity-100"
+              className="absolute right-2 top-1 size-3.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
               aria-hidden="true"
             />
           )}

--- a/src/components/issues/RecentIssuesPanelClient.tsx
+++ b/src/components/issues/RecentIssuesPanelClient.tsx
@@ -51,7 +51,7 @@ export function RecentIssuesPanelClient({
           className
         )}
       >
-        <p className="py-2 text-center text-xs text-on-surface-variant italic">
+        <p className="py-2 text-center text-xs text-muted-foreground italic">
           Select a machine to see recent issues.
         </p>
       </div>
@@ -66,7 +66,7 @@ export function RecentIssuesPanelClient({
       aria-expanded={isOpen}
     >
       <h3
-        className="text-sm font-semibold text-on-surface truncate text-left flex-1"
+        className="text-sm font-semibold text-foreground truncate text-left flex-1"
         title="Recent Issues"
       >
         {isLoading ? "Loading issues..." : "Recent Issues"}
@@ -83,7 +83,7 @@ export function RecentIssuesPanelClient({
         )}
         <ChevronDown
           className={cn(
-            "h-4 w-4 text-on-surface-variant transition-transform duration-200",
+            "h-4 w-4 text-muted-foreground transition-transform duration-200",
             !isOpen && "-rotate-90"
           )}
         />
@@ -124,7 +124,7 @@ export function RecentIssuesPanelClient({
                 ))}
               </div>
             ) : isError ? (
-              <div className="flex items-center gap-2 text-xs text-on-surface-variant italic">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground italic">
                 <AlertCircle className="h-4 w-4" />
                 Could not load recent issues
               </div>
@@ -133,10 +133,10 @@ export function RecentIssuesPanelClient({
                 <div className="flex h-8 w-8 items-center justify-center rounded-full bg-surface-variant/50 mb-1.5">
                   <CheckCircle2 className="h-4 w-4 text-green-600/70 dark:text-green-400/70" />
                 </div>
-                <p className="text-xs font-medium text-on-surface">
+                <p className="text-xs font-medium text-foreground">
                   No recent issues
                 </p>
-                <p className="text-[10px] text-on-surface-variant mt-0.5">
+                <p className="text-[10px] text-muted-foreground mt-0.5">
                   This machine is running smoothly.
                 </p>
               </div>
@@ -152,7 +152,7 @@ export function RecentIssuesPanelClient({
                     )}`}
                   >
                     <div className="flex h-[36px] items-center justify-between gap-2 rounded-md border border-transparent bg-surface hover:border-outline-variant px-2 transition-all active:scale-[0.98]">
-                      <p className="truncate text-xs font-medium text-on-surface group-hover:text-primary transition-colors">
+                      <p className="truncate text-xs font-medium text-foreground group-hover:text-primary transition-colors">
                         {issue.title}
                       </p>
                       <IssueBadge type="status" value={issue.status} />

--- a/src/components/issues/fields/FrequencySelect.tsx
+++ b/src/components/issues/fields/FrequencySelect.tsx
@@ -42,7 +42,7 @@ export function FrequencySelect({
       name={name}
     >
       <SelectTrigger
-        className="w-full border-outline-variant bg-surface text-on-surface"
+        className="w-full border-outline-variant bg-surface text-foreground"
         aria-label={
           value
             ? `Frequency: ${FREQUENCY_CONFIG[value].label}`

--- a/src/components/issues/fields/PrioritySelect.tsx
+++ b/src/components/issues/fields/PrioritySelect.tsx
@@ -38,7 +38,7 @@ export function PrioritySelect({
       name={name}
     >
       <SelectTrigger
-        className="w-full border-outline-variant bg-surface text-on-surface"
+        className="w-full border-outline-variant bg-surface text-foreground"
         aria-label={
           value
             ? `Priority: ${PRIORITY_CONFIG[value].label}`

--- a/src/components/issues/fields/SeveritySelect.tsx
+++ b/src/components/issues/fields/SeveritySelect.tsx
@@ -43,7 +43,7 @@ export function SeveritySelect({
       name={name}
     >
       <SelectTrigger
-        className="w-full border-outline-variant bg-surface text-on-surface"
+        className="w-full border-outline-variant bg-surface text-foreground"
         aria-label={
           value
             ? `Severity: ${SEVERITY_CONFIG[value].label}`

--- a/src/components/issues/fields/StatusSelect.tsx
+++ b/src/components/issues/fields/StatusSelect.tsx
@@ -65,7 +65,7 @@ export function StatusSelect({
       name={name}
     >
       <SelectTrigger
-        className="w-full border-outline-variant bg-surface text-on-surface"
+        className="w-full border-outline-variant bg-surface text-foreground"
         aria-label={`Status: ${STATUS_CONFIG[value].label}`}
         data-testid="issue-status-select"
       >

--- a/src/components/layout/user-menu-client.tsx
+++ b/src/components/layout/user-menu-client.tsx
@@ -71,14 +71,14 @@ export function UserMenu({
       <DropdownMenuContent align="end" className="w-56 bg-surface-variant">
         {/* User Info Header */}
         <div className="flex flex-col px-2 py-1.5 outline-none">
-          <p className="text-sm font-semibold text-on-surface">{userName}</p>
+          <p className="text-sm font-semibold text-foreground">{userName}</p>
         </div>
         <DropdownMenuSeparator className="bg-outline-variant" />
 
         {/* Profile - future implementation */}
         <DropdownMenuItem
           disabled
-          className="cursor-not-allowed opacity-50 text-on-surface-variant"
+          className="cursor-not-allowed opacity-50 text-muted-foreground"
         >
           <User className="mr-2 size-4" />
           <span>Profile</span>

--- a/src/components/machines/MachineFilters.tsx
+++ b/src/components/machines/MachineFilters.tsx
@@ -196,11 +196,11 @@ export function MachineFilters({
               isSearching && "opacity-70"
             )}
           >
-            <Search className="h-4 w-4 text-on-surface-variant shrink-0" />
+            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
             <div className="flex-1 min-w-0 relative flex items-center gap-1.5 overflow-hidden">
               <input
                 placeholder="Search machines by name or initials..."
-                className="flex-1 bg-transparent border-0 text-sm focus:outline-none placeholder:text-on-surface-variant h-full"
+                className="flex-1 bg-transparent border-0 text-sm focus:outline-none placeholder:text-muted-foreground h-full"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
               />

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -94,7 +94,7 @@ export function OwnerSelect({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label htmlFor="ownerId" className="text-on-surface">
+        <Label htmlFor="ownerId" className="text-foreground">
           Machine Owner
         </Label>
         {!disabled && (
@@ -121,7 +121,7 @@ export function OwnerSelect({
       >
         <SelectTrigger
           id="ownerId"
-          className="border-outline bg-surface text-on-surface"
+          className="border-outline bg-surface text-foreground"
           aria-describedby="owner-help"
           data-testid="owner-select"
         >
@@ -133,12 +133,12 @@ export function OwnerSelect({
               <div className="flex items-center gap-2">
                 <span>{user.name}</span>
                 {user.machineCount > 0 && (
-                  <span className="text-[10px] text-on-surface-variant/70">
+                  <span className="text-[10px] text-muted-foreground/70">
                     ({user.machineCount})
                   </span>
                 )}
                 {user.status === "invited" && (
-                  <span className="text-[10px] font-medium uppercase tracking-wider text-on-surface-variant/70">
+                  <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
                     (Invited)
                   </span>
                 )}
@@ -147,7 +147,7 @@ export function OwnerSelect({
           ))}
         </SelectContent>
       </Select>
-      <p id="owner-help" className="text-xs text-on-surface-variant">
+      <p id="owner-help" className="text-xs text-muted-foreground">
         The owner receives notifications for new issues on this machine.
       </p>
 

--- a/src/components/password-strength.tsx
+++ b/src/components/password-strength.tsx
@@ -82,14 +82,14 @@ export function PasswordStrength({
             style={{ width: `${widthPercentage}%` }}
           />
         </div>
-        <span className="text-xs font-medium text-on-surface-variant min-w-16">
+        <span className="text-xs font-medium text-muted-foreground min-w-16">
           {label}
         </span>
       </div>
 
       {/* Feedback */}
       {strength.feedback.length > 0 && (
-        <ul className="text-xs text-on-surface-variant space-y-1">
+        <ul className="text-xs text-muted-foreground space-y-1">
           {strength.feedback.map((message, i) => (
             <li key={i}>• {message}</li>
           ))}

--- a/src/components/save-cancel-buttons.tsx
+++ b/src/components/save-cancel-buttons.tsx
@@ -47,12 +47,12 @@ export function SaveCancelButtons({
       >
         {isPending ? (
           <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            <Loader2 className="mr-2 size-4 animate-spin" />
             Saving...
           </>
         ) : showSaved ? (
           <>
-            <Check className="mr-2 h-4 w-4" />
+            <Check className="mr-2 size-4" />
             Saved!
           </>
         ) : (

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -47,7 +47,7 @@ export function CopyButton({
             size={size}
             variant={variant}
             className={cn(
-              "relative z-10 size-8 text-on-surface-variant hover:bg-surface-variant hover:text-on-surface",
+              "relative z-10 size-8 text-muted-foreground hover:bg-surface-variant hover:text-foreground",
               className
             )}
             onClick={() => {

--- a/src/lib/machines/presence.ts
+++ b/src/lib/machines/presence.ts
@@ -32,11 +32,11 @@ export function getMachinePresenceStyles(
     on_the_floor:
       "bg-success-container text-on-success-container border-success",
     off_the_floor:
-      "bg-surface-container-highest text-on-surface-variant border-outline-variant",
+      "bg-surface-container-highest text-muted-foreground border-outline-variant",
     on_loan: "bg-tertiary-container text-on-tertiary-container border-tertiary",
     pending_arrival:
       "bg-secondary-container text-on-secondary-container border-secondary",
-    removed: "bg-surface-container text-on-surface-variant border-outline",
+    removed: "bg-surface-container text-muted-foreground border-outline",
   };
 
   return styles[status];

--- a/src/lib/machines/status.ts
+++ b/src/lib/machines/status.ts
@@ -56,7 +56,7 @@ export function getMachineStatusStyles(status: MachineStatus): string {
       "bg-success-container text-on-success-container border-success",
     needs_service:
       "bg-warning-container text-on-warning-container border-warning",
-    unplayable: "bg-error-container text-on-error-container border-error",
+    unplayable: "bg-destructive/10 text-destructive border-error",
   };
   return styles[status];
 }

--- a/src/lib/machines/status.ts
+++ b/src/lib/machines/status.ts
@@ -56,7 +56,7 @@ export function getMachineStatusStyles(status: MachineStatus): string {
       "bg-success-container text-on-success-container border-success",
     needs_service:
       "bg-warning-container text-on-warning-container border-warning",
-    unplayable: "bg-destructive/10 text-destructive border-error",
+    unplayable: "bg-destructive/10 text-destructive border-destructive/20",
   };
   return styles[status];
 }

--- a/src/test/unit/lib/machines/status.test.ts
+++ b/src/test/unit/lib/machines/status.test.ts
@@ -77,7 +77,7 @@ describe("getMachineStatusStyles", () => {
     expect(needsServiceStyles).toContain("text-on-warning-container");
 
     const unplayableStyles = getMachineStatusStyles("unplayable");
-    expect(unplayableStyles).toContain("bg-error-container");
-    expect(unplayableStyles).toContain("text-on-error-container");
+    expect(unplayableStyles).toContain("bg-destructive/10");
+    expect(unplayableStyles).toContain("text-destructive");
   });
 });


### PR DESCRIPTION
## Summary

Removed redundant style overrides and upgraded to canonical shadcn tokens across five mechanical tasks:

### Task 1: Button variant cleanup (auth forms)
Removed redundant `bg-primary text-primary-foreground hover:bg-primary/90` classes from submit buttons in:
- `src/app/(auth)/login/login-form.tsx`
- `src/app/(auth)/signup/signup-form.tsx`
- `src/app/(auth)/reset-password/reset-password-form.tsx`

These classes are already provided by the Button component's default variant.

### Task 2: Icon sizing
Replaced `h-4 w-4` with `size-4` in:
- `src/components/save-cancel-buttons.tsx` (lines 50, 55)

### Task 3: Checkbox component upgrade
Replaced raw `<input type=\"checkbox\">` with shadcn `<Checkbox>` component:
- `src/app/(auth)/login/login-form.tsx` (Remember Me checkbox)

Preserved form integration with native form submission and `defaultChecked` behavior.

### Task 4: Admin user badges
Updated status indicators in `src/app/(app)/admin/users/page.tsx` with semantic tokens:
- Active badge: `bg-success-container text-on-success-container`
- Invited badge: `bg-warning-container text-on-warning-container`

### Task 5: Material Design token deprecation
Codebase-wide sweep (31 files) replacing deprecated MD tokens:
- `text-on-surface` → `text-foreground`
- `text-on-surface-variant` → `text-muted-foreground`
- `bg-error-container` → `bg-destructive/10`
- `text-on-error-container` → `text-destructive`

Files touched:
- Auth flows (login, signup, reset-password, forgot-password)
- Machine management (create, edit, display, filters)
- Report submission and success flows
- User admin dashboard
- Component library (buttons, selects, password strength)
- Utility functions and tests

All tests pass. Closes PP-fhc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)