### PR TITLE
feat(machines): owner picker hides guests + promote dialog (PP-6oi)

### DIFF
--- a/e2e/full/invite-signup.spec.ts
+++ b/e2e/full/invite-signup.spec.ts
@@ -167,6 +167,9 @@ test.describe("User Invitation & Signup Flow", () => {
     await page.getByTestId("edit-machine-button").click();
     await expect(page.getByRole("dialog")).toBeVisible();
 
+    // Show invited users in the picker before opening the dropdown
+    await page.getByTestId("owner-show-hidden-checkbox").click();
+
     // Click the owner dropdown and select the invited user (shown with "(Invited)" suffix)
     const ownerSelect = page.getByTestId("owner-select");
     await ownerSelect.click();

--- a/e2e/full/issues-crud-extended.spec.ts
+++ b/e2e/full/issues-crud-extended.spec.ts
@@ -74,9 +74,11 @@ test.describe("Issues System - Extended", () => {
       await expect(page).toHaveURL(/\/m\/[A-Z0-9]{2,6}\/i\/[0-9]+/);
       rememberIssueId(page);
 
-      // On detail page, watch button should show "Watch" (not watching)
+      // On detail page, watch button should show "Watch" (not watching).
+      // The page renders two accessible "Watch Issue" elements (header icon-only +
+      // sidebar text button); use .first() to tolerate this without strict-mode error.
       await expect(
-        page.getByRole("button", { name: /^Watch Issue$/i })
+        page.getByRole("button", { name: /^Watch Issue$/i }).first()
       ).toBeVisible();
     });
   });

--- a/e2e/full/machine-details-extended.spec.ts
+++ b/e2e/full/machine-details-extended.spec.ts
@@ -143,6 +143,9 @@ test.describe("Machine Details - Extended", () => {
   test("should hide owner requirements from unauthenticated users", async ({
     page,
   }, testInfo) => {
+    // Ensure we're on a known page with the user menu before logging out.
+    // A previous test may leave the browser on a non-dashboard route.
+    await page.goto("/dashboard");
     // Logout to become unauthenticated
     await logout(page, testInfo);
 
@@ -158,7 +161,9 @@ test.describe("Machine Details - Extended", () => {
   test("should display owner requirements callout on issue page", async ({
     page,
   }, testInfo) => {
-    // First, let's login as admin and set owner requirements on a machine
+    // First, let's login as admin and set owner requirements on a machine.
+    // Navigate to dashboard first to ensure user menu is available for logout.
+    await page.goto("/dashboard");
     await logout(page, testInfo);
     await loginAs(page, testInfo, {
       email: TEST_USERS.admin.email,

--- a/e2e/full/promote-on-assign.spec.ts
+++ b/e2e/full/promote-on-assign.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * E2E Test: Promote-on-Assign Flow
+ *
+ * Verifies the "Promote and assign" dialog that appears when an admin assigns
+ * a guest user as a machine owner. Covers both create and update flows.
+ *
+ * Also exercises the OwnerSelect search input that bypasses the
+ * "Show guests and invited users" filter (a new interactive control with no
+ * other E2E coverage — folded in here per Copilot review feedback).
+ */
+
+import { test, expect } from "@playwright/test";
+import { STORAGE_STATE } from "../support/auth-state.js";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import {
+  createTestUser,
+  deleteTestUser,
+  getUserRole,
+} from "../support/supabase-admin.js";
+
+const testMachines = new Set<string>();
+const testEmails = new Set<string>();
+const createdUserIds: string[] = [];
+
+test.describe("Promote-on-assign (Create + Update flows)", () => {
+  test.use({ storageState: STORAGE_STATE.admin });
+
+  test.afterEach(async ({ request }) => {
+    if (testMachines.size > 0 || testEmails.size > 0) {
+      await cleanupTestEntities(request, {
+        machineInitials: Array.from(testMachines),
+        userEmails: Array.from(testEmails),
+      });
+      testMachines.clear();
+      testEmails.clear();
+    }
+  });
+
+  test.afterAll(async () => {
+    // Backstop: ensure auth users created via supabase-admin are removed even
+    // if cleanupTestEntities missed something. Errors are swallowed because
+    // some users may have already been deleted via the cleanup endpoint.
+    for (const userId of createdUserIds) {
+      try {
+        await deleteTestUser(userId);
+      } catch {
+        // already deleted
+      }
+    }
+    createdUserIds.length = 0;
+  });
+
+  test("create flow: assigning a guest opens promote dialog and promotes on confirm", async ({
+    page,
+  }) => {
+    const testId = Math.random().toString(36).substring(7);
+    const guestEmail = `guest-create-${testId}@example.com`;
+    const guestFirstName = "Guest";
+    const guestLastName = `Create${testId}`;
+    const guestFullName = `${guestFirstName} ${guestLastName}`;
+    const machineInitials = `PC${testId.toUpperCase()}`.substring(0, 5);
+    const machineName = `Promote Create ${testId}`;
+
+    testEmails.add(guestEmail);
+    testMachines.add(machineInitials);
+
+    // Create the guest user directly via Supabase admin so they're a guest
+    // BEFORE the test runs — the promote flow then has something to promote.
+    // createTestUser leaves them as guest (handle_new_user trigger default).
+    const guestUser = await createTestUser(guestEmail, "TestPassword123", {
+      firstName: guestFirstName,
+      lastName: guestLastName,
+    });
+    createdUserIds.push(guestUser.id);
+    expect(await getUserRole(guestUser.id)).toBe("guest");
+
+    await page.goto("/m/new");
+
+    await page.getByLabel(/Initials/i).fill(machineInitials);
+    await page.getByLabel(/Machine Name/i).fill(machineName);
+
+    // Reveal hidden user groups so the guest is selectable in the dropdown
+    await page.getByTestId("owner-show-hidden-checkbox").click();
+
+    // Open the owner select and pick the guest user
+    const ownerSelect = page.getByTestId("owner-select");
+    await ownerSelect.click();
+    await page
+      .getByRole("option", { name: new RegExp(guestFullName) })
+      .click({ force: true });
+    await expect(ownerSelect).toContainText(guestFullName);
+    await expect(ownerSelect).toContainText("(Guest)");
+
+    // Submit — server returns ASSIGNEE_NOT_MEMBER → promote dialog opens
+    await page.getByRole("button", { name: /Create Machine/i }).click();
+
+    const promoteDialog = page.getByRole("dialog", {
+      name: /Promote to member and assign/i,
+    });
+    await expect(promoteDialog).toBeVisible();
+    await expect(promoteDialog).toContainText(guestFullName);
+    await expect(promoteDialog).toContainText(/(Guest)/);
+
+    // Confirm promotion + assignment (one transaction)
+    await promoteDialog
+      .getByRole("button", { name: /Promote and assign/i })
+      .click();
+
+    // Machine should be created and we should land on its detail page
+    await expect(page).toHaveURL(`/m/${machineInitials}`);
+    await expect(
+      page.getByRole("heading", { name: machineName })
+    ).toBeVisible();
+
+    // Verify the user was promoted from guest → member in the database
+    expect(await getUserRole(guestUser.id)).toBe("member");
+  });
+
+  test("create flow: search bypasses 'show hidden' filter for guests/invited", async ({
+    page,
+  }) => {
+    const testId = Math.random().toString(36).substring(7);
+    const guestEmail = `guest-search-${testId}@example.com`;
+    const guestFirstName = "Guest";
+    const guestLastName = `Search${testId}`;
+    const guestFullName = `${guestFirstName} ${guestLastName}`;
+
+    testEmails.add(guestEmail);
+
+    const guestUser = await createTestUser(guestEmail, "TestPassword123", {
+      firstName: guestFirstName,
+      lastName: guestLastName,
+    });
+    createdUserIds.push(guestUser.id);
+    expect(await getUserRole(guestUser.id)).toBe("guest");
+
+    await page.goto("/m/new");
+
+    // Confirm "Show guests and invited users" is unchecked (default state)
+    const showHiddenCheckbox = page.getByTestId("owner-show-hidden-checkbox");
+    await expect(showHiddenCheckbox).not.toBeChecked();
+
+    const ownerSelect = page.getByTestId("owner-select");
+
+    // Type the guest's last name into the search input — this bypasses the
+    // "show hidden" filter and should surface guests/invited users that match.
+    // The checkbox stays unchecked the entire time, proving search bypass works.
+    await page.getByTestId("owner-search-input").fill(guestLastName);
+
+    // Open the dropdown — guest should now appear via the search bypass
+    await ownerSelect.click();
+    await expect(
+      page.getByRole("option", { name: new RegExp(guestFullName) })
+    ).toBeVisible();
+
+    // Sanity check — checkbox is still unchecked, proving the bypass came
+    // from the search input, not from a state change.
+    await expect(showHiddenCheckbox).not.toBeChecked();
+  });
+
+  test("update flow: assigning a guest opens promote dialog and promotes on confirm", async ({
+    page,
+  }) => {
+    const testId = Math.random().toString(36).substring(7);
+    const guestEmail = `guest-update-${testId}@example.com`;
+    const guestFirstName = "Guest";
+    const guestLastName = `Update${testId}`;
+    const guestFullName = `${guestFirstName} ${guestLastName}`;
+
+    // Pre-existing admin-owned machine (admin will reassign to the guest).
+    // We can't use createTestMachine because it auto-promotes the owner;
+    // instead, we create the guest, then create a machine via the UI as
+    // admin (admin is already member+ via storage state setup).
+    const adminOwnerMachineInitials = `PU${testId.toUpperCase()}`.substring(
+      0,
+      5
+    );
+    const machineName = `Promote Update ${testId}`;
+
+    testEmails.add(guestEmail);
+    testMachines.add(adminOwnerMachineInitials);
+
+    const guestUser = await createTestUser(guestEmail, "TestPassword123", {
+      firstName: guestFirstName,
+      lastName: guestLastName,
+    });
+    createdUserIds.push(guestUser.id);
+    expect(await getUserRole(guestUser.id)).toBe("guest");
+
+    // Create a machine via the UI (admin owns it by default — no promotion)
+    await page.goto("/m/new");
+    await page.getByLabel(/Initials/i).fill(adminOwnerMachineInitials);
+    await page.getByLabel(/Machine Name/i).fill(machineName);
+    await page.getByRole("button", { name: /Create Machine/i }).click();
+    await expect(page).toHaveURL(`/m/${adminOwnerMachineInitials}`);
+
+    // Open the edit dialog
+    await page.getByTestId("edit-machine-button").click();
+    await expect(
+      page.getByRole("heading", { name: /Edit Machine/i })
+    ).toBeVisible();
+
+    // Reveal guests in the owner picker, then select the guest
+    await page.getByTestId("owner-show-hidden-checkbox").click();
+    const ownerSelect = page.getByTestId("owner-select");
+    await ownerSelect.click();
+    await page
+      .getByRole("option", { name: new RegExp(guestFullName) })
+      .click({ force: true });
+    await expect(ownerSelect).toContainText(guestFullName);
+    await expect(ownerSelect).toContainText("(Guest)");
+
+    // Submit — server returns ASSIGNEE_NOT_MEMBER → promote dialog opens
+    await page.getByRole("button", { name: /Update Machine/i }).click();
+
+    const promoteDialog = page.getByRole("dialog", {
+      name: /Promote to member and assign/i,
+    });
+    await expect(promoteDialog).toBeVisible();
+    await expect(promoteDialog).toContainText(guestFullName);
+
+    // Confirm promotion + assignment
+    await promoteDialog
+      .getByRole("button", { name: /Promote and assign/i })
+      .click();
+
+    // Edit dialog should close after successful update
+    await expect(
+      page.getByRole("heading", { name: /Edit Machine/i })
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Verify the user was promoted from guest → member
+    expect(await getUserRole(guestUser.id)).toBe("member");
+  });
+});

--- a/e2e/full/promote-on-assign.spec.ts
+++ b/e2e/full/promote-on-assign.spec.ts
@@ -101,13 +101,16 @@ test.describe("Promote-on-assign (Create + Update flows)", () => {
     await expect(promoteDialog).toContainText(guestFullName);
     await expect(promoteDialog).toContainText(/(Guest)/);
 
-    // Confirm promotion + assignment (one transaction)
-    await promoteDialog
-      .getByRole("button", { name: /Promote and assign/i })
-      .click();
+    // Confirm promotion + assignment (one transaction).
+    // Wait for the form re-submit to land via Promise.all to avoid races
+    // between the click handler running and Playwright moving on.
+    await Promise.all([
+      page.waitForURL(`**/m/${machineInitials}`, { timeout: 30_000 }),
+      promoteDialog
+        .getByRole("button", { name: /Promote and assign/i })
+        .click(),
+    ]);
 
-    // Machine should be created and we should land on its detail page
-    await expect(page).toHaveURL(`/m/${machineInitials}`);
     await expect(
       page.getByRole("heading", { name: machineName })
     ).toBeVisible();

--- a/e2e/support/supabase-admin.ts
+++ b/e2e/support/supabase-admin.ts
@@ -174,6 +174,22 @@ export async function updateUserRole(
 }
 
 /**
+ * Get a user's role from the user_profiles table.
+ * Useful for asserting promotion side-effects in E2E tests.
+ */
+export async function getUserRole(
+  userId: string
+): Promise<"guest" | "member" | "admin"> {
+  const { data, error } = await supabaseAdmin
+    .from("user_profiles")
+    .select("role")
+    .eq("id", userId)
+    .single();
+  if (error) throw error;
+  return data.role as "guest" | "member" | "admin";
+}
+
+/**
  * Delete a test user by ID (admin only)
  */
 export async function deleteTestUser(userId: string) {

--- a/src/app/(app)/m/[initials]/page.tsx
+++ b/src/app/(app)/m/[initials]/page.tsx
@@ -177,6 +177,7 @@ export default async function MachineDetailPage({
     lastName: u.lastName,
     machineCount: u.machineCount,
     status: u.status,
+    role: u.role,
   }));
 
   const totalIssuesCount = totalIssuesCountResult[0]?.count ?? 0;

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -160,16 +160,27 @@ export function EditMachineDialog({
 
   const confirmPromote = (): void => {
     if (!assignee || !formRef.current) return;
+    const form = formRef.current;
     setIsPromoteOpen(false);
 
-    // Inject the hidden forcePromoteUserId field and re-submit
+    // Inject the hidden forcePromoteUserId field and re-submit.
+    // Removing the input synchronously after requestSubmit() races the browser's
+    // FormData serialization (which can happen on a later task). Defer cleanup
+    // to the `formdata` event so the value is guaranteed to be captured.
     const hiddenInput = document.createElement("input");
     hiddenInput.type = "hidden";
     hiddenInput.name = "forcePromoteUserId";
     hiddenInput.value = assignee.id;
-    formRef.current.appendChild(hiddenInput);
-    formRef.current.requestSubmit();
-    formRef.current.removeChild(hiddenInput);
+
+    const cleanup = (): void => {
+      if (hiddenInput.parentNode === form) {
+        form.removeChild(hiddenInput);
+      }
+    };
+
+    form.addEventListener("formdata", cleanup, { once: true });
+    form.appendChild(hiddenInput);
+    form.requestSubmit();
   };
 
   return (
@@ -202,11 +213,15 @@ export function EditMachineDialog({
           >
             <input type="hidden" name="id" value={machine.id} />
 
-            {/* Flash message — suppress ASSIGNEE_NOT_MEMBER when the promote dialog
-                will handle it; show inline if user lacks promote permission */}
+            {/* Flash message — suppress ASSIGNEE_NOT_MEMBER only while the
+                promote dialog is open and handling it. After the dialog is
+                dismissed (Cancel/Escape) or when the user lacks promote
+                permission, show the inline error so they have guidance. */}
             {state &&
               !state.ok &&
-              (state.code !== "ASSIGNEE_NOT_MEMBER" || !canEditAnyMachine) && (
+              (state.code !== "ASSIGNEE_NOT_MEMBER" ||
+                !canEditAnyMachine ||
+                !isPromoteOpen) && (
                 <div
                   className={cn(
                     "rounded-md border p-4",

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -81,18 +81,16 @@ export function EditMachineDialog({
   const [open, setOpen] = useState(false);
   const [showTransferConfirm, setShowTransferConfirm] = useState(false);
   const [isPromoteOpen, setIsPromoteOpen] = useState(false);
-  // Hidden form value driven by state so React owns the DOM. When set, the
-  // useEffect below triggers requestSubmit AFTER the input is in the DOM —
-  // avoiding the timing race that imperative DOM injection had.
-  const [forcePromoteUserId, setForcePromoteUserId] = useState<string | null>(
-    null
-  );
   const formRef = useRef<HTMLFormElement>(null);
   const transferConfirmedRef = useRef(false);
   const [selectedOwnerId, setSelectedOwnerId] = useState(
     machine.ownerId ?? machine.invitedOwnerId ?? ""
   );
   const currentOwnerId = machine.ownerId ?? machine.invitedOwnerId ?? "";
+  // Stable per-instance form id so the promote-dialog submit button can use
+  // form="..." to associate with the form even when Radix portals it
+  // outside the DOM tree of the form.
+  const formId = `edit-machine-form-${machine.id}`;
 
   const [state, formAction, isPending] = useActionState<
     UpdateMachineResult | undefined,
@@ -119,15 +117,6 @@ export function EditMachineDialog({
       setIsPromoteOpen(true);
     }
   }, [state, canEditAnyMachine]);
-
-  // When forcePromoteUserId is set, submit the form (the hidden input is now
-  // rendered in the DOM with the value). Then clear it for the next attempt.
-  useEffect(() => {
-    if (forcePromoteUserId && formRef.current) {
-      formRef.current.requestSubmit();
-      setForcePromoteUserId(null);
-    }
-  }, [forcePromoteUserId]);
 
   // Reset selectedOwnerId when dialog reopens to avoid stale selection
   useEffect(() => {
@@ -173,14 +162,6 @@ export function EditMachineDialog({
       ? state.meta?.assignee
       : undefined;
 
-  const confirmPromote = (): void => {
-    if (!assignee || !formRef.current) return;
-    setIsPromoteOpen(false);
-    // Drive the hidden input via state — the useEffect above submits once the
-    // input is in the DOM, eliminating any race with FormData serialization.
-    setForcePromoteUserId(assignee.id);
-  };
-
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
@@ -205,22 +186,12 @@ export function EditMachineDialog({
 
           <form
             ref={formRef}
+            id={formId}
             action={formAction}
             onSubmit={handleSubmit}
             className="space-y-6"
           >
             <input type="hidden" name="id" value={machine.id} />
-            {/* Persistent hidden input controlled by React for the promote
-                flow. When forcePromoteUserId is non-null, the useEffect
-                above triggers requestSubmit() so the value is always in the
-                DOM by the time the form submits. */}
-            {forcePromoteUserId !== null && (
-              <input
-                type="hidden"
-                name="forcePromoteUserId"
-                value={forcePromoteUserId}
-              />
-            )}
 
             {/* Flash message — suppress ASSIGNEE_NOT_MEMBER only while the
                 promote dialog is open and handling it. After the dialog is
@@ -420,10 +391,28 @@ export function EditMachineDialog({
               </Alert>
             </div>
             <DialogFooter>
-              <Button variant="outline" onClick={() => setIsPromoteOpen(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setIsPromoteOpen(false);
+                }}
+              >
                 Cancel
               </Button>
-              <Button onClick={confirmPromote}>Promote and assign</Button>
+              <Button
+                type="submit"
+                form={formId}
+                name="forcePromoteUserId"
+                value={assignee.id}
+                onClick={() => {
+                  // Close the dialog after the click. The native submit fires
+                  // first, capturing forcePromoteUserId before unmount.
+                  setIsPromoteOpen(false);
+                }}
+              >
+                Promote and assign
+              </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -100,12 +100,19 @@ export function EditMachineDialog({
     }
   }, [state]);
 
-  // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  // Open promote dialog only when server returns ASSIGNEE_NOT_MEMBER
+  // and the current user can actually promote guests (admin/technician).
+  // Non-privileged owners get an inline error instead.
   useEffect(() => {
-    if (state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER") {
+    if (
+      state &&
+      !state.ok &&
+      state.code === "ASSIGNEE_NOT_MEMBER" &&
+      canEditAnyMachine
+    ) {
       setIsPromoteOpen(true);
     }
-  }, [state]);
+  }, [state, canEditAnyMachine]);
 
   // Reset selectedOwnerId when dialog reopens to avoid stale selection
   useEffect(() => {
@@ -195,17 +202,20 @@ export function EditMachineDialog({
           >
             <input type="hidden" name="id" value={machine.id} />
 
-            {/* Flash message — suppress ASSIGNEE_NOT_MEMBER since it opens a dialog */}
-            {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
-              <div
-                className={cn(
-                  "rounded-md border p-4",
-                  "border-destructive/20 bg-destructive/10 text-destructive"
-                )}
-              >
-                <p className="text-sm font-medium">{state.message}</p>
-              </div>
-            )}
+            {/* Flash message — suppress ASSIGNEE_NOT_MEMBER when the promote dialog
+                will handle it; show inline if user lacks promote permission */}
+            {state &&
+              !state.ok &&
+              (state.code !== "ASSIGNEE_NOT_MEMBER" || !canEditAnyMachine) && (
+                <div
+                  className={cn(
+                    "rounded-md border p-4",
+                    "border-destructive/20 bg-destructive/10 text-destructive"
+                  )}
+                >
+                  <p className="text-sm font-medium">{state.message}</p>
+                </div>
+              )}
 
             {/* Machine Initials (Read Only) */}
             <div className="space-y-2">
@@ -368,8 +378,8 @@ export function EditMachineDialog({
                 <strong>{assignee.name}</strong>
                 <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground ml-1">
                   {assignee.type === "invited"
-                    ? "(INVITED · GUEST)"
-                    : "(GUEST)"}
+                    ? "(Invited · Guest)"
+                    : "(Guest)"}
                 </span>{" "}
                 is currently a guest. Assigning them as owner of{" "}
                 <strong>{machine.name}</strong> will promote them to member.

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -42,6 +42,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "~/components/ui/alert-dialog";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { Pencil } from "lucide-react";
 
 import type { OwnerSelectUser } from "~/components/machines/OwnerSelect";
@@ -79,6 +80,7 @@ export function EditMachineDialog({
 }: EditMachineDialogProps): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const [showTransferConfirm, setShowTransferConfirm] = useState(false);
+  const [isPromoteOpen, setIsPromoteOpen] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
   const transferConfirmedRef = useRef(false);
   const [selectedOwnerId, setSelectedOwnerId] = useState(
@@ -95,6 +97,13 @@ export function EditMachineDialog({
   useEffect(() => {
     if (state?.ok) {
       setOpen(false);
+    }
+  }, [state]);
+
+  // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  useEffect(() => {
+    if (state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER") {
+      setIsPromoteOpen(true);
     }
   }, [state]);
 
@@ -136,6 +145,26 @@ export function EditMachineDialog({
     formRef.current?.requestSubmit();
   };
 
+  // Assignee from ASSIGNEE_NOT_MEMBER result
+  const assignee =
+    state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER"
+      ? state.meta?.assignee
+      : undefined;
+
+  const confirmPromote = (): void => {
+    if (!assignee || !formRef.current) return;
+    setIsPromoteOpen(false);
+
+    // Inject the hidden forcePromoteUserId field and re-submit
+    const hiddenInput = document.createElement("input");
+    hiddenInput.type = "hidden";
+    hiddenInput.name = "forcePromoteUserId";
+    hiddenInput.value = assignee.id;
+    formRef.current.appendChild(hiddenInput);
+    formRef.current.requestSubmit();
+    formRef.current.removeChild(hiddenInput);
+  };
+
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
@@ -166,8 +195,8 @@ export function EditMachineDialog({
           >
             <input type="hidden" name="id" value={machine.id} />
 
-            {/* Flash message */}
-            {state && !state.ok && (
+            {/* Flash message — suppress ASSIGNEE_NOT_MEMBER since it opens a dialog */}
+            {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
               <div
                 className={cn(
                   "rounded-md border p-4",
@@ -281,7 +310,7 @@ export function EditMachineDialog({
             <DialogFooter>
               <Button
                 type="submit"
-                className="bg-primary text-on-primary hover:bg-primary/90"
+                className="bg-primary text-primary-foreground hover:bg-primary/90"
                 loading={isPending}
               >
                 Update Machine
@@ -316,6 +345,55 @@ export function EditMachineDialog({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Promote guest to member confirmation */}
+      {assignee && (
+        <Dialog
+          open={isPromoteOpen}
+          onOpenChange={(o) => {
+            if (!o) {
+              setIsPromoteOpen(false);
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Promote to member and assign?</DialogTitle>
+              <DialogDescription>
+                This updates the user&apos;s role and assigns them as owner.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3">
+              <p>
+                <strong>{assignee.name}</strong>
+                <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground ml-1">
+                  {assignee.type === "invited"
+                    ? "(INVITED · GUEST)"
+                    : "(GUEST)"}
+                </span>{" "}
+                is currently a guest. Assigning them as owner of{" "}
+                <strong>{machine.name}</strong> will promote them to member.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                As a member they&apos;ll be able to edit the machine&apos;s
+                details, owner notes, tournament notes, and owner requirements.
+              </p>
+              <Alert>
+                <AlertDescription>
+                  Promotion and assignment run in one transaction — both succeed
+                  or both roll back.
+                </AlertDescription>
+              </Alert>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsPromoteOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={confirmPromote}>Promote and assign</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </>
   );
 }

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -81,6 +81,12 @@ export function EditMachineDialog({
   const [open, setOpen] = useState(false);
   const [showTransferConfirm, setShowTransferConfirm] = useState(false);
   const [isPromoteOpen, setIsPromoteOpen] = useState(false);
+  // Hidden form value driven by state so React owns the DOM. When set, the
+  // useEffect below triggers requestSubmit AFTER the input is in the DOM —
+  // avoiding the timing race that imperative DOM injection had.
+  const [forcePromoteUserId, setForcePromoteUserId] = useState<string | null>(
+    null
+  );
   const formRef = useRef<HTMLFormElement>(null);
   const transferConfirmedRef = useRef(false);
   const [selectedOwnerId, setSelectedOwnerId] = useState(
@@ -113,6 +119,15 @@ export function EditMachineDialog({
       setIsPromoteOpen(true);
     }
   }, [state, canEditAnyMachine]);
+
+  // When forcePromoteUserId is set, submit the form (the hidden input is now
+  // rendered in the DOM with the value). Then clear it for the next attempt.
+  useEffect(() => {
+    if (forcePromoteUserId && formRef.current) {
+      formRef.current.requestSubmit();
+      setForcePromoteUserId(null);
+    }
+  }, [forcePromoteUserId]);
 
   // Reset selectedOwnerId when dialog reopens to avoid stale selection
   useEffect(() => {
@@ -160,27 +175,10 @@ export function EditMachineDialog({
 
   const confirmPromote = (): void => {
     if (!assignee || !formRef.current) return;
-    const form = formRef.current;
     setIsPromoteOpen(false);
-
-    // Inject the hidden forcePromoteUserId field and re-submit.
-    // Removing the input synchronously after requestSubmit() races the browser's
-    // FormData serialization (which can happen on a later task). Defer cleanup
-    // to the `formdata` event so the value is guaranteed to be captured.
-    const hiddenInput = document.createElement("input");
-    hiddenInput.type = "hidden";
-    hiddenInput.name = "forcePromoteUserId";
-    hiddenInput.value = assignee.id;
-
-    const cleanup = (): void => {
-      if (hiddenInput.parentNode === form) {
-        form.removeChild(hiddenInput);
-      }
-    };
-
-    form.addEventListener("formdata", cleanup, { once: true });
-    form.appendChild(hiddenInput);
-    form.requestSubmit();
+    // Drive the hidden input via state — the useEffect above submits once the
+    // input is in the DOM, eliminating any race with FormData serialization.
+    setForcePromoteUserId(assignee.id);
   };
 
   return (
@@ -212,6 +210,17 @@ export function EditMachineDialog({
             className="space-y-6"
           >
             <input type="hidden" name="id" value={machine.id} />
+            {/* Persistent hidden input controlled by React for the promote
+                flow. When forcePromoteUserId is non-null, the useEffect
+                above triggers requestSubmit() so the value is always in the
+                DOM by the time the form submits. */}
+            {forcePromoteUserId !== null && (
+              <input
+                type="hidden"
+                name="forcePromoteUserId"
+                value={forcePromoteUserId}
+              />
+            )}
 
             {/* Flash message — suppress ASSIGNEE_NOT_MEMBER only while the
                 promote dialog is open and handling it. After the dialog is

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -60,31 +60,46 @@ export function CreateMachineForm({
 
   const confirmPromote = (): void => {
     if (!assignee || !formRef.current) return;
+    const form = formRef.current;
     setIsPromoteOpen(false);
 
-    // Inject the hidden forcePromoteUserId field and re-submit
+    // Inject the hidden forcePromoteUserId field and re-submit.
+    // Removing the input synchronously after requestSubmit() races the browser's
+    // FormData serialization (which can happen on a later task). Defer cleanup
+    // to the `formdata` event so the value is guaranteed to be captured.
     const hiddenInput = document.createElement("input");
     hiddenInput.type = "hidden";
     hiddenInput.name = "forcePromoteUserId";
     hiddenInput.value = assignee.id;
-    formRef.current.appendChild(hiddenInput);
-    formRef.current.requestSubmit();
-    formRef.current.removeChild(hiddenInput);
+
+    const cleanup = (): void => {
+      if (hiddenInput.parentNode === form) {
+        form.removeChild(hiddenInput);
+      }
+    };
+
+    form.addEventListener("formdata", cleanup, { once: true });
+    form.appendChild(hiddenInput);
+    form.requestSubmit();
   };
 
   return (
     <>
-      {/* Flash message — suppress ASSIGNEE_NOT_MEMBER since it opens a dialog */}
-      {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
-        <div
-          className={cn(
-            "mb-6 rounded-md border p-4",
-            "border-destructive/20 bg-destructive/10 text-destructive"
-          )}
-        >
-          <p className="text-sm font-medium">{state.message}</p>
-        </div>
-      )}
+      {/* Flash message — suppress ASSIGNEE_NOT_MEMBER only while the promote
+          dialog is open and handling it. After dismissal (Cancel/Escape) the
+          inline error is shown so the user has guidance on what happened. */}
+      {state &&
+        !state.ok &&
+        (state.code !== "ASSIGNEE_NOT_MEMBER" || !isPromoteOpen) && (
+          <div
+            className={cn(
+              "mb-6 rounded-md border p-4",
+              "border-destructive/20 bg-destructive/10 text-destructive"
+            )}
+          >
+            <p className="text-sm font-medium">{state.message}</p>
+          </div>
+        )}
 
       <form ref={formRef} action={formAction} className="space-y-6">
         {/* Machine Name */}

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -179,8 +179,8 @@ export function CreateMachineForm({
                 <strong>{assignee.name}</strong>
                 <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground ml-1">
                   {assignee.type === "invited"
-                    ? "(INVITED · GUEST)"
-                    : "(GUEST)"}
+                    ? "(Invited · Guest)"
+                    : "(Guest)"}
                 </span>{" "}
                 is currently a guest. Assigning them as owner of this machine
                 will promote them to member.

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -43,6 +43,12 @@ export function CreateMachineForm({
   // Lift users state to client so we can append new users without full refresh
   const [users, setUsers] = useState<OwnerSelectUser[]>(allUsers);
   const [isPromoteOpen, setIsPromoteOpen] = useState(false);
+  // Hidden form value driven by state so React owns the DOM. When set, the
+  // useEffect below triggers requestSubmit AFTER the input is in the DOM —
+  // avoiding the timing race that imperative DOM injection had.
+  const [forcePromoteUserId, setForcePromoteUserId] = useState<string | null>(
+    null
+  );
   const formRef = useRef<HTMLFormElement>(null);
 
   // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
@@ -52,6 +58,15 @@ export function CreateMachineForm({
     }
   }, [state]);
 
+  // When forcePromoteUserId is set, submit the form (the hidden input is now
+  // rendered in the DOM with the value). Then clear it for the next attempt.
+  useEffect(() => {
+    if (forcePromoteUserId && formRef.current) {
+      formRef.current.requestSubmit();
+      setForcePromoteUserId(null);
+    }
+  }, [forcePromoteUserId]);
+
   // Assignee from ASSIGNEE_NOT_MEMBER result
   const assignee =
     state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER"
@@ -60,27 +75,10 @@ export function CreateMachineForm({
 
   const confirmPromote = (): void => {
     if (!assignee || !formRef.current) return;
-    const form = formRef.current;
     setIsPromoteOpen(false);
-
-    // Inject the hidden forcePromoteUserId field and re-submit.
-    // Removing the input synchronously after requestSubmit() races the browser's
-    // FormData serialization (which can happen on a later task). Defer cleanup
-    // to the `formdata` event so the value is guaranteed to be captured.
-    const hiddenInput = document.createElement("input");
-    hiddenInput.type = "hidden";
-    hiddenInput.name = "forcePromoteUserId";
-    hiddenInput.value = assignee.id;
-
-    const cleanup = (): void => {
-      if (hiddenInput.parentNode === form) {
-        form.removeChild(hiddenInput);
-      }
-    };
-
-    form.addEventListener("formdata", cleanup, { once: true });
-    form.appendChild(hiddenInput);
-    form.requestSubmit();
+    // Drive the hidden input via state — the useEffect above submits once the
+    // input is in the DOM, eliminating any race with FormData serialization.
+    setForcePromoteUserId(assignee.id);
   };
 
   return (
@@ -102,6 +100,17 @@ export function CreateMachineForm({
         )}
 
       <form ref={formRef} action={formAction} className="space-y-6">
+        {/* Persistent hidden input controlled by React. When forcePromoteUserId
+            is non-null, the useEffect above will trigger requestSubmit() so the
+            value is always in the DOM by the time the form submits. */}
+        {forcePromoteUserId !== null && (
+          <input
+            type="hidden"
+            name="forcePromoteUserId"
+            value={forcePromoteUserId}
+          />
+        )}
+
         {/* Machine Name */}
         <div className="space-y-2">
           <Label htmlFor="name" className="text-foreground">

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useActionState } from "react";
 import { Button } from "~/components/ui/button";
@@ -43,13 +43,6 @@ export function CreateMachineForm({
   // Lift users state to client so we can append new users without full refresh
   const [users, setUsers] = useState<OwnerSelectUser[]>(allUsers);
   const [isPromoteOpen, setIsPromoteOpen] = useState(false);
-  // Hidden form value driven by state so React owns the DOM. When set, the
-  // useEffect below triggers requestSubmit AFTER the input is in the DOM —
-  // avoiding the timing race that imperative DOM injection had.
-  const [forcePromoteUserId, setForcePromoteUserId] = useState<string | null>(
-    null
-  );
-  const formRef = useRef<HTMLFormElement>(null);
 
   // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
   useEffect(() => {
@@ -58,28 +51,11 @@ export function CreateMachineForm({
     }
   }, [state]);
 
-  // When forcePromoteUserId is set, submit the form (the hidden input is now
-  // rendered in the DOM with the value). Then clear it for the next attempt.
-  useEffect(() => {
-    if (forcePromoteUserId && formRef.current) {
-      formRef.current.requestSubmit();
-      setForcePromoteUserId(null);
-    }
-  }, [forcePromoteUserId]);
-
   // Assignee from ASSIGNEE_NOT_MEMBER result
   const assignee =
     state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER"
       ? state.meta?.assignee
       : undefined;
-
-  const confirmPromote = (): void => {
-    if (!assignee || !formRef.current) return;
-    setIsPromoteOpen(false);
-    // Drive the hidden input via state — the useEffect above submits once the
-    // input is in the DOM, eliminating any race with FormData serialization.
-    setForcePromoteUserId(assignee.id);
-  };
 
   return (
     <>
@@ -99,18 +75,7 @@ export function CreateMachineForm({
           </div>
         )}
 
-      <form ref={formRef} action={formAction} className="space-y-6">
-        {/* Persistent hidden input controlled by React. When forcePromoteUserId
-            is non-null, the useEffect above will trigger requestSubmit() so the
-            value is always in the DOM by the time the form submits. */}
-        {forcePromoteUserId !== null && (
-          <input
-            type="hidden"
-            name="forcePromoteUserId"
-            value={forcePromoteUserId}
-          />
-        )}
-
+      <form id="create-machine-form" action={formAction} className="space-y-6">
         {/* Machine Name */}
         <div className="space-y-2">
           <Label htmlFor="name" className="text-foreground">
@@ -181,7 +146,15 @@ export function CreateMachineForm({
         </div>
       </form>
 
-      {/* Promote guest to member confirmation */}
+      {/*
+       * Promote-on-assign dialog. The "Promote and assign" button uses the
+       * `form="create-machine-form"` attribute to associate with the form
+       * even though Radix Dialog portals it outside the form's DOM tree.
+       * `name`/`value` on the submit button injects forcePromoteUserId into
+       * the submitted FormData — natively, no requestSubmit() needed. This
+       * sidesteps the React server-action submit-interception race that
+       * affected programmatic requestSubmit() from a closing dialog.
+       */}
       {assignee && (
         <Dialog
           open={isPromoteOpen}
@@ -221,10 +194,28 @@ export function CreateMachineForm({
               </Alert>
             </div>
             <DialogFooter>
-              <Button variant="outline" onClick={() => setIsPromoteOpen(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setIsPromoteOpen(false);
+                }}
+              >
                 Cancel
               </Button>
-              <Button onClick={confirmPromote}>Promote and assign</Button>
+              <Button
+                type="submit"
+                form="create-machine-form"
+                name="forcePromoteUserId"
+                value={assignee.id}
+                onClick={() => {
+                  // Close the dialog after the click. The native submit fires
+                  // first, capturing forcePromoteUserId before unmount.
+                  setIsPromoteOpen(false);
+                }}
+              >
+                Promote and assign
+              </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useActionState } from "react";
 import { Button } from "~/components/ui/button";
@@ -16,6 +16,15 @@ import {
   OwnerSelect,
   type OwnerSelectUser,
 } from "~/components/machines/OwnerSelect";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 
 interface CreateMachineFormProps {
   allUsers: OwnerSelectUser[];
@@ -33,11 +42,40 @@ export function CreateMachineForm({
 
   // Lift users state to client so we can append new users without full refresh
   const [users, setUsers] = useState<OwnerSelectUser[]>(allUsers);
+  const [isPromoteOpen, setIsPromoteOpen] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  useEffect(() => {
+    if (state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER") {
+      setIsPromoteOpen(true);
+    }
+  }, [state]);
+
+  // Assignee from ASSIGNEE_NOT_MEMBER result
+  const assignee =
+    state && !state.ok && state.code === "ASSIGNEE_NOT_MEMBER"
+      ? state.meta?.assignee
+      : undefined;
+
+  const confirmPromote = (): void => {
+    if (!assignee || !formRef.current) return;
+    setIsPromoteOpen(false);
+
+    // Inject the hidden forcePromoteUserId field and re-submit
+    const hiddenInput = document.createElement("input");
+    hiddenInput.type = "hidden";
+    hiddenInput.name = "forcePromoteUserId";
+    hiddenInput.value = assignee.id;
+    formRef.current.appendChild(hiddenInput);
+    formRef.current.requestSubmit();
+    formRef.current.removeChild(hiddenInput);
+  };
 
   return (
     <>
-      {/* Flash message */}
-      {state && !state.ok && (
+      {/* Flash message — suppress ASSIGNEE_NOT_MEMBER since it opens a dialog */}
+      {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
         <div
           className={cn(
             "mb-6 rounded-md border p-4",
@@ -48,7 +86,7 @@ export function CreateMachineForm({
         </div>
       )}
 
-      <form action={formAction} className="space-y-6">
+      <form ref={formRef} action={formAction} className="space-y-6">
         {/* Machine Name */}
         <div className="space-y-2">
           <Label htmlFor="name" className="text-foreground">
@@ -102,7 +140,7 @@ export function CreateMachineForm({
         <div className="flex gap-3 pt-4">
           <Button
             type="submit"
-            className="flex-1 bg-primary text-on-primary hover:bg-primary/90"
+            className="flex-1 bg-primary text-primary-foreground hover:bg-primary/90"
             loading={isPending}
           >
             Create Machine
@@ -118,6 +156,55 @@ export function CreateMachineForm({
           </Link>
         </div>
       </form>
+
+      {/* Promote guest to member confirmation */}
+      {assignee && (
+        <Dialog
+          open={isPromoteOpen}
+          onOpenChange={(o) => {
+            if (!o) {
+              setIsPromoteOpen(false);
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Promote to member and assign?</DialogTitle>
+              <DialogDescription>
+                This updates the user&apos;s role and assigns them as owner.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3">
+              <p>
+                <strong>{assignee.name}</strong>
+                <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground ml-1">
+                  {assignee.type === "invited"
+                    ? "(INVITED · GUEST)"
+                    : "(GUEST)"}
+                </span>{" "}
+                is currently a guest. Assigning them as owner of this machine
+                will promote them to member.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                As a member they&apos;ll be able to edit the machine&apos;s
+                details, owner notes, tournament notes, and owner requirements.
+              </p>
+              <Alert>
+                <AlertDescription>
+                  Promotion and assignment run in one transaction — both succeed
+                  or both roll back.
+                </AlertDescription>
+              </Alert>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setIsPromoteOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={confirmPromote}>Promote and assign</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </>
   );
 }

--- a/src/app/(app)/m/new/page.tsx
+++ b/src/app/(app)/m/new/page.tsx
@@ -52,6 +52,7 @@ export default async function NewMachinePage(): Promise<React.JSX.Element> {
     lastName: u.lastName,
     machineCount: u.machineCount,
     status: u.status,
+    role: u.role,
   }));
 
   return (

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -15,7 +15,7 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Checkbox } from "~/components/ui/checkbox";
 
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 import type { UserStatus, UserRole } from "~/lib/types";
 import { InviteUserDialog } from "~/components/users/InviteUserDialog";
 import { Plus } from "lucide-react";
@@ -27,8 +27,7 @@ import { compareUnifiedUsers } from "~/lib/users/comparators";
  * ## Pattern
  * Standard `<Select>` with an inline "Invite New" button that opens an
  * `<InviteUserDialog>`. After a user is invited, the new user is
- * optimistically added to the list and auto-selected via a pending
- * selection ref that fires once the `users` prop updates.
+ * optimistically added to the list and auto-selected.
  *
  * ## Composition
  * - Users are sorted by `compareUnifiedUsers` (confirmed first, by machine
@@ -45,12 +44,14 @@ import { compareUnifiedUsers } from "~/lib/users/comparators";
  * ## Key Abstractions
  * - `OwnerSelectUser` includes `role`, `machineCount`, and `status` for
  *   metadata display and filtering
- * - `pendingSelectionRef` handles the async flow: invite dialog closes ->
- *   parent updates users -> effect detects the new user and selects them
+ * - After an invite, `setSelectedId` and `onUsersChange` are called together
+ *   so React batches them into one render — the new user is visible in the
+ *   content and the trigger shows their name immediately
  * - `compareUnifiedUsers` from `~/lib/users/comparators` drives sort order
  * - The help text below the select explains the notification implication of
  *   owner assignment
  */
+
 /** Minimal user shape for owner selection (CORE-SEC-006) */
 export interface OwnerSelectUser {
   id: string;
@@ -69,6 +70,59 @@ interface OwnerSelectProps {
   onValueChange?: (id: string) => void;
 }
 
+// Module-scope helper components — must NOT be defined inside OwnerSelect.
+// Defining components inside a render function creates a new component type on
+// every render, causing Radix UI to unmount/remount items and lose their refs,
+// which triggers "Cannot read properties of undefined (reading 'ref')" crashes.
+
+function RoleBadge({
+  user,
+}: {
+  user: OwnerSelectUser;
+}): React.JSX.Element | null {
+  const isGuest = user.role === "guest"; // permissions-audit-allow: UI badge display, not a permission gate
+  const isInvited = user.status === "invited";
+
+  if (isGuest && isInvited) {
+    return (
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        (Invited · Guest)
+      </span>
+    );
+  }
+  if (isInvited) {
+    return (
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        (Invited)
+      </span>
+    );
+  }
+  if (isGuest) {
+    return (
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        (Guest)
+      </span>
+    );
+  }
+  return null;
+}
+
+function UserItem({ user }: { user: OwnerSelectUser }): React.JSX.Element {
+  return (
+    <SelectItem value={user.id}>
+      <div className="flex items-center gap-2">
+        <span>{user.name}</span>
+        {user.machineCount > 0 && (
+          <span className="text-[10px] text-muted-foreground/70">
+            ({user.machineCount})
+          </span>
+        )}
+        <RoleBadge user={user} />
+      </div>
+    </SelectItem>
+  );
+}
+
 export function OwnerSelect({
   users,
   defaultValue,
@@ -80,22 +134,6 @@ export function OwnerSelect({
   const [selectedId, setSelectedId] = useState(defaultValue ?? "");
   const [showHidden, setShowHidden] = useState(false);
   const [query, setQuery] = useState("");
-
-  // Ref to track pending user ID to select after users list updates
-  const pendingSelectionRef = useRef<string | null>(null);
-
-  // Effect to apply pending selection after users list is updated
-  useEffect(() => {
-    if (pendingSelectionRef.current) {
-      const pendingId = pendingSelectionRef.current;
-      // Check if the pending ID now exists in the users list
-      if (users.some((u) => u.id === pendingId)) {
-        setSelectedId(pendingId);
-        onValueChange?.(pendingId);
-        pendingSelectionRef.current = null;
-      }
-    }
-  }, [users, onValueChange]);
 
   // Re-sort users after client-side mutations (e.g., inviting a new user)
   // to maintain consistent ordering: confirmed first, by machine count desc, then by last name
@@ -142,52 +180,6 @@ export function OwnerSelect({
       guestUsers: guestGroup,
     };
   }, [sortedUsers, query, showHidden, selectedId]);
-
-  const RoleBadge = ({
-    user,
-  }: {
-    user: OwnerSelectUser;
-  }): React.JSX.Element | null => {
-    const isGuest = user.role === "guest"; // permissions-audit-allow: UI badge display, not a permission gate
-    const isInvited = user.status === "invited";
-
-    if (isGuest && isInvited) {
-      return (
-        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          (Invited · Guest)
-        </span>
-      );
-    }
-    if (isInvited) {
-      return (
-        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          (Invited)
-        </span>
-      );
-    }
-    if (isGuest) {
-      return (
-        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          (Guest)
-        </span>
-      );
-    }
-    return null;
-  };
-
-  const UserItem = ({ user }: { user: OwnerSelectUser }): React.JSX.Element => (
-    <SelectItem key={user.id} value={user.id}>
-      <div className="flex items-center gap-2">
-        <span>{user.name}</span>
-        {user.machineCount > 0 && (
-          <span className="text-[10px] text-muted-foreground/70">
-            ({user.machineCount})
-          </span>
-        )}
-        <RoleBadge user={user} />
-      </div>
-    </SelectItem>
-  );
 
   return (
     <div className="space-y-2">
@@ -310,8 +302,12 @@ export function OwnerSelect({
         open={inviteDialogOpen}
         onOpenChange={setInviteDialogOpen}
         onSuccess={(newUserId, newUser) => {
-          // Store the pending selection - it will be applied after users list updates
-          pendingSelectionRef.current = newUserId;
+          // Select the new user and show hidden groups so the invited user
+          // appears in the content. Both state updates are batched with
+          // onUsersChange into a single render — trigger shows correct name.
+          setSelectedId(newUserId);
+          setShowHidden(true);
+          onValueChange?.(newUserId);
           // Add the new user to the list immediately (no server refresh needed)
           if (onUsersChange) {
             onUsersChange([...users, newUser]);

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -3,6 +3,7 @@
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectLabel,
   SelectSeparator,
@@ -188,15 +189,6 @@ export function OwnerSelect({
     </SelectItem>
   );
 
-  const SectionDivider = ({ label }: { label: string }): React.JSX.Element => (
-    <>
-      <SelectSeparator />
-      <SelectLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-        {label}
-      </SelectLabel>
-    </>
-  );
-
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
@@ -264,27 +256,39 @@ export function OwnerSelect({
         </SelectTrigger>
         <SelectContent>
           {/* Member+ active users (no section header — default group) */}
-          {memberUsers.map((user) => (
-            <UserItem key={user.id} user={user} />
-          ))}
+          <SelectGroup>
+            {memberUsers.map((user) => (
+              <UserItem key={user.id} user={user} />
+            ))}
+          </SelectGroup>
 
           {/* Invited section */}
           {invitedUsers.length > 0 && (
             <>
-              <SectionDivider label="Invited" />
-              {invitedUsers.map((user) => (
-                <UserItem key={user.id} user={user} />
-              ))}
+              <SelectSeparator />
+              <SelectGroup>
+                <SelectLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                  Invited
+                </SelectLabel>
+                {invitedUsers.map((user) => (
+                  <UserItem key={user.id} user={user} />
+                ))}
+              </SelectGroup>
             </>
           )}
 
           {/* Guests section */}
           {guestUsers.length > 0 && (
             <>
-              <SectionDivider label="Guests" />
-              {guestUsers.map((user) => (
-                <UserItem key={user.id} user={user} />
-              ))}
+              <SelectSeparator />
+              <SelectGroup>
+                <SelectLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                  Guests
+                </SelectLabel>
+                {guestUsers.map((user) => (
+                  <UserItem key={user.id} user={user} />
+                ))}
+              </SelectGroup>
             </>
           )}
 

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -4,6 +4,8 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
@@ -104,6 +106,8 @@ export function OwnerSelect({
   // Filter and section logic.
   // When query is empty and showHidden is false: only member+ active users.
   // When query has content: all users matching the search (filter bypassed).
+  // The currently selected user is always included regardless of filter so
+  // Radix Select can display the trigger value correctly.
   const { memberUsers, invitedUsers, guestUsers } = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     const isSearching = normalizedQuery.length > 0;
@@ -115,8 +119,10 @@ export function OwnerSelect({
       : showHidden
         ? sortedUsers
         : sortedUsers.filter(
-            // permissions-audit-allow: UI display filter, not a permission gate
-            (u) => u.role !== "guest" && u.status !== "invited"
+            (u) =>
+              u.id === selectedId ||
+              // permissions-audit-allow: UI display filter, not a permission gate
+              (u.role !== "guest" && u.status !== "invited")
           );
 
     const memberGroup = visibleUsers.filter(
@@ -134,7 +140,7 @@ export function OwnerSelect({
       invitedUsers: invitedGroup,
       guestUsers: guestGroup,
     };
-  }, [sortedUsers, query, showHidden]);
+  }, [sortedUsers, query, showHidden, selectedId]);
 
   const RoleBadge = ({
     user,
@@ -147,21 +153,21 @@ export function OwnerSelect({
     if (isGuest && isInvited) {
       return (
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          (INVITED · GUEST)
+          (Invited · Guest)
         </span>
       );
     }
     if (isInvited) {
       return (
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          (INVITED)
+          (Invited)
         </span>
       );
     }
     if (isGuest) {
       return (
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          (GUEST)
+          (Guest)
         </span>
       );
     }
@@ -182,12 +188,13 @@ export function OwnerSelect({
     </SelectItem>
   );
 
-  const SectionHeader = ({ label }: { label: string }): React.JSX.Element => (
-    <div className="px-2 py-1.5">
-      <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+  const SectionDivider = ({ label }: { label: string }): React.JSX.Element => (
+    <>
+      <SelectSeparator />
+      <SelectLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
         {label}
-      </p>
-    </div>
+      </SelectLabel>
+    </>
   );
 
   return (
@@ -264,7 +271,7 @@ export function OwnerSelect({
           {/* Invited section */}
           {invitedUsers.length > 0 && (
             <>
-              <SectionHeader label="Invited" />
+              <SectionDivider label="Invited" />
               {invitedUsers.map((user) => (
                 <UserItem key={user.id} user={user} />
               ))}
@@ -274,7 +281,7 @@ export function OwnerSelect({
           {/* Guests section */}
           {guestUsers.length > 0 && (
             <>
-              <SectionHeader label="Guests" />
+              <SectionDivider label="Guests" />
               {guestUsers.map((user) => (
                 <UserItem key={user.id} user={user} />
               ))}

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -149,12 +149,36 @@ export function OwnerSelect({
   // happen before the users prop is updated, without triggering extra renders.
   const pendingSelectionRef = useRef<string | null>(null);
 
-  // Re-sort users after client-side mutations (e.g., inviting a new user)
-  // to maintain consistent ordering: confirmed first, by machine count desc, then by last name
-  const sortedUsers = useMemo(
-    () => [...users, ...localExtraUsers].sort(compareUnifiedUsers),
-    [users, localExtraUsers]
-  );
+  // Merge users (prop) and localExtraUsers (post-invite optimistic additions),
+  // de-duping by id so the parent re-rendering with the invited user in `users`
+  // doesn't produce duplicate React keys / duplicate dropdown entries.
+  // Sort: confirmed first, by machine count desc, then by last name.
+  const sortedUsers = useMemo(() => {
+    const mergedUsers = new Map<string, OwnerSelectUser>();
+    for (const user of users) {
+      mergedUsers.set(user.id, user);
+    }
+    for (const user of localExtraUsers) {
+      mergedUsers.set(user.id, user);
+    }
+    return [...mergedUsers.values()].sort(compareUnifiedUsers);
+  }, [users, localExtraUsers]);
+
+  // Once the parent's `users` prop catches up and includes an optimistically
+  // invited user, drop the duplicate from `localExtraUsers` so props remain the
+  // single source of truth. Avoids stale local copies if the server returns an
+  // updated user record (e.g. corrected casing or normalized name).
+  useEffect(() => {
+    if (localExtraUsers.length === 0) return;
+    const userIds = new Set(users.map((user) => user.id));
+    // Bail out if no local extras are now in props — avoids creating a new
+    // array reference and triggering an unnecessary re-render every time
+    // `users` updates.
+    if (!localExtraUsers.some((user) => userIds.has(user.id))) return;
+    setLocalExtraUsers((current) =>
+      current.filter((user) => !userIds.has(user.id))
+    );
+  }, [users, localExtraUsers]);
 
   // Apply the pending selection once the invited user appears in sortedUsers.
   // This effect fires after the render where localExtraUsers is updated (adding
@@ -173,17 +197,21 @@ export function OwnerSelect({
   }, [sortedUsers, onValueChange]);
 
   // Filter and section logic.
-  // When query is empty and showHidden is false: only member+ active users.
-  // When query has content: all users matching the search (filter bypassed).
-  // The currently selected user is always included regardless of filter so
-  // Radix Select can display the trigger value correctly.
+  // When query is empty and showHidden is false: only member+ active users
+  // (plus the currently selected user, so the trigger can render the label).
+  // When query has content: matches by name, but also force-include the
+  // selected user so a non-matching query never unmounts the selected
+  // SelectItem (which would blank the trigger via Radix's portal mechanism).
+  // showHidden=true bypasses the role/status filter entirely.
   const { memberUsers, invitedUsers, guestUsers } = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     const isSearching = normalizedQuery.length > 0;
 
     const visibleUsers = isSearching
-      ? sortedUsers.filter((u) =>
-          u.name.toLowerCase().includes(normalizedQuery)
+      ? sortedUsers.filter(
+          (u) =>
+            u.id === selectedId ||
+            u.name.toLowerCase().includes(normalizedQuery)
         )
       : showHidden
         ? sortedUsers

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -44,9 +44,10 @@ import { compareUnifiedUsers } from "~/lib/users/comparators";
  * ## Key Abstractions
  * - `OwnerSelectUser` includes `role`, `machineCount`, and `status` for
  *   metadata display and filtering
- * - After an invite, `setSelectedId` and `onUsersChange` are called together
- *   so React batches them into one render — the new user is visible in the
- *   content and the trigger shows their name immediately
+ * - After an invite, the new user is added to `localExtraUsers` (local state)
+ *   so they appear in `sortedUsers` immediately in the same render — no parent
+ *   re-render required for the trigger to display the correct name. The parent
+ *   is also notified via `onUsersChange` for form-submission purposes.
  * - `compareUnifiedUsers` from `~/lib/users/comparators` drives sort order
  * - The help text below the select explains the notification implication of
  *   owner assignment
@@ -135,11 +136,17 @@ export function OwnerSelect({
   const [showHidden, setShowHidden] = useState(false);
   const [query, setQuery] = useState("");
 
+  // Users added via the inline invite flow are tracked locally so they are
+  // immediately available in sortedUsers within the SAME render cycle as
+  // setSelectedId — no parent re-render required. The parent is also notified
+  // via onUsersChange so the hidden form field submits the correct value.
+  const [localExtraUsers, setLocalExtraUsers] = useState<OwnerSelectUser[]>([]);
+
   // Re-sort users after client-side mutations (e.g., inviting a new user)
   // to maintain consistent ordering: confirmed first, by machine count desc, then by last name
   const sortedUsers = useMemo(
-    () => [...users].sort(compareUnifiedUsers),
-    [users]
+    () => [...users, ...localExtraUsers].sort(compareUnifiedUsers),
+    [users, localExtraUsers]
   );
 
   // Filter and section logic.
@@ -302,13 +309,16 @@ export function OwnerSelect({
         open={inviteDialogOpen}
         onOpenChange={setInviteDialogOpen}
         onSuccess={(newUserId, newUser) => {
-          // Select the new user and show hidden groups so the invited user
-          // appears in the content. Both state updates are batched with
-          // onUsersChange into a single render — trigger shows correct name.
+          // Add the new user to localExtraUsers so they appear in sortedUsers
+          // immediately — this avoids a render-cycle dependency on the parent
+          // re-rendering with a new `users` prop before the trigger can display
+          // the selected user's name.
+          setLocalExtraUsers((prev) => [...prev, newUser]);
           setSelectedId(newUserId);
           setShowHidden(true);
           onValueChange?.(newUserId);
-          // Add the new user to the list immediately (no server refresh needed)
+          // Also notify parent so it can persist the updated user list
+          // (e.g. for form submission or other UI concerns).
           if (onUsersChange) {
             onUsersChange([...users, newUser]);
           }

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -9,9 +9,11 @@ import {
 } from "~/components/ui/select";
 import { Label } from "~/components/ui/label";
 import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Checkbox } from "~/components/ui/checkbox";
 
 import React, { useState, useEffect, useRef, useMemo } from "react";
-import type { UserStatus } from "~/lib/types";
+import type { UserStatus, UserRole } from "~/lib/types";
 import { InviteUserDialog } from "~/components/users/InviteUserDialog";
 import { Plus } from "lucide-react";
 import { compareUnifiedUsers } from "~/lib/users/comparators";
@@ -28,13 +30,18 @@ import { compareUnifiedUsers } from "~/lib/users/comparators";
  * ## Composition
  * - Users are sorted by `compareUnifiedUsers` (confirmed first, by machine
  *   count descending, then by last name)
- * - Each option shows: name, machine count badge (if > 0), and "(Invited)"
- *   tag for users with `status === "invited"`
+ * - Default view: member+ active users only. "Show guests and invited users"
+ *   checkbox reveals hidden groups. Typed search bypasses the filter.
+ * - Sections: member+ active (no header), then "Invited" header + invited,
+ *   then "Guests" header + guest users. Sections only shown when populated.
+ * - Each option shows: name, machine count badge (if > 0), and role badges
+ *   matching the existing `(INVITED)` pattern.
  * - `onUsersChange` callback allows the parent to update its user list
  *   without a server round-trip after an invite
  *
  * ## Key Abstractions
- * - `OwnerSelectUser` includes `machineCount` and `status` for metadata display
+ * - `OwnerSelectUser` includes `role`, `machineCount`, and `status` for
+ *   metadata display and filtering
  * - `pendingSelectionRef` handles the async flow: invite dialog closes ->
  *   parent updates users -> effect detects the new user and selects them
  * - `compareUnifiedUsers` from `~/lib/users/comparators` drives sort order
@@ -48,6 +55,7 @@ export interface OwnerSelectUser {
   lastName: string;
   machineCount: number;
   status: UserStatus;
+  role: UserRole;
 }
 
 interface OwnerSelectProps {
@@ -67,6 +75,8 @@ export function OwnerSelect({
 }: OwnerSelectProps): React.JSX.Element {
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const [selectedId, setSelectedId] = useState(defaultValue ?? "");
+  const [showHidden, setShowHidden] = useState(false);
+  const [query, setQuery] = useState("");
 
   // Ref to track pending user ID to select after users list updates
   const pendingSelectionRef = useRef<string | null>(null);
@@ -91,6 +101,95 @@ export function OwnerSelect({
     [users]
   );
 
+  // Filter and section logic.
+  // When query is empty and showHidden is false: only member+ active users.
+  // When query has content: all users matching the search (filter bypassed).
+  const { memberUsers, invitedUsers, guestUsers } = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const isSearching = normalizedQuery.length > 0;
+
+    const visibleUsers = isSearching
+      ? sortedUsers.filter((u) =>
+          u.name.toLowerCase().includes(normalizedQuery)
+        )
+      : showHidden
+        ? sortedUsers
+        : sortedUsers.filter(
+            // permissions-audit-allow: UI display filter, not a permission gate
+            (u) => u.role !== "guest" && u.status !== "invited"
+          );
+
+    const memberGroup = visibleUsers.filter(
+      // permissions-audit-allow: UI sectioning by role, not a permission gate
+      (u) => u.status === "active" && u.role !== "guest"
+    );
+    const invitedGroup = visibleUsers.filter((u) => u.status === "invited");
+    const guestGroup = visibleUsers.filter(
+      // permissions-audit-allow: UI sectioning by role, not a permission gate
+      (u) => u.status === "active" && u.role === "guest"
+    );
+
+    return {
+      memberUsers: memberGroup,
+      invitedUsers: invitedGroup,
+      guestUsers: guestGroup,
+    };
+  }, [sortedUsers, query, showHidden]);
+
+  const RoleBadge = ({
+    user,
+  }: {
+    user: OwnerSelectUser;
+  }): React.JSX.Element | null => {
+    const isGuest = user.role === "guest"; // permissions-audit-allow: UI badge display, not a permission gate
+    const isInvited = user.status === "invited";
+
+    if (isGuest && isInvited) {
+      return (
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          (INVITED · GUEST)
+        </span>
+      );
+    }
+    if (isInvited) {
+      return (
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          (INVITED)
+        </span>
+      );
+    }
+    if (isGuest) {
+      return (
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          (GUEST)
+        </span>
+      );
+    }
+    return null;
+  };
+
+  const UserItem = ({ user }: { user: OwnerSelectUser }): React.JSX.Element => (
+    <SelectItem key={user.id} value={user.id}>
+      <div className="flex items-center gap-2">
+        <span>{user.name}</span>
+        {user.machineCount > 0 && (
+          <span className="text-[10px] text-muted-foreground/70">
+            ({user.machineCount})
+          </span>
+        )}
+        <RoleBadge user={user} />
+      </div>
+    </SelectItem>
+  );
+
+  const SectionHeader = ({ label }: { label: string }): React.JSX.Element => (
+    <div className="px-2 py-1.5">
+      <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+    </div>
+  );
+
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
@@ -110,6 +209,35 @@ export function OwnerSelect({
           </Button>
         )}
       </div>
+
+      {/* Search input */}
+      <Input
+        type="text"
+        placeholder="Search users..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="border-outline bg-surface text-foreground placeholder:text-muted-foreground"
+        disabled={!!disabled}
+        data-testid="owner-search-input"
+      />
+
+      {/* Show guests and invited users toggle */}
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="owner-show-hidden"
+          checked={showHidden}
+          onCheckedChange={(checked) => setShowHidden(checked === true)}
+          disabled={!!disabled}
+          data-testid="owner-show-hidden-checkbox"
+        />
+        <label
+          htmlFor="owner-show-hidden"
+          className="text-xs text-muted-foreground cursor-pointer select-none"
+        >
+          Show guests and invited users
+        </label>
+      </div>
+
       <Select
         name="ownerId"
         value={selectedId}
@@ -128,23 +256,39 @@ export function OwnerSelect({
           <SelectValue placeholder="Select an owner" />
         </SelectTrigger>
         <SelectContent>
-          {sortedUsers.map((user) => (
-            <SelectItem key={user.id} value={user.id}>
-              <div className="flex items-center gap-2">
-                <span>{user.name}</span>
-                {user.machineCount > 0 && (
-                  <span className="text-[10px] text-muted-foreground/70">
-                    ({user.machineCount})
-                  </span>
-                )}
-                {user.status === "invited" && (
-                  <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
-                    (Invited)
-                  </span>
-                )}
-              </div>
-            </SelectItem>
+          {/* Member+ active users (no section header — default group) */}
+          {memberUsers.map((user) => (
+            <UserItem key={user.id} user={user} />
           ))}
+
+          {/* Invited section */}
+          {invitedUsers.length > 0 && (
+            <>
+              <SectionHeader label="Invited" />
+              {invitedUsers.map((user) => (
+                <UserItem key={user.id} user={user} />
+              ))}
+            </>
+          )}
+
+          {/* Guests section */}
+          {guestUsers.length > 0 && (
+            <>
+              <SectionHeader label="Guests" />
+              {guestUsers.map((user) => (
+                <UserItem key={user.id} user={user} />
+              ))}
+            </>
+          )}
+
+          {/* Empty state */}
+          {memberUsers.length === 0 &&
+            invitedUsers.length === 0 &&
+            guestUsers.length === 0 && (
+              <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+                No users found
+              </div>
+            )}
         </SelectContent>
       </Select>
       <p id="owner-help" className="text-xs text-muted-foreground">

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -8,13 +8,14 @@ import {
   SelectLabel,
   SelectSeparator,
   SelectTrigger,
+  SelectValue,
 } from "~/components/ui/select";
 import { Label } from "~/components/ui/label";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Checkbox } from "~/components/ui/checkbox";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import type { UserStatus, UserRole } from "~/lib/types";
 import { InviteUserDialog } from "~/components/users/InviteUserDialog";
 import { Plus } from "lucide-react";
@@ -43,10 +44,11 @@ import { compareUnifiedUsers } from "~/lib/users/comparators";
  * ## Key Abstractions
  * - `OwnerSelectUser` includes `role`, `machineCount`, and `status` for
  *   metadata display and filtering
- * - After an invite, the new user is added to `localExtraUsers` (local state)
- *   so they appear in `sortedUsers` immediately in the same render — no parent
- *   re-render required for the trigger to display the correct name. The parent
- *   is also notified via `onUsersChange` for form-submission purposes.
+ * - After an invite, `pendingSelectionRef` stores the new user's ID and
+ *   `localExtraUsers` adds them to `sortedUsers` immediately. A `useEffect`
+ *   applies `setSelectedId` once the user appears in `sortedUsers` — by then
+ *   their `SelectItem` is registered in Radix's DocumentFragment collection
+ *   and `SelectValue` can portal the text into the trigger correctly.
  * - `compareUnifiedUsers` from `~/lib/users/comparators` drives sort order
  * - The help text below the select explains the notification implication of
  *   owner assignment
@@ -123,32 +125,6 @@ function UserItem({ user }: { user: OwnerSelectUser }): React.JSX.Element {
   );
 }
 
-/**
- * TriggerDisplay — shows the selected user's name + role badges in the trigger.
- * Used instead of <SelectValue> because Radix Select's SelectValue only
- * renders the selected item's text when the item was registered via
- * SelectPrimitive.ItemText inside an open SelectContent. Programmatic value
- * changes (e.g. after invite) bypass this registry — this component sidesteps
- * that limitation by reading from sortedUsers directly.
- */
-function TriggerDisplay({
-  user,
-}: {
-  user: OwnerSelectUser;
-}): React.JSX.Element {
-  return (
-    <div className="flex items-center gap-2">
-      <span>{user.name}</span>
-      {user.machineCount > 0 && (
-        <span className="text-[10px] text-muted-foreground/70">
-          ({user.machineCount})
-        </span>
-      )}
-      <RoleBadge user={user} />
-    </div>
-  );
-}
-
 export function OwnerSelect({
   users,
   defaultValue,
@@ -162,10 +138,16 @@ export function OwnerSelect({
   const [query, setQuery] = useState("");
 
   // Users added via the inline invite flow are tracked locally so they are
-  // immediately available in sortedUsers within the SAME render cycle as
-  // setSelectedId — no parent re-render required. The parent is also notified
-  // via onUsersChange so the hidden form field submits the correct value.
+  // immediately available in sortedUsers (and thus the SelectContent's
+  // DocumentFragment) before the parent re-renders with the updated users prop.
+  // This ensures the invited user's SelectItem is registered in Radix's item
+  // collection so SelectValue can portal the text into the trigger.
   const [localExtraUsers, setLocalExtraUsers] = useState<OwnerSelectUser[]>([]);
+
+  // Ref to track pending user ID to select after users list updates.
+  // Using a ref (not state) here is intentional: it survives re-renders that
+  // happen before the users prop is updated, without triggering extra renders.
+  const pendingSelectionRef = useRef<string | null>(null);
 
   // Re-sort users after client-side mutations (e.g., inviting a new user)
   // to maintain consistent ordering: confirmed first, by machine count desc, then by last name
@@ -174,13 +156,21 @@ export function OwnerSelect({
     [users, localExtraUsers]
   );
 
-  // The currently selected user object — drives the trigger display directly
-  // instead of relying on Radix SelectValue's internal ItemText registry
-  const selectedUser = useMemo(
-    () =>
-      selectedId ? sortedUsers.find((u) => u.id === selectedId) : undefined,
-    [sortedUsers, selectedId]
-  );
+  // Apply the pending selection once the invited user appears in sortedUsers.
+  // This effect fires after the render where localExtraUsers is updated (adding
+  // the new user) OR after the parent re-renders with the updated users prop.
+  // At that point, Radix's SelectItem for the new user is mounted in the
+  // DocumentFragment and its ItemText is portaled into the SelectValue node.
+  useEffect(() => {
+    if (pendingSelectionRef.current) {
+      const pendingId = pendingSelectionRef.current;
+      if (sortedUsers.some((u) => u.id === pendingId)) {
+        setSelectedId(pendingId);
+        onValueChange?.(pendingId);
+        pendingSelectionRef.current = null;
+      }
+    }
+  }, [sortedUsers, onValueChange]);
 
   // Filter and section logic.
   // When query is empty and showHidden is false: only member+ active users.
@@ -284,22 +274,7 @@ export function OwnerSelect({
           aria-describedby="owner-help"
           data-testid="owner-select"
         >
-          {/*
-           * Render the trigger label manually instead of using <SelectValue>.
-           * Radix Select's SelectValue looks up the selected item text from its
-           * internal ItemText registry, which is only populated when a SelectItem
-           * is rendered inside an open SelectContent. When value is set
-           * programmatically (e.g. after an invite), the content is closed and
-           * unmounted, so the registry has no entry for the new user — causing
-           * the trigger to show "Select an owner" despite value being set.
-           * By looking up the user in sortedUsers directly we bypass this
-           * limitation entirely.
-           */}
-          {selectedUser ? (
-            <TriggerDisplay user={selectedUser} />
-          ) : (
-            <span className="text-muted-foreground">Select an owner</span>
-          )}
+          <SelectValue placeholder="Select an owner" />
         </SelectTrigger>
         <SelectContent>
           {/* Member+ active users (no section header — default group) */}
@@ -357,14 +332,19 @@ export function OwnerSelect({
         open={inviteDialogOpen}
         onOpenChange={setInviteDialogOpen}
         onSuccess={(newUserId, newUser) => {
-          // Add the new user to localExtraUsers so they appear in sortedUsers
-          // immediately — this avoids a render-cycle dependency on the parent
-          // re-rendering with a new `users` prop before the trigger can display
-          // the selected user's name.
+          // Store the pending selection ID in a ref (survives re-renders
+          // triggered by Next.js router cache updates after the server action).
+          // The useEffect above applies the selection once sortedUsers includes
+          // the new user — at which point Radix's SelectItem is mounted in the
+          // DocumentFragment and SelectValue can display the correct name.
+          pendingSelectionRef.current = newUserId;
+          // Add the new user to localExtraUsers immediately — this makes them
+          // available in sortedUsers (and thus the closed SelectContent's
+          // DocumentFragment) in the NEXT render, without waiting for the
+          // parent to re-render with an updated users prop.
           setLocalExtraUsers((prev) => [...prev, newUser]);
-          setSelectedId(newUserId);
+          // Show hidden groups so the invited user appears in the content.
           setShowHidden(true);
-          onValueChange?.(newUserId);
           // Also notify parent so it can persist the updated user list
           // (e.g. for form submission or other UI concerns).
           if (onUsersChange) {

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -8,7 +8,6 @@ import {
   SelectLabel,
   SelectSeparator,
   SelectTrigger,
-  SelectValue,
 } from "~/components/ui/select";
 import { Label } from "~/components/ui/label";
 import { Button } from "~/components/ui/button";
@@ -124,6 +123,32 @@ function UserItem({ user }: { user: OwnerSelectUser }): React.JSX.Element {
   );
 }
 
+/**
+ * TriggerDisplay — shows the selected user's name + role badges in the trigger.
+ * Used instead of <SelectValue> because Radix Select's SelectValue only
+ * renders the selected item's text when the item was registered via
+ * SelectPrimitive.ItemText inside an open SelectContent. Programmatic value
+ * changes (e.g. after invite) bypass this registry — this component sidesteps
+ * that limitation by reading from sortedUsers directly.
+ */
+function TriggerDisplay({
+  user,
+}: {
+  user: OwnerSelectUser;
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-2">
+      <span>{user.name}</span>
+      {user.machineCount > 0 && (
+        <span className="text-[10px] text-muted-foreground/70">
+          ({user.machineCount})
+        </span>
+      )}
+      <RoleBadge user={user} />
+    </div>
+  );
+}
+
 export function OwnerSelect({
   users,
   defaultValue,
@@ -147,6 +172,14 @@ export function OwnerSelect({
   const sortedUsers = useMemo(
     () => [...users, ...localExtraUsers].sort(compareUnifiedUsers),
     [users, localExtraUsers]
+  );
+
+  // The currently selected user object — drives the trigger display directly
+  // instead of relying on Radix SelectValue's internal ItemText registry
+  const selectedUser = useMemo(
+    () =>
+      selectedId ? sortedUsers.find((u) => u.id === selectedId) : undefined,
+    [sortedUsers, selectedId]
   );
 
   // Filter and section logic.
@@ -251,7 +284,22 @@ export function OwnerSelect({
           aria-describedby="owner-help"
           data-testid="owner-select"
         >
-          <SelectValue placeholder="Select an owner" />
+          {/*
+           * Render the trigger label manually instead of using <SelectValue>.
+           * Radix Select's SelectValue looks up the selected item text from its
+           * internal ItemText registry, which is only populated when a SelectItem
+           * is rendered inside an open SelectContent. When value is set
+           * programmatically (e.g. after an invite), the content is closed and
+           * unmounted, so the registry has no entry for the new user — causing
+           * the trigger to show "Select an owner" despite value being set.
+           * By looking up the user in sortedUsers directly we bypass this
+           * limitation entirely.
+           */}
+          {selectedUser ? (
+            <TriggerDisplay user={selectedUser} />
+          ) : (
+            <span className="text-muted-foreground">Select an owner</span>
+          )}
         </SelectTrigger>
         <SelectContent>
           {/* Member+ active users (no section header — default group) */}

--- a/src/components/users/InviteUserDialog.tsx
+++ b/src/components/users/InviteUserDialog.tsx
@@ -27,13 +27,6 @@ import {
   FormLabel,
   FormMessage,
 } from "~/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
 import { Switch } from "~/components/ui/switch";
 import { inviteUser } from "~/app/(app)/admin/users/actions";
 import { inviteUserSchema } from "~/app/(app)/admin/users/schema";
@@ -60,7 +53,7 @@ export function InviteUserDialog({
       lastName: "",
       email: "",
       role: "member",
-      sendInvite: false,
+      sendInvite: true,
     },
   });
 
@@ -80,12 +73,14 @@ export function InviteUserDialog({
           toast.success("User invited successfully");
           form.reset();
           // Build minimal user object for the callback (CORE-SEC-006)
+          // Role is always "member" — the role field was removed from this dialog
           const newUser: OwnerSelectUser = {
             id: result.userId,
             name: `${values.firstName} ${values.lastName}`,
             lastName: values.lastName,
             status: "invited",
             machineCount: 0,
+            role: "member",
           };
           // Call onSuccess with both the ID and minimal OwnerSelectUser, then close dialog
           // Note: router.refresh() removed - parent manages users state directly
@@ -161,31 +156,6 @@ export function InviteUserDialog({
                   <FormControl>
                     <Input type="email" {...field} />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="role"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a role" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="guest">Guest</SelectItem>
-                      <SelectItem value="member">Member</SelectItem>
-                    </SelectContent>
-                  </Select>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
## Summary

- **OwnerSelect refactor**: guests and invited users are hidden by default; a "Show guests and invited users" checkbox reveals them; typed search bypasses the filter. Sectioned rendering: member+ active users (no header), then "Invited" + "Guests" sections only when populated. Inline role badges `(GUEST)`, `(INVITED)`, `(INVITED · GUEST)` matching the existing pattern.
- **InviteUserDialog**: role field removed entirely (owners must be member+); `sendInvite` defaults to `true` (invitee is becoming a machine owner — they should hear from us).
- **Promote dialog**: when `createMachineAction` or `updateMachineAction` returns `ASSIGNEE_NOT_MEMBER`, a `<Dialog>` opens (not `<AlertDialog>` — this is a state change, not destructive). Confirm re-submits the form with a dynamically injected `forcePromoteUserId` hidden field, triggering the atomic promote + assign transaction on the server.
- **Role wiring**: `role: u.role` added to the `OwnerSelectUser` mapper in `m/[initials]/page.tsx` and `m/new/page.tsx`.
- **Token cleanup**: `text-on-primary` → `text-primary-foreground` in button classes (opportunistic).

## Dependencies

- Requires PR #1197 (preflight script) ✅ merged
- Requires PR #1198 (backend layer) ✅ merged

## Verification

- `pnpm run check` passes (906 tests, typecheck, lint, format, audit:role-checks)
- Pre-commit hook clean
- **Manual browser walkthrough**: Could not complete locally due to Supabase port conflict (port 54922 allocated to a sibling worktree). CI will exercise this fully. The code path is straightforward — visual verification recommended on the CI preview deployment.

## Test plan

- [ ] Open `/m/new` as admin — owner picker default: only member+ users visible
- [ ] Toggle "Show guests and invited users" — guests appear in "Guests" section, invited users in "Invited" section
- [ ] Type a guest's name in search — appears regardless of toggle state
- [ ] Pick a guest, submit — promote dialog opens with name + badge
- [ ] Confirm promote — machine created, user is now member
- [ ] Repeat flow as tech user
- [ ] Click "Invite New" — dialog opens with NO role field, "Send Invitation Email" toggle ON by default
- [ ] Edit an existing machine, change owner to a guest — same promote dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)