### PR TITLE
fix(a11y): destructive contrast, focus ring, color-blind rule

### DIFF
--- a/.agent/skills/pinpoint-design-bible/SKILL.md
+++ b/.agent/skills/pinpoint-design-bible/SKILL.md
@@ -35,6 +35,7 @@ PinPoint uses a **dark neon aesthetic** -- deep charcoal backgrounds with neon g
 - Status colors come from `STATUS_CONFIG` -- never freestyle status colors.
 - Glow effects (`glow-primary`, `glow-secondary`) are for interactive hover states only, never static decoration.
 - Frosted glass (bg-card with opacity + `backdrop-blur-sm`) is reserved for navigation chrome.
+- **Never rely on color alone to convey semantics.** Destructive, warning, success, and status cues must ship with an accompanying icon or verb label. Under deuteranopia / protanopia (combined ~8% of men), destructive-red and warning-amber collapse to similar mustard shades and are not distinguishable by hue. Concretely: `<Alert variant="destructive">` and `<Alert variant="warning">` take a leading `AlertOctagon` / `AlertTriangle` (or equivalent) icon child; destructive buttons carry a verb label like "Delete"; status / severity / priority badges pull their icon from `STATUS_CONFIG` / `SEVERITY_CONFIG` / `PRIORITY_CONFIG`.
 
 ## 2. Surface Hierarchy
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,13 +25,13 @@
   /* Accents & Status */
   --color-accent: #27272a;
   --color-accent-foreground: #f8fafc;
-  --color-destructive: #ef4444;
+  --color-destructive: #dc2626; /* red-600 — white on red-500 failed AA (~3.8:1); red-600 passes (~5.3:1) */
   --color-destructive-foreground: #ffffff;
 
   /* Status Specific */
   --color-status-new: #4ade80;
   --color-status-in-progress: #d946ef;
-  --color-status-unplayable: #ef4444;
+  --color-status-unplayable: #dc2626; /* red-600 — kept in sync with --color-destructive */
 
   /* Semantic Status Colors */
   --color-success: #22c55e;
@@ -44,7 +44,7 @@
   --color-warning-container: #713f12;
   --color-on-warning-container: #fef9c3;
 
-  --color-error: #ef4444;
+  --color-error: #dc2626; /* red-600 — kept in sync with --color-destructive */
   --color-error-foreground: #ffffff;
   --color-error-container: #7f1d1d;
   --color-on-error-container: #fee2e2;
@@ -52,7 +52,7 @@
   /* Borders & Inputs */
   --color-border: #27272a;
   --color-input: #27272a;
-  --color-ring: #4ade80;
+  --color-ring: #f8fafc; /* foreground — was primary green, which made focus invisible on primary buttons */
 
   /* Extended Surface Palette */
   --color-surface: #0f0f11;


### PR DESCRIPTION
## Summary

Three targeted accessibility fixes from the palette audit, plus a design-bible rule for the class of problems.

### Destructive WCAG AA contrast
`--color-destructive` was `#ef4444` (red-500). White-on-red-500 = ~3.8:1 → fails AA body text. Every destructive button and alert was below the bar. Shifted to `#dc2626` (red-600) = ~5.3:1, AA clean. Kept `--color-error` and `--color-status-unplayable` in sync.

### Focus ring visibility
`--color-ring` was `#4ade80` (same as `--color-primary`). A ring the same color as the primary button fill is effectively invisible when a primary CTA is focused. Swapped to `#f8fafc` (foreground white) for universal contrast.

### Design bible rule (§1)
Added a "never rely on color alone to convey semantics" rule. Under deuteranopia/protanopia (~8% of men) destructive-red and warning-amber collapse to similar mustard shades — hue alone is not enough. Codifies the codebase's existing pattern (Alert variants take icon children, STATUS_CONFIG supplies icons).

## Not in this PR (tracked)

- Primary-vs-secondary hue proximity (green 142° / teal 170°, 28° apart). User confirmed teal reads distinctly enough for them; accepted.
- Raw `purple-*` in STATUS_CONFIG / PRIORITY_CONFIG — PP-4ej follow-up.
- Token aliasing (muted/accent/border/input all `#27272a`) — clarity, not a11y.

## Test plan

- [x] `pnpm run check` — 906/906 pass locally
- [ ] CI green
- [ ] Visual spot-check: focus state on primary button shows a white ring; destructive button/alert reads legibly; no regressions in red/amber badges

## Review notes

This PR is independent of [#1204](https://github.com/timothyfroehlich/PinPoint/pull/1204) — it branches off `main`, not off the purple-to-teal branch. Either can land first; if #1204 merges first, this one should still apply cleanly (they touch different lines in `globals.css`).