### PR TITLE
chore(ui): apply text-balance and text-pretty across wrapping copy (PP-yxw.16)

### DIFF
--- a/.agent/skills/pinpoint-design-bible/SKILL.md
+++ b/.agent/skills/pinpoint-design-bible/SKILL.md
@@ -257,6 +257,14 @@ Use shadcn defaults: `CardHeader` (px-6 pt-6 pb-3), `CardContent` (px-6 pb-6). O
 | Issue IDs                  | `font-mono` (e.g., AFM-3)                                                |
 | Machine name in cards      | `text-xs font-medium underline decoration-primary/30 underline-offset-2` |
 
+**Text wrapping (text-balance / text-pretty):**
+
+- `text-balance` on headings that may wrap onto multiple lines (page titles, card titles, dialog titles, hero copy, section headings).
+- `text-pretty` on multi-line body copy that may wrap (card descriptions, alert/dialog descriptions, PageHeader subtitles, auth intro copy, feature descriptions).
+- Skip both for short definitely-single-line labels, table cells, badge/chip labels, and legends.
+
+The shared primitives (`CardTitle`/`CardDescription`, `AlertTitle`/`AlertDescription`, `DialogTitle`/`DialogDescription`, `AlertDialogTitle`/`AlertDialogDescription`, `EmptyState`, `PageHeader`) bake these in by default — call sites rarely need to add them manually.
+
 ## 10. Border & Divider Rules
 
 | Context            | Treatment                              |

--- a/src/app/(app)/admin/users/user-management-header.tsx
+++ b/src/app/(app)/admin/users/user-management-header.tsx
@@ -12,8 +12,10 @@ export function UserManagementHeader(): React.JSX.Element {
   return (
     <div className="flex items-center justify-between">
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">User Management</h2>
-        <p className="text-muted-foreground">
+        <h2 className="text-balance text-2xl font-bold tracking-tight">
+          User Management
+        </h2>
+        <p className="text-pretty text-muted-foreground">
           Manage activated and invited users.
         </p>
       </div>

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/editable-issue-title.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/editable-issue-title.tsx
@@ -83,7 +83,7 @@ export function EditableIssueTitle({
     return (
       <h1
         className={cn(
-          "font-extrabold tracking-tight",
+          "text-balance font-extrabold tracking-tight",
           className ?? "text-3xl @3xl:text-4xl"
         )}
         title={title.length > 60 ? title : undefined}
@@ -134,7 +134,7 @@ export function EditableIssueTitle({
     <div className="group/title flex items-center gap-2">
       <h1
         className={cn(
-          "font-extrabold tracking-tight",
+          "text-balance font-extrabold tracking-tight",
           className ?? "text-3xl @3xl:text-4xl"
         )}
         title={title.length > 60 ? title : undefined}

--- a/src/app/(app)/report/success/page.tsx
+++ b/src/app/(app)/report/success/page.tsx
@@ -50,10 +50,10 @@ export default async function ReportSuccessPage({
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="space-y-3">
-            <p className="text-lg text-foreground">
+            <p className="text-pretty text-lg text-foreground">
               Thank you for reporting this issue.
             </p>
-            <p className="text-sm text-muted-foreground leading-relaxed">
+            <p className="text-pretty text-sm text-muted-foreground leading-relaxed">
               Our maintenance team has been notified. We appreciate your help
               keeping these machines running smoothly for everyone.
             </p>
@@ -61,10 +61,10 @@ export default async function ReportSuccessPage({
 
           {isNewPending && (
             <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-left">
-              <h4 className="text-sm font-semibold text-primary mb-1">
+              <h4 className="text-balance text-sm font-semibold text-primary mb-1">
                 Want to track your reports?
               </h4>
-              <p className="text-xs text-muted-foreground mb-3">
+              <p className="text-pretty text-xs text-muted-foreground mb-3">
                 We&apos;ve saved your details. Create a full account to see
                 status updates and manage all your reports in one place.
               </p>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -86,7 +86,9 @@ export default async function SettingsPage(): Promise<React.JSX.Element> {
 
       <div className="space-y-6">
         <div>
-          <h2 className="text-xl font-semibold mb-4">Profile Settings</h2>
+          <h2 className="text-balance text-xl font-semibold mb-4">
+            Profile Settings
+          </h2>
           <ProfileForm
             firstName={profile.firstName}
             lastName={profile.lastName}
@@ -99,7 +101,7 @@ export default async function SettingsPage(): Promise<React.JSX.Element> {
         <Separator />
 
         <div>
-          <h2 className="text-xl font-semibold mb-4">
+          <h2 className="text-balance text-xl font-semibold mb-4">
             Notification Preferences
           </h2>
           {/* CORE-SEC-006: Map to minimal shape, strip userId */}
@@ -128,8 +130,8 @@ export default async function SettingsPage(): Promise<React.JSX.Element> {
         <Separator />
 
         <div>
-          <h2 className="text-xl font-semibold mb-4">Security</h2>
-          <p className="text-sm text-muted-foreground mb-4">
+          <h2 className="text-balance text-xl font-semibold mb-4">Security</h2>
+          <p className="text-pretty text-sm text-muted-foreground mb-4">
             Change your account password.
           </p>
           <ChangePasswordSection />
@@ -138,10 +140,10 @@ export default async function SettingsPage(): Promise<React.JSX.Element> {
         <Separator />
 
         <div>
-          <h2 className="text-xl font-semibold mb-2 text-destructive">
+          <h2 className="text-balance text-xl font-semibold mb-2 text-destructive">
             Danger Zone
           </h2>
-          <p className="text-sm text-muted-foreground mb-4">
+          <p className="text-pretty text-sm text-muted-foreground mb-4">
             Permanently delete your account and anonymize your contributions.
           </p>
           <DeleteAccountSection

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -28,7 +28,7 @@ export default async function ForgotPasswordPage(): Promise<React.JSX.Element> {
         <CardTitle className="text-2xl font-bold text-foreground">
           Reset Password
         </CardTitle>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-pretty text-sm text-muted-foreground">
           Enter your email address and we'll send you a link to reset your
           password
         </p>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -34,7 +34,7 @@ export default async function LoginPage({
         <CardTitle className="text-2xl font-bold text-foreground">
           Sign In
         </CardTitle>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-pretty text-sm text-muted-foreground">
           Enter your credentials to access your account
         </p>
       </CardHeader>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -51,7 +51,7 @@ export default async function ResetPasswordPage({
         <CardTitle className="text-2xl font-bold text-foreground">
           Set New Password
         </CardTitle>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-pretty text-sm text-muted-foreground">
           Enter your new password below
         </p>
       </CardHeader>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -72,7 +72,7 @@ export default async function SignupPage({
         <CardTitle className="text-2xl font-bold text-foreground">
           Create Account
         </CardTitle>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-pretty text-sm text-muted-foreground">
           Join PinPoint to report and track issues
         </p>
       </CardHeader>

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -35,10 +35,10 @@ export default function LandingPage(): React.JSX.Element {
             />
           </a>
         </div>
-        <h1 className="text-4xl md:text-5xl font-bold text-foreground">
+        <h1 className="text-balance text-4xl md:text-5xl font-bold text-foreground">
           Welcome to PinPoint
         </h1>
-        <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+        <p className="text-pretty text-xl text-muted-foreground max-w-2xl mx-auto">
           The issue tracker for the{" "}
           <a
             href="https://austinpinballcollective.org"
@@ -78,10 +78,10 @@ export default function LandingPage(): React.JSX.Element {
             <div className="mx-auto w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
               <Target className="size-6 text-primary" />
             </div>
-            <h3 className="text-lg font-semibold text-foreground">
+            <h3 className="text-balance text-lg font-semibold text-foreground">
               Track Issues
             </h3>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-pretty text-muted-foreground text-sm">
               Report problems with any machine. Track severity, status, and
               priority so fixes happen faster.
             </p>
@@ -93,10 +93,10 @@ export default function LandingPage(): React.JSX.Element {
             <div className="mx-auto w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
               <Wrench className="size-6 text-primary" />
             </div>
-            <h3 className="text-lg font-semibold text-foreground">
+            <h3 className="text-balance text-lg font-semibold text-foreground">
               Stay Informed
             </h3>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-pretty text-muted-foreground text-sm">
               See which machines need attention, which were recently fixed, and
               what&apos;s being worked on.
             </p>
@@ -108,10 +108,10 @@ export default function LandingPage(): React.JSX.Element {
             <div className="mx-auto w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
               <Users className="size-6 text-primary" />
             </div>
-            <h3 className="text-lg font-semibold text-foreground">
+            <h3 className="text-balance text-lg font-semibold text-foreground">
               Community Driven
             </h3>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-pretty text-muted-foreground text-sm">
               Anyone can report issues. Sign up to comment, get notifications,
               and help keep machines in top shape.
             </p>
@@ -121,7 +121,7 @@ export default function LandingPage(): React.JSX.Element {
 
       {/* Secondary CTA - View Dashboard */}
       <section className="text-center pt-4">
-        <p className="text-muted-foreground mb-4">
+        <p className="text-pretty text-muted-foreground mb-4">
           Want to see the full picture?
         </p>
         <Button asChild variant="outline" data-testid="cta-dashboard">

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -18,7 +18,9 @@ export function PageHeader({
     <div className={cn("border-b border-outline-variant pb-2", className)}>
       <div className="flex items-center justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+          <h1 className="text-balance text-3xl font-bold tracking-tight">
+            {title}
+          </h1>
           {titleAdornment}
         </div>
         {actions != null && (

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -113,7 +113,7 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        "text-balance text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
         className
       )}
       {...props}
@@ -130,7 +130,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-pretty text-muted-foreground text-sm", className)}
       {...props}
     />
   );

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -40,7 +40,10 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
-    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    className={cn(
+      "text-balance mb-1 font-medium leading-none tracking-tight",
+      className
+    )}
     {...props}
   />
 ));
@@ -52,7 +55,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    className={cn("text-pretty text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
 ));

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -41,7 +41,7 @@ function CardTitle({
   return (
     <h2
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("text-balance leading-none font-semibold", className)}
       {...props}
     />
   );
@@ -54,7 +54,7 @@ function CardDescription({
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-pretty text-muted-foreground text-sm", className)}
       {...props}
     />
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -116,7 +116,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn(
+        "text-balance text-lg leading-none font-semibold",
+        className
+      )}
       {...props}
     />
   );
@@ -131,7 +134,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-pretty text-muted-foreground text-sm", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Apply Tailwind's `text-balance` and `text-pretty` utilities across the codebase to prevent orphan words and uneven line breaks. Follows the pattern established in PR #1193 (EmptyState extraction).

## Changes

**Shared primitives (baked-in by default):**
- `CardTitle`/`CardDescription` → `text-balance`/`text-pretty`
- `AlertTitle`/`AlertDescription` → `text-balance`/`text-pretty`
- `DialogTitle`/`DialogDescription` → `text-balance`/`text-pretty`
- `AlertDialogTitle`/`AlertDialogDescription` → `text-balance`/`text-pretty`
- `PageHeader` title → `text-balance`
- `EmptyState` → already present

**Call sites updated:**
- Auth pages: sign-in, signup, forgot-password, reset-password intro copy
- Report success page: confirmation and CTA copy
- Settings page: section headings and descriptions
- Admin user management: header and subtitle
- Landing page: hero heading, feature descriptions
- Issue detail: editable issue title

**Design bible (§9 Typography Scale):**
- Added text-wrapping rule with guidance on `text-balance` vs `text-pretty`
- Noted that shared primitives handle most cases

## Test Plan

- [x] Run `pnpm run check` — all tests pass
- [x] Verify no style regressions on auth pages, settings, and landing page
- [x] Confirm primitives still merge with call-site overrides via `cn()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)