### PR TITLE
feat(machines): owner picker UX + promote dialog + invite cleanup (PP-6oi)

### DIFF
--- a/e2e/full/invite-signup.spec.ts
+++ b/e2e/full/invite-signup.spec.ts
@@ -167,9 +167,11 @@ test.describe("User Invitation & Signup Flow", () => {
     await page.getByTestId("edit-machine-button").click();
     await expect(page.getByRole("dialog")).toBeVisible();
 
-    // Click the owner dropdown and select the invited user (shown with "(Invited)" suffix)
+    // Click the owner dropdown and select the invited user (shown with "(INVITED)" suffix).
+    // Invited users are hidden by default — toggle the checkbox to reveal them.
     const ownerSelect = page.getByTestId("owner-select");
     await ownerSelect.click();
+    await page.getByLabel(/Show guests and invited users/i).click();
     await page
       .getByRole("option", { name: /Owner Transfer.*\(Invited\)/i })
       .click();

--- a/e2e/full/machine-owner-picker.spec.ts
+++ b/e2e/full/machine-owner-picker.spec.ts
@@ -59,7 +59,9 @@ test.describe("Machine Owner Picker UX (PP-6oi)", () => {
 
     // "Guest User" should now appear under "Guests" section
     await expect(list.getByText("Guest User")).toBeVisible();
-    await expect(list.getByText("(GUEST)")).toBeVisible();
+    // At least one "(GUEST)" badge is visible — .first() avoids strict-mode
+    // violations when preview DBs contain multiple guest users.
+    await expect(list.getByText("(GUEST)").first()).toBeVisible();
   });
 
   test("typed search bypasses the guest filter", async ({ page }) => {

--- a/e2e/full/machine-owner-picker.spec.ts
+++ b/e2e/full/machine-owner-picker.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * E2E Tests: Machine Owner Picker UX (PP-6oi)
+ *
+ * Verifies:
+ * 1. Default state hides guests and invited users
+ * 2. "Show guests and invited users" checkbox reveals them
+ * 3. Typed search bypasses the filter
+ * 4. ASSIGNEE_NOT_MEMBER promote dialog opens when a guest is selected
+ * 5. Confirm promote: machine created, guest promoted to member
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import { STORAGE_STATE } from "../support/auth-state.js";
+
+const testMachines = new Set<string>();
+const testEmails = new Set<string>();
+
+/** Open the owner picker popover. */
+async function openOwnerPicker(page: Page) {
+  await page.getByTestId("owner-select").click();
+  // Wait for the popover content to be visible (checkbox is a reliable anchor)
+  await expect(page.getByLabel(/Show guests and invited users/i)).toBeVisible();
+}
+
+test.describe("Machine Owner Picker UX (PP-6oi)", () => {
+  test.use({ storageState: STORAGE_STATE.admin });
+
+  test.afterEach(async ({ request }) => {
+    if (testMachines.size > 0 || testEmails.size > 0) {
+      await cleanupTestEntities(request, {
+        machineInitials: Array.from(testMachines),
+        userEmails: Array.from(testEmails),
+      });
+      testMachines.clear();
+      testEmails.clear();
+    }
+  });
+
+  test("owner picker hides guests by default and reveals them via checkbox", async ({
+    page,
+  }) => {
+    await page.goto("/m/new");
+    await openOwnerPicker(page);
+
+    // Default state: "Guest User" text should NOT appear in the list
+    // (it may appear elsewhere but not in the command list)
+    const list = page.locator("[data-slot=command-list]");
+    await expect(list.getByText("Guest User")).not.toBeVisible();
+
+    // The "(GUEST)" badge should not appear by default
+    await expect(list.getByText("(GUEST)")).not.toBeVisible();
+
+    // Click the checkbox to reveal guests and invited users
+    const checkbox = page.getByLabel(/Show guests and invited users/i);
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+
+    // "Guest User" should now appear under "Guests" section
+    await expect(list.getByText("Guest User")).toBeVisible();
+    await expect(list.getByText("(GUEST)")).toBeVisible();
+  });
+
+  test("typed search bypasses the guest filter", async ({ page }) => {
+    await page.goto("/m/new");
+    await openOwnerPicker(page);
+
+    const list = page.locator("[data-slot=command-list]");
+
+    // Default: checkbox unchecked — Guest User hidden in list
+    await expect(list.getByText("Guest User")).not.toBeVisible();
+
+    // Type "Guest" in search — should bypass the filter
+    await page.getByPlaceholder("Search users...").fill("Guest");
+
+    // Guest User should appear because search bypasses the filter
+    await expect(list.getByText("Guest User")).toBeVisible();
+  });
+
+  test("InviteUserDialog has no role field and sendInvite defaults to ON", async ({
+    page,
+  }) => {
+    await page.goto("/m/new");
+
+    // Click "Invite New" button
+    await page.getByRole("button", { name: /Invite New/i }).click();
+
+    // Dialog should open
+    await expect(
+      page.getByRole("heading", { name: /Invite New User/i })
+    ).toBeVisible();
+
+    // Role field should NOT be present
+    await expect(page.getByLabel(/^Role$/i)).not.toBeVisible();
+
+    // "Send Invitation Email" toggle should default to ON
+    const inviteSwitch = page.getByRole("switch", {
+      name: /Send invitation email/i,
+    });
+    await expect(inviteSwitch).toBeVisible();
+    await expect(inviteSwitch).toHaveAttribute("aria-checked", "true");
+
+    // Close dialog
+    await page.getByRole("button", { name: /Cancel/i }).click();
+    await expect(
+      page.getByRole("heading", { name: /Invite New User/i })
+    ).not.toBeVisible();
+  });
+
+  test("promote dialog appears when a guest owner is selected", async ({
+    page,
+  }) => {
+    const testId = Math.random().toString(36).substring(7);
+    const machineInitials = `OPK${testId.toUpperCase()}`.substring(0, 5);
+
+    testMachines.add(machineInitials);
+
+    await page.goto("/m/new");
+
+    // Fill required fields
+    await page.getByLabel(/Initials/i).fill(machineInitials);
+    await page.getByLabel(/Machine Name/i).fill(`Owner Picker Test ${testId}`);
+
+    // Open picker and reveal guests
+    await openOwnerPicker(page);
+    const checkbox = page.getByLabel(/Show guests and invited users/i);
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+
+    // Select the Guest User from the command list
+    const list = page.locator("[data-slot=command-list]");
+    await expect(list.getByText("Guest User")).toBeVisible();
+    await list.getByText("Guest User").click();
+
+    // Owner trigger should show "Guest User" selected
+    await expect(page.getByTestId("owner-select")).toContainText("Guest User");
+
+    // Submit the form
+    await page.getByRole("button", { name: /Create Machine/i }).click();
+
+    // Promote dialog should appear
+    await expect(
+      page.getByRole("heading", { name: /Promote to member and assign/i })
+    ).toBeVisible();
+
+    // Dialog should show "(GUEST)" badge
+    const promoteDialog = page.getByRole("dialog").filter({
+      has: page.getByText("Promote to member and assign"),
+    });
+    await expect(promoteDialog.getByText("(GUEST)")).toBeVisible();
+
+    // Cancel button should close the dialog
+    await promoteDialog.getByRole("button", { name: /Cancel/i }).click();
+    await expect(
+      page.getByRole("heading", { name: /Promote to member and assign/i })
+    ).not.toBeVisible();
+  });
+
+  test("promote dialog confirm creates machine and promotes guest to member", async ({
+    page,
+  }) => {
+    const testId = Math.random().toString(36).substring(7);
+    const machineInitials = `OPC${testId.toUpperCase()}`.substring(0, 5);
+
+    testMachines.add(machineInitials);
+
+    await page.goto("/m/new");
+
+    // Fill required fields
+    await page.getByLabel(/Initials/i).fill(machineInitials);
+    await page
+      .getByLabel(/Machine Name/i)
+      .fill(`Owner Picker Confirm ${testId}`);
+
+    // Open picker and reveal guests
+    await openOwnerPicker(page);
+    const checkbox = page.getByLabel(/Show guests and invited users/i);
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+
+    // Select Guest User
+    const list = page.locator("[data-slot=command-list]");
+    await expect(list.getByText("Guest User")).toBeVisible();
+    await list.getByText("Guest User").click();
+
+    // Verify selection
+    await expect(page.getByTestId("owner-select")).toContainText("Guest User");
+
+    // Submit
+    await page.getByRole("button", { name: /Create Machine/i }).click();
+
+    // Promote dialog should appear — confirm it
+    await expect(
+      page.getByRole("heading", { name: /Promote to member and assign/i })
+    ).toBeVisible();
+    await page.getByRole("button", { name: /Promote and assign/i }).click();
+
+    // Should redirect to machine detail page
+    await expect(page).toHaveURL(new RegExp(`/m/${machineInitials}`), {
+      timeout: 15000,
+    });
+    await expect(
+      page.getByRole("heading", { name: `Owner Picker Confirm ${testId}` })
+    ).toBeVisible();
+  });
+});

--- a/src/app/(app)/m/[initials]/page.tsx
+++ b/src/app/(app)/m/[initials]/page.tsx
@@ -177,6 +177,7 @@ export default async function MachineDetailPage({
     lastName: u.lastName,
     machineCount: u.machineCount,
     status: u.status,
+    role: u.role,
   }));
 
   const totalIssuesCount = totalIssuesCountResult[0]?.count ?? 0;

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -15,6 +15,7 @@ import {
 import {
   updateMachineAction,
   type UpdateMachineResult,
+  type AssigneeNotMemberMeta,
 } from "~/app/(app)/m/actions";
 import { cn } from "~/lib/utils";
 import { OwnerSelect } from "~/components/machines/OwnerSelect";
@@ -42,6 +43,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "~/components/ui/alert-dialog";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { Pencil } from "lucide-react";
 
 import type { OwnerSelectUser } from "~/components/machines/OwnerSelect";
@@ -86,27 +88,66 @@ export function EditMachineDialog({
   );
   const currentOwnerId = machine.ownerId ?? machine.invitedOwnerId ?? "";
 
+  // Promote dialog state — populated when server returns ASSIGNEE_NOT_MEMBER
+  const [promoteAssignee, setPromoteAssignee] = useState<
+    AssigneeNotMemberMeta["assignee"] | null
+  >(null);
+  const [isPromoteOpen, setIsPromoteOpen] = useState(false);
+
+  // State-driven hidden input for re-submission with forcePromoteUserId.
+  // Using state (not ref) so React flushes the value before requestSubmit.
+  const [forcePromoteUserId, setForcePromoteUserId] = useState("");
+
+  // Track whether we need to submit after forcePromoteUserId state flushes
+  const [pendingSubmit, setPendingSubmit] = useState(false);
+
   const [state, formAction, isPending] = useActionState<
     UpdateMachineResult | undefined,
     FormData
   >(updateMachineAction, undefined);
 
-  // Close dialog on successful update
+  // Close edit dialog on successful update
   useEffect(() => {
     if (state?.ok) {
       setOpen(false);
     }
   }, [state]);
 
-  // Reset selectedOwnerId when dialog reopens to avoid stale selection
+  // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  useEffect(() => {
+    if (
+      state &&
+      !state.ok &&
+      state.code === "ASSIGNEE_NOT_MEMBER" &&
+      state.meta?.assignee &&
+      !isPromoteOpen
+    ) {
+      setPromoteAssignee(state.meta.assignee);
+      setIsPromoteOpen(true);
+    }
+  }, [state, isPromoteOpen]);
+
+  // Reset state when edit dialog opens/closes
   useEffect(() => {
     if (open) {
       setSelectedOwnerId(currentOwnerId);
       transferConfirmedRef.current = false;
+      setForcePromoteUserId("");
+      setPromoteAssignee(null);
+      setIsPromoteOpen(false);
+      setPendingSubmit(false);
     }
   }, [open, currentOwnerId]);
 
-  // Find the selected owner's name for the confirmation dialog
+  // Submit after forcePromoteUserId has been set in state (ensures React flushed it)
+  useEffect(() => {
+    if (pendingSubmit && forcePromoteUserId) {
+      setPendingSubmit(false);
+      formRef.current?.requestSubmit();
+    }
+  }, [pendingSubmit, forcePromoteUserId]);
+
+  // Find the selected owner's name for the transfer confirmation dialog
   const selectedOwnerName =
     allUsers.find((u) => u.id === selectedOwnerId)?.name ?? "the selected user";
 
@@ -136,6 +177,21 @@ export function EditMachineDialog({
     formRef.current?.requestSubmit();
   };
 
+  const confirmPromote = (): void => {
+    if (!promoteAssignee) return;
+    setForcePromoteUserId(promoteAssignee.id);
+    setIsPromoteOpen(false);
+    // Signal that we want to submit after state flushes (useEffect handles the actual call)
+    setPendingSubmit(true);
+  };
+
+  const cancelPromote = (): void => {
+    setIsPromoteOpen(false);
+    setPromoteAssignee(null);
+    setForcePromoteUserId("");
+    setPendingSubmit(false);
+  };
+
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
@@ -162,12 +218,19 @@ export function EditMachineDialog({
             ref={formRef}
             action={formAction}
             onSubmit={handleSubmit}
+            id="edit-machine-form"
             className="space-y-6"
           >
             <input type="hidden" name="id" value={machine.id} />
+            {/* State-driven hidden input for re-submission with forcePromoteUserId */}
+            <input
+              type="hidden"
+              name="forcePromoteUserId"
+              value={forcePromoteUserId}
+            />
 
-            {/* Flash message */}
-            {state && !state.ok && (
+            {/* Flash message — suppress ASSIGNEE_NOT_MEMBER since dialog handles it */}
+            {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
               <div
                 className={cn(
                   "rounded-md border p-4",
@@ -288,6 +351,54 @@ export function EditMachineDialog({
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      {/*
+       * Promote-and-assign confirmation dialog.
+       * Duplicated from create-machine-form.tsx — pending extraction at 3rd consumer.
+       *
+       * Radix portals DialogContent outside the form tree. The confirm button
+       * cannot implicitly target the outer form, so we use a state-driven
+       * hidden forcePromoteUserId input + requestAnimationFrame to flush state
+       * before programmatic requestSubmit fires on the outer form.
+       */}
+      <Dialog open={isPromoteOpen} onOpenChange={setIsPromoteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Promote to member and assign?</DialogTitle>
+            <DialogDescription>
+              This updates the user&apos;s role and assigns them as owner.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <p>
+              <strong>{promoteAssignee?.name}</strong>
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground ml-1">
+                {promoteAssignee?.type === "invited"
+                  ? "(INVITED · GUEST)"
+                  : "(GUEST)"}
+              </span>{" "}
+              is currently a guest. Assigning them as owner of{" "}
+              <strong>{machine.name}</strong> will promote them to member.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              As a member they&apos;ll be able to edit the machine&apos;s
+              details, owner notes, tournament notes, and owner requirements.
+            </p>
+            <Alert>
+              <AlertDescription>
+                Promotion and assignment run in one transaction — both succeed
+                or both roll back.
+              </AlertDescription>
+            </Alert>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={cancelPromote}>
+              Cancel
+            </Button>
+            <Button onClick={confirmPromote}>Promote and assign</Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import type React from "react";
-import { useActionState, useState, useRef, useEffect } from "react";
+import {
+  useActionState,
+  useState,
+  useRef,
+  useEffect,
+  startTransition,
+} from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
@@ -94,17 +100,13 @@ export function EditMachineDialog({
   >(null);
   const [isPromoteOpen, setIsPromoteOpen] = useState(false);
 
-  // State-driven hidden input for re-submission with forcePromoteUserId.
-  // Using state (not ref) so React flushes the value before requestSubmit.
-  const [forcePromoteUserId, setForcePromoteUserId] = useState("");
-
-  // Track whether we need to submit after forcePromoteUserId state flushes
-  const [pendingSubmit, setPendingSubmit] = useState(false);
-
   const [state, formAction, isPending] = useActionState<
     UpdateMachineResult | undefined,
     FormData
   >(updateMachineAction, undefined);
+
+  // Track the last state we've already handled to avoid re-opening on cancel
+  const handledStateRef = useRef<typeof state>(undefined);
 
   // Close edit dialog on successful update
   useEffect(() => {
@@ -113,39 +115,30 @@ export function EditMachineDialog({
     }
   }, [state]);
 
-  // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  // Open promote dialog when server returns ASSIGNEE_NOT_MEMBER (once per state)
   useEffect(() => {
     if (
       state &&
+      state !== handledStateRef.current &&
       !state.ok &&
       state.code === "ASSIGNEE_NOT_MEMBER" &&
-      state.meta?.assignee &&
-      !isPromoteOpen
+      state.meta?.assignee
     ) {
+      handledStateRef.current = state;
       setPromoteAssignee(state.meta.assignee);
       setIsPromoteOpen(true);
     }
-  }, [state, isPromoteOpen]);
+  }, [state]);
 
   // Reset state when edit dialog opens/closes
   useEffect(() => {
     if (open) {
       setSelectedOwnerId(currentOwnerId);
       transferConfirmedRef.current = false;
-      setForcePromoteUserId("");
       setPromoteAssignee(null);
       setIsPromoteOpen(false);
-      setPendingSubmit(false);
     }
   }, [open, currentOwnerId]);
-
-  // Submit after forcePromoteUserId has been set in state (ensures React flushed it)
-  useEffect(() => {
-    if (pendingSubmit && forcePromoteUserId) {
-      setPendingSubmit(false);
-      formRef.current?.requestSubmit();
-    }
-  }, [pendingSubmit, forcePromoteUserId]);
 
   // Find the selected owner's name for the transfer confirmation dialog
   const selectedOwnerName =
@@ -178,18 +171,23 @@ export function EditMachineDialog({
   };
 
   const confirmPromote = (): void => {
-    if (!promoteAssignee) return;
-    setForcePromoteUserId(promoteAssignee.id);
+    if (!promoteAssignee || !formRef.current) return;
     setIsPromoteOpen(false);
-    // Signal that we want to submit after state flushes (useEffect handles the actual call)
-    setPendingSubmit(true);
+    // Build FormData from the live form DOM (captures all current field values)
+    // then inject forcePromoteUserId before dispatching directly to the action.
+    // This avoids the DOM requestSubmit() → useActionState wiring uncertainty.
+    const fd = new FormData(formRef.current);
+    fd.set("forcePromoteUserId", promoteAssignee.id);
+    // useActionState dispatch must be called inside a transition — calling it
+    // outside a transition silently skips the server action (React 19 requirement).
+    startTransition(() => {
+      formAction(fd);
+    });
   };
 
   const cancelPromote = (): void => {
     setIsPromoteOpen(false);
     setPromoteAssignee(null);
-    setForcePromoteUserId("");
-    setPendingSubmit(false);
   };
 
   return (
@@ -222,12 +220,6 @@ export function EditMachineDialog({
             className="space-y-6"
           >
             <input type="hidden" name="id" value={machine.id} />
-            {/* State-driven hidden input for re-submission with forcePromoteUserId */}
-            <input
-              type="hidden"
-              name="forcePromoteUserId"
-              value={forcePromoteUserId}
-            />
 
             {/* Flash message — suppress ASSIGNEE_NOT_MEMBER since dialog handles it */}
             {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
@@ -359,9 +351,8 @@ export function EditMachineDialog({
        * Duplicated from create-machine-form.tsx — pending extraction at 3rd consumer.
        *
        * Radix portals DialogContent outside the form tree. The confirm button
-       * cannot implicitly target the outer form, so we use a state-driven
-       * hidden forcePromoteUserId input + requestAnimationFrame to flush state
-       * before programmatic requestSubmit fires on the outer form.
+       * cannot implicitly target the outer form, so we read the live form DOM
+       * via formRef, inject forcePromoteUserId, and call formAction(fd) directly.
        */}
       <Dialog open={isPromoteOpen} onOpenChange={setIsPromoteOpen}>
         <DialogContent>

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useActionState } from "react";
 import { Button } from "~/components/ui/button";
@@ -10,12 +10,22 @@ import { Label } from "~/components/ui/label";
 import {
   createMachineAction,
   type CreateMachineResult,
+  type AssigneeNotMemberMeta,
 } from "~/app/(app)/m/actions";
 import { cn } from "~/lib/utils";
 import {
   OwnerSelect,
   type OwnerSelectUser,
 } from "~/components/machines/OwnerSelect";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 
 interface CreateMachineFormProps {
   allUsers: OwnerSelectUser[];
@@ -34,10 +44,61 @@ export function CreateMachineForm({
   // Lift users state to client so we can append new users without full refresh
   const [users, setUsers] = useState<OwnerSelectUser[]>(allUsers);
 
+  // Promote dialog state — populated when server returns ASSIGNEE_NOT_MEMBER
+  const [promoteAssignee, setPromoteAssignee] = useState<
+    AssigneeNotMemberMeta["assignee"] | null
+  >(null);
+  const [isPromoteOpen, setIsPromoteOpen] = useState(false);
+
+  // Controlled hidden input value for forcePromoteUserId on re-submission
+  const [forcePromoteUserId, setForcePromoteUserId] = useState("");
+
+  // Ref to the outer form for programmatic re-submission
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Track whether we need to submit after forcePromoteUserId state flushes
+  const [pendingSubmit, setPendingSubmit] = useState(false);
+
+  // Open the promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  useEffect(() => {
+    if (
+      state &&
+      !state.ok &&
+      state.code === "ASSIGNEE_NOT_MEMBER" &&
+      state.meta?.assignee &&
+      !isPromoteOpen
+    ) {
+      setPromoteAssignee(state.meta.assignee);
+      setIsPromoteOpen(true);
+    }
+  }, [state, isPromoteOpen]);
+
+  // Submit after forcePromoteUserId has been set in state (ensures React flushed it)
+  useEffect(() => {
+    if (pendingSubmit && forcePromoteUserId) {
+      setPendingSubmit(false);
+      formRef.current?.requestSubmit();
+    }
+  }, [pendingSubmit, forcePromoteUserId]);
+
+  const confirmPromote = (): void => {
+    if (!promoteAssignee) return;
+    setForcePromoteUserId(promoteAssignee.id);
+    setIsPromoteOpen(false);
+    // Signal that we want to submit after state flushes
+    setPendingSubmit(true);
+  };
+
+  const cancelPromote = (): void => {
+    setIsPromoteOpen(false);
+    setPromoteAssignee(null);
+    setForcePromoteUserId("");
+  };
+
   return (
     <>
-      {/* Flash message */}
-      {state && !state.ok && (
+      {/* Flash message (non-ASSIGNEE_NOT_MEMBER errors) */}
+      {state && !state.ok && state.code !== "ASSIGNEE_NOT_MEMBER" && (
         <div
           className={cn(
             "mb-6 rounded-md border p-4",
@@ -48,7 +109,67 @@ export function CreateMachineForm({
         </div>
       )}
 
-      <form action={formAction} className="space-y-6">
+      {/*
+       * Promote-and-assign confirmation dialog.
+       * Duplicated from update-machine-form.tsx — pending extraction at 3rd consumer.
+       *
+       * Radix portals the DialogContent outside the form tree, so the confirm
+       * button cannot use type="submit" to target the outer form. Instead we
+       * use a state-driven hidden input + requestAnimationFrame to ensure React
+       * flushes the forcePromoteUserId state before programmatic requestSubmit.
+       */}
+      <Dialog open={isPromoteOpen} onOpenChange={setIsPromoteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Promote to member and assign?</DialogTitle>
+            <DialogDescription>
+              This updates the user&apos;s role and assigns them as owner.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <p>
+              <strong>{promoteAssignee?.name}</strong>
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground ml-1">
+                {promoteAssignee?.type === "invited"
+                  ? "(INVITED · GUEST)"
+                  : "(GUEST)"}
+              </span>{" "}
+              is currently a guest. Assigning them as owner of this machine will
+              promote them to member.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              As a member they&apos;ll be able to edit the machine&apos;s
+              details, owner notes, tournament notes, and owner requirements.
+            </p>
+            <Alert>
+              <AlertDescription>
+                Promotion and assignment run in one transaction — both succeed
+                or both roll back.
+              </AlertDescription>
+            </Alert>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={cancelPromote}>
+              Cancel
+            </Button>
+            <Button onClick={confirmPromote}>Promote and assign</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <form
+        ref={formRef}
+        action={formAction}
+        id="create-machine-form"
+        className="space-y-6"
+      >
+        {/* State-driven hidden input for re-submission with forcePromoteUserId */}
+        <input
+          type="hidden"
+          name="forcePromoteUserId"
+          value={forcePromoteUserId}
+        />
+
         {/* Machine Name */}
         <div className="space-y-2">
           <Label htmlFor="name" className="text-foreground">

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, startTransition } from "react";
 import Link from "next/link";
 import { useActionState } from "react";
 import { Button } from "~/components/ui/button";
@@ -44,55 +44,66 @@ export function CreateMachineForm({
   // Lift users state to client so we can append new users without full refresh
   const [users, setUsers] = useState<OwnerSelectUser[]>(allUsers);
 
+  // Controlled field values so they survive re-renders after server action errors
+  const [nameValue, setNameValue] = useState("");
+  const [initialsValue, setInitialsValue] = useState("");
+  const [ownerIdValue, setOwnerIdValue] = useState("");
+
   // Promote dialog state — populated when server returns ASSIGNEE_NOT_MEMBER
   const [promoteAssignee, setPromoteAssignee] = useState<
     AssigneeNotMemberMeta["assignee"] | null
   >(null);
   const [isPromoteOpen, setIsPromoteOpen] = useState(false);
 
-  // Controlled hidden input value for forcePromoteUserId on re-submission
-  const [forcePromoteUserId, setForcePromoteUserId] = useState("");
+  // Snapshot of the form's field values captured at first submission time,
+  // so the promote-confirm re-submission has the correct data even if the
+  // server action response caused a component re-render.
+  const submittedDataRef = useRef<{
+    name: string;
+    initials: string;
+    ownerId: string;
+  } | null>(null);
 
-  // Ref to the outer form for programmatic re-submission
-  const formRef = useRef<HTMLFormElement>(null);
+  // Track the last state we've already handled to avoid re-opening on cancel
+  const handledStateRef = useRef<typeof state>(undefined);
 
-  // Track whether we need to submit after forcePromoteUserId state flushes
-  const [pendingSubmit, setPendingSubmit] = useState(false);
-
-  // Open the promote dialog when server returns ASSIGNEE_NOT_MEMBER
+  // Open the promote dialog when server returns ASSIGNEE_NOT_MEMBER (once per state)
   useEffect(() => {
     if (
       state &&
+      state !== handledStateRef.current &&
       !state.ok &&
       state.code === "ASSIGNEE_NOT_MEMBER" &&
-      state.meta?.assignee &&
-      !isPromoteOpen
+      state.meta?.assignee
     ) {
+      handledStateRef.current = state;
       setPromoteAssignee(state.meta.assignee);
       setIsPromoteOpen(true);
     }
-  }, [state, isPromoteOpen]);
-
-  // Submit after forcePromoteUserId has been set in state (ensures React flushed it)
-  useEffect(() => {
-    if (pendingSubmit && forcePromoteUserId) {
-      setPendingSubmit(false);
-      formRef.current?.requestSubmit();
-    }
-  }, [pendingSubmit, forcePromoteUserId]);
+  }, [state]);
 
   const confirmPromote = (): void => {
     if (!promoteAssignee) return;
-    setForcePromoteUserId(promoteAssignee.id);
     setIsPromoteOpen(false);
-    // Signal that we want to submit after state flushes
-    setPendingSubmit(true);
+    // Build FormData from the snapshotted submission values captured at first
+    // submission — these survive any component re-renders caused by server action.
+    const snapshot = submittedDataRef.current;
+    const fd = new FormData();
+    fd.set("name", snapshot?.name ?? nameValue);
+    fd.set("initials", snapshot?.initials ?? initialsValue);
+    const ownerId = snapshot?.ownerId ?? ownerIdValue;
+    if (ownerId) fd.set("ownerId", ownerId);
+    fd.set("forcePromoteUserId", promoteAssignee.id);
+    // useActionState dispatch must be called inside a transition — calling it
+    // outside a transition silently skips the server action (React 19 requirement).
+    startTransition(() => {
+      formAction(fd);
+    });
   };
 
   const cancelPromote = (): void => {
     setIsPromoteOpen(false);
     setPromoteAssignee(null);
-    setForcePromoteUserId("");
   };
 
   return (
@@ -114,9 +125,10 @@ export function CreateMachineForm({
        * Duplicated from update-machine-form.tsx — pending extraction at 3rd consumer.
        *
        * Radix portals the DialogContent outside the form tree, so the confirm
-       * button cannot use type="submit" to target the outer form. Instead we
-       * use a state-driven hidden input + requestAnimationFrame to ensure React
-       * flushes the forcePromoteUserId state before programmatic requestSubmit.
+       * button cannot use type="submit" to target the outer form. We build
+       * FormData from controlled state values (nameValue, initialsValue, ownerIdValue)
+       * and call formAction(fd) directly — this avoids relying on uncontrolled
+       * DOM inputs that may lose their values after a server action re-render.
        */}
       <Dialog open={isPromoteOpen} onOpenChange={setIsPromoteOpen}>
         <DialogContent>
@@ -158,18 +170,19 @@ export function CreateMachineForm({
       </Dialog>
 
       <form
-        ref={formRef}
         action={formAction}
+        onSubmit={(e) => {
+          // Snapshot field values at first submission time for use in confirmPromote
+          const fd = new FormData(e.currentTarget);
+          submittedDataRef.current = {
+            name: (fd.get("name") as string | null) ?? "",
+            initials: (fd.get("initials") as string | null) ?? "",
+            ownerId: (fd.get("ownerId") as string | null) ?? "",
+          };
+        }}
         id="create-machine-form"
         className="space-y-6"
       >
-        {/* State-driven hidden input for re-submission with forcePromoteUserId */}
-        <input
-          type="hidden"
-          name="forcePromoteUserId"
-          value={forcePromoteUserId}
-        />
-
         {/* Machine Name */}
         <div className="space-y-2">
           <Label htmlFor="name" className="text-foreground">
@@ -183,6 +196,8 @@ export function CreateMachineForm({
             placeholder="e.g., Medieval Madness"
             className="border-outline bg-surface text-foreground placeholder:text-muted-foreground"
             autoFocus
+            value={nameValue}
+            onChange={(e) => setNameValue(e.target.value)}
           />
           <p className="text-xs text-muted-foreground">
             Enter the full name of the pinball machine
@@ -203,10 +218,11 @@ export function CreateMachineForm({
             maxLength={6}
             placeholder="e.g., MM"
             className="border-outline bg-surface text-foreground placeholder:text-muted-foreground uppercase"
+            value={initialsValue}
             onChange={(e) => {
-              e.target.value = e.target.value
-                .toUpperCase()
-                .replace(/[^A-Z0-9]/g, "");
+              setInitialsValue(
+                e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, "")
+              );
             }}
           />
           <p className="text-xs text-muted-foreground">
@@ -216,7 +232,11 @@ export function CreateMachineForm({
 
         {/* Owner Select (Admin/Technician Only) */}
         {canSelectOwner && (
-          <OwnerSelect users={users} onUsersChange={setUsers} />
+          <OwnerSelect
+            users={users}
+            onUsersChange={setUsers}
+            onValueChange={setOwnerIdValue}
+          />
         )}
 
         {/* Actions */}

--- a/src/app/(app)/m/new/page.tsx
+++ b/src/app/(app)/m/new/page.tsx
@@ -52,6 +52,7 @@ export default async function NewMachinePage(): Promise<React.JSX.Element> {
     lastName: u.lastName,
     machineCount: u.machineCount,
     status: u.status,
+    role: u.role,
   }));
 
   return (

--- a/src/components/machines/OwnerSelect.tsx
+++ b/src/components/machines/OwnerSelect.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { ChevronsUpDown, Plus } from "lucide-react";
 import type { UserStatus } from "~/lib/types";
 import { InviteUserDialog } from "~/components/users/InviteUserDialog";
 import { compareUnifiedUsers } from "~/lib/users/comparators";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
+import { Checkbox } from "~/components/ui/checkbox";
 import {
   Command,
   CommandEmpty,
@@ -33,13 +34,15 @@ import {
  * ## Composition
  * - Users are sorted by `compareUnifiedUsers` (confirmed first, by machine
  *   count descending, then by last name)
- * - Each option shows: name, machine count badge (if > 0), and "(Invited)"
- *   tag for users with `status === "invited"`
+ * - Default state hides guests and invited users; a checkbox reveals them.
+ * - Typed search bypasses the hide-guests filter and shows all matches.
+ * - Each option shows: name, machine count badge (if > 0), and role tags
+ *   ("(GUEST)", "(INVITED)", or "(INVITED · GUEST)") for non-member users
  * - `onUsersChange` callback allows the parent to update its user list
  *   without a server round-trip after an invite
  *
  * ## Key Abstractions
- * - `OwnerSelectUser` includes `machineCount` and `status` for metadata display
+ * - `OwnerSelectUser` includes `role`, `machineCount` and `status` for metadata display
  * - A hidden `<input type="hidden">` preserves native form submission compat
  * - `compareUnifiedUsers` from `~/lib/users/comparators` drives sort order
  */
@@ -51,6 +54,7 @@ export interface OwnerSelectUser {
   lastName: string;
   machineCount: number;
   status: UserStatus;
+  role: "guest" | "member" | "technician" | "admin";
 }
 
 interface OwnerSelectProps {
@@ -71,8 +75,17 @@ export function OwnerSelect({
   const [open, setOpen] = useState(false);
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const [selectedId, setSelectedId] = useState(defaultValue ?? "");
+  const [showHidden, setShowHidden] = useState(false);
+  const [query, setQuery] = useState("");
   // Local extra users added via invite when parent doesn't provide onUsersChange
   const [extraUsers, setExtraUsers] = useState<OwnerSelectUser[]>([]);
+
+  // Reset search when popover closes
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+    }
+  }, [open]);
 
   // Merged user list: prop users + locally-tracked invited users (deduped)
   const allUsers = useMemo(() => {
@@ -90,6 +103,58 @@ export function OwnerSelect({
     () => allUsers.find((u) => u.id === selectedId) ?? null,
     [allUsers, selectedId]
   );
+
+  /**
+   * Filter and partition users into three groups:
+   * 1. Member+ active users (no section header)
+   * 2. Invited users (header "Invited")
+   * 3. Guest users (header "Guests")
+   *
+   * When query is non-empty, all matches are shown regardless of showHidden.
+   * When query is empty and !showHidden, guests and invited users are hidden.
+   */
+  const { memberUsers, invitedUsers, guestUsers } = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const hasQuery = normalized.length > 0;
+
+    const matchesQuery = (u: OwnerSelectUser): boolean =>
+      u.name.toLowerCase().includes(normalized);
+
+    const isGuest = (u: OwnerSelectUser): boolean => u.role === "guest"; // permissions-audit-allow: UI display filter, not a permission gate
+    const isInvited = (u: OwnerSelectUser): boolean =>
+      u.status === "invited" && !isGuest(u);
+    const isMemberPlus = (u: OwnerSelectUser): boolean =>
+      !isGuest(u) && !isInvited(u);
+
+    if (hasQuery) {
+      // Search bypasses the filter — show all matching users across categories
+      return {
+        memberUsers: sortedUsers.filter(
+          (u) => isMemberPlus(u) && matchesQuery(u)
+        ),
+        invitedUsers: sortedUsers.filter(
+          (u) => isInvited(u) && matchesQuery(u)
+        ),
+        guestUsers: sortedUsers.filter((u) => isGuest(u) && matchesQuery(u)),
+      };
+    }
+
+    if (showHidden) {
+      // Show all users, partitioned into groups
+      return {
+        memberUsers: sortedUsers.filter(isMemberPlus),
+        invitedUsers: sortedUsers.filter(isInvited),
+        guestUsers: sortedUsers.filter(isGuest),
+      };
+    }
+
+    // Default: only show member+ active users
+    return {
+      memberUsers: sortedUsers.filter(isMemberPlus),
+      invitedUsers: [],
+      guestUsers: [],
+    };
+  }, [sortedUsers, query, showHidden]);
 
   const handleSelect = (userId: string): void => {
     setSelectedId(userId);
@@ -141,11 +206,24 @@ export function OwnerSelect({
               {selectedUser ? (
                 <>
                   {selectedUser.name}
-                  {selectedUser.status === "invited" && (
-                    <span className="ml-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
-                      (Invited)
-                    </span>
-                  )}
+                  {selectedUser.role !== "guest" &&
+                    selectedUser.status === "invited" && ( // permissions-audit-allow: UI badge display, not a permission gate
+                      <span className="ml-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+                        (Invited)
+                      </span>
+                    )}
+                  {selectedUser.role === "guest" &&
+                    selectedUser.status !== "invited" && ( // permissions-audit-allow: UI badge display, not a permission gate
+                      <span className="ml-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                        (GUEST)
+                      </span>
+                    )}
+                  {selectedUser.role === "guest" &&
+                    selectedUser.status === "invited" && ( // permissions-audit-allow: UI badge display, not a permission gate
+                      <span className="ml-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                        (INVITED · GUEST)
+                      </span>
+                    )}
                 </>
               ) : (
                 "Select an owner"
@@ -158,37 +236,128 @@ export function OwnerSelect({
           className="w-(--radix-popover-trigger-width) p-0"
           align="start"
         >
-          <Command>
-            <CommandInput placeholder="Search users..." />
+          {/*
+           * shouldFilter={false}: we manage filtering manually so guests/invited
+           * are only shown when toggle is on or query is active.
+           */}
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Search users..."
+              value={query}
+              onValueChange={setQuery}
+            />
+            {/* Checkbox to reveal guests and invited users */}
+            <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+              <Checkbox
+                id="show-hidden-users"
+                checked={showHidden}
+                onCheckedChange={(checked) => {
+                  setShowHidden(checked === true);
+                }}
+              />
+              <label
+                htmlFor="show-hidden-users"
+                className="cursor-pointer text-xs text-muted-foreground select-none"
+              >
+                Show guests and invited users
+              </label>
+            </div>
             <CommandList>
               <CommandEmpty>No users found.</CommandEmpty>
-              <CommandGroup>
-                {sortedUsers.map((user) => (
-                  <CommandItem
-                    key={user.id}
-                    value={user.name}
-                    onSelect={() => handleSelect(user.id)}
-                    aria-current={user.id === selectedId ? "true" : undefined}
-                  >
-                    <div className="flex items-center gap-2">
-                      <span>{user.name}</span>
-                      {user.machineCount > 0 && (
-                        <span className="text-[10px] text-muted-foreground/70">
-                          ({user.machineCount})
-                        </span>
-                      )}
-                      {user.status === "invited" && (
-                        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
-                          (Invited)
-                        </span>
-                      )}
-                    </div>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+
+              {/* Section 1: Member+ active users (no header) */}
+              {memberUsers.length > 0 && (
+                <CommandGroup>
+                  {memberUsers.map((user) => (
+                    <CommandItem
+                      key={user.id}
+                      value={user.id}
+                      onSelect={() => handleSelect(user.id)}
+                      aria-current={user.id === selectedId ? "true" : undefined}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span>{user.name}</span>
+                        {user.machineCount > 0 && (
+                          <span className="text-[10px] text-muted-foreground/70">
+                            ({user.machineCount})
+                          </span>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+
+              {/* Section 2: Invited (non-guest) users */}
+              {invitedUsers.length > 0 && (
+                <>
+                  {memberUsers.length > 0 && <CommandSeparator />}
+                  <CommandGroup heading="Invited">
+                    {invitedUsers.map((user) => (
+                      <CommandItem
+                        key={user.id}
+                        value={user.id}
+                        onSelect={() => handleSelect(user.id)}
+                        aria-current={
+                          user.id === selectedId ? "true" : undefined
+                        }
+                      >
+                        <div className="flex items-center gap-2">
+                          <span>{user.name}</span>
+                          {user.machineCount > 0 && (
+                            <span className="text-[10px] text-muted-foreground/70">
+                              ({user.machineCount})
+                            </span>
+                          )}
+                          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                            (INVITED)
+                          </span>
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </>
+              )}
+
+              {/* Section 3: Guest users */}
+              {guestUsers.length > 0 && (
+                <>
+                  {(memberUsers.length > 0 || invitedUsers.length > 0) && (
+                    <CommandSeparator />
+                  )}
+                  <CommandGroup heading="Guests">
+                    {guestUsers.map((user) => (
+                      <CommandItem
+                        key={user.id}
+                        value={user.id}
+                        onSelect={() => handleSelect(user.id)}
+                        aria-current={
+                          user.id === selectedId ? "true" : undefined
+                        }
+                      >
+                        <div className="flex items-center gap-2">
+                          <span>{user.name}</span>
+                          {user.machineCount > 0 && (
+                            <span className="text-[10px] text-muted-foreground/70">
+                              ({user.machineCount})
+                            </span>
+                          )}
+                          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                            {user.status === "invited"
+                              ? "(INVITED · GUEST)"
+                              : "(GUEST)"}
+                          </span>
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </>
+              )}
+
               <CommandSeparator />
               <CommandGroup>
                 <CommandItem
+                  value="invite-new"
                   onSelect={() => {
                     setOpen(false);
                     setInviteDialogOpen(true);

--- a/src/components/users/InviteUserDialog.tsx
+++ b/src/components/users/InviteUserDialog.tsx
@@ -27,13 +27,6 @@ import {
   FormLabel,
   FormMessage,
 } from "~/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
 import { Switch } from "~/components/ui/switch";
 import { inviteUser } from "~/app/(app)/admin/users/actions";
 import { inviteUserSchema } from "~/app/(app)/admin/users/schema";
@@ -60,7 +53,7 @@ export function InviteUserDialog({
       lastName: "",
       email: "",
       role: "member",
-      sendInvite: false,
+      sendInvite: true,
     },
   });
 
@@ -80,12 +73,14 @@ export function InviteUserDialog({
           toast.success("User invited successfully");
           form.reset();
           // Build minimal user object for the callback (CORE-SEC-006)
+          // Invited users are always created with member role (role field removed from UI)
           const newUser: OwnerSelectUser = {
             id: result.userId,
             name: `${values.firstName} ${values.lastName}`,
             lastName: values.lastName,
             status: "invited",
             machineCount: 0,
+            role: "member",
           };
           // Call onSuccess with both the ID and minimal OwnerSelectUser, then close dialog
           // Note: router.refresh() removed - parent manages users state directly
@@ -161,31 +156,6 @@ export function InviteUserDialog({
                   <FormControl>
                     <Input type="email" {...field} />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="role"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a role" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="guest">Guest</SelectItem>
-                      <SelectItem value="member">Member</SelectItem>
-                    </SelectContent>
-                  </Select>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
## Summary

- **OwnerSelect refactor**: Adds Checkbox to show/hide guests & invited users (hidden by default). Typed search bypasses the filter. Three-section CommandList (members, invited, guests) with role badges. `shouldFilter={false}` for manual filtering.
- **InviteUserDialog cleanup**: Removes the role select field (always invites as guest/member per business rules). Sets `sendInvite` default to `true`.
- **Promote dialog** on create + update forms: When a guest is selected as machine owner and the form is submitted, the server returns `ASSIGNEE_NOT_MEMBER`. A dialog asks to promote the guest to member atomically. Confirmed via `startTransition(() => formAction(fd))` — required by React 19 for imperative `useActionState` dispatch.
- **`handledStateRef` pattern**: Prevents the promote dialog re-opening when the user cancels (tracks which state object already triggered the dialog open).
- **E2E coverage**: 5 tests in `e2e/full/machine-owner-picker.spec.ts` covering all UX paths including the full promote+create flow.

## Key technical note

React 19 requires `useActionState` dispatch to be called inside `startTransition`. Calling it directly in a click handler silently drops the server action (no error thrown, no redirect). This was the root cause of the failing E2E test.

## Test plan

- [ ] `pnpm run check` passes
- [ ] `pnpm exec playwright test e2e/full/machine-owner-picker.spec.ts --project=chromium` — all 5 tests pass
- [ ] Smoke tests: Chromium passes (Firefox/Mobile Safari failures are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)