### PR TITLE
fix(a11y): lift DateRangePicker clear out of trigger button (PP-yxw.18)

### DIFF
--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -48,9 +48,7 @@ export function DateRangePicker({
     onChange(result);
   };
 
-  const handleClear = (e: React.MouseEvent): void => {
-    e.preventDefault();
-    e.stopPropagation();
+  const handleClear = (): void => {
     setDate(undefined);
     onChange({ from: undefined, to: undefined });
   };
@@ -58,42 +56,46 @@ export function DateRangePicker({
   return (
     <div className={cn("grid gap-2", className)}>
       <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            id="date"
-            variant={"outline"}
-            data-testid={testId}
-            className={cn(
-              "w-full justify-between text-left font-normal h-9 px-3 group relative pr-8",
-              !date?.from && "text-muted-foreground"
-            )}
-          >
-            <span className="truncate">
-              {date?.from ? (
-                date.to ? (
-                  <>
-                    {format(date.from, "LLL dd, y")} -{" "}
-                    {format(date.to, "LLL dd, y")}
-                  </>
-                ) : (
-                  format(date.from, "LLL dd, y")
-                )
-              ) : (
-                <span>{placeholder}</span>
+        <div className="group relative">
+          <PopoverTrigger asChild>
+            <Button
+              id="date"
+              variant={"outline"}
+              data-testid={testId}
+              className={cn(
+                "w-full justify-between text-left font-normal h-9 px-3",
+                date?.from ? "pr-8" : "",
+                !date?.from && "text-muted-foreground"
               )}
-            </span>
-            <CalendarIcon className="h-4 w-4 shrink-0 opacity-50 ml-2" />
-            {date?.from && (
-              <div
-                role="button"
-                onClick={handleClear}
-                className="absolute right-2 top-1/2 -translate-y-1/2 h-5 w-5 rounded-sm hover:bg-muted flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-              >
-                <X className="h-3 w-3 text-muted-foreground" />
-              </div>
-            )}
-          </Button>
-        </PopoverTrigger>
+            >
+              <span className="truncate">
+                {date?.from ? (
+                  date.to ? (
+                    <>
+                      {format(date.from, "LLL dd, y")} -{" "}
+                      {format(date.to, "LLL dd, y")}
+                    </>
+                  ) : (
+                    format(date.from, "LLL dd, y")
+                  )
+                ) : (
+                  <span>{placeholder}</span>
+                )}
+              </span>
+              <CalendarIcon className="h-4 w-4 shrink-0 opacity-50 ml-2" />
+            </Button>
+          </PopoverTrigger>
+          {date?.from && (
+            <button
+              type="button"
+              onClick={handleClear}
+              aria-label="Clear date range"
+              className="absolute right-2 top-1/2 -translate-y-1/2 h-5 w-5 rounded-sm hover:bg-muted flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-opacity duration-150"
+            >
+              <X className="h-3 w-3 text-muted-foreground" />
+            </button>
+          )}
+        </div>
         <PopoverContent
           className="w-auto max-h-[80dvh] overflow-y-auto p-0"
           align="start"

--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -64,7 +64,7 @@ export function DateRangePicker({
               data-testid={testId}
               className={cn(
                 "w-full justify-between text-left font-normal h-9 px-3",
-                date?.from ? "pr-8" : "",
+                date?.from && "pr-8",
                 !date?.from && "text-muted-foreground"
               )}
             >
@@ -90,7 +90,7 @@ export function DateRangePicker({
               type="button"
               onClick={handleClear}
               aria-label="Clear date range"
-              className="absolute right-2 top-1/2 -translate-y-1/2 h-5 w-5 rounded-sm hover:bg-muted flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-opacity duration-150"
+              className="absolute right-2 top-1/2 -translate-y-1/2 h-5 w-5 rounded-sm hover:bg-muted flex items-center justify-center opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-opacity duration-150"
             >
               <X className="h-3 w-3 text-muted-foreground" />
             </button>


### PR DESCRIPTION
## Summary
Closes PP-yxw.18. Copilot flagged this during #1207 review: the clear \"X\" in `DateRangePicker` was rendered as `<div role=\"button\">` nested inside the `<Button>` trigger — invalid HTML that breaks keyboard/screen-reader behaviour.

## Change
Restructure the trigger + clear as **siblings** inside a `relative group` wrapper:

- `PopoverTrigger` still wraps only the `Button` — one real interactive surface.
- Clear becomes a sibling `<button type=\"button\">` absolutely positioned over the trigger's right edge.
- `aria-label=\"Clear date range\"` for screen readers.
- `pr-8` reservation only when a value exists (avoids dead whitespace in the empty state).
- Keyboard a11y: `focus-visible:opacity-100` + focus ring so keyboard users can see and reach the clear.
- Because the clear is no longer a descendant of the trigger, clicks don't bubble into the popover opener — the manual `preventDefault`/`stopPropagation` on `handleClear` is no longer needed.

Matches Option 1 from the bead (\"lift the clear affordance outside the trigger button\"), which mirrors how `MultiSelect` handles chip-clear.

## Test plan
- [ ] `/issues` → date range filter: pick a range, confirm X appears on hover, click clears, trigger still opens popover.
- [ ] Keyboard: Tab into picker, Enter opens popover, Escape closes, Tab moves to sibling clear button (visible via focus ring), Enter clears.
- [ ] Screen reader announces \"Clear date range\" on the clear button.
- [ ] Empty state (no `from`): no clear button renders, no dead right-padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)