### PR TITLE
fix(settings): hide guests from account-deletion reassign picker (PP-hci)

### DIFF
--- a/e2e/full/account-deletion-reassign-picker.spec.ts
+++ b/e2e/full/account-deletion-reassign-picker.spec.ts
@@ -25,8 +25,9 @@ test.describe("Account Deletion Reassign Picker (PP-hci)", () => {
     await expect(triggerButton).toBeVisible();
     await triggerButton.click();
 
-    // The dialog should be open and show the reassignment section
-    const dialog = page.getByRole("dialog");
+    // The dialog should be open and show the reassignment section.
+    // AlertDialog renders with role "alertdialog" (Radix/shadcn).
+    const dialog = page.getByRole("alertdialog");
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText("Machine Reassignment Needed")).toBeVisible();
 
@@ -34,13 +35,15 @@ test.describe("Account Deletion Reassign Picker (PP-hci)", () => {
     const reassignSelect = dialog.getByRole("combobox");
     await reassignSelect.click();
 
-    // The listbox (open dropdown) should not contain the guest user's name
+    // The listbox (open dropdown) should not contain the guest user's name.
+    // Use .toHaveCount(0) rather than .not.toBeVisible() so the assertion
+    // fails if the option is present but off-screen in a scrollable list.
     const listbox = page.getByRole("listbox");
     await expect(listbox).toBeVisible();
 
     await expect(
       listbox.getByRole("option", { name: TEST_USERS.guest.name })
-    ).not.toBeVisible();
+    ).toHaveCount(0);
 
     // Member, technician, and admin users SHOULD be present
     await expect(
@@ -50,9 +53,8 @@ test.describe("Account Deletion Reassign Picker (PP-hci)", () => {
       listbox.getByRole("option", { name: TEST_USERS.technician.name })
     ).toBeVisible();
 
-    // Close the dialog by pressing Escape
+    // Close the dialog
     await page.keyboard.press("Escape");
-    // Then close the outer alert dialog
     const keepAccountButton = page.getByRole("button", {
       name: "Keep Account",
     });

--- a/e2e/full/account-deletion-reassign-picker.spec.ts
+++ b/e2e/full/account-deletion-reassign-picker.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * E2E Tests: Account Deletion Reassign Picker (PP-hci)
+ *
+ * Verifies that the machine reassignment picker on the account-deletion
+ * dialog does NOT offer guest users as reassignment targets.
+ *
+ * Regression: without the fix, guests appeared in the Select because the
+ * settings/page.tsx query fetched all userProfiles with no role filter.
+ */
+
+import { test, expect } from "@playwright/test";
+import { STORAGE_STATE } from "../support/auth-state.js";
+import { TEST_USERS } from "../support/constants.js";
+
+test.describe("Account Deletion Reassign Picker (PP-hci)", () => {
+  // Admin owns the Godzilla machine (GDZ) in seed data, so the
+  // machine reassignment section will be visible when admin opens the dialog.
+  test.use({ storageState: STORAGE_STATE.admin });
+
+  test("reassign picker does not show guest users", async ({ page }) => {
+    await page.goto("/settings");
+
+    // Open the delete account dialog
+    const triggerButton = page.getByTestId("delete-account-trigger");
+    await expect(triggerButton).toBeVisible();
+    await triggerButton.click();
+
+    // The dialog should be open and show the reassignment section
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Machine Reassignment Needed")).toBeVisible();
+
+    // Open the reassignment Select
+    const reassignSelect = dialog.getByRole("combobox");
+    await reassignSelect.click();
+
+    // The listbox (open dropdown) should not contain the guest user's name
+    const listbox = page.getByRole("listbox");
+    await expect(listbox).toBeVisible();
+
+    await expect(
+      listbox.getByRole("option", { name: TEST_USERS.guest.name })
+    ).not.toBeVisible();
+
+    // Member, technician, and admin users SHOULD be present
+    await expect(
+      listbox.getByRole("option", { name: TEST_USERS.member.name })
+    ).toBeVisible();
+    await expect(
+      listbox.getByRole("option", { name: TEST_USERS.technician.name })
+    ).toBeVisible();
+
+    // Close the dialog by pressing Escape
+    await page.keyboard.press("Escape");
+    // Then close the outer alert dialog
+    const keepAccountButton = page.getByRole("button", {
+      name: "Keep Account",
+    });
+    if (await keepAccountButton.isVisible()) {
+      await keepAccountButton.click();
+    }
+  });
+});

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -8,7 +8,7 @@ import {
   notificationPreferences,
   machines,
 } from "~/server/db/schema";
-import { eq, and, ne, count } from "drizzle-orm";
+import { eq, and, ne, count, inArray } from "drizzle-orm";
 import { isInternalAccount } from "~/lib/auth/internal-accounts";
 import { ProfileForm } from "./profile-form";
 import { NotificationPreferencesForm } from "./notifications/notification-preferences-form";
@@ -63,7 +63,14 @@ export default async function SettingsPage(): Promise<React.JSX.Element> {
     db
       .select({ id: userProfiles.id, name: userProfiles.name })
       .from(userProfiles)
-      .where(ne(userProfiles.id, user.id)),
+      .where(
+        and(
+          ne(userProfiles.id, user.id),
+          // Guests cannot own machines (matrix: machines.edit guest:false).
+          // Only member+ are valid reassignment targets. (PP-hci)
+          inArray(userProfiles.role, ["member", "technician", "admin"])
+        )
+      ),
   ]);
 
   const ownedMachineCount = ownedMachinesResult[0]?.count ?? 0;


### PR DESCRIPTION
## Summary

- **Bug**: The machine reassignment `<Select>` in the account-deletion dialog offered guest users as valid reassignment targets. This would create a stranded state — a guest cannot own a machine per the permissions matrix (`machines.edit guest:false`), and DB triggers landed via PP-rb8 would block the write at the DB layer.
- **Fix**: Added a role filter to the `membersResult` query in `settings/page.tsx` so only `member`, `technician`, and `admin` users are returned as reassignment candidates.
- **E2E**: Added `e2e/full/account-deletion-reassign-picker.spec.ts` — opens the delete-account dialog as the seeded admin user (who owns the Godzilla machine), opens the reassign Select, and asserts that "Guest User" is absent while "Member User" and "Technician User" are present.

## Files changed

- `src/app/(app)/settings/page.tsx` — filter `membersResult` query to `inArray(role, ["member","technician","admin"])`, excluding guests
- `e2e/full/account-deletion-reassign-picker.spec.ts` — new E2E spec covering the picker exclusion

## Manual browser test

Could not run against this worktree's local server (Supabase not started in this worktree). The fix is a server-side query filter change only — no client-side rendering changes. Smoke tests (914 unit/integration tests) passed locally. CI will run the full E2E suite against the preview branch DB.

## Bead

PP-hci — Follow-up: same owner-picker defect in settings/account-deletion reassign flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)