### PR TITLE
fix(deps): force uuid>=14.0.0 to resolve GHSA-w5hq-g745-h8pq

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,8 @@
       "flatted": ">=3.4.2",
       "webpack": ">=5.105.4",
       "brace-expansion": ">=5.0.5",
-      "yaml": ">=2.8.3"
+      "yaml": ">=2.8.3",
+      "uuid": ">=14.0.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   webpack: '>=5.105.4'
   brace-expansion: '>=5.0.5'
   yaml: '>=2.8.3'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -6489,8 +6490,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uzip@0.20201231.0:
@@ -13130,7 +13131,7 @@ snapshots:
   svix@1.88.0:
     dependencies:
       standardwebhooks: 1.0.0
-      uuid: 10.0.0
+      uuid: 14.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -13389,7 +13390,7 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  uuid@10.0.0: {}
+  uuid@14.0.0: {}
 
   uzip@0.20201231.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `uuid>=14.0.0` to `pnpm.overrides` to resolve advisory GHSA-w5hq-g745-h8pq (moderate severity)
- The vulnerable path is `resend@6.10.0 → svix@1.88.0 → uuid@10.0.0`
- No upstream fix is available yet: resend@6.12.2 (latest) still pins svix@1.90.0 which depends on `uuid@^10.0.0`

## Exploitability analysis

**NOT exploitable.** GHSA-w5hq-g745-h8pq only affects `uuid.v3/v5/v6()` when a `buf` output buffer argument is provided. Inspection of svix's source confirms it only uses `uuid.v4()` with no buffer arg:

- `node_modules/.pnpm/svix@1.88.0/node_modules/svix/src/request.ts`: `import { v4 as uuidv4 } from "uuid"` → `auto_${uuidv4()}` (idempotency-key generation only)

The `v4` codepath already had correct bounds checking before uuid@14 and is not mentioned in the advisory.

## Remediation choice: pnpm override

The override `"uuid": ">=14.0.0"` forces svix's transitive dependency to use uuid@14, which:
1. Fixes the missing bounds check in v3/v5/v6 (the advisory's concern)
2. Preserves v4 semantics — svix's only usage — unchanged
3. Silences `pnpm audit` immediately without waiting for upstream resend/svix to update their dep declarations

## Verification

- `pnpm audit` reports **no vulnerabilities** after this change
- `pnpm run check` passes: 106 test files, 950 tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)