### PR TITLE
fix(logger): serialize Error objects logged under `error` key (PP-d5f)

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -71,6 +71,15 @@ function createLogger(): pino.Logger {
         return { level: label };
       },
     },
+    // Pino's stdSerializers.err only fires for the `err` key by default. The
+    // codebase logs errors as `{ error, ... }`, which made Error.message and
+    // Error.stack non-enumerable → JSON output dropped them entirely. Map both
+    // names so existing call sites get full error info (message, stack, code,
+    // cause-chain) in production logs.
+    serializers: {
+      err: pino.stdSerializers.err,
+      error: pino.stdSerializers.err,
+    },
     timestamp: pino.stdTimeFunctions.isoTime,
   };
 


### PR DESCRIPTION
## Summary

- Pino's `stdSerializers.err` only fires for the `err` key. The codebase logs errors as `{ error, ... }`, which silently dropped `message`, `stack`, Postgres `code`, and Drizzle's `cause` chain because Error's properties are non-enumerable.
- Register `pino.stdSerializers.err` for both `err` AND `error` keys in `src/lib/logger.ts` — backwards compatible, no call-site renames.
- Pino 10's serializer walks `cause`, so Drizzle-wrapped Postgres errors will now expose their underlying code/detail/constraint.

## Why now

A user on `pinpoint.austinpinballcollective.org/m/new` reported "Failed to create machine. Please try again." (PP-d5f). The actual error is in `log.error({ error }, "createMachineAction failed")` — but production logs literally contain `"error":{}`. We can't determine root cause until this serializer fix ships.

After merge, ask the user to retry; the next failure will surface the real Postgres/Drizzle error in Vercel runtime logs.

## Test plan

- [x] `pnpm run check` — 950 unit tests, all passing
- [ ] Post-merge: confirm next prod error log surfaces error.message/stack/code

🤖 Generated with [Claude Code](https://claude.com/claude-code)