### PR TITLE
feat(observability): walk error.cause + reportError helpers (PP-3nx, PP-sc3)

### DIFF
--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -29,6 +29,7 @@ import {
   proseMirrorDocSchema,
 } from "~/lib/tiptap/types";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { isPgErrorCode } from "~/lib/db/postgres-errors";
 
 const NEXT_REDIRECT_DIGEST_PREFIX = "NEXT_REDIRECT;";
 
@@ -40,19 +41,6 @@ const isNextRedirectError = (error: unknown): error is { digest: string } => {
   const { digest } = error as { digest?: unknown };
   return (
     typeof digest === "string" && digest.startsWith(NEXT_REDIRECT_DIGEST_PREFIX)
-  );
-};
-
-interface PostgresError extends Error {
-  code: string;
-  constraint_name?: string;
-}
-
-const isPostgresError = (error: unknown): error is PostgresError => {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    typeof (error as PostgresError).code === "string"
   );
 };
 
@@ -276,7 +264,7 @@ export async function createMachineAction(
       if (isNextRedirectError(error)) {
         throw error;
       }
-      if (isPostgresError(error) && error.code === "23505") {
+      if (isPgErrorCode(error, "23505")) {
         return err("VALIDATION", `Initials '${initials}' are already taken.`);
       }
       log.error(
@@ -381,7 +369,7 @@ export async function createMachineAction(
       throw error;
     }
 
-    if (isPostgresError(error) && error.code === "23505") {
+    if (isPgErrorCode(error, "23505")) {
       return err("VALIDATION", `Initials '${initials}' are already taken.`);
     }
 

--- a/src/lib/db/postgres-errors.test.ts
+++ b/src/lib/db/postgres-errors.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  isPostgresError,
+  getPostgresErrorCode,
+  isPgErrorCode,
+} from "~/lib/db/postgres-errors";
+
+const makeBareError = (code: string): Error => {
+  const e = new Error("postgres error") as Error & { code: string };
+  e.code = code;
+  return e;
+};
+
+const makeDrizzleWrap = (cause: Error, message = "Failed query"): Error =>
+  new Error(message, { cause });
+
+describe("postgres-errors", () => {
+  describe("isPostgresError", () => {
+    it("matches a bare postgres-js error with code property", () => {
+      expect(isPostgresError(makeBareError("23505"))).toBe(true);
+    });
+
+    it("matches a Drizzle-wrapped error via cause chain", () => {
+      const wrapped = makeDrizzleWrap(makeBareError("23505"));
+      expect(isPostgresError(wrapped)).toBe(true);
+    });
+
+    it("matches a doubly-wrapped error (e.g. transaction wrapping)", () => {
+      const inner = makeBareError("23503");
+      const middle = makeDrizzleWrap(inner, "Transaction failed");
+      const outer = makeDrizzleWrap(middle, "Outer wrap");
+      expect(isPostgresError(outer)).toBe(true);
+    });
+
+    it("returns false for a plain Error with no code anywhere in the chain", () => {
+      const inner = new Error("plain");
+      const outer = makeDrizzleWrap(inner, "wraps a plain error");
+      expect(isPostgresError(outer)).toBe(false);
+    });
+
+    it("returns false for non-Error values", () => {
+      expect(isPostgresError(null)).toBe(false);
+      expect(isPostgresError(undefined)).toBe(false);
+      expect(isPostgresError("23505")).toBe(false);
+      expect(isPostgresError({ code: "23505" })).toBe(false);
+      expect(isPostgresError(42)).toBe(false);
+    });
+
+    it("stops walking when cause is not an Error", () => {
+      const e = new Error("with non-Error cause", { cause: "string cause" });
+      expect(isPostgresError(e)).toBe(false);
+    });
+
+    it("ignores non-string code values", () => {
+      const e = new Error("bad code type") as Error & { code: number };
+      e.code = 23505;
+      expect(isPostgresError(e)).toBe(false);
+    });
+  });
+
+  describe("getPostgresErrorCode", () => {
+    it("returns the code from a bare error", () => {
+      expect(getPostgresErrorCode(makeBareError("23505"))).toBe("23505");
+    });
+
+    it("returns the code from a wrapped error", () => {
+      const wrapped = makeDrizzleWrap(makeBareError("23503"));
+      expect(getPostgresErrorCode(wrapped)).toBe("23503");
+    });
+
+    it("returns the first code found when traversing", () => {
+      // Outer wrapper has its own code — should win over inner.
+      const inner = makeBareError("23503");
+      const outer = makeDrizzleWrap(inner) as Error & { code: string };
+      outer.code = "23514";
+      expect(getPostgresErrorCode(outer)).toBe("23514");
+    });
+
+    it("returns undefined when no code exists", () => {
+      expect(getPostgresErrorCode(new Error("plain"))).toBeUndefined();
+      expect(getPostgresErrorCode(null)).toBeUndefined();
+      expect(getPostgresErrorCode(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("isPgErrorCode", () => {
+    it("matches the requested code", () => {
+      const wrapped = makeDrizzleWrap(makeBareError("23505"));
+      expect(isPgErrorCode(wrapped, "23505")).toBe(true);
+    });
+
+    it("does not match a different code", () => {
+      const wrapped = makeDrizzleWrap(makeBareError("23505"));
+      expect(isPgErrorCode(wrapped, "23503")).toBe(false);
+    });
+
+    it("returns false for non-Postgres errors", () => {
+      expect(isPgErrorCode(new Error("plain"), "23505")).toBe(false);
+      expect(isPgErrorCode(null, "23505")).toBe(false);
+    });
+  });
+});

--- a/src/lib/db/postgres-errors.ts
+++ b/src/lib/db/postgres-errors.ts
@@ -1,0 +1,61 @@
+/**
+ * Postgres error introspection that walks the `cause` chain.
+ *
+ * Drizzle ORM wraps postgres-js errors in DrizzleQueryError with the original
+ * error attached on `.cause`. A direct `error.code` check on the wrapper is
+ * always undefined, so naive code checks miss every wrapped failure (PP-d5f).
+ *
+ * These helpers walk the cause chain so detection works regardless of how
+ * deeply the underlying postgres-js error is nested.
+ */
+
+const MAX_CAUSE_DEPTH = 10;
+
+const walkCauseChain = (error: unknown): Error[] => {
+  const chain: Error[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (!(current instanceof Error)) break;
+    chain.push(current);
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return chain;
+};
+
+/**
+ * Type guard: any Error in the cause chain has a string `code` property.
+ *
+ * Returns true for both bare postgres-js errors and Drizzle-wrapped errors.
+ */
+export const isPostgresError = (
+  error: unknown
+): error is Error & { code: string } => {
+  for (const link of walkCauseChain(error)) {
+    if ("code" in link && typeof link.code === "string") return true;
+  }
+  return false;
+};
+
+/**
+ * Returns the first string `code` found by walking the cause chain.
+ *
+ * Use this when you need the actual SQL error code (e.g. "23505", "23503")
+ * regardless of whether the error is wrapped by Drizzle.
+ */
+export const getPostgresErrorCode = (error: unknown): string | undefined => {
+  for (const link of walkCauseChain(error)) {
+    if ("code" in link && typeof link.code === "string") return link.code;
+  }
+  return undefined;
+};
+
+/**
+ * Convenience: matches a specific Postgres SQLSTATE code anywhere in the chain.
+ *
+ * @example
+ *   if (isPgErrorCode(error, "23505")) {
+ *     return err("VALIDATION", `Initials '${initials}' are already taken.`);
+ *   }
+ */
+export const isPgErrorCode = (error: unknown, code: string): boolean =>
+  getPostgresErrorCode(error) === code;

--- a/src/lib/db/postgres-errors.ts
+++ b/src/lib/db/postgres-errors.ts
@@ -23,13 +23,14 @@ const walkCauseChain = (error: unknown): Error[] => {
 };
 
 /**
- * Type guard: any Error in the cause chain has a string `code` property.
+ * Returns true when any Error in the cause chain has a string `code` property.
  *
- * Returns true for both bare postgres-js errors and Drizzle-wrapped errors.
+ * Intentionally NOT a type guard — narrowing `error` to `Error & { code: string }`
+ * would be a lie when the matching link is on `error.cause` (the outer error
+ * still has no `code`). Callers that need the actual code must use
+ * `getPostgresErrorCode(error)` or `isPgErrorCode(error, "23505")`.
  */
-export const isPostgresError = (
-  error: unknown
-): error is Error & { code: string } => {
+export const isPostgresError = (error: unknown): boolean => {
   for (const link of walkCauseChain(error)) {
     if ("code" in link && typeof link.code === "string") return true;
   }

--- a/src/lib/observability/report-error.test.ts
+++ b/src/lib/observability/report-error.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const captureExceptionMock = vi.fn();
+const logErrorMock = vi.fn();
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: (...args: unknown[]) =>
+    captureExceptionMock(...(args as Parameters<typeof captureExceptionMock>)),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    error: (...args: unknown[]) =>
+      logErrorMock(...(args as Parameters<typeof logErrorMock>)),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  reportError,
+  serverActionError,
+} from "~/lib/observability/report-error";
+
+beforeEach(() => {
+  captureExceptionMock.mockReset();
+  logErrorMock.mockReset();
+});
+
+describe("reportError", () => {
+  it("forwards the error to Sentry with a pinpoint context", () => {
+    const error = new Error("boom");
+    reportError(error, { action: "createMachineAction", machineId: "abc" });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(error, {
+      contexts: {
+        pinpoint: { action: "createMachineAction", machineId: "abc" },
+      },
+    });
+  });
+
+  it("writes a structured log entry with the error under the err key", () => {
+    const error = new Error("boom");
+    reportError(error, { action: "doThing" });
+
+    expect(logErrorMock).toHaveBeenCalledTimes(1);
+    const [payload, msg] = logErrorMock.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ err: error, action: "doThing" });
+    expect(msg).toBe("doThing");
+  });
+
+  it("uses a default message when no action is provided", () => {
+    reportError(new Error("nope"));
+    const [, msg] = logErrorMock.mock.calls[0] ?? [];
+    expect(msg).toBe("Caught error");
+  });
+
+  it("works with non-Error inputs (still captures)", () => {
+    reportError("string error", { action: "weird" });
+    expect(captureExceptionMock).toHaveBeenCalledWith("string error", {
+      contexts: { pinpoint: { action: "weird" } },
+    });
+  });
+
+  it("preserves a bestEffort flag in both pipelines", () => {
+    const error = new Error("notification failed");
+    reportError(error, { action: "notify", bestEffort: true });
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(error, {
+      contexts: { pinpoint: { action: "notify", bestEffort: true } },
+    });
+    const [payload] = logErrorMock.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ action: "notify", bestEffort: true });
+  });
+});
+
+describe("serverActionError", () => {
+  it("returns a Result err with the supplied code and message", () => {
+    const result = serverActionError(
+      new Error("boom"),
+      "SERVER",
+      "Failed to create machine."
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("SERVER");
+      expect(result.message).toBe("Failed to create machine.");
+    }
+  });
+
+  it("captures the error to Sentry and the logger before returning", () => {
+    const error = new Error("boom");
+    serverActionError(error, "SERVER", "msg", { action: "create" });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(logErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("narrows the Result type to the supplied code literal", () => {
+    const result = serverActionError(
+      new Error("x"),
+      "VALIDATION" as const,
+      "bad input"
+    );
+    if (!result.ok) {
+      // Type assertion: `code` should be the literal "VALIDATION" here.
+      const code: "VALIDATION" = result.code;
+      expect(code).toBe("VALIDATION");
+    }
+  });
+});

--- a/src/lib/observability/report-error.ts
+++ b/src/lib/observability/report-error.ts
@@ -1,0 +1,66 @@
+/**
+ * Server-side error reporting. Captures to Sentry AND structured logs in one call.
+ *
+ * Most server-action catch blocks were silently swallowing errors via `log.error`
+ * alone — Sentry's auto-capture only sees uncaught exceptions, so caught errors
+ * stayed invisible to monitoring (PP-a5y). These helpers route every caught
+ * error to both pipelines from a single canonical entry point.
+ *
+ * SERVER-ONLY: imports the pino logger which is not safe to bundle into client
+ * components. Client-side catch blocks should call Sentry.captureException directly.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+
+import { log } from "~/lib/logger";
+import { err, type Result } from "~/lib/result";
+
+export interface ReportContext {
+  /** Short identifier of the failing operation. Used as the log message. */
+  action?: string;
+  /**
+   * Mark when the error was tolerated by design (post-commit notifications,
+   * blob deletions, etc.). The error is still captured — this flag lets alert
+   * rules treat best-effort failures differently from primary-path failures.
+   */
+  bestEffort?: boolean;
+  /** Arbitrary structured context attached to both Sentry and the log entry. */
+  [key: string]: unknown;
+}
+
+/**
+ * Capture an error to Sentry and write a structured log entry.
+ *
+ * Call from any server-side catch block. Returns void — the caller is
+ * responsible for any user-facing behavior (returning err Result, throwing,
+ * tolerating, etc.).
+ */
+export function reportError(error: unknown, context: ReportContext = {}): void {
+  Sentry.captureException(error, { contexts: { pinpoint: context } });
+  log.error({ err: error, ...context }, context.action ?? "Caught error");
+}
+
+/**
+ * Convenience for server actions: report the error AND return a Result err.
+ *
+ * Replaces the `log.error(...); return err("SERVER", "...")` pattern that
+ * previously left Sentry blind to ~50 caught failures across the codebase.
+ *
+ * @example
+ *   try {
+ *     await db.insert(machines).values(...);
+ *   } catch (error) {
+ *     return serverActionError(error, "SERVER", "Failed to create machine.", {
+ *       action: "createMachineAction",
+ *     });
+ *   }
+ */
+export function serverActionError<C extends string>(
+  error: unknown,
+  code: C,
+  message: string,
+  context: ReportContext = {}
+): Result<never, C> {
+  reportError(error, context);
+  return err(code, message);
+}

--- a/src/lib/observability/report-error.ts
+++ b/src/lib/observability/report-error.ts
@@ -10,6 +10,8 @@
  * components. Client-side catch blocks should call Sentry.captureException directly.
  */
 
+import "server-only";
+
 import * as Sentry from "@sentry/nextjs";
 
 import { log } from "~/lib/logger";
@@ -37,7 +39,8 @@ export interface ReportContext {
  */
 export function reportError(error: unknown, context: ReportContext = {}): void {
   Sentry.captureException(error, { contexts: { pinpoint: context } });
-  log.error({ err: error, ...context }, context.action ?? "Caught error");
+  // Spread context first so a stray `context.err` cannot shadow the actual error.
+  log.error({ ...context, err: error }, context.action ?? "Caught error");
 }
 
 /**


### PR DESCRIPTION
## Summary

Two helper modules anchor the codebase-wide error-propagation cleanup (PP-a5y epic). Both fix or unblock distinct silencing patterns surfaced by the PP-d5f machine-creation collision.

### `src/lib/db/postgres-errors.ts` (new)
- `isPostgresError`, `getPostgresErrorCode`, `isPgErrorCode` walk `error.cause` up to 10 levels deep.
- Drizzle wraps postgres-js errors in `DrizzleQueryError` with the original on `.cause`. Previous `error.code === "23505"` checks against the wrapper always returned undefined → unique/FK/check violations silently fell through to generic SERVER errors.

### `src/lib/observability/report-error.ts` (new)
- `reportError(error, context)` calls `Sentry.captureException` AND `log.error` with structured context. Closes the gap that left ~50 server-action catches invisible to monitoring.
- `serverActionError(error, code, message, context)` additionally returns a `Result` err for use in catch blocks.
- Server-only (imports pino logger).

### `src/app/(app)/m/actions.ts`
- Delete inline `isPostgresError` + `PostgresError` interface.
- Replace 2 sites where Drizzle wrapping was masking the unique-constraint violation. Friendly "Initials 'HD' are already taken." message now fires for collisions on both the non-forcePromote and forcePromote paths.

## Why this is PR 1 of an 8-PR cleanup
Per the epic plan (PP-a5y), W2 (~50 SERVER err mass-apply, split into 5 sub-PRs by directory), W4 (console→logger), W5 (Tiptap fallback), W6 (best-effort routing), and W7 (route-segment error.tsx) all depend on `serverActionError`/`reportError` from this PR.

## Test plan
- [x] `pnpm run check` clean — 972 tests, 108 files (added 22 new test cases across 2 new test files)
- [x] Unit tests cover: bare PG errors, single Drizzle wrap, double wrap, plain Errors, non-Error inputs, non-string codes, mocked Sentry + logger pipelines, Result type narrowing
- [ ] Post-merge manual verification: trigger duplicate-initials `/m/new` submission in production, confirm "Initials 'HD' are already taken." appears
- [ ] Post-merge: confirm Sentry receives any new SERVER err from m/actions.ts within 1 minute (pending W2 PR 3b for full mass-apply)

## Companion PR
PR #1229 (logger serializer fix) is independent of this PR but addresses the same epic. Both should land before downstream PRs in the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)