### PR TITLE
refactor: narrow bare catch blocks in blob/client.ts

### DIFF
--- a/src/lib/blob/client.ts
+++ b/src/lib/blob/client.ts
@@ -106,15 +106,17 @@ export async function deleteFromBlob(pathname: string): Promise<void> {
       }
       await fs.unlink(filePath);
     } catch (error) {
-      // Ignore if file doesn't exist (ENOENT), similar to blob behavior
-      // Re-throw any other filesystem errors
+      // Ignore only if file doesn't exist (ENOENT), similar to blob behavior.
+      // Re-throw everything else (including non-Error throws and Errors
+      // without a `code` property) so unrelated bugs aren't swallowed.
       if (
         error instanceof Error &&
         "code" in error &&
-        error.code !== "ENOENT"
+        error.code === "ENOENT"
       ) {
-        throw error;
+        return;
       }
+      throw error;
     }
     return;
   }

--- a/src/lib/blob/client.ts
+++ b/src/lib/blob/client.ts
@@ -92,8 +92,9 @@ export async function deleteFromBlob(pathname: string): Promise<void> {
       try {
         const url = new URL(pathname);
         resolved = url.pathname.replace(/^\/uploads\//, "");
-      } catch {
-        // Not a URL — use as-is
+      } catch (error) {
+        // Not a URL — use as-is (only catch TypeError from URL parsing)
+        if (!(error instanceof TypeError)) throw error;
       }
       const safePathname = resolved
         .replace(/^(\.\.[/\\])+/, "")
@@ -104,8 +105,16 @@ export async function deleteFromBlob(pathname: string): Promise<void> {
         return; // Ignore invalid paths
       }
       await fs.unlink(filePath);
-    } catch {
-      // Ignore if file doesn't exist, similar to blob behavior
+    } catch (error) {
+      // Ignore if file doesn't exist (ENOENT), similar to blob behavior
+      // Re-throw any other filesystem errors
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code !== "ENOENT"
+      ) {
+        throw error;
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary

Narrowed two bare `catch {}` blocks in `src/lib/blob/client.ts` to catch only the expected error types and re-throw unrelated errors.

## Changes

**Site 1 (line 95)** — URL parsing fallback:
- **Expected error**: `TypeError` from `new URL(pathname)` when the input is not a valid URL
- **Narrowed to**: `catch (error) { if (!(error instanceof TypeError)) throw error; ... }`
- **Why**: Only URL parsing errors should be silently handled here; any other error (e.g., unexpected runtime error) should propagate

**Site 2 (line 107)** — File deletion in mock storage:
- **Expected error**: `ENOENT` (file not found) from `fs.unlink()`
- **Narrowed to**: Check for `error.code === "ENOENT"` and re-throw any other filesystem errors
- **Why**: The intent is to ignore missing files (idempotent deletion), but other FS errors (permission denied, disk full, etc.) should be visible for debugging

## Impact

- Preserves all original behavior for expected errors
- Prevents silent swallowing of unrelated bugs
- Makes error handling more explicit and easier to understand
- Aligns with the original intent comments in the code