### PR TITLE
feat: add route-segment error.tsx coverage (PP-opk)

### DIFF
--- a/src/app/(app)/admin/error.tsx
+++ b/src/app/(app)/admin/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Admin segment error boundary.
+ *
+ * Catches unhandled errors within the admin section (user management,
+ * integrations). Provides a recovery path back to the admin dashboard.
+ */
+export default function AdminErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="admin"
+      context="loading admin"
+      backLabel="Back to Admin"
+      backHref="/admin"
+    />
+  );
+}

--- a/src/app/(app)/admin/error.tsx
+++ b/src/app/(app)/admin/error.tsx
@@ -24,7 +24,7 @@ export default function AdminErrorPage({
       error={error}
       reset={reset}
       segment="admin"
-      context="loading admin"
+      context="loading the admin section"
       backLabel="Back to Admin"
       backHref="/admin"
     />

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * App segment error boundary.
+ *
+ * Catches unhandled errors within the authenticated app shell (dashboard,
+ * issues, machines, settings, admin, etc.) before they bubble to the root
+ * boundary. Provides a recovery path back to the dashboard.
+ */
+export default function AppErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="app"
+      context="in the app"
+      backLabel="Back to Dashboard"
+      backHref="/dashboard"
+    />
+  );
+}

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -25,7 +25,7 @@ export default function AppErrorPage({
       error={error}
       reset={reset}
       segment="app"
-      context="in the app"
+      context="loading the page"
       backLabel="Back to Dashboard"
       backHref="/dashboard"
     />

--- a/src/app/(app)/issues/error.tsx
+++ b/src/app/(app)/issues/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Issues segment error boundary.
+ *
+ * Catches unhandled errors within the issues section (issue list, issue
+ * detail, report form). Provides a recovery path back to the issue list.
+ */
+export default function IssuesErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="issues"
+      context="loading issues"
+      backLabel="Back to Issues"
+      backHref="/issues"
+    />
+  );
+}

--- a/src/app/(app)/m/error.tsx
+++ b/src/app/(app)/m/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Machines segment error boundary.
+ *
+ * Catches unhandled errors within the machines section (machine list, machine
+ * detail, new machine form). Provides a recovery path back to the machine list.
+ */
+export default function MachinesErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="machines"
+      context="loading machines"
+      backLabel="Back to Machines"
+      backHref="/m"
+    />
+  );
+}

--- a/src/app/(app)/settings/error.tsx
+++ b/src/app/(app)/settings/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Settings segment error boundary.
+ *
+ * Catches unhandled errors within the settings section (profile, account,
+ * notifications, connected accounts). Provides a recovery path back to
+ * settings.
+ */
+export default function SettingsErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="settings"
+      context="loading settings"
+      backLabel="Back to Settings"
+      backHref="/settings"
+    />
+  );
+}

--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -24,7 +24,7 @@ export default function AuthErrorPage({
       error={error}
       reset={reset}
       segment="auth"
-      context="during sign in"
+      context="signing you in"
       backLabel="Back to Login"
       backHref="/login"
     />

--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Auth segment error boundary.
+ *
+ * Catches unhandled errors within the authentication flow (login, signup,
+ * forgot password, reset password). Provides a recovery path back to login.
+ */
+export default function AuthErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="auth"
+      context="during sign in"
+      backLabel="Back to Login"
+      backHref="/login"
+    />
+  );
+}

--- a/src/app/(site)/error.tsx
+++ b/src/app/(site)/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type React from "react";
+
+import { SegmentErrorBoundary } from "~/components/errors/SegmentErrorBoundary";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Site segment error boundary.
+ *
+ * Catches unhandled errors within public site pages (about, help, privacy,
+ * terms, changelog). Provides a recovery path back to the home page.
+ */
+export default function SiteErrorPage({
+  error,
+  reset,
+}: ErrorPageProps): React.JSX.Element {
+  return (
+    <SegmentErrorBoundary
+      error={error}
+      reset={reset}
+      segment="site"
+      context="loading this page"
+      backLabel="Back to Home"
+      backHref="/"
+    />
+  );
+}

--- a/src/components/errors/SegmentErrorBoundary.tsx
+++ b/src/components/errors/SegmentErrorBoundary.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { AlertTriangle } from "lucide-react";
+import Link from "next/link";
+import type React from "react";
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+
+interface SegmentErrorBoundaryProps {
+  /** The error passed from Next.js error boundary */
+  error: Error & { digest?: string };
+  /** The reset function passed from Next.js error boundary */
+  reset: () => void;
+  /** Sentry segment label, e.g. "app", "issues", "machines" */
+  segment: string;
+  /** User-facing description of what failed, e.g. "loading machines" */
+  context: string;
+  /** Link label for the recovery navigation, e.g. "Back to Machines" */
+  backLabel: string;
+  /** URL for the recovery navigation link, e.g. "/m" */
+  backHref: string;
+}
+
+/**
+ * Shared error boundary UI for per-segment error.tsx files.
+ *
+ * Each segment error.tsx wraps this with its own segment/context/backLabel/backHref.
+ * Captures to Sentry via useEffect (required — error.tsx is always a Client Component).
+ */
+export function SegmentErrorBoundary({
+  error,
+  reset,
+  segment,
+  context,
+  backLabel,
+  backHref,
+}: SegmentErrorBoundaryProps): React.JSX.Element {
+  useEffect(() => {
+    Sentry.captureException(error, {
+      contexts: {
+        pinpoint: {
+          segment,
+          digest: error.digest,
+        },
+      },
+    });
+
+    // Log full error details only in development to avoid leaking stack traces
+    // in production DevTools. In production, log digest only for correlation.
+    if (process.env.NODE_ENV !== "production") {
+      console.error(`Unhandled error in segment "${segment}":`, error);
+    } else if (error.digest) {
+      console.error(
+        `Unhandled error in segment "${segment}" (digest only):`,
+        error.digest
+      );
+    }
+  }, [error, segment]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center px-4">
+      <div className="text-center">
+        <div className="mb-4 inline-flex size-16 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangle
+            className="size-8 text-destructive"
+            aria-hidden="true"
+          />
+        </div>
+        <h2 className="text-xl font-semibold text-balance">
+          Something went wrong {context}
+        </h2>
+        <p className="mt-2 max-w-sm text-pretty text-muted-foreground">
+          An unexpected error occurred. You can try again or navigate away to
+          recover.
+        </p>
+        <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <Button onClick={reset}>Try Again</Button>
+          <Button variant="outline" asChild>
+            <Link href={backHref}>{backLabel}</Link>
+          </Button>
+        </div>
+        {error.digest && (
+          <p className="mt-8 text-xs text-muted-foreground/60">
+            Error ID: {error.digest}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/errors/SegmentErrorBoundary.tsx
+++ b/src/components/errors/SegmentErrorBoundary.tsx
@@ -15,7 +15,11 @@ interface SegmentErrorBoundaryProps {
   reset: () => void;
   /** Sentry segment label, e.g. "app", "issues", "machines" */
   segment: string;
-  /** User-facing description of what failed, e.g. "loading machines" */
+  /**
+   * User-facing description of what failed, completing the heading
+   * "Something went wrong while ___". E.g. "loading machines",
+   * "loading this page", "signing you in".
+   */
   context: string;
   /** Link label for the recovery navigation, e.g. "Back to Machines" */
   backLabel: string;
@@ -48,13 +52,19 @@ export function SegmentErrorBoundary({
     });
 
     // Log full error details only in development to avoid leaking stack traces
-    // in production DevTools. In production, log digest only for correlation.
+    // in production DevTools. In production, log digest if present for
+    // correlation with Sentry; always emit a generic line so the error is
+    // visible in Vercel runtime logs even when digest is unavailable.
     if (process.env.NODE_ENV !== "production") {
       console.error(`Unhandled error in segment "${segment}":`, error);
     } else if (error.digest) {
       console.error(
         `Unhandled error in segment "${segment}" (digest only):`,
         error.digest
+      );
+    } else {
+      console.error(
+        `Unhandled error in segment "${segment}" (no digest available)`
       );
     }
   }, [error, segment]);
@@ -69,7 +79,7 @@ export function SegmentErrorBoundary({
           />
         </div>
         <h2 className="text-xl font-semibold text-balance">
-          Something went wrong {context}
+          Something went wrong while {context}
         </h2>
         <p className="mt-2 max-w-sm text-pretty text-muted-foreground">
           An unexpected error occurred. You can try again or navigate away to

--- a/src/components/errors/index.ts
+++ b/src/components/errors/index.ts
@@ -1,1 +1,2 @@
 export { Forbidden } from "./Forbidden";
+export { SegmentErrorBoundary } from "./SegmentErrorBoundary";


### PR DESCRIPTION
## Summary

- Adds 7 per-segment `error.tsx` Next.js error boundaries under `(app)`, `(auth)`, `(site)`, `m`, `issues`, `settings`, and `admin`
- Extracts a shared `SegmentErrorBoundary` helper (`src/components/errors/SegmentErrorBoundary.tsx`) so each segment file is a thin wrapper — satisfies Rule of Three from AGENTS.md
- Each boundary captures to Sentry with `{ contexts: { pinpoint: { segment, digest } } }` via `useEffect` (client-side requirement for error boundaries)
- Also calls `console.error` as a Vercel runtime log fallback (digest-only in production to avoid leaking stack traces)

## New files

| File | Segment | Recovery link |
|---|---|---|
| `src/app/(app)/error.tsx` | App shell | `/dashboard` |
| `src/app/(auth)/error.tsx` | Auth flow | `/login` |
| `src/app/(site)/error.tsx` | Public site | `/` |
| `src/app/(app)/m/error.tsx` | Machine list/detail | `/m` |
| `src/app/(app)/issues/error.tsx` | Issue list/detail | `/issues` |
| `src/app/(app)/settings/error.tsx` | Settings | `/settings` |
| `src/app/(app)/admin/error.tsx` | Admin section | `/admin` |
| `src/components/errors/SegmentErrorBoundary.tsx` | Shared helper | — |

## Sentry capture approach

`error.tsx` files are always Client Components (Next.js requirement for error boundaries), so `reportError` (server-only) cannot be used here. Each boundary calls `Sentry.captureException` directly in a `useEffect`, which is the correct client-side pattern matching the existing `src/app/error.tsx` and `src/app/global-error.tsx`.

## Manual verification plan

To verify a segment boundary renders, add `if (process.env.NEXT_PUBLIC_TEST_ERROR === "1") throw new Error("test")` to a page.tsx in the target segment, set the env var, navigate to that route, and confirm the segment-specific boundary and recovery link appear. Restore the page after testing. (Verified on machines segment manually.)

## Test plan

- [x] `pnpm run check` passes (108 test files, 972 tests, typecheck, lint, format all clean)
- [ ] Navigate to each segment after a deliberate throw to confirm correct boundary renders
- [ ] "Try Again" button wired to `reset()` prop
- [ ] Recovery link points to correct parent route per segment
- [ ] Sentry event includes `contexts.pinpoint.segment` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)