### PR TITLE
refactor: replace console.* with structured logger (PP-pmv)

### DIFF
--- a/src/app/(app)/notifications/actions.ts
+++ b/src/app/(app)/notifications/actions.ts
@@ -6,6 +6,7 @@ import { db } from "~/server/db";
 import { notifications } from "~/server/db/schema";
 import { eq, and } from "drizzle-orm";
 import { type Result, ok, err } from "~/lib/result";
+import { serverActionError } from "~/lib/observability/report-error";
 
 export type MarkAsReadResult = Result<
   { success: boolean },
@@ -37,8 +38,15 @@ export async function markAsReadAction(
     revalidatePath("/", "layout"); // Revalidate everywhere to update notification count
     return ok({ success: true });
   } catch (error) {
-    console.error("markAsReadAction failed", error);
-    return err("SERVER", "Failed to mark notification as read");
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to mark notification as read",
+      {
+        action: "markAsReadAction",
+        notificationId,
+      }
+    );
   }
 }
 
@@ -60,7 +68,8 @@ export async function markAllAsReadAction(): Promise<MarkAsReadResult> {
     revalidatePath("/", "layout");
     return ok({ success: true });
   } catch (error) {
-    console.error("markAllAsReadAction failed", error);
-    return err("SERVER", "Failed to mark all as read");
+    return serverActionError(error, "SERVER", "Failed to mark all as read", {
+      action: "markAllAsReadAction",
+    });
   }
 }

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -16,6 +16,7 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 import { type Result, ok, err } from "~/lib/result";
 import { deleteFromBlob } from "~/lib/blob/client";
+import { serverActionError } from "~/lib/observability/report-error";
 import { log } from "~/lib/logger";
 import { checkLoginAccountLimit } from "~/lib/rate-limit";
 import {
@@ -86,8 +87,9 @@ export async function updateProfileAction(
 
     return ok({ success: true });
   } catch (error) {
-    console.error("Failed to update profile:", error);
-    return err("SERVER", "Failed to update profile");
+    return serverActionError(error, "SERVER", "Failed to update profile", {
+      action: "updateProfileAction",
+    });
   }
 }
 

--- a/src/app/(app)/settings/notifications/actions.ts
+++ b/src/app/(app)/settings/notifications/actions.ts
@@ -5,6 +5,7 @@ import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
 import { notificationPreferences } from "~/server/db/schema";
 import { type Result, ok, err } from "~/lib/result";
+import { serverActionError } from "~/lib/observability/report-error";
 import { z } from "zod";
 
 const updatePreferencesSchema = z.object({
@@ -91,7 +92,8 @@ export async function updateNotificationPreferencesAction(
     revalidatePath("/settings");
     return ok({ success: true });
   } catch (error) {
-    console.error("updateNotificationPreferencesAction failed", error);
-    return err("SERVER", "Failed to update preferences");
+    return serverActionError(error, "SERVER", "Failed to update preferences", {
+      action: "updateNotificationPreferencesAction",
+    });
   }
 }

--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -11,6 +11,7 @@ import { type NextRequest } from "next/server";
 import type { EmailOtpType } from "@supabase/supabase-js";
 import { getSupabaseEnv } from "~/lib/supabase/env";
 import { getSiteUrl, isInternalUrl } from "~/lib/url";
+import { reportError } from "~/lib/observability/report-error";
 
 export function resolveRedirectPath(nextParam: string | null): string {
   const fallback = "/";
@@ -100,8 +101,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return applyCookies(redirectToTarget(), pendingCookies);
     }
 
-    console.error("auth/callback: exchangeCodeForSession failed", {
-      error: error.message,
+    reportError(error, {
+      action: "auth.callback",
+      step: "exchangeCodeForSession",
     });
   }
 
@@ -119,8 +121,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return applyCookies(redirectToTarget(), pendingCookies);
     }
 
-    console.error("auth/callback: verifyOtp failed", {
-      error: error.message,
+    reportError(error, {
+      action: "auth.callback",
+      step: "verifyOtp",
       type: otpType,
     });
   }

--- a/src/components/feedback/FeedbackWidget.tsx
+++ b/src/components/feedback/FeedbackWidget.tsx
@@ -68,6 +68,9 @@ function openSentryFeedbackWidget(
             }
           }
         } catch (err) {
+          // Intentionally console.error — this IS the Sentry feedback widget.
+          // Calling Sentry.captureException here would recursively invoke the
+          // widget we're already trying to open, causing an infinite loop.
           console.error("[FeedbackWidget] Error calling createForm:", err);
         }
       })();
@@ -133,6 +136,9 @@ function handleFeedback(type: "bug" | "feature"): void {
             }
           }
         } catch (err) {
+          // Intentionally console.error — this IS the Sentry feedback widget.
+          // Calling Sentry.captureException here would recursively invoke the
+          // widget we're already trying to open, causing an infinite loop.
           console.error("[FeedbackWidget] Error calling createForm:", err);
         }
       })();
@@ -146,11 +152,8 @@ function handleFeedback(type: "bug" | "feature"): void {
 
 export function FeedbackWidget(): React.JSX.Element | null {
   useEffect(() => {
-    // Optional: Mount checks/logging if needed in dev
-    if (process.env.NODE_ENV === "development") {
-      const feedback = Sentry.getFeedback();
-      console.log("[FeedbackWidget] Mounted.", { feedback });
-    }
+    // Dev-only mount check — intentionally not routed through Sentry since this
+    // is the Sentry feedback widget itself; recursive capture would be noisy.
   }, []);
 
   return (

--- a/src/components/feedback/FeedbackWidget.tsx
+++ b/src/components/feedback/FeedbackWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import React, { useEffect } from "react";
+import React from "react";
 import { Button } from "~/components/ui/button";
 import { MessageSquare, Bug, Lightbulb } from "lucide-react";
 import {
@@ -151,11 +151,6 @@ function handleFeedback(type: "bug" | "feature"): void {
 }
 
 export function FeedbackWidget(): React.JSX.Element | null {
-  useEffect(() => {
-    // Dev-only mount check — intentionally not routed through Sentry since this
-    // is the Sentry feedback widget itself; recursive capture would be noisy.
-  }, []);
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/src/components/images/ImageUploadButton.tsx
+++ b/src/components/images/ImageUploadButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useRef } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
@@ -62,9 +63,11 @@ export function ImageUploadButton({
         toast.error(`Upload failed: ${result.message}`);
       }
     } catch (error) {
-      // Client-side component - use console.error as logger is server-side only
-
-      console.error("Upload error:", error);
+      Sentry.captureException(error, {
+        contexts: {
+          pinpoint: { action: "ImageUploadButton.handleFileChange", issueId },
+        },
+      });
       toast.error(getUploadErrorMessage(error));
     } finally {
       setIsUploading(false);

--- a/src/lib/blob/compression.ts
+++ b/src/lib/blob/compression.ts
@@ -1,4 +1,5 @@
 import imageCompression from "browser-image-compression";
+import * as Sentry from "@sentry/nextjs";
 import { BLOB_CONFIG } from "./config";
 
 /**
@@ -29,7 +30,13 @@ export async function compressImage(
       lastModified: Date.now(),
     });
   } catch (err) {
-    console.error("Compression failed:", err);
+    // Best-effort: compression failure is tolerated — we fall back to the original file.
+    // Captured so we can track how often this degrades in production.
+    Sentry.captureException(err, {
+      contexts: {
+        pinpoint: { action: "compressImage", mode, bestEffort: true },
+      },
+    });
     return file; // Fallback to original
   }
 }

--- a/src/lib/email/client.ts
+++ b/src/lib/email/client.ts
@@ -6,6 +6,8 @@ import {
   SMTPTransport,
   EMAIL_FROM,
 } from "./transport";
+import { log } from "~/lib/logger";
+import { reportError } from "~/lib/observability/report-error";
 
 // Re-export for backward compatibility
 export { EMAIL_FROM };
@@ -37,20 +39,21 @@ function createTransport(): EmailTransport | null {
       return raw ? parseInt(raw, 10) : 1025;
     })();
 
-    console.log(`[Email] Using SMTP transport on port ${port}`);
+    log.info({ port }, "[Email] Using SMTP transport");
     return new SMTPTransport({ port });
   }
 
   // Production/Dev: use Resend if API key is present
   const apiKey = process.env["RESEND_API_KEY"];
   if (apiKey) {
-    console.log("[Email] Using Resend transport with API key");
+    log.info({}, "[Email] Using Resend transport with API key");
     return new ResendTransport(apiKey);
   }
 
   // No transport configured
-  console.warn(
-    "[Email] ⚠️ No email transport configured - RESEND_API_KEY not found"
+  log.warn(
+    {},
+    "[Email] No email transport configured - RESEND_API_KEY not found"
   );
   return null;
 }
@@ -62,21 +65,21 @@ export async function sendEmail({
   subject,
   html,
 }: EmailParams): Promise<EmailResult> {
-  console.log(`[Email] Attempting to send email to ${to}: ${subject}`);
+  log.info({ to, subject }, "[Email] Attempting to send email");
 
   if (!transport) {
-    console.warn("⚠️ No email transport configured. Email not sent:", {
-      to,
-      subject,
-    });
+    log.warn(
+      { to, subject },
+      "[Email] No transport configured. Email not sent."
+    );
     return { success: false, error: "No transport configured" };
   }
 
   const result = await transport.send({ to, subject, html });
   if (result.success) {
-    console.log(`✅ Email sent successfully to ${to}: ${subject}`);
+    log.info({ to, subject }, "[Email] Email sent successfully");
   } else {
-    console.error(`❌ Email failed to send to ${to}:`, result.error);
+    reportError(result.error, { action: "sendEmail", to, subject });
   }
   return result;
 }

--- a/src/lib/email/client.ts
+++ b/src/lib/email/client.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import {
   type EmailTransport,
   type EmailParams,
@@ -79,7 +81,7 @@ export async function sendEmail({
   if (result.success) {
     log.info({ to, subject }, "[Email] Email sent successfully");
   } else {
-    reportError(result.error, { action: "sendEmail", to, subject });
+    reportError(result.error, { action: "sendEmail" });
   }
   return result;
 }

--- a/src/lib/email/transport.ts
+++ b/src/lib/email/transport.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 import nodemailer from "nodemailer";
 import type Mail from "nodemailer/lib/mailer";
+import { reportError } from "~/lib/observability/report-error";
 
 export const EMAIL_FROM =
   "PinPoint <notifications@pinpoint.austinpinballcollective.org>";
@@ -46,7 +47,7 @@ export class ResendTransport implements EmailTransport {
 
       return { success: true, data };
     } catch (error) {
-      console.error("❌ Failed to send email via Resend:", error);
+      reportError(error, { action: "ResendTransport.send", to });
       return { success: false, error };
     }
   }
@@ -84,7 +85,7 @@ export class SMTPTransport implements EmailTransport {
 
       return { success: true, data: info };
     } catch (error) {
-      console.error("❌ Failed to send email via SMTP:", error);
+      reportError(error, { action: "SMTPTransport.send", to });
       return { success: false, error };
     }
   }

--- a/src/lib/email/transport.ts
+++ b/src/lib/email/transport.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { Resend } from "resend";
 import nodemailer from "nodemailer";
 import type Mail from "nodemailer/lib/mailer";
@@ -47,7 +49,7 @@ export class ResendTransport implements EmailTransport {
 
       return { success: true, data };
     } catch (error) {
-      reportError(error, { action: "ResendTransport.send", to });
+      reportError(error, { action: "ResendTransport.send" });
       return { success: false, error };
     }
   }
@@ -85,7 +87,7 @@ export class SMTPTransport implements EmailTransport {
 
       return { success: true, data: info };
     } catch (error) {
-      reportError(error, { action: "SMTPTransport.send", to });
+      reportError(error, { action: "SMTPTransport.send" });
       return { success: false, error };
     }
   }


### PR DESCRIPTION
## Summary

Closes PP-pmv. Part of the error-silencing cleanup series (PP-d5f root cause).

Replaces 13 `console.*` calls across 9 files with the appropriate structured helpers so every caught error reaches both pino (structured logs) and Sentry (alerting).

## Files touched

| File | Change |
|------|--------|
| `src/lib/email/transport.ts` | `console.error` in `ResendTransport.send` + `SMTPTransport.send` → `reportError()` |
| `src/lib/email/client.ts` | `console.log/warn` for transport selection → `log.info/warn`; `console.error` for send failure → `reportError()` |
| `src/lib/blob/compression.ts` | `console.error` in catch → `Sentry.captureException` (client-side file — `reportError` is `server-only`) with `bestEffort: true` context |
| `src/app/(app)/notifications/actions.ts` | Two `console.error` in action catch blocks → `serverActionError()` |
| `src/app/(app)/settings/notifications/actions.ts` | `console.error` in action catch block → `serverActionError()` |
| `src/app/(app)/settings/actions.ts` | `console.error` in `updateProfileAction` catch → `serverActionError()` |
| `src/app/(auth)/auth/callback/route.ts` | Two `console.error` for `exchangeCodeForSession`/`verifyOtp` failures → `reportError()` |
| `src/components/feedback/FeedbackWidget.tsx` | Two `console.error` inside `createForm` try/catch **kept as `console.error`** (see judgment call below); removed dev-only `console.log` in `useEffect` |
| `src/components/images/ImageUploadButton.tsx` | `console.error` in upload catch → `Sentry.captureException` with `issueId` context |

## Judgment calls

**`compression.ts` uses `Sentry.captureException` not `reportError`**: The dispatch contract said `reportError` for this file, but `compression.ts` is a client-side module (`browser-image-compression` is browser-only, only imported from `ImageUploadButton.tsx` which is `"use client"`). Importing `reportError` would pull in `server-only` and crash the client bundle. Using `Sentry.captureException` directly is the correct client-side equivalent.

**`FeedbackWidget.tsx` `console.error` calls retained**: These two `catch` blocks are inside the Sentry feedback widget itself. Calling `Sentry.captureException` here would attempt to re-open the widget we're currently failing to open — a potential recursive loop. Comments added to document the rationale. The dev-only `console.log` in `useEffect` was removed entirely (it was debugging scaffolding with no production value).

## Test plan

- [x] `pnpm run check` — 972 tests pass, types clean, lint clean, format clean
- [ ] CI Gate green
- [ ] Verify Copilot comments addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)