### PR TITLE
chore: session follow-ups — Sentry preview filter, label-ready worktree lookup, briefing skill cleanup (PP-d8u)

### DIFF
--- a/.agent/skills/pinpoint-briefing/SKILL.md
+++ b/.agent/skills/pinpoint-briefing/SKILL.md
@@ -12,11 +12,34 @@ Goal: answer "what's broken, what shipped, what needs attention" before picking 
 
 Run all data-gathering steps **in parallel** (one Bash call per logical group). Then synthesize into a structured briefing output.
 
-**Pre-flight first**: verify Sentry auth (Step 0) BEFORE launching the parallel batch. Group E silently returns empty if Sentry isn't authenticated, and the briefing misses real production errors.
+**Pre-flight first**: run both checks in Step 0 BEFORE launching the parallel batch. The briefing reads local files (lockfile, `package.json`) AND remote services (Sentry MCP) — if either is stale or unauthenticated, the briefing reports rotten data without warning.
 
 ---
 
-## Step 0 — Pre-flight: Verify Sentry Auth
+## Step 0 — Pre-flight checks
+
+Two independent gates. Each one failing is a stop-and-ask, not a soft warning.
+
+### 0a — Confirm we're on a fresh main
+
+The audit, the lockfile, and the package overrides are read from the **local** working tree. If local main is days behind, `pnpm audit` will flag CVEs that have already been patched upstream and the briefing ships a "regression" finding that's actually just stale state. (We've shipped this exact bug — a `uuid` override "regression" turned out to be a 2-day-old local checkout.)
+
+```bash
+git fetch origin main
+current=$(git symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
+if [ "$current" = "main" ]; then
+  git pull --ff-only origin main
+fi
+```
+
+- If `current == main` → fast-forward and proceed.
+- Otherwise → **STOP. Do NOT run the briefing yet.** Tell the user:
+
+  > ⚠️ I'm on `<branch>`, not main. The briefing reads local files (`pnpm-lock.yaml`, `package.json`) and would silently report stale CVEs from before main moved on. Want me to switch to main first, or run anyway with that caveat in mind?
+
+  Wait for an explicit answer. If they say "run anyway", state in the briefing's Security section that the audit was run from a non-main checkout and any CVE finding should be re-verified.
+
+### 0b — Verify Sentry auth
 
 The Sentry MCP server only exposes its real query tools (`find_organizations`, `search_issues`, etc.) AFTER the user has completed OAuth. Pre-auth, only `authenticate` / `complete_authentication` stubs are registered. The briefing's Group E depends on the real tools — without them it returns empty and you ship a briefing that missed live production errors.
 

--- a/.agent/skills/pinpoint-briefing/SKILL.md
+++ b/.agent/skills/pinpoint-briefing/SKILL.md
@@ -12,6 +12,34 @@ Goal: answer "what's broken, what shipped, what needs attention" before picking 
 
 Run all data-gathering steps **in parallel** (one Bash call per logical group). Then synthesize into a structured briefing output.
 
+**Pre-flight first**: verify Sentry auth (Step 0) BEFORE launching the parallel batch. Group E silently returns empty if Sentry isn't authenticated, and the briefing misses real production errors.
+
+---
+
+## Step 0 — Pre-flight: Verify Sentry Auth
+
+The Sentry MCP server only exposes its real query tools (`find_organizations`, `search_issues`, etc.) AFTER the user has completed OAuth. Pre-auth, only `authenticate` / `complete_authentication` stubs are registered. The briefing's Group E depends on the real tools — without them it returns empty and you ship a briefing that missed live production errors.
+
+**Check (Claude Code)**: attempt to load the `search_issues` schema via the tool catalog:
+
+```
+ToolSearch query: "select:mcp__plugin_sentry_sentry__search_issues", max_results: 1
+```
+
+- If the tool schema comes back → Sentry is authenticated. Proceed to Step 1.
+- If `No matching deferred tools found` → Sentry is NOT authenticated. **STOP. Do NOT run the briefing yet.**
+
+**When auth is missing**, tell the user (verbatim wording optional but cover these points):
+
+> ⚠️ Sentry MCP isn't authenticated — the briefing would miss production errors. Please:
+>
+> 1. Run `mcp__plugin_sentry_sentry__authenticate` (this triggers a browser OAuth flow).
+> 2. Complete the Sentry login in your browser.
+> 3. **Run `/reload-plugins`** — MCP tool registration is a one-time handshake, so OAuth completion does NOT retroactively expose the real Sentry tools. A reload is required.
+> 4. Tell me to re-run the briefing.
+
+Do not proceed past this step until auth is confirmed. Partial briefings that skip Sentry hide production issues.
+
 ---
 
 ## Step 1 — Parallel Data Gathering
@@ -29,12 +57,14 @@ Covers: open PRs (CI + Copilot + merge), worktree health, beads ready/in-progres
 ### Group B: Security Audit
 
 ```bash
-bash -c 'set -o pipefail
-pnpm audit --audit-level=moderate 2>&1 | tail -20
-pnpm outdated 2>&1 | head -30'
+pnpm audit --audit-level=moderate 2>&1 | tail -20; true
 ```
 
-`pnpm audit` catches CVEs not yet in Dependabot. `pnpm outdated` flags major bumps worth a scheduled update.
+`pnpm audit` catches CVEs not yet flagged by Dependabot.
+
+**We intentionally do NOT run `pnpm outdated`.** Dependabot is our source of truth for version bumps — it has a configured soak time that protects against supply-chain compromise (e.g., a malicious release being unpublished within hours of publication). `pnpm outdated` has no such soak and always suggests the newest version, so bumping from its output would defeat the soak protection. If you find yourself wanting to suggest a bump, file it as "let Dependabot propose it" instead.
+
+**Do not add `set -o pipefail` here.** `pnpm audit` exits non-zero whenever it finds vulnerabilities at/above `--audit-level` (normal signaling, not an error). With `pipefail`, that non-zero exit propagates through the pipe and aborts the parallel tool batch — the trailing `; true` keeps the whole line exit 0 regardless.
 
 ### Group C: Main Branch CI
 
@@ -83,7 +113,6 @@ Synthesize all gathered data into this format:
 ## 🔐 Security
 pnpm audit:    [X vulns (critical/high/moderate)] or ✅ clean
 Dependabot:    [X open alerts] — link to any mergeable PRs
-pnpm outdated: [notable major bumps] or ✅ up to date
 
 ## 📋 Open PRs
 [Table from pr-dashboard.sh: PR# | Title | CI | Copilot | Merge Ready]

--- a/scripts/workflow/label-ready.sh
+++ b/scripts/workflow/label-ready.sh
@@ -121,6 +121,11 @@ fi
 
 # Cleanup worktree
 if [ "$CLEANUP" = "true" ]; then
+    # The main worktree is always the first entry in 'git worktree list --porcelain'.
+    # We never want to clean it up — running worktree_cleanup.py on it would stop
+    # the user's Supabase and try to remove their primary checkout.
+    main_worktree=$(git worktree list --porcelain | awk '/^worktree / { print substr($0, 10); exit }')
+
     # Ask git for the worktree path bound to this branch — handles every layout
     # (pinpoint-worktrees/<branch>, pinpoint-worktrees/<branch-with-slashes-as-dashes>,
     # and Claude Code's .claude/worktrees/agent-<hash>).
@@ -154,6 +159,8 @@ if [ "$CLEANUP" = "true" ]; then
 
     if [ -z "$worktree_path" ] || [ ! -d "$worktree_path" ]; then
         echo "No worktree found for branch ${branch}."
+    elif [ "$worktree_path" = "$main_worktree" ]; then
+        echo "SKIP: Branch lives in the main worktree (${worktree_path}); cleanup would stop Supabase and try to remove the primary checkout."
     elif [ "$is_locked" = "true" ]; then
         echo "SKIP: Worktree at ${worktree_path} is locked (likely an active subagent). Remove manually after the agent finishes."
     elif [ "$DRY_RUN" = "true" ]; then

--- a/scripts/workflow/label-ready.sh
+++ b/scripts/workflow/label-ready.sh
@@ -143,8 +143,8 @@ if [ "$CLEANUP" = "true" ]; then
     if [ -z "$worktree_path" ]; then
         branch_dir=$(echo "$branch" | tr '/' '-')
         for candidate in \
-            "/home/froeht/Code/pinpoint-worktrees/${branch_dir}" \
-            "/home/froeht/Code/pinpoint-worktrees/${branch}"; do
+            "${HOME}/Code/pinpoint-worktrees/${branch_dir}" \
+            "${HOME}/Code/pinpoint-worktrees/${branch}"; do
             if [ -d "$candidate" ]; then
                 worktree_path="$candidate"
                 break

--- a/scripts/workflow/label-ready.sh
+++ b/scripts/workflow/label-ready.sh
@@ -121,27 +121,52 @@ fi
 
 # Cleanup worktree
 if [ "$CLEANUP" = "true" ]; then
-    branch_dir=$(echo "$branch" | tr '/' '-')
-    worktree_path="/home/froeht/Code/pinpoint-worktrees/${branch_dir}"
-    # Fallback to old nested path
-    if [ ! -d "$worktree_path" ]; then
-        worktree_path="/home/froeht/Code/pinpoint-worktrees/${branch}"
-    fi
-    if [ -d "$worktree_path" ]; then
-        if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY RUN: Would remove worktree at ${worktree_path}"
-        else
-            echo "Removing worktree: ${worktree_path}"
-            if [ -f "./scripts/worktree_cleanup.py" ]; then
-                python3 ./scripts/worktree_cleanup.py "$worktree_path" || echo "WARN: worktree cleanup failed."
-            fi
-            if [ -d "$worktree_path" ]; then
-                git worktree remove "$worktree_path" 2>/dev/null || \
-                    echo "WARN: Could not remove worktree (it may contain uncommitted changes). Clean up manually."
-            fi
+    # Ask git for the worktree path bound to this branch — handles every layout
+    # (pinpoint-worktrees/<branch>, pinpoint-worktrees/<branch-with-slashes-as-dashes>,
+    # and Claude Code's .claude/worktrees/agent-<hash>).
+    worktree_path=$(git worktree list --porcelain | awk -v target="refs/heads/${branch}" '
+        /^worktree / { wt = substr($0, 10) }
+        /^branch /   { if ($2 == target) { print wt; exit } }
+    ')
+    is_locked=false
+    if [ -n "$worktree_path" ]; then
+        if git worktree list --porcelain | awk -v wt="$worktree_path" '
+            /^worktree / { current = ($0 == "worktree " wt) }
+            /^locked/    { if (current) { exit 0 } }
+            END          { exit 1 }
+        '; then
+            is_locked=true
         fi
+    fi
+
+    # Fallbacks for older naming conventions in case git's metadata is missing
+    if [ -z "$worktree_path" ]; then
+        branch_dir=$(echo "$branch" | tr '/' '-')
+        for candidate in \
+            "/home/froeht/Code/pinpoint-worktrees/${branch_dir}" \
+            "/home/froeht/Code/pinpoint-worktrees/${branch}"; do
+            if [ -d "$candidate" ]; then
+                worktree_path="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "$worktree_path" ] || [ ! -d "$worktree_path" ]; then
+        echo "No worktree found for branch ${branch}."
+    elif [ "$is_locked" = "true" ]; then
+        echo "SKIP: Worktree at ${worktree_path} is locked (likely an active subagent). Remove manually after the agent finishes."
+    elif [ "$DRY_RUN" = "true" ]; then
+        echo "DRY RUN: Would remove worktree at ${worktree_path}"
     else
-        echo "No worktree found at ${worktree_path}."
+        echo "Removing worktree: ${worktree_path}"
+        if [ -f "./scripts/worktree_cleanup.py" ]; then
+            python3 ./scripts/worktree_cleanup.py "$worktree_path" || echo "WARN: worktree cleanup failed."
+        fi
+        if [ -d "$worktree_path" ]; then
+            git worktree remove "$worktree_path" 2>/dev/null || \
+                echo "WARN: Could not remove worktree (it may contain uncommitted changes). Clean up manually."
+        fi
     fi
 fi
 

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -57,6 +57,26 @@ def main() -> None:
         print(f"Warning: {worktree_path} does not exist, skipping", file=sys.stderr)
         return
 
+    # Refuse to operate on the main worktree. Inside a main worktree, .git is a
+    # directory; inside an additional worktree, .git is a file with a "gitdir:"
+    # pointer. A caller pointing this script at the main worktree (e.g., a
+    # cleanup script that misidentified the path) would otherwise stop the
+    # user's primary Supabase and try to remove their main checkout.
+    git_marker = worktree_path / ".git"
+    if git_marker.is_dir():
+        print(
+            f"Refusing to clean up the main worktree at {worktree_path}. "
+            "worktree_cleanup.py is for additional (git worktree add) worktrees only.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if not git_marker.is_file():
+        print(
+            f"Warning: {worktree_path} has no .git marker — not a worktree. Skipping.",
+            file=sys.stderr,
+        )
+        return
+
     # Get branch name for Docker volume cleanup
     try:
         result = subprocess.run(

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -14,4 +14,19 @@ Sentry.init({
   // Do not send PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: false,
+
+  beforeSend(event) {
+    // Drop Supabase auth cold-start transients on Vercel preview deployments —
+    // the branch DB is still provisioning, so auth checks fail until it's ready.
+    if (process.env["VERCEL_ENV"] === "preview") {
+      const msg = "Tenant or user not found";
+      const inMessage = event.message?.includes(msg) ?? false;
+      const inException =
+        event.exception?.values?.some(
+          (ex) => ex.value?.includes(msg) ?? false
+        ) ?? false;
+      if (inMessage || inException) return null;
+    }
+    return event;
+  },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -14,4 +14,19 @@ Sentry.init({
   // Do not send PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: false,
+
+  beforeSend(event) {
+    // Drop Supabase auth cold-start transients on Vercel preview deployments —
+    // the branch DB is still provisioning, so auth checks fail until it's ready.
+    if (process.env["VERCEL_ENV"] === "preview") {
+      const msg = "Tenant or user not found";
+      const inMessage = event.message?.includes(msg) ?? false;
+      const inException =
+        event.exception?.values?.some(
+          (ex) => ex.value?.includes(msg) ?? false
+        ) ?? false;
+      if (inMessage || inException) return null;
+    }
+    return event;
+  },
 });


### PR DESCRIPTION
## Summary

Three independent session follow-up fixes bundled together (each its own commit).

- **Sentry**: drop `Tenant or user not found` events on Vercel preview deployments. These fire while the Supabase branch DB is still provisioning during preview cold-starts — they're not bugs, just noise that hides real signal. Filter is scoped to `VERCEL_ENV=preview`, so production still alarms if the same string ever appears there.
- **`label-ready.sh --cleanup`**: resolve the worktree path via `git worktree list --porcelain` instead of guessing two hardcoded paths under `~/Code/pinpoint-worktrees/`. Catches Claude Code's isolation-mode worktrees under `.claude/worktrees/agent-<hash>/`, and skips removal when the worktree is locked (active subagent) instead of silently failing.
- **`pinpoint-briefing` skill**: add a Step 0 pre-flight that confirms Sentry MCP is authenticated before the parallel batch fires (the `/reload-plugins` reminder is included, since OAuth alone doesn't expose the real query tools); drop the `set -o pipefail` wrapper on Group B (it was aborting sibling tool calls when `pnpm audit` exited non-zero on real vulns); remove `pnpm outdated` since Dependabot's configured soak time is our supply-chain-compromise defense and `pnpm outdated` has no such soak.

## Test plan

- [x] `pnpm run check` — 950 tests pass, 0 lint findings
- [x] Sentry filter is type-safe under ts-strictest (no `any`, no `!`, no `as`)
- [x] Sentry filter scoped to preview only — production behavior unchanged
- [ ] Verify on next preview deployment that "Tenant or user not found" is dropped (passive — we'll see Sentry quiet down or not)
- [ ] Verify `label-ready.sh --cleanup` finds an `.claude/worktrees/agent-*` worktree on the next ready-for-review run

🤖 Generated with [Claude Code](https://claude.com/claude-code)