### PR TITLE
refactor(auth): route caught errors to Sentry via serverActionError (PP-x1p)

### DIFF
--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -230,7 +230,7 @@ export async function loginAction(
       throw error;
     }
 
-    reportError(error, { action: "login", submittedEmail });
+    reportError(error, { action: "login" });
     return err("SERVER", "An unexpected error occurred", {
       submittedEmail,
     });

--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -12,6 +12,10 @@ import {
 } from "./schemas";
 import { log } from "~/lib/logger";
 import {
+  serverActionError,
+  reportError,
+} from "~/lib/observability/report-error";
+import {
   checkLoginIpLimit,
   checkLoginAccountLimit,
   checkSignupLimit,
@@ -226,15 +230,7 @@ export async function loginAction(
       throw error;
     }
 
-    log.error(
-      {
-        error: error instanceof Error ? error.message : "Unknown",
-        stack: error instanceof Error ? error.stack : undefined,
-        action: "login",
-      },
-      "Login server error"
-    );
-
+    reportError(error, { action: "login", submittedEmail });
     return err("SERVER", "An unexpected error occurred", {
       submittedEmail,
     });
@@ -422,16 +418,9 @@ export async function signupAction(
       throw error;
     }
 
-    log.error(
-      {
-        error: error instanceof Error ? error.message : "Unknown",
-        stack: error instanceof Error ? error.stack : undefined,
-        action: "signup",
-      },
-      "Signup server error"
-    );
-
-    return err("SERVER", "An unexpected error occurred");
+    return serverActionError(error, "SERVER", "An unexpected error occurred", {
+      action: "signup",
+    });
   }
 }
 
@@ -465,14 +454,7 @@ export async function logoutAction(): Promise<void> {
       "User logged out successfully"
     );
   } catch (cause) {
-    log.error(
-      {
-        error: cause instanceof Error ? cause.message : "Unknown",
-        stack: cause instanceof Error ? cause.stack : undefined,
-        action: "logout",
-      },
-      "Logout server error"
-    );
+    reportError(cause, { action: "logout" });
   }
 
   // Always redirect to dashboard after logout attempt
@@ -569,15 +551,9 @@ export async function forgotPasswordAction(
     // This prevents email enumeration attacks
     return ok(undefined);
   } catch (error) {
-    log.error(
-      {
-        error: error instanceof Error ? error.message : "Unknown",
-        stack: error instanceof Error ? error.stack : undefined,
-        action: "forgot-password",
-      },
-      "Forgot password server error"
-    );
-    return err("SERVER", "An unexpected error occurred");
+    return serverActionError(error, "SERVER", "An unexpected error occurred", {
+      action: "forgot-password",
+    });
   }
 }
 
@@ -681,15 +657,8 @@ export async function resetPasswordAction(
       throw error;
     }
 
-    log.error(
-      {
-        error: error instanceof Error ? error.message : "Unknown",
-        stack: error instanceof Error ? error.stack : undefined,
-        action: "reset-password",
-      },
-      "Reset password server error"
-    );
-
-    return err("SERVER", "An unexpected error occurred");
+    return serverActionError(error, "SERVER", "An unexpected error occurred", {
+      action: "reset-password",
+    });
   }
 }


### PR DESCRIPTION
## Summary

Routes 5 caught errors in auth server actions to Sentry via the new `serverActionError` and `reportError` helpers. Previously, these errors were silently swallowed by `log.error` alone — Sentry's auto-capture only sees uncaught exceptions, so caught errors stayed invisible to monitoring.

## Files Modified

- `src/app/(auth)/actions.ts`: 5 catch blocks converted

## Breakdown

| Action | Pattern | Notes |
|--------|---------|-------|
| **loginAction** | reportError + err | Preserves `submittedEmail` meta (required by LoginResult type) |
| **signupAction** | serverActionError | No meta required |
| **logoutAction** | reportError | Void return, always redirects |
| **forgotPasswordAction** | serverActionError | No meta required |
| **resetPasswordAction** | serverActionError | No meta required |

## Intentionally Skipped

- `src/app/(auth)/oauth-actions-core.ts`: No try-catch blocks (error handling via if statements on Supabase responses)

## Code Changes

- Replaced 47 lines of redundant error normalization (`error instanceof Error ? error.message : "Unknown"`)
- Both Sentry AND structured logs now receive the same error from a single entry point
- All context (action name, relevant IDs) flows to both Sentry and logs
- Reduced error handling boilerplate while improving observability

## Testing

- pnpm run check: ✅ passed (all unit tests, lint, typecheck)
- No functional changes to error codes or user-facing messages

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>