### PR TITLE
docs(design): refresh design docs against standardization drift (PP-spm)

### DIFF
--- a/.agent/skills/pinpoint-design-bible/SKILL.md
+++ b/.agent/skills/pinpoint-design-bible/SKILL.md
@@ -379,14 +379,14 @@ Single-select dropdowns over a moderate-to-large list of users (or other entitie
 **Rules:**
 
 - Reach for the picker pattern, not a `<Select>`, when the list exceeds ~10 items, needs search, or needs per-row metadata (avatar, secondary text, badge).
-- Always include a hidden `<input type="hidden" name="...">` so the picker works inside `<form action={serverAction}>` without JS (progressive enhancement).
+- If the picker participates in native form submission (especially `<form action={serverAction}>`), include a hidden `<input type="hidden" name="...">` so the selected value submits without JS (progressive enhancement). Action-driven pickers that commit selection directly via callback (for example, [`AssigneePicker`](../../../src/components/issues/AssigneePicker.tsx)) do not need a hidden input.
 - Reserve sentinel values (`"unassigned"`, `""`) for "no selection" — never make the picker required-by-omission.
 - Keyboard navigation, focus management, and filter highlighting come free from cmdk; do not reimplement them.
 - Sort users via [`compareUnifiedUsers`](../../../src/lib/users/comparators.ts) so order is consistent across pickers.
 
 ### TooltipProvider hoist
 
-`<TooltipProvider>` is mounted once in [`ClientProviders`](../../../src/components/layout/ClientProviders.tsx) with `delayDuration={300}`. **Do not add nested providers** — `<Tooltip>` components anywhere in the tree just work. Sole documented exception: [`CopyButton`](../../../src/components/ui/copy-button.tsx) keeps a local `<TooltipProvider delayDuration={0}>` so the "Copied!" toast appears instantly.
+`<TooltipProvider>` is mounted once in [`ClientProviders`](../../../src/components/layout/ClientProviders.tsx) with `delayDuration={300}`. **Do not add nested providers** — `<Tooltip>` components anywhere in the tree just work. Sole documented exception: [`CopyButton`](../../../src/components/ui/copy-button.tsx) keeps a local `<TooltipProvider delayDuration={0}>` so the "Copied!" tooltip appears instantly.
 
 ## 13. Cross-Cutting UI States
 

--- a/.agent/skills/pinpoint-design-bible/SKILL.md
+++ b/.agent/skills/pinpoint-design-bible/SKILL.md
@@ -134,47 +134,58 @@ Use container queries when the decision depends on the component's available wid
 
 ## 5. Page Archetypes
 
-When building a new page, pick the closest archetype and follow its pattern.
+When building a new page, pick the closest archetype and follow its pattern. Every page should start with `<MainLayout>` → `<PageContainer>` → `<PageHeader>` → content; the archetype only changes the `size` prop and the body grid.
+
+### Picking a `PageContainer` size
+
+| Content type                               | `size` prop          | max-width   |
+| :----------------------------------------- | :------------------- | :---------- |
+| Settings forms, info pages, content pages  | `narrow`             | `max-w-3xl` |
+| Dashboard, detail pages, standard forms    | `standard` (default) | `max-w-6xl` |
+| List/table views (issues, machines)        | `wide`               | `max-w-7xl` |
+| Edge-to-edge dashboards (currently unused) | `full`               | none        |
+
+The archetype tables below give the canonical `size` and the body-level grid for each kind of page. Auth pages opt out of `MainLayout`/`PageContainer` entirely (they get a centered card on the bare background).
 
 ### Dashboard
 
-`max-w-6xl` -- Stats in `grid-cols-1 md:grid-cols-3`, lists in `md:grid-cols-2`.
+`size="standard"` (max-w-6xl) -- Stats in `grid-cols-1 md:grid-cols-3`, lists in `md:grid-cols-2`.
 
 ### List Page (issues, machines)
 
-`max-w-7xl` -- Filters + card grid `md:grid-cols-2 lg:grid-cols-3`.
+`size="wide"` (max-w-7xl) -- Filters + card grid `md:grid-cols-2 lg:grid-cols-3`.
 
 ### Detail Page with Sidebar (issue detail)
 
-`grid md:grid-cols-[minmax(0,1fr)_320px]` -- Sidebar `hidden md:block`, collapses to inline strips on mobile.
+`size="standard"` -- Body uses `grid md:grid-cols-[minmax(0,1fr)_320px]`. Sidebar `hidden md:block`, collapses to inline strips on mobile.
 
 ### Detail Page with Internal Grid (machine detail)
 
-`max-w-6xl` -- Single card body uses `lg:grid-cols-2` internally.
+`size="standard"` (max-w-6xl) -- Single card body uses `lg:grid-cols-2` internally.
 
 ### Form Page (report, create machine)
 
-`max-w-2xl` -- Form inside a card, back button + title in header.
+`size="narrow"` (max-w-3xl) -- Form inside a card, back button + title in header.
 
 ### Settings Page
 
-`max-w-3xl` -- Vertical sections separated by `Separator` components.
+`size="narrow"` (max-w-3xl) -- Vertical sections separated by `Separator` components.
 
 ### Admin Table
 
-`max-w-6xl` -- Full-width `Table` with fixed column widths.
+`size="standard"` (max-w-6xl) -- Full-width `Table` with fixed column widths.
 
 ### Auth Page
 
-`max-w-md` -- Centered card, no MainLayout wrapper.
+`max-w-md` -- Centered card on bare `bg-background`. **No `MainLayout` / `PageContainer` wrapper.**
 
 ### Content Page (about, privacy, changelog)
 
-`max-w-3xl` -- Prose content inside a card.
+`size="narrow"` (max-w-3xl) -- Prose content inside a card.
 
 ### Help Hub
 
-`max-w-3xl` -- Card grid `sm:grid-cols-2`.
+`size="narrow"` (max-w-3xl) -- Card grid `md:grid-cols-2`.
 
 ## 6. Spacing Rhythm
 
@@ -297,25 +308,85 @@ Two canonical durations standardize all animated feedback:
 
 Before building something new, check if one of these already exists:
 
+### Page shell & layout
+
+| Component         | Purpose                                                                                                                 |
+| :---------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `MainLayout`      | App shell — `AppHeader` + content + `BottomTabBar` + horizontal padding. Wraps every authenticated route.               |
+| `PageContainer`   | Width + vertical padding wrapper. `size="narrow" \| "standard" (default) \| "wide" \| "full"`. See §5 for size mapping. |
+| `PageHeader`      | Page title (h1, `text-balance`, 3xl bold) + optional `titleAdornment` + optional `actions`. Bottom border separator.    |
+| `AppHeader`       | Two-tier responsive header. Icon-only nav at `md:`, icon+text at `lg:`. APC logo at `lg:` only.                         |
+| `HelpMenu`        | Dropdown with Feedback, What's New, Help, About. Badge dot for unread changelog.                                        |
+| `BottomTabBar`    | Mobile tab bar (`md:hidden`). Dashboard, Issues, Machines, Report, More.                                                |
+| `ClientProviders` | Client-only provider hoist (TooltipProvider with `delayDuration={300}`, etc.). Don't add nested `<TooltipProvider>`s.   |
+
+### Issues
+
+| Component          | Purpose                                                                |
+| :----------------- | :--------------------------------------------------------------------- |
+| `IssueBadgeGrid`   | Status/severity/priority/frequency display                             |
+| `IssueBadge`       | Individual status badge with color                                     |
+| `IssueCard`        | Issue summary card (normal/compact)                                    |
+| `IssueRow`         | Table row variant of issue display                                     |
+| `IssueSidebar`     | Right-rail sidebar on issue detail (metadata, watchers, actions)       |
+| `IssueTimeline`    | Comment + activity timeline                                            |
+| `IssueFilters`     | List-page filter bar (status, machine, assignee, more-filters drawer)  |
+| `SidebarActions`   | Issue metadata editing (compact/full, rowLayout)                       |
+| `AssigneePicker`   | Single-select user picker for issue assignee. See **§Picker Pattern**. |
+| `OwnerBadge`       | Inline display of an issue's owner with avatar                         |
+| `BackToIssuesLink` | Breadcrumb back navigation                                             |
+| `WatchButton`      | Watch/unwatch toggle for an issue                                      |
+
+### Machines
+
+| Component                  | Purpose                                                                                      |
+| :------------------------- | :------------------------------------------------------------------------------------------- |
+| `MachineStatusBadge`       | Operational status pill. Colors derive from `STATUS_CONFIG` in `src/lib/issues/status.ts`.   |
+| `MachinePresenceBadge`     | At-location / off-location indicator                                                         |
+| `MachineFilters`           | Inline filter bar + sort dropdown for the machines list                                      |
+| `MachineEmptyState`        | Wrapper around `<EmptyState>` for the machine list contexts                                  |
+| `OwnerSelect`              | Single-select user picker for machine owner with invite-on-the-fly. See **§Picker Pattern**. |
+| `OwnerRequirementsCallout` | Explainer for why a machine needs an owner                                                   |
+| `WatchMachineButton`       | Watch/unwatch toggle for a machine                                                           |
+
+### Cross-cutting UI primitives
+
 | Component                             | Purpose                                                                                         |
 | :------------------------------------ | :---------------------------------------------------------------------------------------------- |
-| `AppHeader`                           | Two-tier responsive header. Icon-only nav at `md:`, icon+text at `lg:`. APC logo at `lg:` only. |
-| `HelpMenu`                            | Dropdown with Feedback, What's New, Help, About. Badge dot for unread changelog.                |
-| `BottomTabBar`                        | Mobile tab bar (`md:hidden`). Dashboard, Issues, Machines, Report, More.                        |
-| `IssueBadgeGrid`                      | Status/severity/priority/frequency display                                                      |
-| `IssueBadge`                          | Individual status badge with color                                                              |
-| `IssueCard`                           | Issue summary card (normal/compact)                                                             |
-| `IssueRow`                            | Table row variant of issue display                                                              |
-| `SidebarActions`                      | Issue metadata editing (compact/full, rowLayout)                                                |
-| `SaveCancelButtons`                   | Form action buttons                                                                             |
-| `Card` / `CardHeader` / `CardContent` | shadcn/ui card                                                                                  |
-| `Sheet`                               | Bottom drawer (mobile "More" menu)                                                              |
+| `EmptyState`                          | Icon + title + optional body + optional action. `variant="card"` (default) or `variant="bare"`. |
+| `SaveCancelButtons`                   | Form action buttons with built-in green "Saved!" success flash                                  |
 | `NotificationList`                    | Notification bell + dropdown                                                                    |
 | `UserMenu`                            | Avatar + dropdown menu (includes Admin link for admin role)                                     |
-| `BackToIssuesLink`                    | Breadcrumb back navigation                                                                      |
-| `EmptyState`                          | Icon + title + optional body + optional action. `variant="card"` (default) or `variant="bare"`. |
+| `DateRangePicker`                     | Calendar-popover date range input                                                               |
+| `MultiSelect`                         | Grouped/flat multi-select with selected-items-first sorting and indeterminate group headers     |
+| `Card` / `CardHeader` / `CardContent` | shadcn/ui card                                                                                  |
+| `Popover`                             | shadcn/ui popover. Building block for the **Picker Pattern**.                                   |
+| `Command`                             | shadcn/ui (cmdk) command palette. Building block for the **Picker Pattern**.                    |
+| `Sheet`                               | Bottom drawer (mobile "More" menu)                                                              |
+| `Drawer`                              | Vaul-based bottom sheet for mobile-first overlays                                               |
 | `Alert` (shadcn)                      | Inline message. `variant="destructive"` for errors. Never hand-roll `<div role="alert">`.       |
 | `Skeleton` (shadcn)                   | Loading placeholder. Shape it like the content that will arrive.                                |
+
+### Picker Pattern (Popover + cmdk Command)
+
+Single-select dropdowns over a moderate-to-large list of users (or other entities) follow one shared pattern: a `<Popover>` whose content is a `<Command>` from [`~/components/ui/command`](../../../src/components/ui/command.tsx) (cmdk-based). The trigger is a `<Button variant="outline">` showing the current selection or a placeholder; the popover holds a `<CommandInput>` for search, optional `<CommandGroup>` sections, and `<CommandItem>` rows.
+
+**Reference implementations:**
+
+- [`OwnerSelect`](../../../src/components/machines/OwnerSelect.tsx) — machine owner picker with invite-on-the-fly via `<InviteUserDialog>`, hide-guests toggle, and metadata pills (machine count, role tags).
+- [`AssigneePicker`](../../../src/components/issues/AssigneePicker.tsx) — issue assignee picker with an "Unassigned" sentinel value and "Me" quick-select.
+
+**Rules:**
+
+- Reach for the picker pattern, not a `<Select>`, when the list exceeds ~10 items, needs search, or needs per-row metadata (avatar, secondary text, badge).
+- Always include a hidden `<input type="hidden" name="...">` so the picker works inside `<form action={serverAction}>` without JS (progressive enhancement).
+- Reserve sentinel values (`"unassigned"`, `""`) for "no selection" — never make the picker required-by-omission.
+- Keyboard navigation, focus management, and filter highlighting come free from cmdk; do not reimplement them.
+- Sort users via [`compareUnifiedUsers`](../../../src/lib/users/comparators.ts) so order is consistent across pickers.
+
+### TooltipProvider hoist
+
+`<TooltipProvider>` is mounted once in [`ClientProviders`](../../../src/components/layout/ClientProviders.tsx) with `delayDuration={300}`. **Do not add nested providers** — `<Tooltip>` components anywhere in the tree just work. Sole documented exception: [`CopyButton`](../../../src/components/ui/copy-button.tsx) keeps a local `<TooltipProvider delayDuration={0}>` so the "Copied!" toast appears instantly.
 
 ## 13. Cross-Cutting UI States
 
@@ -323,9 +394,7 @@ Every page will eventually need one of these three states: empty, loading, error
 
 ### Empty State
 
-> **Status — planned component, not yet implemented.** `<EmptyState>` **will live** at `~/components/ui/empty-state`; the file doesn't exist today. Extraction is tracked as **PP-yxw.5** (Wave 2a of the consistency pass). This section specifies the contract that PR will build to. Until the component lands, existing inline empty states stay where they are; new code should wait for the component rather than hand-rolling another inline variant.
-
-Once the component is in place: use `<EmptyState>` whenever a list, collection, or section has zero items to display.
+`<EmptyState>` lives at [`~/components/ui/empty-state`](../../../src/components/ui/empty-state.tsx). Use it whenever a list, collection, or section has zero items to display. Never hand-roll another inline empty state.
 
 | Prop          | Purpose                                                              |
 | :------------ | :------------------------------------------------------------------- |
@@ -410,9 +479,7 @@ When something happens in response to user action, where should they see feedbac
 
 ## 15. Date Formatting Vocabulary
 
-> **Status — planned API, not yet implemented.** Three canonical helpers **will live** in `src/lib/dates.ts`; the module doesn't exist today. Extraction is tracked as **PP-yxw.7** (Wave 2c of the consistency pass). This section specifies the contract that PR will build to. Until the module lands, existing inline `formatDistanceToNow` and `toLocaleDateString` callers stay where they are; new code should wait for the helpers rather than adding more inline calls.
-
-Once the module is in place: use the helpers below. Never call `formatDistanceToNow` or `toLocaleDateString` directly from a component.
+Three canonical helpers live in [`src/lib/dates.ts`](../../../src/lib/dates.ts). Use them; never call `formatDistanceToNow` or `toLocaleDateString` directly from a component.
 
 | Helper                 | Output                         | When to use                                                  |
 | :--------------------- | :----------------------------- | :----------------------------------------------------------- |
@@ -420,7 +487,7 @@ Once the module is in place: use the helpers below. Never call `formatDistanceTo
 | `formatDate(date)`     | `"Apr 17, 2026"`               | Absolute dates in detail views, created-at fields            |
 | `formatDateTime(date)` | `"Apr 17, 2026, 9:30 PM"`      | Admin audit logs, precise timestamps, debug info             |
 
-All three will accept `Date | string | number` input. For `null` / `undefined` input, all three will return the canonical fallback `"—"` — callers should not have to null-guard before calling.
+All three accept `Date | string | number | null | undefined`. For `null` / `undefined` input they return `""` — wrap with surrounding text only when the date is guaranteed to be present, or null-guard at the call site for clean fallbacks like `<EmptyState>` or em-dash placeholders. (`formatRelative` uses `date-fns`; `formatDate` / `formatDateTime` use a hoisted `Intl.DateTimeFormat` instance for performance.)
 
 **Why a vocabulary instead of raw calls?**
 

--- a/.agent/skills/pinpoint-ui/SKILL.md
+++ b/.agent/skills/pinpoint-ui/SKILL.md
@@ -26,7 +26,8 @@ Use this skill when:
 3. **shadcn/ui only**: No MUI components
 4. **Direct Server Action references**: No inline wrappers in forms
 5. **Dropdown Server Actions**: Use `onSelect`, not forms
-6. **Tailwind CSS v4**: Use CSS variables, no hardcoded hex colors
+6. **Tailwind CSS v4 + semantic tokens**: Use `bg-primary`, `text-destructive`, etc. — no raw palette classes (`bg-cyan-500`, `text-red-500`) and no hardcoded hex
+7. **TooltipProvider is hoisted**: `<TooltipProvider>` is mounted once in `ClientProviders` — don't add nested providers. See `pinpoint-design-bible` §12.
 
 ### Adding Components
 
@@ -60,11 +61,13 @@ These are the canonical pattern sources. Read these files to understand PinPoint
 
 ### Pickers & Selects
 
-| File                                         | What It Teaches                                                 |
-| :------------------------------------------- | :-------------------------------------------------------------- |
-| `src/components/issues/AssigneePicker.tsx`   | Listbox pattern, "Unassigned" special value, user search/filter |
-| `src/components/machines/MachineFilters.tsx` | Inline filter bar, sort dropdown, owner display with metadata   |
-| `src/components/machines/OwnerSelect.tsx`    | Owner select with machine count and invite status metadata      |
+Single-select user pickers all follow the **Picker Pattern** (Popover + cmdk Command) — see `pinpoint-design-bible` §12 for the canonical pattern + rules. Don't reimplement; copy from one of these.
+
+| File                                         | What It Teaches                                                                         |
+| :------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| `src/components/issues/AssigneePicker.tsx`   | Picker pattern, "Unassigned" sentinel, "Me" quick-select, hidden input for form compat  |
+| `src/components/machines/OwnerSelect.tsx`    | Picker pattern, hide-guests toggle, invite-on-the-fly via `<InviteUserDialog>`          |
+| `src/components/machines/MachineFilters.tsx` | Inline filter bar (not a picker — filter composition + sort dropdown for the list page) |
 
 ### Styling & Tokens
 
@@ -75,27 +78,33 @@ These are the canonical pattern sources. Read these files to understand PinPoint
 
 ### Layout
 
-| File                                     | What It Teaches                                                    |
-| :--------------------------------------- | :----------------------------------------------------------------- |
-| `src/components/layout/MainLayout.tsx`   | App shell (AppHeader + content + BottomTabBar), horizontal padding |
-| `src/components/layout/AppHeader.tsx`    | Unified responsive header (icon-only at md:, icon+text at lg:)     |
-| `src/components/layout/BottomTabBar.tsx` | Mobile tab bar (md:hidden), More sheet with secondary nav          |
-| `src/components/layout/nav-config.ts`    | Shared NAV_ITEMS array used by AppHeader and BottomTabBar          |
-| `src/components/layout/HelpMenu.tsx`     | Help dropdown (Feedback, What's New, Help, About) with badge       |
+Every authenticated page should compose `<MainLayout>` → `<PageContainer>` → `<PageHeader>` → content. See `pinpoint-design-bible` §5 for the size mapping (narrow/standard/wide/full).
 
-## Label Standards (Decided)
+| File                                        | What It Teaches                                                                                                   |
+| :------------------------------------------ | :---------------------------------------------------------------------------------------------------------------- |
+| `src/components/layout/MainLayout.tsx`      | App shell (AppHeader + content + BottomTabBar), horizontal padding                                                |
+| `src/components/layout/PageContainer.tsx`   | Width + vertical padding wrapper. `size="narrow" \| "standard" (default) \| "wide" \| "full"`                     |
+| `src/components/layout/PageHeader.tsx`      | Page title (h1, text-balance, 3xl bold) + optional `titleAdornment` + optional `actions`. Bottom border separator |
+| `src/components/layout/AppHeader.tsx`       | Unified responsive header (icon-only at md:, icon+text at lg:)                                                    |
+| `src/components/layout/BottomTabBar.tsx`    | Mobile tab bar (md:hidden), More sheet with secondary nav                                                         |
+| `src/components/layout/nav-config.ts`       | Shared NAV_ITEMS array used by AppHeader and BottomTabBar                                                         |
+| `src/components/layout/HelpMenu.tsx`        | Help dropdown (Feedback, What's New, Help, About) with badge                                                      |
+| `src/components/layout/ClientProviders.tsx` | Hoists `<TooltipProvider>` (`delayDuration={300}`) — don't add nested providers                                   |
 
-- Status group labels: "Open" (not "New"), "In Progress", "Closed" -- decided standard for Phase 2. Currently hardcoded as "New" in StatusSelect.tsx and IssueFilters.tsx; `STATUS_GROUP_LABELS` will be added in the label rename PR.
-- Quick-select labels: "Me" (assignee), "My machines" (not "Your machines") -- decided standard for Phase 2. Will be added in the "Me" quick-select (PinPoint-2y2) and "My machines" (PinPoint-x04) PRs.
-- Status "wait_owner": Use `STATUS_CONFIG.wait_owner.label` as canonical source (currently "Pending Owner"). Note: mockups use "Wait Owner" -- this may be reconciled later.
+## Label Standards
+
+- Status group labels: import from `STATUS_GROUP_LABELS` in `src/lib/issues/status.ts` ("Open", "In Progress", "Closed"). Never hardcode the strings.
+- Quick-select labels for "current user" filters are "Me" (assignee) and "My machines" (machines). Both shipped — see `AssigneePicker` and `MachineFilters`.
+- Status `wait_owner`: use `STATUS_CONFIG.wait_owner.label` as the canonical display string (currently "Pending Owner"). Mockups occasionally use "Wait Owner"; the config wins.
 
 ## Color System
 
-- **Always use Tailwind token names** (e.g., `bg-cyan-500`), never hex values
-- Status colors are defined in `STATUS_CONFIG` in `status.ts` -- never hardcode
-- Theme uses Material Design 3 via CSS custom properties in `globals.css`
-- Primary: `--color-primary` (APC Neon Green #4ade80)
-- Secondary: `--color-secondary` (Fuchsia #d946ef)
+- **Use semantic tokens** (`bg-primary`, `text-destructive`, `text-muted-foreground`, `border-success/40`). Raw Tailwind palette classes (`bg-cyan-500`, `text-red-500`, `border-fuchsia-500`) and hardcoded hex are **forbidden in component code** — see design-bible §1 for the full rule and the design-layer config exceptions.
+- Status / severity / priority / frequency colors come from `STATUS_CONFIG` / `SEVERITY_CONFIG` / `PRIORITY_CONFIG` / `FREQUENCY_CONFIG` in `src/lib/issues/status.ts` — never freestyle.
+- Theme tokens are defined in `src/app/globals.css` via Tailwind v4 `@theme` block. Dark-only — `dark:` utility classes are dead code, remove them when you touch the file.
+- Primary: `--color-primary` (APC Neon Green `#4ade80`)
+- Secondary: `--color-secondary` (Teal `#2dd4bf`) — **purple/fuchsia secondary was removed in PR #1204; do not reintroduce.**
+- For the full visual identity (surface hierarchy, glow rules, accessibility constraints) see `pinpoint-design-bible` §1–§2.
 
 ## Core UI Patterns
 
@@ -165,7 +174,7 @@ export function CreateIssueForm() {
   return (
     <form action={formAction}>
       <input name="title" required />
-      {state.message && <p className="text-red-500">{state.message}</p>}
+      {state.message && <p className="text-destructive">{state.message}</p>}
       <button type="submit">Create Issue</button>
     </form>
   );
@@ -392,7 +401,7 @@ export function IssueForm() {
 
 // Peer patterns for form validation
 <Input className="peer" />
-<p className="peer-invalid:visible invisible text-red-500">
+<p className="peer-invalid:visible invisible text-destructive">
   Invalid input
 </p>
 ```
@@ -418,34 +427,41 @@ export function IssueForm() {
 ### Page Layout
 
 ```typescript
-// Consistent page structure
+// Canonical page structure: PageContainer + PageHeader + body grid.
+// MainLayout wraps the route — don't re-add it here.
+import { PageContainer } from "~/components/layout/PageContainer";
+import { PageHeader } from "~/components/layout/PageHeader";
+
 export default async function MachinesPage() {
   const machines = await getMachines();
 
   return (
-    <div className="container mx-auto py-8">
-      <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-3xl font-bold">Machines</h1>
-        <Button asChild>
-          <Link href="/machines/new">Add Machine</Link>
-        </Button>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <PageContainer size="wide">
+      <PageHeader
+        title="Machines"
+        actions={
+          <Button asChild>
+            <Link href="/m/new">Add Machine</Link>
+          </Button>
+        }
+      />
+      <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {machines.map((machine) => (
           <MachineCard key={machine.id} machine={machine} />
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }
 ```
 
 ### Responsive Grid
 
+Per the **Two-Layer Responsive Framework** (AGENTS.md rule #16): viewport breakpoints (`md:`, `lg:`, `xl:`) for page-level grid columns; container queries for component internals. **`sm:` is padding/spacing only — never `sm:grid-cols-*`.**
+
 ```typescript
-// Responsive grid with Tailwind
-<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+// Page-level grid (Layer 1, viewport breakpoints)
+<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
   {items.map((item) => (
     <Card key={item.id}>{item.name}</Card>
   ))}
@@ -465,8 +481,12 @@ export default async function MachinesPage() {
   padding: 0;
 }
 
-/* GOOD: Use Tailwind's Preflight */
-@tailwind base;
+/* GOOD: Use Tailwind v4's Preflight (already in src/app/globals.css) */
+@import "tailwindcss";
+
+@theme {
+  /* token definitions */
+}
 ```
 
 **Hardcoded Spacing in Components**:
@@ -489,8 +509,8 @@ export function Card({ children, className }: CardProps) {
 // BAD: Inline styles
 <div style={{ marginTop: '10px', color: '#ff0000' }}>
 
-// GOOD: Tailwind utilities
-<div className="mt-2.5 text-red-500">
+// GOOD: Tailwind utilities with semantic tokens
+<div className="mt-2.5 text-destructive">
 ```
 
 ## Troubleshooting

--- a/.agent/skills/pinpoint-ui/SKILL.md
+++ b/.agent/skills/pinpoint-ui/SKILL.md
@@ -63,11 +63,11 @@ These are the canonical pattern sources. Read these files to understand PinPoint
 
 Single-select user pickers all follow the **Picker Pattern** (Popover + cmdk Command) — see `pinpoint-design-bible` §12 for the canonical pattern + rules. Don't reimplement; copy from one of these.
 
-| File                                         | What It Teaches                                                                         |
-| :------------------------------------------- | :-------------------------------------------------------------------------------------- |
-| `src/components/issues/AssigneePicker.tsx`   | Picker pattern, "Unassigned" sentinel, "Me" quick-select, hidden input for form compat  |
-| `src/components/machines/OwnerSelect.tsx`    | Picker pattern, hide-guests toggle, invite-on-the-fly via `<InviteUserDialog>`          |
-| `src/components/machines/MachineFilters.tsx` | Inline filter bar (not a picker — filter composition + sort dropdown for the list page) |
+| File                                         | What It Teaches                                                                                     |
+| :------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| `src/components/issues/AssigneePicker.tsx`   | Picker pattern, "Unassigned" sentinel, "Me" quick-select, callback-driven assignment via `onAssign` |
+| `src/components/machines/OwnerSelect.tsx`    | Picker pattern, hide-guests toggle, invite-on-the-fly via `<InviteUserDialog>`                      |
+| `src/components/machines/MachineFilters.tsx` | Inline filter bar (not a picker — filter composition + sort dropdown for the list page)             |
 
 ### Styling & Tokens
 


### PR DESCRIPTION
## Summary

Reconciles `.agent/skills/pinpoint-design-bible/SKILL.md` and `.agent/skills/pinpoint-ui/SKILL.md` with the current codebase. Both files had drifted — design-bible since the §13–§18 additions in PR #1189 (~30 days), pinpoint-ui since the AppHeader unification in PR #1141 (~3 months).

Closes **PP-spm** (audit) and **PP-13v** (PageContainer documentation gap).

## Why

Agents read these skills on every UI task. Stale "planned, not yet implemented" markers, shipped components missing from inventories, and outdated code examples cause agents to reinvent shipped components or ship broken code (raw palette classes, Tailwind v3 syntax, etc.).

## What changed

**design-bible**
- §13 EmptyState + §15 Date Formatting: removed "planned, not yet implemented" callouts (both shipped via PRs #1192 / #1193).
- §15 Date helpers API: updated to match shipped `src/lib/dates.ts` (returns `""` for null, not the originally-spec'd `"—"` — see Notes below).
- §12 Component Inventory: restructured into Page-shell / Issues / Machines / Cross-cutting subsections; added 20+ shipped components.
- §5 Page Archetypes: added PageContainer vocabulary + size mapping table; converted each archetype to use the size prop.
- New: **Picker Pattern** (Popover + cmdk Command) section documenting the shared OwnerSelect / AssigneePicker pattern.
- New: TooltipProvider hoist note (PR #1187).

**pinpoint-ui** (3-month drift backlog)
- Color System: replaced "use `bg-cyan-500`" with semantic-token rule; updated secondary from fuchsia `#d946ef` to teal `#2dd4bf` (PR #1204); removed "Material Design 3" framing.
- Label Standards: STATUS_GROUP_LABELS, "Me", "My machines" all shipped — rewrote section to reflect current reality.
- Pickers & Selects: relabeled AssigneePicker from "Listbox pattern" to actual Popover + cmdk Command; cross-linked design-bible.
- Layout registry: added PageContainer, PageHeader, ClientProviders.
- Page Layout example: replaced raw `container mx-auto py-8` with canonical PageContainer + PageHeader composition.
- Responsive Grid example: removed `sm:grid-cols-*` (violates rule #16); added Two-Layer Responsive Framework reminder.
- Tailwind v4 syntax: `@tailwind base;` → `@import "tailwindcss";` + `@theme {}`.
- `text-red-500` → `text-destructive` in 3 code examples.
- Critical UI Rules: added rule #7 (TooltipProvider hoist).

## Notes — discrepancy worth a follow-up decision

§15 originally specified `formatDate(null)` → `"—"`, but the shipped `src/lib/dates.ts` returns `""`. I updated the spec to match the code (since that's what's running in prod), but this means call sites like `Fixed {formatDate(machine.fixedAt)}` render `"Fixed "` (trailing space) when the date is null. If you want the em-dash fallback back, that's a small `dates.ts` change — not a doc change.

## Test plan

- [x] All four reconciliation sweeps come back clean (file paths resolve, no stale "planned" language, no forbidden patterns in code examples, inventory matches `src/components/`).
- [x] `pnpm run check` passes (972 tests).
- [x] Cross-doc check: design-bible and pinpoint-ui agree on colors, picker pattern, TooltipProvider hoist.
- [ ] Manual read-through after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)