### PR TITLE
chore(agents): drop merge-ban hook + add web-ready triage workflow

### DIFF
--- a/.claude/hooks/block-bad-shell-patterns.cjs
+++ b/.claude/hooks/block-bad-shell-patterns.cjs
@@ -5,7 +5,10 @@
  * Rules:
  * 1. Manual CI polling loops → use ./scripts/workflow/pr-watch.py
  * 2. Ad-hoc curl health checks → use `pnpm run dev:status`
- * 3. Merge commands → present command to user, don't run directly
+ *
+ * Note: `gh pr merge` is gated by the "ask" tier in settings.json, not by this
+ * hook. That keeps the confirmation interactive (and overridable) instead of a
+ * hard deny that can't be authorized in-conversation.
  */
 
 const rules = [
@@ -32,20 +35,6 @@ const rules = [
     },
     reason:
       "Ad-hoc curl health check detected. Use `pnpm run dev:status` instead — it checks Next.js, Supabase, and Postgres in one command and respects worktree port config.",
-  },
-  {
-    name: "merge-command",
-    test: (cmd) => {
-      // Strip quoted strings and heredocs to avoid false positives in commit messages
-      const stripped = cmd
-        .replace(/\$\(cat <<'EOF'[\s\S]*?EOF\s*\)/g, "")
-        .replace(/"[^"]*"/g, '""')
-        .replace(/'[^']*'/g, "''");
-      // Block `gh pr merge` (merging a PR). Allow `git merge origin/main` (syncing from main).
-      return /\bgh\s+pr\s+merge\b/.test(stripped);
-    },
-    reason:
-      "Merge commands are banned for agents. Present the exact command to the user and let them run it directly. We use squash merges only (gh pr merge --squash).",
   },
 ];
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,13 +116,12 @@ conflicts across worktrees and force-push requirements on open PRs.
 - Only use when user explicitly requests it
 - Never add `gh pr merge` or broad wildcard tool patterns without explicit user approval.
 
-### Merge Ban
+### Merge Policy
 
-- **Agents MUST NOT run merge commands** (`gh pr merge`, `git merge` into main, etc.)
-- When a PR is ready to merge, present the exact command to the user and let them run it directly
-- This applies to all agents — lead, teammates, and subagents
+- **Default: do not merge.** Agents do not merge PRs on their own initiative — propose readiness and wait for the user to authorize.
+- The user can authorize merges in conversation. The "ask" tier in `~/.claude/settings.json` gates `gh pr merge` so the user gets a confirmation prompt for each merge.
 - We use **squash merges only**: `gh pr merge --squash <PR>`
-- A PreToolUse hook blocks merge commands and reminds you of this rule
+- This applies to all agents — lead, teammates, and subagents. Subagents in `bypassPermissions` mode skip the prompt; their dispatch contract must explicitly authorize merging if it's expected.
 
 ### CI Workflow
 
@@ -273,6 +272,27 @@ For multiple independent tasks, use worktree-isolated subagents.
 - DON'T forget to check Copilot comments before merging
 
 See `pinpoint-orchestrator` skill for the full workflow.
+
+### Claude-in-Web Candidates
+
+Some work is well-suited for Claude in Web — the cloud session that runs in a browser-based environment without local Supabase, dev server, or interactive debugging. Tag those issues with the `web-ready` label so they're easy to discover and dispatch.
+
+**Triage gates — all must pass before tagging `web-ready`:**
+
+1. **Decision-closed.** No open architecture questions, no "discuss with user", no TBDs in design notes.
+2. **Scope-pinned.** Specific files or unambiguous instructions (e.g., "rename X to Y wherever it appears"). Acceptance criteria writable as test cases.
+3. **UI gate.** No UI, or only mechanical UI (rename, prop rewire, copy change, icon swap, delete dead element). Excludes work where "does this look right?" matters.
+4. **Test gate.** Pure unit (`pnpm run check`) **or** integration/E2E that runs in CI against the auto-provisioned Supabase branch DB. The verification plan must say "CI passing is sufficient" — no local stack iteration required.
+5. **Self-contained.** No cross-PR coordination, no dependency on an open PR.
+
+**Workflow:**
+
+- Tag during grooming: `bd label add web-ready <id>` and append a one-line note explaining the fit (e.g., "Web-ready: unit tests, single-file scope").
+- If a fixable gate fails (missing acceptance criteria, undecided UI, etc.), leave a note describing the gap instead of tagging — surface for refinement.
+- Discover candidates: `bd query "label=web-ready AND status=open"` (combine with `--priority-max` to prioritize).
+- After Claude-in-Web ships a PR, treat it like any other agent PR: Copilot review, CI, ready-for-review label, then user merges.
+
+**On Supabase branching:** every PR auto-provisions a branch DB with migrations + seed via the `Supabase Branch Setup` workflow. Claude-in-Web never touches local Supabase — CI exercises the integration path.
 
 ## 5. Documentation Philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,9 +273,11 @@ For multiple independent tasks, use worktree-isolated subagents.
 
 See `pinpoint-orchestrator` skill for the full workflow.
 
-### Claude-in-Web Candidates
+### Claude in Web Candidates
 
 Some work is well-suited for Claude in Web — the cloud session that runs in a browser-based environment without local Supabase, dev server, or interactive debugging. Tag those issues with the `web-ready` label so they're easy to discover and dispatch.
+
+> Commands below use `bd` (the [beads](https://github.com/timothyfroehlich/beads) issue tracker that PinPoint uses for task management — the full command reference is loaded at session start via the `bd prime` hook). `<id>` refers to a beads issue ID like `PP-3or`.
 
 **Triage gates — all must pass before tagging `web-ready`:**
 
@@ -290,9 +292,9 @@ Some work is well-suited for Claude in Web — the cloud session that runs in a 
 - Tag during grooming: `bd label add web-ready <id>` and append a one-line note explaining the fit (e.g., "Web-ready: unit tests, single-file scope").
 - If a fixable gate fails (missing acceptance criteria, undecided UI, etc.), leave a note describing the gap instead of tagging — surface for refinement.
 - Discover candidates: `bd query "label=web-ready AND status=open"` (combine with `--priority-max` to prioritize).
-- After Claude-in-Web ships a PR, treat it like any other agent PR: Copilot review, CI, ready-for-review label, then user merges.
+- After Claude in Web ships a PR, treat it like any other agent PR: Copilot review, CI, ready-for-review label, then user merges.
 
-**On Supabase branching:** every PR auto-provisions a branch DB with migrations + seed via the `Supabase Branch Setup` workflow. Claude-in-Web never touches local Supabase — CI exercises the integration path.
+**On Supabase branching:** every PR auto-provisions a branch DB with migrations + seed via the `Supabase Branch Setup` workflow. Claude in Web never touches local Supabase — CI exercises the integration path.
 
 ## 5. Documentation Philosophy
 


### PR DESCRIPTION
## Summary

- **Hook**: drop the `merge-command` rule from `block-bad-shell-patterns.cjs`. Merge gating now lives in the "ask" tier of `~/.claude/settings.json`, so the user gets a confirmation prompt per merge instead of a hard deny that can't be authorized in-conversation.
- **AGENTS.md "Merge Ban" → "Merge Policy"**: agents default to not merging; user can authorize in conversation. Notes that subagents in `bypassPermissions` mode skip the prompt — their dispatch contract must explicitly authorize merging if expected.
- **AGENTS.md new "Claude-in-Web Candidates" section**: five-gate triage criteria (decision-closed, scope-pinned, UI gate, test gate, self-contained) plus the workflow for tagging beads issues with `web-ready` and the discovery query.

## Why now

We've been dispatching error-cleanup work to local Sonnet/Haiku subagents and hitting watchdog stalls + scope creep. Pivoting to Claude-in-Web for mechanical, well-scoped issues. The triage criteria are written so we can identify candidates before dispatching, instead of finding out mid-PR that the issue needed local UI iteration.

## Test plan

- [x] `pnpm run check` (972 tests pass)
- [x] Hook syntax-checks via `node -c`
- [ ] Confirm the next `gh pr merge` attempt prompts via the "ask" tier instead of being denied (verified earlier this session — three PRs merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)