### PR TITLE
chore(claude): web-env fixes — bootstrap CWD + bd prime SessionStart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,6 @@
     ],
     "SessionStart": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,18 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bd prime",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/scripts/agent-bootstrap.sh
+++ b/scripts/agent-bootstrap.sh
@@ -33,6 +33,16 @@ BEADS_PREFIX="PP"
 log()  { printf '\033[36m[bootstrap]\033[0m %s\n' "$*"; }
 warn() { printf '\033[33m[bootstrap]\033[0m %s\n' "$*" >&2; }
 
+# Anchor CWD to the repo root regardless of where the setup command was
+# invoked from. Setup commands in some web envs run from $HOME with the
+# script passed by absolute path, which breaks every relative path below
+# (.beads/, package.json, etc.). BASH_SOURCE is reliable across relative,
+# absolute, and symlink invocations.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+log "working from $repo_root"
+
 ensure_path() {
   local d=$1
   case ":$PATH:" in *":$d:"*) ;; *) export PATH="$d:$PATH" ;; esac


### PR DESCRIPTION
## Summary

Two related fixes that make the web-env Claude Code experience match the local Mac one:

### 1. Anchor bootstrap script CWD to the repo root
`scripts/agent-bootstrap.sh` was running with `\$CWD = \$HOME` in the web env (because the env's setup command invokes scripts via absolute path while preserving the user's home as CWD). Result: `pnpm install` failed with `ERR_PNPM_NO_PKG_MANIFEST` because `./package.json` resolved to `/home/user/package.json`, which doesn't exist. The dolt block has the same bug but only triggers when `DOLT_CREDS_JWK` is set.

Fix: at the top of the script, resolve its own filesystem location via `BASH_SOURCE[0]` and `cd` to the parent of `scripts/`. Works for relative, absolute, and symlinked invocations.

### 2. Bring `bd prime` SessionStart hook into project settings
The `bd prime` SessionStart hook lives in `~/.claude/settings.json` (global) on the Mac. Web-env Claude doesn't see that — it has its own settings layer. Mirror the hook into project `.claude/settings.json` so web sessions also start primed with beads workflow context.

Tradeoff: local Mac sessions in this project will fire `bd prime` twice (project + global). Output is idempotent (~50 tokens MCP / 1-2k CLI), so the cost is duplicate context, not broken state. Can de-dupe by removing the global entry once we've confirmed web sessions reliably pick this up.

## Test plan
- [x] `shellcheck scripts/agent-bootstrap.sh` clean
- [x] Path-resolution logic verified to find repo root from arbitrary CWD
- [x] JSON in `.claude/settings.json` validates
- [x] `bd prime` runs cleanly through the worktree redirect on the Mac
- [ ] **Verify via web env**: rerun setup command — expect `[bootstrap] working from /<repo path>` log line, then `pnpm install` succeeding instead of ERR_PNPM_NO_PKG_MANIFEST
- [ ] **Verify via web env**: fresh session prints `bd prime` output before the first user prompt