### PR TITLE
refactor(m): implement serverActionError in machines cluster (PP-3or.1)

### DIFF
--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -23,7 +23,10 @@ import { eq, and } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { log } from "~/lib/logger";
 import { createNotification } from "~/lib/notifications";
-import { reportError } from "~/lib/observability/report-error";
+import {
+  reportError,
+  serverActionError,
+} from "~/lib/observability/report-error";
 import {
   type ProseMirrorDoc,
   docToPlainText,
@@ -265,11 +268,12 @@ export async function createMachineAction(
       if (isPgErrorCode(error, "23505")) {
         return err("VALIDATION", `Initials '${initials}' are already taken.`);
       }
-      log.error(
-        { error, action: "createMachineAction" },
-        "createMachineAction (forcePromote) failed"
+      return serverActionError(
+        error,
+        "SERVER",
+        "Failed to create machine. Please try again.",
+        { action: "createMachineAction (forcePromote)" }
       );
-      return err("SERVER", "Failed to create machine. Please try again.");
     }
   }
 
@@ -371,11 +375,12 @@ export async function createMachineAction(
       return err("VALIDATION", `Initials '${initials}' are already taken.`);
     }
 
-    log.error(
-      { error, action: "createMachineAction" },
-      "createMachineAction failed"
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to create machine. Please try again.",
+      { action: "createMachineAction" }
     );
-    return err("SERVER", "Failed to create machine. Please try again.");
   }
 }
 
@@ -744,11 +749,12 @@ export async function updateMachineAction(
     if (isNextRedirectError(error)) {
       throw error;
     }
-    log.error(
-      { error, action: "updateMachineAction" },
-      "updateMachineAction failed"
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to update machine. Please try again.",
+      { action: "updateMachineAction" }
     );
-    return err("SERVER", "Failed to update machine. Please try again.");
   }
 }
 
@@ -791,11 +797,12 @@ export async function deleteMachineAction(
 
     return ok({ machineId });
   } catch (error) {
-    log.error(
-      { error, action: "deleteMachineAction" },
-      "deleteMachineAction failed"
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to delete machine. Please try again.",
+      { action: "deleteMachineAction" }
     );
-    return err("SERVER", "Failed to delete machine. Please try again.");
   }
 }
 
@@ -954,10 +961,11 @@ async function updateMachineTextField(
     if (isNextRedirectError(error)) {
       throw error;
     }
-    log.error(
-      { error, action: "updateMachineTextField", field },
-      `updateMachineTextField (${field}) failed`
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to update field. Please try again.",
+      { action: "updateMachineTextField", field }
     );
-    return err("SERVER", "Failed to update field. Please try again.");
   }
 }

--- a/src/app/(app)/m/watcher-actions.ts
+++ b/src/app/(app)/m/watcher-actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "~/lib/supabase/server";
-import { log } from "~/lib/logger";
+import { serverActionError } from "~/lib/observability/report-error";
 import { type Result, ok, err } from "~/lib/result";
 import {
   toggleMachineWatcher,
@@ -45,11 +45,12 @@ export async function toggleMachineWatcherAction(
 
     return ok(result.value);
   } catch (error) {
-    log.error(
-      { error, action: "toggleMachineWatcher" },
-      "toggleMachineWatcherAction failed"
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to toggle machine watcher",
+      { action: "toggleMachineWatcherAction", machineId }
     );
-    return err("SERVER", "Failed to toggle machine watcher");
   }
 }
 
@@ -87,11 +88,12 @@ export async function updateMachineWatchModeAction(
 
     return ok(result.value);
   } catch (error) {
-    log.error(
-      { error, action: "updateMachineWatchMode" },
-      "updateMachineWatchModeAction failed"
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to update machine watch mode",
+      { action: "updateMachineWatchModeAction", machineId, watchMode }
     );
-    return err("SERVER", "Failed to update machine watch mode");
   }
 }
 

--- a/src/lib/observability/report-error.ts
+++ b/src/lib/observability/report-error.ts
@@ -57,6 +57,12 @@ export function reportError(error: unknown, context: ReportContext = {}): void {
  *       action: "createMachineAction",
  *     });
  *   }
+ *
+ * @param error The caught error to report.
+ * @param code The Result error code.
+ * @param message The user-facing error message.
+ * @param context Log/Sentry context (not returned to caller).
+ * @param meta Result metadata (returned to caller in Result.meta).
  */
 export function serverActionError<C extends string, M = undefined>(
   error: unknown,

--- a/src/lib/observability/report-error.ts
+++ b/src/lib/observability/report-error.ts
@@ -58,12 +58,13 @@ export function reportError(error: unknown, context: ReportContext = {}): void {
  *     });
  *   }
  */
-export function serverActionError<C extends string>(
+export function serverActionError<C extends string, M = undefined>(
   error: unknown,
   code: C,
   message: string,
-  context: ReportContext = {}
-): Result<never, C> {
+  context: ReportContext = {},
+  meta?: M
+): Result<never, C, M> {
   reportError(error, context);
-  return err(code, message);
+  return err(code, message, meta);
 }

--- a/src/services/machines.ts
+++ b/src/services/machines.ts
@@ -3,7 +3,7 @@ import { db } from "~/server/db";
 import { machineWatchers } from "~/server/db/schema";
 import { type Result, ok, err } from "~/lib/result";
 import { z } from "zod";
-import { log } from "~/lib/logger";
+import { serverActionError } from "~/lib/observability/report-error";
 
 const watchModeSchema = z.enum(["notify", "subscribe"]);
 
@@ -49,8 +49,11 @@ export async function toggleMachineWatcher({
       return ok({ isWatching: true, watchMode });
     }
   } catch (error) {
-    log.error({ error, machineId, userId }, "Failed to toggle machine watcher");
-    return err("SERVER", "Failed to toggle watch status");
+    return serverActionError(error, "SERVER", "Failed to toggle watch status", {
+      action: "toggleMachineWatcher",
+      machineId,
+      userId,
+    });
   }
 }
 
@@ -98,10 +101,11 @@ export async function updateMachineWatchMode({
 
     return ok({ watchMode });
   } catch (error) {
-    log.error(
-      { error, machineId, userId, watchMode },
-      "Failed to update machine watch mode"
-    );
-    return err("SERVER", "Failed to update watch mode");
+    return serverActionError(error, "SERVER", "Failed to update watch mode", {
+      action: "updateMachineWatchMode",
+      machineId,
+      userId,
+      watchMode,
+    });
   }
 }


### PR DESCRIPTION
Apply serverActionError(...) to remaining bare catch + return err('SERVER', ...) sites in the m/ cluster.

Scope:
- src/services/machines.ts (2 sites)
- src/app/(app)/m/actions.ts (5 sites)
- src/app/(app)/m/watcher-actions.ts (2 sites)

Total: 9 sites replaced.

Also updated serverActionError in src/lib/observability/report-error.ts to be generic over M to support strict Result types.

Verified with pnpm run check.