### PR TITLE
refactor(settings,report): route caught errors to Sentry (PP-3or.3)

### DIFF
--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -30,7 +30,7 @@ import type { ActionState } from "./unified-report-form";
 import { imagesMetadataArraySchema } from "../issues/schemas";
 import { deleteFromBlob } from "~/lib/blob/client";
 import { z } from "zod";
-import { ok, err, type Result } from "~/lib/result";
+import { ok, type Result } from "~/lib/result";
 import {
   type ProseMirrorDoc,
   plainTextToDoc,
@@ -424,11 +424,12 @@ export async function getRecentIssuesAction(
 ): Promise<Result<RecentIssueData[], "SERVER">> {
   const parsed = recentIssuesParamsSchema.safeParse({ machineInitials, limit });
   if (!parsed.success) {
-    log.warn(
-      { machineInitials, limit, issues: parsed.error.issues },
-      "getRecentIssuesAction: invalid input"
-    );
-    return err("SERVER", "Invalid input");
+    return serverActionError(parsed.error, "SERVER", "Invalid input", {
+      action: "getRecentIssuesActionValidation",
+      machineInitials,
+      limit,
+      issues: parsed.error.issues,
+    });
   }
 
   try {

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -198,8 +198,14 @@ export async function deleteAccountAction(
         "You are the only admin. Promote another user to admin before deleting your account."
       );
     }
-    log.error({ error }, "Account deletion failed");
-    return err("SERVER", "Failed to delete account. Please try again.");
+    return serverActionError(
+      error,
+      "SERVER",
+      "Failed to delete account. Please try again.",
+      {
+        action: "deleteAccountAction",
+      }
+    );
   }
 
   redirect("/");
@@ -272,20 +278,22 @@ export async function changePasswordAction(
   // Rate-limit password change attempts per account (reuses login account limiter)
   const accountLimit = await checkLoginAccountLimit(user.email ?? user.id);
   if (!accountLimit.success) {
-    log.warn(
-      { userId: user.id, action: "change-password" },
-      "Change password rate limit exceeded"
+    return serverActionError(
+      new Error("Change password rate limit exceeded"),
+      "SERVER",
+      "Too many attempts. Please try again later.",
+      { userId: user.id, action: "changePasswordRateLimit" }
     );
-    return err("SERVER", "Too many attempts. Please try again later.");
   }
 
   try {
     if (!user.email) {
-      log.error(
-        { userId: user.id, action: "change-password" },
-        "User has no email — cannot verify password"
+      return serverActionError(
+        new Error("User has no email — cannot verify password"),
+        "SERVER",
+        "Unable to verify your identity.",
+        { userId: user.id, action: "changePasswordMissingEmail" }
       );
-      return err("SERVER", "Unable to verify your identity.");
     }
 
     // Supabase has no "verify password" API, so we use signInWithPassword.
@@ -310,15 +318,12 @@ export async function changePasswordAction(
     });
 
     if (updateError) {
-      log.error(
-        {
-          userId: user.id,
-          action: "change-password",
-          error: updateError.message,
-        },
-        "Password update failed"
+      return serverActionError(
+        updateError,
+        "SERVER",
+        "Failed to update password. Please try again.",
+        { userId: user.id, action: "changePasswordUpdateError" }
       );
-      return err("SERVER", "Failed to update password. Please try again.");
     }
 
     log.info(
@@ -328,14 +333,9 @@ export async function changePasswordAction(
 
     return ok({ success: true });
   } catch (error) {
-    log.error(
-      {
-        userId: user.id,
-        error: error instanceof Error ? error.message : "Unknown",
-        action: "change-password",
-      },
-      "Change password server error"
-    );
-    return err("SERVER", "An unexpected error occurred.");
+    return serverActionError(error, "SERVER", "An unexpected error occurred.", {
+      action: "changePasswordAction",
+      userId: user.id,
+    });
   }
 }


### PR DESCRIPTION
Apply serverActionError(...) to remaining bare catch + return err('SERVER', ...) sites in settings and report clusters.

- src/app/(app)/settings/actions.ts (~5 sites)
- src/app/(app)/report/actions.ts (~1 site)
- src/app/(app)/settings/notifications/actions.ts (already converted, verified)

Existing user-facing error messages preserved.
Verified with pnpm run check.