### PR TITLE
fix(e2e): use waitForResponse() for Mobile Safari redirect detection (PP-7nb)

### DIFF
--- a/e2e/smoke/issue-list.spec.ts
+++ b/e2e/smoke/issue-list.spec.ts
@@ -19,6 +19,11 @@ test.describe("Issue List Features", () => {
     const title2 = seededIssues.TAF[1].title;
 
     await page.goto("/issues");
+    // Wait for hydration before interacting with the search form. In Mobile
+    // Safari/WebKit, pressing Enter before React has bound the onSubmit handler
+    // triggers a default browser form submit (the input has no `name` attr,
+    // so ?q is never set in the URL).
+    await page.waitForLoadState("networkidle");
 
     // 2. Test Searching
     // Search for Issue 1

--- a/e2e/smoke/issue-list.spec.ts
+++ b/e2e/smoke/issue-list.spec.ts
@@ -22,8 +22,11 @@ test.describe("Issue List Features", () => {
     // Wait for hydration before interacting with the search form. In Mobile
     // Safari/WebKit, pressing Enter before React has bound the onSubmit handler
     // triggers a default browser form submit (the input has no `name` attr,
-    // so ?q is never set in the URL).
-    await page.waitForLoadState("networkidle");
+    // so ?q is never set in the URL). Best-effort with timeout to handle
+    // Chromium HMR keeping the network busy indefinitely in dev.
+    await page
+      .waitForLoadState("networkidle", { timeout: 5000 })
+      .catch(() => undefined);
 
     // 2. Test Searching
     // Search for Issue 1

--- a/e2e/smoke/issues-crud.spec.ts
+++ b/e2e/smoke/issues-crud.spec.ts
@@ -30,6 +30,7 @@ const rememberIssueId = (page: Page): void => {
 
 test.describe("Issues System", () => {
   test.use({ storageState: STORAGE_STATE.member });
+  // eslint-disable-next-line no-empty-pattern -- Playwright requires destructuring pattern for first arg
   test.beforeEach(({}, testInfo) => {
     // Mobile Safari can take longer to settle Server Action redirects.
     test.setTimeout(
@@ -93,6 +94,10 @@ test.describe("Issues System", () => {
       await expect(
         page.getByRole("heading", { name: "Machines" })
       ).toBeVisible();
+      // Wait for hydration so the search input's React onChange handler is
+      // bound — without it, fill() triggers a default browser input event but
+      // React's debounced URL update never runs (Mobile Safari/WebKit).
+      await page.waitForLoadState("networkidle");
 
       const machineSearchInput = page.getByPlaceholder(
         "Search machines by name or initials..."

--- a/e2e/smoke/issues-crud.spec.ts
+++ b/e2e/smoke/issues-crud.spec.ts
@@ -97,7 +97,11 @@ test.describe("Issues System", () => {
       // Wait for hydration so the search input's React onChange handler is
       // bound — without it, fill() triggers a default browser input event but
       // React's debounced URL update never runs (Mobile Safari/WebKit).
-      await page.waitForLoadState("networkidle");
+      // Best-effort with timeout to handle Chromium HMR keeping the network
+      // busy indefinitely in dev.
+      await page
+        .waitForLoadState("networkidle", { timeout: 5000 })
+        .catch(() => undefined);
 
       const machineSearchInput = page.getByPlaceholder(
         "Search machines by name or initials..."

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -13,16 +13,24 @@
 import type { Page, Locator } from "@playwright/test";
 import { selectOption } from "./actions";
 
-const escapeRegex = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
 /**
  * Submit a form and wait for Server Action redirect to complete
  *
- * Safari-specific issues:
- * - Server Action redirects may not trigger immediately
- * - Safari may stay on the current page longer than other browsers
- * - Need explicit wait for URL change, not just network idle
+ * For authenticated users, the /report Server Action returns
+ * `{ success: true, redirectTo: "/m/TAF/i/42" }` in the RSC wire format.
+ * The client form then calls `window.location.assign(redirectTo)`.
+ *
+ * Strategy: Race between two branches:
+ *
+ * Branch A: waitForURL — browser navigates on its own (Chromium/Firefox/fast WebKit)
+ * Branch B: waitForResponse() captures the POST response body and extracts redirectTo
+ *   from the RSC wire format, then calls page.goto() directly. This bypasses
+ *   window.location.assign() for Mobile Safari where WebKit stalls navigation.
+ *
+ * IMPORTANT: waitForResponse() must be set up BEFORE submitButton.click() so that
+ * Playwright is already buffering the response when it arrives. Using page.on('response')
+ * with async response.text() fails in WebKit because the response body stream may be
+ * closed before the async callback can read it.
  *
  * @param page - Playwright Page object
  * @param submitButton - The submit button locator
@@ -36,71 +44,66 @@ export async function submitFormAndWaitForRedirect(
     awayFrom?: string;
     /** Maximum time to wait for redirect (default: 60000ms for Safari) */
     timeout?: number;
-    /** Expected issue title for /report fallback when Safari drops redirect */
+    // expectedIssueTitle is kept for call-site compatibility but no longer used.
+    /** @deprecated No longer used; kept for API compatibility */
     expectedIssueTitle?: string;
   }
 ): Promise<void> {
   const currentUrl = page.url();
   const awayFrom = options?.awayFrom ?? new URL(currentUrl).pathname;
-  const timeout = options?.timeout ?? 60000; // Increased from 30s to 60s for WebKit
-  const expectedIssueTitle = options?.expectedIssueTitle;
-  const actionResponsePromise = page
-    .waitForResponse(
-      (response) => {
-        if (response.request().method() !== "POST") {
-          return false;
+  const timeout = options?.timeout ?? 60000; // 60s for WebKit
+
+  // Branch B: set up waitForResponse BEFORE clicking so Playwright buffers the body.
+  // page.on('response') with async .text() fails in WebKit because the response stream
+  // may be closed before the callback fires. waitForResponse() buffers the full body.
+  //
+  // Filter to the POST that goes to the form's own URL (awayFrom path), not third-party
+  // POSTs (e.g. Cloudflare Turnstile). This ensures we capture the Server Action response.
+  //
+  // This promise only resolves when it successfully navigates (found redirectTo + goto done).
+  // If no redirectTo is found (e.g. anonymous form with server-side redirect), this promise
+  // never resolves, so Branch A (waitForURL) wins the race instead.
+  const responseNavPromise: Promise<void> = new Promise<void>((resolve) => {
+    void page
+      .waitForResponse(
+        (r) =>
+          r.request().method() === "POST" &&
+          new URL(r.url()).pathname.startsWith(awayFrom),
+        { timeout }
+      )
+      .then(async (response) => {
+        const body = await response.text();
+        const match =
+          /"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/.exec(body) ??
+          /\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/.exec(body);
+        if (match?.[1]) {
+          // Found redirectTo in RSC wire format — navigate directly via Playwright.
+          // This bypasses window.location.assign() which stalls in Mobile Safari.
+          await page.goto(match[1], { waitUntil: "domcontentloaded" });
+          resolve();
         }
-        return new URL(response.url()).pathname.startsWith(awayFrom);
-      },
-      { timeout }
-    )
-    .catch(() => null);
+        // If no redirectTo found (e.g. anonymous form redirect), Branch A handles it.
+        // Do NOT resolve here — let Branch A win the race.
+      })
+      .catch(() => {
+        // If waitForResponse times out or fails, Branch A is already racing.
+        // Do NOT resolve — let Branch A handle navigation detection.
+      });
+  });
 
   await submitButton.click();
 
-  try {
-    // Wait for URL to change away from current page.
-    // This is more reliable than waitForLoadState for Safari Server Actions.
-    await page.waitForURL((url) => !url.pathname.startsWith(awayFrom), {
+  // Branch A: wait for the browser to navigate away from awayFrom naturally.
+  // Branch B runs concurrently via the response promise established above.
+  // Use "commit" so waitForURL resolves as soon as the URL commits,
+  // without waiting for page resources (prevents stalling in Mobile Safari).
+  await Promise.race([
+    page.waitForURL((url) => !url.pathname.startsWith(awayFrom), {
       timeout,
-    });
-    return;
-  } catch (error) {
-    // If Safari dropped the redirect but the Server Action response contains
-    // the destination issue URL, navigate there directly.
-    const actionResponse = await actionResponsePromise;
-    if (actionResponse) {
-      const responseBody = await actionResponse.text();
-      const redirectToMatch =
-        responseBody.match(/"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/) ??
-        responseBody.match(/\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/);
-      if (redirectToMatch?.[1]) {
-        await page.goto(redirectToMatch[1]);
-        return;
-      }
-    }
-
-    // Safari/WebKit can drop the client redirect even when issue creation succeeds.
-    // If we have an expected title and we're still on /report, use the freshly-added
-    // "Recent Issues" item as a deterministic fallback path to the created issue.
-    if (awayFrom === "/report" && expectedIssueTitle) {
-      const issueLink = page
-        .getByRole("link", {
-          name: new RegExp(
-            `^View issue: ${escapeRegex(expectedIssueTitle)}\\s-\\s`
-          ),
-        })
-        .first();
-      await issueLink.waitFor({ state: "visible", timeout: 15000 });
-      const href = await issueLink.getAttribute("href");
-      if (href) {
-        await page.goto(href);
-        return;
-      }
-    }
-
-    throw error;
-  }
+      waitUntil: "commit",
+    }),
+    responseNavPromise,
+  ]);
 }
 
 /**

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -131,12 +131,17 @@ export async function submitFormAndWaitForRedirect(
 
   // Coordination flag: only one branch should perform navigation. The first
   // branch to claim it wins; later branches see claimed === true and skip
-  // their page.goto() call, preventing duplicate / racing navigations.
+  // their page.goto() call, preventing duplicate / racing navigations. If a
+  // branch's page.goto() throws (e.g., navigation already in progress), it
+  // releases the claim so other branches can still succeed.
   let claimed = false;
   const claimNavigation = (): boolean => {
     if (claimed) return false;
     claimed = true;
     return true;
+  };
+  const releaseClaim = (): void => {
+    claimed = false;
   };
 
   // Branch B: poll for the captured redirect target every 100ms. When the
@@ -160,8 +165,19 @@ export async function submitFormAndWaitForRedirect(
         .catch(() => null);
       if (target) {
         if (claimNavigation()) {
-          await page.goto(target, { waitUntil: "domcontentloaded" });
+          try {
+            await page.goto(target, { waitUntil: "domcontentloaded" });
+            return;
+          } catch {
+            // page.goto can race with sibling branches and throw (frame
+            // detached, navigation already in progress). Release the claim
+            // so Branch A's natural-nav or Branch C can still succeed.
+            releaseClaim();
+          }
         }
+        // Either claim failed (another branch won) or page.goto threw.
+        // Either way, stop polling and let other branches resolve the race.
+        await new Promise<void>(() => undefined);
         return;
       }
       await new Promise<void>((r) => {
@@ -172,16 +188,17 @@ export async function submitFormAndWaitForRedirect(
     await new Promise<void>(() => undefined);
   })();
 
-  // Branch C: response body fallback. Filter to the POST that goes to the
-  // form's own URL (awayFrom path), not third-party POSTs. waitForResponse()
-  // buffers the full body before resolving, which is essential in WebKit
-  // (page.on('response') with async .text() loses the body to a closed stream).
+  // Branch C: response body fallback. Match the form's exact pathname so we
+  // capture only the Server Action POST, not unrelated POSTs that share a
+  // prefix (e.g., /m vs /m/whatever). waitForResponse() buffers the full body
+  // before resolving, which is essential in WebKit (page.on('response') with
+  // async .text() loses the body to a closed stream).
   const responseNavPromise: Promise<void> = new Promise<void>((resolve) => {
     void page
       .waitForResponse(
         (r) =>
           r.request().method() === "POST" &&
-          new URL(r.url()).pathname.startsWith(awayFrom),
+          new URL(r.url()).pathname === awayFrom,
         { timeout }
       )
       .then(async (response) => {
@@ -190,10 +207,15 @@ export async function submitFormAndWaitForRedirect(
           /"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/.exec(body) ??
           /\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/.exec(body);
         if (match?.[1] && claimNavigation()) {
-          await page.goto(match[1], { waitUntil: "domcontentloaded" });
-          resolve();
+          try {
+            await page.goto(match[1], { waitUntil: "domcontentloaded" });
+            resolve();
+          } catch {
+            // Same race-with-sibling-branch handling as Branch B.
+            releaseClaim();
+          }
         }
-        // No match (or already claimed): stay quiet, let other branches handle it.
+        // No match (or already claimed, or page.goto threw): stay quiet.
       })
       .catch(() => {
         // waitForResponse timed out: stay quiet.

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -13,24 +13,80 @@
 import type { Page, Locator } from "@playwright/test";
 import { selectOption } from "./actions";
 
+declare global {
+  interface Window {
+    __E2E_REDIRECT_TARGET?: string;
+  }
+}
+
+/**
+ * Install a monkey-patch on Location.prototype.assign that captures the
+ * redirect target into window.__E2E_REDIRECT_TARGET instead of triggering
+ * navigation. The unified report form's useEffect calls
+ * `window.location.assign(state.redirectTo)` after a successful Server Action,
+ * but Mobile Safari/WebKit stalls navigation triggered by location.assign
+ * during/after a Server Action POST. By intercepting it, we sidestep the
+ * navigation stall entirely and use Playwright's page.goto() instead.
+ *
+ * Why patch the prototype instead of the instance: in WebKit,
+ * `window.location.assign` is non-configurable (`Object.defineProperty`
+ * throws "Attempting to change configurable attribute of unconfigurable
+ * property"). The Location.prototype, however, IS patchable, and
+ * `instance.assign(url)` resolves through prototype lookup if the instance
+ * property is not its own. We override `Location.prototype.assign` directly.
+ *
+ * Idempotent: safe to call multiple times in the same context. Always clears
+ * any previously captured target so each form submission starts fresh.
+ */
+async function installRedirectInterceptor(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    interface PatchedWindow extends Window {
+      __E2E_REDIRECT_PATCHED?: boolean;
+    }
+    const w = window as PatchedWindow;
+    // Always reset the captured target so each click starts with a clean slate.
+    w.__E2E_REDIRECT_TARGET = undefined;
+    if (w.__E2E_REDIRECT_PATCHED) return;
+    w.__E2E_REDIRECT_PATCHED = true;
+    // Patch Location.prototype.assign — works in WebKit even though
+    // window.location.assign as an own property is non-configurable.
+    const proto = Object.getPrototypeOf(window.location) as Location;
+    Object.defineProperty(proto, "assign", {
+      value: (url: string | URL): void => {
+        const href = typeof url === "string" ? url : url.toString();
+        w.__E2E_REDIRECT_TARGET = href;
+        // Don't actually navigate — the test driver will navigate via page.goto().
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+}
+
 /**
  * Submit a form and wait for Server Action redirect to complete
  *
  * For authenticated users, the /report Server Action returns
  * `{ success: true, redirectTo: "/m/TAF/i/42" }` in the RSC wire format.
- * The client form then calls `window.location.assign(redirectTo)`.
+ * The client form's useEffect then calls `window.location.assign(redirectTo)`.
  *
- * Strategy: Race between two branches:
+ * Strategy: Three concurrent branches racing in Promise.race:
  *
- * Branch A: waitForURL — browser navigates on its own (Chromium/Firefox/fast WebKit)
- * Branch B: waitForResponse() captures the POST response body and extracts redirectTo
- *   from the RSC wire format, then calls page.goto() directly. This bypasses
- *   window.location.assign() for Mobile Safari where WebKit stalls navigation.
+ * Branch A (waitForURL): browser navigates on its own (Chromium / Firefox /
+ *   fast WebKit). Fast path for non-WebKit browsers and anonymous forms (which
+ *   use server-side `redirect()` rather than client-side location.assign).
  *
- * IMPORTANT: waitForResponse() must be set up BEFORE submitButton.click() so that
- * Playwright is already buffering the response when it arrives. Using page.on('response')
- * with async response.text() fails in WebKit because the response body stream may be
- * closed before the async callback can read it.
+ * Branch B (interceptor poll): we monkey-patch window.location.assign before
+ *   clicking. When the form's useEffect calls it, we capture the URL into
+ *   window.__E2E_REDIRECT_TARGET instead of triggering navigation. We then
+ *   poll for that global and call page.goto() directly. This bypasses Mobile
+ *   Safari's location.assign stall entirely.
+ *
+ * Branch C (waitForResponse): fallback that captures the POST response body
+ *   and looks for redirectTo in the RSC wire format. waitForResponse() buffers
+ *   the full body before resolving, which is essential in WebKit (the
+ *   page.on('response') event with async .text() loses the body to a closed
+ *   stream).
  *
  * @param page - Playwright Page object
  * @param submitButton - The submit button locator
@@ -53,16 +109,40 @@ export async function submitFormAndWaitForRedirect(
   const awayFrom = options?.awayFrom ?? new URL(currentUrl).pathname;
   const timeout = options?.timeout ?? 60000; // 60s for WebKit
 
-  // Branch B: set up waitForResponse BEFORE clicking so Playwright buffers the body.
-  // page.on('response') with async .text() fails in WebKit because the response stream
-  // may be closed before the callback fires. waitForResponse() buffers the full body.
-  //
-  // Filter to the POST that goes to the form's own URL (awayFrom path), not third-party
-  // POSTs (e.g. Cloudflare Turnstile). This ensures we capture the Server Action response.
-  //
-  // This promise only resolves when it successfully navigates (found redirectTo + goto done).
-  // If no redirectTo is found (e.g. anonymous form with server-side redirect), this promise
-  // never resolves, so Branch A (waitForURL) wins the race instead.
+  // Install the location.assign interceptor BEFORE clicking. The form is
+  // already rendered (we're on the same page as the form), so this is safe
+  // to apply via page.evaluate().
+  await installRedirectInterceptor(page);
+
+  // Branch B: poll for the captured redirect target every 100ms. When the
+  // form's useEffect calls window.location.assign(redirectTo), our patch sets
+  // window.__E2E_REDIRECT_TARGET. We then call page.goto() to perform the
+  // actual navigation, bypassing Mobile Safari's location.assign stall.
+  // We use a setTimeout-based delay rather than page.waitForTimeout because
+  // ESLint forbids waitForTimeout (Playwright auto-wait is preferred for app
+  // assertions, but here we genuinely need a fixed poll interval).
+  const interceptorNavPromise: Promise<void> = (async () => {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const target = await page
+        .evaluate(() => window.__E2E_REDIRECT_TARGET ?? null)
+        .catch(() => null);
+      if (target) {
+        await page.goto(target, { waitUntil: "domcontentloaded" });
+        return;
+      }
+      await new Promise<void>((r) => {
+        setTimeout(r, 100);
+      });
+    }
+    // Timeout: never resolve. Let other branches win the race.
+    await new Promise<void>(() => undefined);
+  })();
+
+  // Branch C: response body fallback. Filter to the POST that goes to the
+  // form's own URL (awayFrom path), not third-party POSTs. waitForResponse()
+  // buffers the full body before resolving, which is essential in WebKit
+  // (page.on('response') with async .text() loses the body to a closed stream).
   const responseNavPromise: Promise<void> = new Promise<void>((resolve) => {
     void page
       .waitForResponse(
@@ -77,31 +157,26 @@ export async function submitFormAndWaitForRedirect(
           /"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/.exec(body) ??
           /\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/.exec(body);
         if (match?.[1]) {
-          // Found redirectTo in RSC wire format — navigate directly via Playwright.
-          // This bypasses window.location.assign() which stalls in Mobile Safari.
           await page.goto(match[1], { waitUntil: "domcontentloaded" });
           resolve();
         }
-        // If no redirectTo found (e.g. anonymous form redirect), Branch A handles it.
-        // Do NOT resolve here — let Branch A win the race.
+        // No match: stay quiet, let other branches handle it.
       })
       .catch(() => {
-        // If waitForResponse times out or fails, Branch A is already racing.
-        // Do NOT resolve — let Branch A handle navigation detection.
+        // waitForResponse timed out: stay quiet.
       });
   });
 
   await submitButton.click();
 
-  // Branch A: wait for the browser to navigate away from awayFrom naturally.
-  // Branch B runs concurrently via the response promise established above.
-  // Use "commit" so waitForURL resolves as soon as the URL commits,
-  // without waiting for page resources (prevents stalling in Mobile Safari).
+  // Branch A: natural navigation. Use "commit" so we resolve as soon as the
+  // URL commits, without waiting for page load.
   await Promise.race([
     page.waitForURL((url) => !url.pathname.startsWith(awayFrom), {
       timeout,
       waitUntil: "commit",
     }),
+    interceptorNavPromise,
     responseNavPromise,
   ]);
 }
@@ -137,6 +212,13 @@ export async function fillReportForm(
     includePriority = true,
     watchIssue = true,
   } = options;
+
+  // Wait for the page to settle (hydration + dynamic chunk loads). In Mobile
+  // Safari/WebKit, clicking the submit button before the form is fully
+  // hydrated silently no-ops the submission — no POST is sent. Waiting for
+  // networkidle lets React 19's `<form action={serverAction}>` finish hooking
+  // up the action handler before tests interact with it.
+  await page.waitForLoadState("networkidle", { timeout: 15000 });
 
   await page.getByLabel("Issue Title *").fill(title);
 

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -51,11 +51,20 @@ async function installRedirectInterceptor(page: Page): Promise<void> {
     // Patch Location.prototype.assign — works in WebKit even though
     // window.location.assign as an own property is non-configurable.
     const proto = Object.getPrototypeOf(window.location) as Location;
+    const original = proto.assign;
     Object.defineProperty(proto, "assign", {
-      value: (url: string | URL): void => {
+      value: function patchedAssign(this: Location, url: string | URL): void {
         const href = typeof url === "string" ? url : url.toString();
         w.__E2E_REDIRECT_TARGET = href;
-        // Don't actually navigate — the test driver will navigate via page.goto().
+        // Still invoke the original. In Chromium this triggers natural
+        // navigation (Branch A wins). In WebKit it stalls, so Branch B's
+        // poll picks up __E2E_REDIRECT_TARGET and navigates via page.goto().
+        // A try/catch shields the form's useEffect from any sync throw.
+        try {
+          original.call(this, href);
+        } catch {
+          // ignore — Branch B will pick up the captured target
+        }
       },
       writable: true,
       configurable: true,
@@ -109,10 +118,26 @@ export async function submitFormAndWaitForRedirect(
   const awayFrom = options?.awayFrom ?? new URL(currentUrl).pathname;
   const timeout = options?.timeout ?? 60000; // 60s for WebKit
 
+  // Predicate for "we have left awayFrom". Use exact-pathname comparison so
+  // nested paths like /report/success (the anonymous form's destination) ARE
+  // treated as having navigated away from /report. A startsWith() check would
+  // incorrectly keep waiting in that case.
+  const isAway = (urlObj: URL): boolean => urlObj.pathname !== awayFrom;
+
   // Install the location.assign interceptor BEFORE clicking. The form is
   // already rendered (we're on the same page as the form), so this is safe
   // to apply via page.evaluate().
   await installRedirectInterceptor(page);
+
+  // Coordination flag: only one branch should perform navigation. The first
+  // branch to claim it wins; later branches see claimed === true and skip
+  // their page.goto() call, preventing duplicate / racing navigations.
+  let claimed = false;
+  const claimNavigation = (): boolean => {
+    if (claimed) return false;
+    claimed = true;
+    return true;
+  };
 
   // Branch B: poll for the captured redirect target every 100ms. When the
   // form's useEffect calls window.location.assign(redirectTo), our patch sets
@@ -124,11 +149,19 @@ export async function submitFormAndWaitForRedirect(
   const interceptorNavPromise: Promise<void> = (async () => {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- claimed is mutated from sibling async branches; TS narrows it to false in this scope
+      if (claimed) {
+        // Another branch already navigated. Stop polling.
+        await new Promise<void>(() => undefined);
+        return;
+      }
       const target = await page
         .evaluate(() => window.__E2E_REDIRECT_TARGET ?? null)
         .catch(() => null);
       if (target) {
-        await page.goto(target, { waitUntil: "domcontentloaded" });
+        if (claimNavigation()) {
+          await page.goto(target, { waitUntil: "domcontentloaded" });
+        }
         return;
       }
       await new Promise<void>((r) => {
@@ -156,11 +189,11 @@ export async function submitFormAndWaitForRedirect(
         const match =
           /"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/.exec(body) ??
           /\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/.exec(body);
-        if (match?.[1]) {
+        if (match?.[1] && claimNavigation()) {
           await page.goto(match[1], { waitUntil: "domcontentloaded" });
           resolve();
         }
-        // No match: stay quiet, let other branches handle it.
+        // No match (or already claimed): stay quiet, let other branches handle it.
       })
       .catch(() => {
         // waitForResponse timed out: stay quiet.
@@ -170,12 +203,31 @@ export async function submitFormAndWaitForRedirect(
   await submitButton.click();
 
   // Branch A: natural navigation. Use "commit" so we resolve as soon as the
-  // URL commits, without waiting for page load.
-  await Promise.race([
-    page.waitForURL((url) => !url.pathname.startsWith(awayFrom), {
+  // URL commits, without waiting for page load. We claim the navigation slot
+  // when it fires so Branches B/C don't double-navigate.
+  //
+  // The catch handles the case where Branch B/C navigates via page.goto()
+  // while Branch A's waitForURL is in flight — the navigation context detaches
+  // and waitForURL throws "ERR_ABORTED; maybe frame was detached?". By that
+  // point another branch has already navigated, so we treat it as a no-op.
+  const naturalNavPromise = page
+    .waitForURL((url) => isAway(url), {
       timeout,
       waitUntil: "commit",
-    }),
+    })
+    .then(() => {
+      claimNavigation();
+    })
+    .catch((error: unknown) => {
+      if (claimed) {
+        // Another branch won the race and detached the frame — that's fine.
+        return;
+      }
+      throw error;
+    });
+
+  await Promise.race([
+    naturalNavPromise,
     interceptorNavPromise,
     responseNavPromise,
   ]);
@@ -218,7 +270,14 @@ export async function fillReportForm(
   // hydrated silently no-ops the submission — no POST is sent. Waiting for
   // networkidle lets React 19's `<form action={serverAction}>` finish hooking
   // up the action handler before tests interact with it.
-  await page.waitForLoadState("networkidle", { timeout: 15000 });
+  //
+  // Best-effort: in Chromium with HMR connections, networkidle can never
+  // settle. We wrap in try/catch so other browsers proceed after the timeout
+  // instead of failing the test. WebKit, where this matters, reaches
+  // networkidle within a few seconds.
+  await page
+    .waitForLoadState("networkidle", { timeout: 5000 })
+    .catch(() => undefined);
 
   await page.getByLabel("Issue Title *").fill(title);
 


### PR DESCRIPTION
## Summary

- **Root cause #1 (form submission silently no-ops)**: In Mobile Safari/WebKit, clicking submit or pressing Enter on a React `<form action={serverAction}>` BEFORE React 19 has bound the action handler silently no-ops — no POST is sent, no error is thrown. The form just sits there until the test times out at 60s. **Fix**: wait for `networkidle` (best-effort, 5s timeout) before interacting with form elements (`fillReportForm` + the two test sites that use plain inputs/keyboard input).
- **Root cause #2 (location.assign stalls in WebKit)**: When the form's useEffect calls `window.location.assign(redirectTo)` after a successful Server Action, Mobile Safari/WebKit can stall navigation indefinitely. **Fix**: monkey-patch `Location.prototype.assign` to capture the URL into `window.__E2E_REDIRECT_TARGET` AND still call the original (so Chromium's natural nav still works); the helper polls for the captured target and calls `page.goto()` if WebKit stalls.
- The original `page.on('response')` + async `.text()` approach was fundamentally broken in WebKit (response stream closed before the callback fires). Replaced with `waitForResponse()` which buffers the body before resolving.
- Removed the broken step-3 fallback (Recent Issues panel scraping) — the panel only refreshes on machine-selection changes, never after submission.

**Failing run**: https://github.com/timothyfroehlich/PinPoint/actions/runs/24975711844

Refs PP-7nb.

## Race coordination

`Promise.race` between three branches; a `claimNavigation` flag prevents duplicate navigation:

- **Branch A** — `waitForURL` (Chromium / Firefox / fast WebKit): natural navigation
- **Branch B** — `Location.prototype.assign` interceptor + poll: captures the URL when the form's useEffect calls `window.location.assign`, navigates via `page.goto()`
- **Branch C** — `waitForResponse` body fallback: parses redirectTo from RSC wire format

## Files changed

- `e2e/support/page-helpers.ts` — interceptor + 3-branch race in `submitFormAndWaitForRedirect`; `fillReportForm` waits for hydration
- `e2e/smoke/issue-list.spec.ts:14` — wait for hydration before keyboard.press("Enter") on search form
- `e2e/smoke/issues-crud.spec.ts:89` — wait for hydration on `/m` before fill() on machine search input

## Test plan

- [x] `pnpm run check` — all 968 unit tests pass
- [x] `pnpm exec playwright test e2e/smoke/issues-crud.spec.ts e2e/smoke/issue-list.spec.ts --project=chromium` — all pass
- [x] **Mobile Safari local: 5/5 pass without retries** (project=`Mobile Safari`, ~27s, 3 consecutive clean runs):
  - `e2e/smoke/issues-crud.spec.ts:89` (was :88; line numbers shifted +1 from added eslint-disable)
  - `e2e/smoke/issues-crud.spec.ts:191` (was :182; +9 from added hydration waits + Copilot fixes)
  - `e2e/smoke/issues-crud.spec.ts:277` (was :268; +9)
  - `e2e/smoke/issues-crud.spec.ts:318` (was :309; +9)
  - `e2e/smoke/issue-list.spec.ts:14`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)