### PR TITLE
fix(settings,report): address Copilot review for PP-3or.3

### DIFF
--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -30,7 +30,7 @@ import type { ActionState } from "./unified-report-form";
 import { imagesMetadataArraySchema } from "../issues/schemas";
 import { deleteFromBlob } from "~/lib/blob/client";
 import { z } from "zod";
-import { ok, type Result } from "~/lib/result";
+import { ok, err, type Result } from "~/lib/result";
 import {
   type ProseMirrorDoc,
   plainTextToDoc,
@@ -424,12 +424,11 @@ export async function getRecentIssuesAction(
 ): Promise<Result<RecentIssueData[], "SERVER">> {
   const parsed = recentIssuesParamsSchema.safeParse({ machineInitials, limit });
   if (!parsed.success) {
-    return serverActionError(parsed.error, "SERVER", "Invalid input", {
-      action: "getRecentIssuesActionValidation",
-      machineInitials,
-      limit,
-      issues: parsed.error.issues,
-    });
+    log.warn(
+      { machineInitials, limit, issues: parsed.error.issues },
+      "getRecentIssuesAction: invalid input"
+    );
+    return err("SERVER", "Invalid input");
   }
 
   try {

--- a/src/app/(app)/settings/actions.ts
+++ b/src/app/(app)/settings/actions.ts
@@ -278,12 +278,11 @@ export async function changePasswordAction(
   // Rate-limit password change attempts per account (reuses login account limiter)
   const accountLimit = await checkLoginAccountLimit(user.email ?? user.id);
   if (!accountLimit.success) {
-    return serverActionError(
-      new Error("Change password rate limit exceeded"),
-      "SERVER",
-      "Too many attempts. Please try again later.",
-      { userId: user.id, action: "changePasswordRateLimit" }
+    log.warn(
+      { userId: user.id, action: "changePasswordRateLimit" },
+      "Change password rate limit exceeded"
     );
+    return err("SERVER", "Too many attempts. Please try again later.");
   }
 
   try {


### PR DESCRIPTION
Follow-up to #1247 to address Copilot review comments:
- Revert Sentry capture for rate limit in settings actions (avoid noise).
- Revert Sentry capture for Zod validation failure in report actions (avoid noise).
Both reverted to log.warn + err as suggested by Copilot. —Gemini