### PR TITLE
refactor(admin): tighten inviteUserSchema role to member

### DIFF
--- a/src/app/(app)/admin/users/schema.ts
+++ b/src/app/(app)/admin/users/schema.ts
@@ -21,6 +21,6 @@ export const inviteUserSchema = z.object({
     .max(254, "Email is too long")
     .trim()
     .toLowerCase(),
-  role: z.enum(["guest", "member", "technician"]), // Explicitly exclude "admin"
+  role: z.literal("member"),
   sendInvite: z.boolean().optional(),
 });

--- a/src/test/unit/invite-user-validation.test.ts
+++ b/src/test/unit/invite-user-validation.test.ts
@@ -56,4 +56,26 @@ describe("InviteUser Validation", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("should fail validation for 'guest' role", () => {
+    const result = inviteUserSchema.safeParse({
+      firstName: "John",
+      lastName: "Doe",
+      email: "test@example.com",
+      role: "guest",
+      sendInvite: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should fail validation for 'technician' role", () => {
+    const result = inviteUserSchema.safeParse({
+      firstName: "John",
+      lastName: "Doe",
+      email: "test@example.com",
+      role: "technician",
+      sendInvite: false,
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/test/unit/invite-user-validation.test.ts
+++ b/src/test/unit/invite-user-validation.test.ts
@@ -66,6 +66,10 @@ describe("InviteUser Validation", () => {
       sendInvite: false,
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      const roleIssue = result.error.issues.find((i) => i.path[0] === "role");
+      expect(roleIssue).toBeDefined();
+    }
   });
 
   it("should fail validation for 'technician' role", () => {
@@ -77,5 +81,9 @@ describe("InviteUser Validation", () => {
       sendInvite: false,
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      const roleIssue = result.error.issues.find((i) => i.path[0] === "role");
+      expect(roleIssue).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary\n\nThis PR tightens the `inviteUserSchema` to only allow the `member` role, removing the obsolete `guest` and `technician` roles that are no longer selectable in the UI. This aligns the schema with the `InviteUserDialog` component which hardcodes the role to `member`.\n\n## Changes\n\n- Updated `src/app/(app)/admin/users/schema.ts` to change `role` to `z.literal("member")` in `inviteUserSchema`.\n- Updated `src/test/unit/invite-user-validation.test.ts` to add test cases asserting rejection of `guest` and `technician` roles.\n\n## Testing\n\n- ✅ Unit tests updated and passing (`pnpm run test`)\n- ✅ Integration tests passing (`pnpm run test:integration`)\n- ✅ Preflight passed (`pnpm run preflight`)\n\nCloses PP-at0