### PR TITLE
refactor(notifications): report fan-out failures to Sentry (PP-0gv)

### DIFF
--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -11,6 +11,7 @@ import {
 } from "~/server/db/schema";
 import type { IssueWatcher } from "~/lib/types/database";
 import { log } from "~/lib/logger";
+import { reportError } from "~/lib/observability/report-error";
 import { getChannels } from "./channels/registry";
 import type { ChannelContext, DeliveryResult } from "./channels/types";
 
@@ -269,9 +270,11 @@ export async function createNotification(
     for (const r of results) {
       if (r.status === "rejected") {
         // Channel.deliver() is expected to catch its own errors and return
-        // {ok:false}. A rejection here means a bug — log at error level.
-        const err: unknown = r.reason;
-        log.error({ err }, "Notification channel delivery rejected");
+        // {ok:false}. A rejection here means a bug — log at error level and report to Sentry.
+        reportError(r.reason, {
+          bestEffort: false,
+          action: "notifications.dispatch.fanout",
+        });
       }
     }
   }


### PR DESCRIPTION
Add reportError() call inside the Promise.allSettled rejection branch in createNotification. This ensures that silent failures in the all-channels notification dispatch (which were explicitly deferred in PR #1237) are now captured by Sentry for better visibility.

- action: 'notifications.dispatch.fanout'
- bestEffort: false