### PR TITLE
ci: require always-runs jobs strictly, treat path-filtered as optional (PP-cfy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -963,6 +963,28 @@ jobs:
           }
           echo "$output"
 
+  # ==============================================================================
+  # CI Gate (Aggregator)
+  #
+  # Two tiers of required jobs:
+  #
+  #   1. ALWAYS-RUNS (must succeed): linters, gitleaks
+  #      These run on every PR including docs-only changes. Their `success` is
+  #      strictly required - failure or cancellation fails the gate.
+  #
+  #   2. PATH-FILTERED (optional outcomes): build, lint, format, typecheck,
+  #      test-*, pnpm-audit
+  #      These only run when source changes. On docs-only PRs they cascade-skip
+  #      because they depend on `setup` which is gated by `changes.outputs.code`.
+  #      `skipped` and `cancelled` pass; only `failure` fails the gate.
+  #
+  # Why allow `cancelled`?
+  #   - Cascade-skips from a gated `needs:` chain can surface as `cancelled`
+  #     instead of `skipped` depending on how the runner schedules them.
+  #   - Concurrency cancel-in-progress (when a new push supersedes an old run)
+  #     marks queued jobs `cancelled`. The replacement run becomes the
+  #     authoritative status, so it is safe to treat the cancelled run as pass.
+  # ==============================================================================
   ci-gate:
     name: CI Gate
     if: always()
@@ -989,18 +1011,47 @@ jobs:
           egress-policy: audit
 
       - name: Check required job results
+        env:
+          # Tier 1: always-runs jobs - must be `success`.
+          LINTERS_RESULT: ${{ needs.linters.result }}
+          GITLEAKS_RESULT: ${{ needs.gitleaks.result }}
+          # Tier 2: path-filtered jobs - `failure` fails the gate;
+          # `success`, `skipped`, and `cancelled` all pass.
+          BUILD_RESULT: ${{ needs.build.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          FORMAT_RESULT: ${{ needs.format.result }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          TEST_UNIT_RESULT: ${{ needs.test-unit.result }}
+          TEST_INTEGRATION_RESULT: ${{ needs.test-integration.result }}
+          TEST_MIGRATIONS_RESULT: ${{ needs.test-migrations.result }}
+          TEST_INTEGRATION_SUPABASE_RESULT: ${{ needs.test-integration-supabase.result }}
+          TEST_E2E_SMOKE_RESULT: ${{ needs.test-e2e-smoke.result }}
+          TEST_E2E_SMOKE_MOBILE_CHROME_RESULT: ${{ needs.test-e2e-smoke-mobile-chrome.result }}
+          TEST_E2E_FULL_CHROMIUM_RESULT: ${{ needs.test-e2e-full-chromium.result }}
+          PNPM_AUDIT_RESULT: ${{ needs.pnpm-audit.result }}
         run: |
-          results=("${{ needs.linters.result }}" "${{ needs.gitleaks.result }}" \
-                   "${{ needs.build.result }}" "${{ needs.lint.result }}" \
-                   "${{ needs.format.result }}" "${{ needs.typecheck.result }}" \
-                   "${{ needs.test-unit.result }}" "${{ needs.test-integration.result }}" \
-                   "${{ needs.test-migrations.result }}" "${{ needs.test-integration-supabase.result }}" \
-                   "${{ needs.test-e2e-smoke.result }}" "${{ needs.test-e2e-smoke-mobile-chrome.result }}" \
-                   "${{ needs.test-e2e-full-chromium.result }}" "${{ needs.pnpm-audit.result }}")
-          for r in "${results[@]}"; do
-            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
-              echo "::error::One or more required jobs failed or were cancelled"
+          # Tier 1: always-runs jobs - must be `success`.
+          required=("$LINTERS_RESULT" "$GITLEAKS_RESULT")
+          for r in "${required[@]}"; do
+            if [[ "$r" != "success" ]]; then
+              echo "::error::Always-runs job did not succeed (result=$r)"
               exit 1
             fi
           done
-          echo "All required jobs passed or were skipped"
+
+          # Tier 2: path-filtered jobs - `failure` fails; `success`, `skipped`,
+          # and `cancelled` all pass. Cascade-skips on docs-only PRs and
+          # concurrency cancellations are intentional and should not block merge.
+          optional=("$BUILD_RESULT" "$LINT_RESULT" \
+                    "$FORMAT_RESULT" "$TYPECHECK_RESULT" \
+                    "$TEST_UNIT_RESULT" "$TEST_INTEGRATION_RESULT" \
+                    "$TEST_MIGRATIONS_RESULT" "$TEST_INTEGRATION_SUPABASE_RESULT" \
+                    "$TEST_E2E_SMOKE_RESULT" "$TEST_E2E_SMOKE_MOBILE_CHROME_RESULT" \
+                    "$TEST_E2E_FULL_CHROMIUM_RESULT" "$PNPM_AUDIT_RESULT")
+          for r in "${optional[@]}"; do
+            if [[ "$r" == "failure" ]]; then
+              echo "::error::Path-filtered job failed (result=$r)"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed; path-filtered jobs passed, were skipped, or were cancelled"


### PR DESCRIPTION
## Summary

Restructure the **CI Gate** aggregator so docs-only PRs and concurrency-cancelled runs no longer fail the gate, while still strictly gating real test failures on source-touching PRs.

Closes PP-cfy.

## Approach (Option 2 from the bead)

Per the bead, picked **Option 2: only require always-runs jobs as needs; treat path-filtered jobs as optional** — lowest blast-radius. Implemented as two tiers inside the `Check required job results` step:

- **Tier 1 — Always-runs (must be `success`)**: `linters`, `gitleaks`. These run on every PR regardless of changed paths. Anything other than `success` (failure, cancelled, skipped) fails the gate.
- **Tier 2 — Path-filtered (only `failure` fails)**: `build`, `lint`, `format`, `typecheck`, `test-unit`, `test-integration`, `test-migrations`, `test-integration-supabase`, `test-e2e-smoke`, `test-e2e-smoke-mobile-chrome`, `test-e2e-full-chromium`, `pnpm-audit`. These all transitively depend on `setup`, which is gated by `changes.outputs.code`. On docs-only PRs they cascade-skip (or, in some scheduling cases, cascade-cancel). On concurrency cancel-in-progress they get cancelled too. Either outcome now passes the gate.

`needs:` is unchanged — CI Gate still waits for every job, so a real `failure` in any tier-2 job blocks merge as before. Job result lookups now flow through `env:` per the workflow-injection hardening guidance, so the inner `run:` block is free of `${{ ... }}` expansions.

## Why allow `cancelled`?

Two distinct sources of `cancelled` that should not block merge:

1. **Cascade-skips** from a gated `needs:` chain can surface as `cancelled` instead of `skipped` depending on how the runner schedules them.
2. **Concurrency cancel-in-progress** — when a new push supersedes an older run, GitHub cancels the older run's queued jobs. The replacement run reposts a CI Gate status and becomes the authoritative check, so the cancelled run's gate result does not need to be a hard fail.

A genuine user-initiated cancel still passes the gate, but that's an explicit user action and is acceptable.

## What is NOT changed

- `needs:` list — every job is still listed, so CI Gate can't complete until they all settle.
- `linters` / `gitleaks` strictness — both must still be `success`.
- The required check name (`CI Gate`) — ruleset 6326455 keeps the same context.
- The `dorny/paths-filter` config — note that the existing `predicate-quantifier: every` filter for `docs_only` does not currently fire correctly on observed docs-only PRs (#1239, #1251 changed only `.agent/skills/**/*.md` and still triggered all jobs). That's a separate, deeper bug; this fix lives downstream of it and works regardless of whether the path filter is triggering.

## Cross-bead context

- #1251 (`docs/typescript-skill-audit-PP-n6j`) was red on `main`'s CI Gate due to a concurrency-cancelled prior run. **Re-check #1251 after this lands** — its status should clear once the next CI run uses the new gate logic.
- #1239 was bitten by the same root cause earlier and merged via empty-commit re-push.

## Validation

- `pnpm run check` — green (typecheck, lint, prettier, unit tests, yamllint, actionlint, ruff, shellcheck, zizmor, ratchet)
- `actionlint .github/workflows/ci.yml` — clean
- `yamllint .github/workflows/ci.yml` — clean

## Test plan

- [ ] CI Gate passes on this PR (source-touching workflow change → all jobs run as normal)
- [ ] After merge, re-run CI on #1251 and confirm CI Gate goes green
- [ ] Future docs-only PR observation: cascade-skipped/cancelled tier-2 jobs no longer fail the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)