### PR TITLE
chore(workflow): worktree cleanup fix + relocate merge ban to GEMINI.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,13 +116,6 @@ conflicts across worktrees and force-push requirements on open PRs.
 - Only use when user explicitly requests it
 - Never add `gh pr merge` or broad wildcard tool patterns without explicit user approval.
 
-### Merge Policy
-
-- **Default: do not merge.** Agents do not merge PRs on their own initiative — propose readiness and wait for the user to authorize.
-- The user can authorize merges in conversation. The "ask" tier in `~/.claude/settings.json` gates `gh pr merge` so the user gets a confirmation prompt for each merge.
-- We use **squash merges only**: `gh pr merge --squash <PR>`
-- This applies to all agents — lead, teammates, and subagents. Subagents in `bypassPermissions` mode skip the prompt; their dispatch contract must explicitly authorize merging if it's expected.
-
 ### CI Workflow
 
 - When investigating CI failures, check for merge conflicts FIRST:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,6 +5,12 @@ It serves as a supplement to the core mandates and instructions provided in the 
 
 ## Gemini CLI-Specific
 
+### Merge Policy (Gemini)
+
+- **Do NOT merge PRs.** Even if the user authorized merging another PR earlier in the conversation, that authorization does NOT carry to this PR. Always present the exact `gh pr merge --squash <PR>` command and let the user run it.
+- We use **squash merges only**: `gh pr merge --squash <PR>`
+- This rule is stricter than the policy for other agents on this project. Do not infer otherwise.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 
 ## Beads Issue Tracker

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -114,7 +114,15 @@ def main() -> None:
             subprocess.run(["docker", "volume", "rm"] + volumes, capture_output=True)
             print(f"Removed {len(volumes)} Docker volume(s)", file=sys.stderr)
 
-    # Remove git worktree first — only deallocate slot if removal succeeds
+    # Unlock first. Claude Code agent runtimes lock worktrees while in use,
+    # and the lock persists after the agent finishes; `git worktree remove
+    # --force` does NOT bypass these locks. Unlock errors (e.g., "not locked")
+    # are harmless and intentionally ignored.
+    subprocess.run(
+        ["git", "worktree", "unlock", str(worktree_path)],
+        capture_output=True,
+    )
+
     result = subprocess.run(
         ["git", "worktree", "remove", "--force", str(worktree_path)],
         capture_output=True,
@@ -122,12 +130,13 @@ def main() -> None:
     )
     if result.returncode != 0:
         print(
-            f"Warning: git worktree remove failed: {result.stderr.strip()}",
+            f"Failed to remove worktree {worktree_path}: {result.stderr.strip()}",
             file=sys.stderr,
         )
-    else:
-        subprocess.run(["git", "worktree", "prune"], capture_output=True)
-        deallocate_slot(str(worktree_path))
+        sys.exit(1)
+
+    subprocess.run(["git", "worktree", "prune"], capture_output=True)
+    deallocate_slot(str(worktree_path))
 
     print(f"Cleaned up worktree: {worktree_path}", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

Two related agent-workflow fixes surfaced while cleaning up stale worktrees this session.

### 1. `worktree_cleanup.py` was silently lying on failure

`scripts/worktree_cleanup.py` printed `Cleaned up worktree: <path>` whether `git worktree remove --force` succeeded or not. This masked a real bug: `--force` does NOT bypass the locks Claude Code's agent runtimes leave on worktrees, so 9 of 19 cleanup attempts in a recent batch left their directories intact (~9 GB) while reporting success.

**Fix:**
- Run `git worktree unlock` before `git worktree remove`. The unlock is idempotent — a no-op when the worktree was never locked — so no branch on lock state is needed.
- Exit `1` with the actual error message when remove fails. The "cleaned up" message now only prints on actual success.

### 2. Move the blanket merge ban out of AGENTS.md, add a stricter Gemini-specific version to GEMINI.md

The `### Merge Policy` section in `AGENTS.md` applied to every agent on the project. We trust some agents' judgment more than others, so the project-wide ban is over-restrictive. Removed from `AGENTS.md` (Claude/Antigravity/etc. fall back to standard authorization patterns), and added a tighter rule to `GEMINI.md`:

- Per-PR authorization does NOT carry forward across the conversation
- Explicitly noted as stricter than the general policy, to avoid Gemini inferring leniency from session context

## Files Modified

- `scripts/worktree_cleanup.py` — unlock step + accurate failure exit
- `AGENTS.md` — drop `### Merge Policy` section
- `GEMINI.md` — add `### Merge Policy (Gemini)` section

## Testing

- `pnpm run check` — passing (108 test files, 968 tests, ruff + actionlint clean)
- Cleanup script verified manually on `agent-ac91d7d371fa6aec0` worktree (the unlock+remove pattern that motivated the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)