### PR TITLE
chore(gitignore): ignore .gemini/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ logs/
 
 # Temporary files
 /tmp
-.gemini/tmp/
+.gemini/
 .recycle_bin/
 /data/
 #index.html


### PR DESCRIPTION
## Summary
- Replaces narrower `.gemini/tmp/` rule with directory-level `.gemini/` so all Gemini CLI local state is ignored.
- Mirrors how other AI-tool state directories (`.claude/`, `.beads/`) are handled.

Closes PP-87m.

## Test plan
- [x] `git check-ignore -v .gemini/` matches the new rule
- [x] Pre-commit (typecheck + prettier) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)