### PR TITLE
feat(page-header): accept React.ReactNode for title (PP-yxw.9)

### DIFF
--- a/src/components/layout/PageHeader.test.tsx
+++ b/src/components/layout/PageHeader.test.tsx
@@ -1,55 +1,58 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { PageHeader } from "./PageHeader";
 
 describe("PageHeader", () => {
-  it("renders the title as an h1", () => {
+  it("auto-wraps a string title in an h1 with typography classes", () => {
     render(<PageHeader title="My Page" />);
-    expect(
-      screen.getByRole("heading", { level: 1, name: "My Page" })
-    ).toBeInTheDocument();
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toHaveTextContent("My Page");
+    expect(h1).toHaveClass("text-balance");
+    expect(h1).toHaveClass("text-3xl");
+    expect(h1).toHaveClass("font-bold");
+    expect(h1).toHaveClass("tracking-tight");
   });
 
-  it("always renders border-b class", () => {
-    const { container } = render(<PageHeader title="Test" />);
-    expect(container.firstChild).toHaveClass("border-b");
+  it("renders a ReactNode title directly without auto-wrapping", () => {
+    render(
+      <PageHeader
+        title={
+          <h1
+            data-testid="custom-h1"
+            className="text-balance text-3xl font-bold tracking-tight"
+          >
+            Custom Title
+          </h1>
+        }
+      />
+    );
+    expect(screen.getByTestId("custom-h1")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Custom Title"
+    );
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
   });
 
-  it("renders titleAdornment alongside the title", () => {
+  it("renders titleAdornment alongside a string title", () => {
     render(
       <PageHeader
         title="My Page"
-        titleAdornment={<span data-testid="badge">Active</span>}
+        titleAdornment={<span data-testid="adornment">Badge</span>}
       />
     );
-    expect(screen.getByTestId("badge")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "My Page"
+    );
+    expect(screen.getByTestId("adornment")).toBeInTheDocument();
   });
 
-  it("renders actions when provided", () => {
+  it("renders actions in a flex container when provided", () => {
     render(
-      <PageHeader title="My Page" actions={<button>Do Something</button>} />
+      <PageHeader
+        title="My Page"
+        actions={<button data-testid="action">Action</button>}
+      />
     );
-    expect(
-      screen.getByRole("button", { name: "Do Something" })
-    ).toBeInTheDocument();
-  });
-
-  it("does not render actions container when actions is undefined", () => {
-    render(<PageHeader title="My Page" />);
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
-  });
-
-  it("does not render actions container when actions is null", () => {
-    render(<PageHeader title="My Page" actions={null} />);
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
-  });
-
-  it("merges additional className", () => {
-    const { container } = render(
-      <PageHeader title="Test" className="extra-class" />
-    );
-    expect(container.firstChild).toHaveClass("extra-class");
+    expect(screen.getByTestId("action")).toBeInTheDocument();
   });
 });

--- a/src/components/layout/PageHeader.test.tsx
+++ b/src/components/layout/PageHeader.test.tsx
@@ -17,20 +17,21 @@ describe("PageHeader", () => {
     render(
       <PageHeader
         title={
-          <h1
-            data-testid="custom-h1"
-            className="text-balance text-3xl font-bold tracking-tight"
-          >
+          <h1 className="text-balance text-3xl font-bold tracking-tight">
             Custom Title
           </h1>
         }
       />
     );
-    expect(screen.getByTestId("custom-h1")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "Custom Title"
     );
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+  });
+
+  it("always renders border-b class", () => {
+    const { container } = render(<PageHeader title="Test" />);
+    expect(container.firstChild).toHaveClass("border-b");
   });
 
   it("renders titleAdornment alongside a string title", () => {
@@ -46,13 +47,29 @@ describe("PageHeader", () => {
     expect(screen.getByTestId("adornment")).toBeInTheDocument();
   });
 
-  it("renders actions in a flex container when provided", () => {
+  it("renders actions when provided", () => {
     render(
-      <PageHeader
-        title="My Page"
-        actions={<button data-testid="action">Action</button>}
-      />
+      <PageHeader title="My Page" actions={<button>Do Something</button>} />
     );
-    expect(screen.getByTestId("action")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Do Something" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render actions container when actions is undefined", () => {
+    render(<PageHeader title="My Page" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("does not render actions container when actions is null", () => {
+    render(<PageHeader title="My Page" actions={null} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("merges additional className", () => {
+    const { container } = render(
+      <PageHeader title="Test" className="extra-class" />
+    );
+    expect(container.firstChild).toHaveClass("extra-class");
   });
 });

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -5,7 +5,7 @@ interface PageHeaderProps {
   /**
    * Title content. Pass a string for the default `<h1 className="text-balance text-3xl font-bold tracking-tight">` treatment,
    * or a React node for full control (e.g., to embed an editable title component). When passing a node, the consumer is
-   * responsible for the heading element and matching typography.
+   * responsible for the heading element and matching typography. Passing `null` or `undefined` renders no heading element.
    */
   title: React.ReactNode;
   titleAdornment?: React.ReactNode;

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -2,7 +2,12 @@ import type React from "react";
 import { cn } from "~/lib/utils";
 
 interface PageHeaderProps {
-  title: string;
+  /**
+   * Title content. Pass a string for the default `<h1 className="text-balance text-3xl font-bold tracking-tight">` treatment,
+   * or a React node for full control (e.g., to embed an editable title component). When passing a node, the consumer is
+   * responsible for the heading element and matching typography.
+   */
+  title: React.ReactNode;
   titleAdornment?: React.ReactNode;
   actions?: React.ReactNode;
   className?: string;
@@ -18,9 +23,13 @@ export function PageHeader({
     <div className={cn("border-b border-outline-variant pb-2", className)}>
       <div className="flex items-center justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-balance text-3xl font-bold tracking-tight">
-            {title}
-          </h1>
+          {typeof title === "string" ? (
+            <h1 className="text-balance text-3xl font-bold tracking-tight">
+              {title}
+            </h1>
+          ) : (
+            title
+          )}
           {titleAdornment}
         </div>
         {actions != null && (


### PR DESCRIPTION
## Summary
- Widen `PageHeader.title` from `string` to `React.ReactNode`
- Render conditionally: string → auto-h1 with existing typography classes; ReactNode → rendered directly (consumer brings own heading)
- Backward compatible — every existing call site passes a string and continues to typecheck without changes

## Why
Slice 1 of the issue detail rework ([PP-yxw.9](https://github.com/timothyfroehlich/PinPoint/blob/feat/issue-detail-rework-PP-yxw.9/docs/superpowers/specs/2026-05-01-issue-detail-rework-design.md)). Issue detail's \`EditableIssueTitle\` is JSX, not a string — without this widening, that page can't use \`PageHeader\` and ends up hand-rolling header chrome. Splitting this typing change into its own PR keeps Slice 2's blast radius contained to layout + component additions.

## Test plan
- [x] Unit tests cover string-mode auto-wrap (with class assertions) and ReactNode-mode pass-through (with single-h1 invariant)
- [x] Pre-existing tests preserved: border-b class, two actions guard variants, className merge
- [x] \`pnpm run check\` clean (1007 unit tests, types, lint, format, all green)
- [ ] CI Gate green (waiting on remote)

## Notes for review
- The conditional render uses \`typeof title === \"string\"\` rather than \`React.isValidElement\` so it correctly narrows for TypeScript and treats fragments / arrays / null / undefined as the passthrough case
- JSDoc explicitly documents that null/undefined title renders no heading element
- 8 tests total (4 new for the widening, 4 preserved from before) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)