### PR TITLE
chore(hooks): auto-push beads to DoltHub on git push and worktree teardown

### DIFF
--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -21,6 +21,14 @@ fi
 MAIN_WT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
 CLEANUP="$MAIN_WT/scripts/worktree_cleanup.py"
 
+# Flush bead state to DoltHub before tearing the worktree down.
+# Runs from main worktree (where the Dolt server data lives).
+# Non-blocking: cleanup proceeds even if the push fails.
+if command -v bd >/dev/null 2>&1; then
+  (cd "$MAIN_WT" && bd dolt push --quiet) >&2 \
+    || echo "Warning: bd dolt push failed (non-fatal)" >&2
+fi
+
 if [ -f "$CLEANUP" ]; then
   python3 "$CLEANUP" "$WORKTREE_PATH" >&2 || echo "Warning: cleanup failed" >&2
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,7 @@ set -e
 
 if command -v bd >/dev/null 2>&1; then
   bd hooks run pre-push "$@" || true
+  # Flush local Dolt commits to DoltHub alongside the git push.
+  # Non-blocking: a transient bd push failure should not abort code push.
+  bd dolt push --quiet 2>&1 || echo "Warning: bd dolt push failed (non-fatal)" >&2
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,5 +4,5 @@ if command -v bd >/dev/null 2>&1; then
   bd hooks run pre-push "$@" || true
   # Flush local Dolt commits to DoltHub alongside the git push.
   # Non-blocking: a transient bd push failure should not abort code push.
-  bd dolt push --quiet 2>&1 || echo "Warning: bd dolt push failed (non-fatal)" >&2
+  bd dolt push --quiet >&2 || echo "Warning: bd dolt push failed (non-fatal)" >&2
 fi


### PR DESCRIPTION
## Summary

Adds `bd dolt push` to two existing hooks so DoltHub stays current without manual sync.

- `.husky/pre-push` runs `bd dolt push --quiet` alongside every `git push`.
- `.claude/hooks/worktree-remove.sh` pushes from the main worktree before the existing cleanup script runs.

Both calls are non-blocking via `|| echo "Warning..."` so a transient push failure (network, expired auth) doesn't abort the surrounding operation.

## Background

Investigation today found the last actual `bd dolt push` was **2026-04-26 — a week stale**. Today's session closed 8 beads against local Dolt that never reached DoltHub until manually pushed. The `bd backup` system *appears* to auto-run every 15 minutes but has no destination configured (the existing Dolt remote `origin` conflicts with using the same URL as a backup destination, by design — beads keeps primary sync and disaster-recovery backup separate). `bd dolt push` itself has no built-in scheduler.

## Coverage

| Trigger | Catches |
|--------|---------|
| Any `git push` from any worktree | All bead changes since last push |
| Claude `WorktreeRemove` hook | Bead changes in that worktree's session before teardown |
| Manual `git worktree remove` | Not covered (existing limitation, same as Supabase cleanup) |
| Pure bead-only changes with no subsequent `git push` | Not covered (acceptable per discussion) |

## Test plan

- [x] `bash -n` passes on both edited hooks
- [x] `bd dolt push --quiet` exits 0 in current environment (auth via `DOLT_REMOTE_USER`/`DOLT_REMOTE_PASSWORD` env vars already wired)
- [x] **Live test on this PR's push**: pre-push hook fired, output included `Pushing to Dolt remote... Push complete.` before the GitHub push lines
- [ ] Worktree teardown hook will be exercised on next agent worktree removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)