### PR TITLE
feat(captcha): skip CAPTCHA for signed-in reporters (PP-5px)

### DIFF
--- a/src/app/(app)/report/actions.test.ts
+++ b/src/app/(app)/report/actions.test.ts
@@ -62,8 +62,15 @@ vi.mock("~/lib/blob/client", () => ({
   deleteFromBlob: vi.fn(),
 }));
 
-import { getRecentIssuesAction } from "./actions";
+import { getRecentIssuesAction, submitPublicIssueAction } from "./actions";
 import { db } from "~/server/db";
+import { verifyTurnstileToken } from "~/lib/security/turnstile";
+import {
+  checkPublicIssueLimit,
+  formatResetTime,
+  getClientIp,
+} from "~/lib/rate-limit";
+import { createClient } from "~/lib/supabase/server";
 
 describe("getRecentIssuesAction", () => {
   beforeEach(() => {
@@ -299,5 +306,93 @@ describe("getRecentIssuesAction", () => {
         expect(result.message).toBe("Could not load recent issues");
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitPublicIssueAction — CAPTCHA branching
+//
+// These tests focus narrowly on whether verifyTurnstileToken gets called and
+// what the action returns on CAPTCHA failure. They short-circuit at form
+// validation (empty FormData is rejected by parsePublicIssueForm) rather than
+// mocking the full happy path.
+// ---------------------------------------------------------------------------
+describe("submitPublicIssueAction — CAPTCHA branching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClientIp).mockResolvedValue("127.0.0.1");
+    vi.mocked(checkPublicIssueLimit).mockResolvedValue({
+      success: true,
+      reset: 0,
+    } as any);
+    vi.mocked(formatResetTime).mockReturnValue("0s");
+  });
+
+  it("skips verifyTurnstileToken when the user is logged in", async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi
+          .fn()
+          .mockResolvedValue({ data: { user: { id: "user-123" } } }),
+      },
+    } as any);
+    vi.mocked(verifyTurnstileToken).mockResolvedValue(true);
+
+    // Empty FormData fails parsePublicIssueForm, returning { error: "..." }
+    // BEFORE any further side effects. We don't care about that error — we
+    // only care that the CAPTCHA verifier was never called.
+    await submitPublicIssueAction({}, new FormData());
+
+    expect(verifyTurnstileToken).not.toHaveBeenCalled();
+  });
+
+  it("calls verifyTurnstileToken when the user is anonymous", async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+    } as any);
+    vi.mocked(verifyTurnstileToken).mockResolvedValue(true);
+
+    await submitPublicIssueAction({}, new FormData());
+
+    expect(verifyTurnstileToken).toHaveBeenCalledOnce();
+  });
+
+  it("returns CAPTCHA error when anonymous user fails verification", async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+    } as any);
+    vi.mocked(verifyTurnstileToken).mockResolvedValue(false);
+
+    const formData = new FormData();
+    formData.set("captchaToken", "invalid-token");
+
+    const result = await submitPublicIssueAction({}, formData);
+
+    expect(result).toEqual({
+      error: "CAPTCHA verification failed. Please try again.",
+    });
+  });
+
+  it("reads the token from the captchaToken FormData field", async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+    } as any);
+    vi.mocked(verifyTurnstileToken).mockResolvedValue(true);
+
+    const formData = new FormData();
+    formData.set("captchaToken", "valid-cf-token");
+
+    await submitPublicIssueAction({}, formData);
+
+    expect(verifyTurnstileToken).toHaveBeenCalledWith(
+      "valid-cf-token",
+      "127.0.0.1"
+    );
   });
 });

--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -16,6 +16,7 @@ import {
 } from "~/lib/rate-limit";
 import { parsePublicIssueForm } from "./validation";
 import { verifyTurnstileToken } from "~/lib/security/turnstile";
+import { extractCaptchaToken } from "~/lib/auth/errors";
 import { BLOB_CONFIG } from "~/lib/blob/config";
 import { db } from "~/server/db";
 import {
@@ -95,19 +96,28 @@ export async function submitPublicIssueAction(
     };
   }
 
-  // 3. Verify Turnstile CAPTCHA
-  const turnstileToken = formData.get("cf-turnstile-response");
-  const tokenStr = typeof turnstileToken === "string" ? turnstileToken : "";
-  const captchaValid = await verifyTurnstileToken(tokenStr, ip);
+  // 3. Resolve current user (used to skip CAPTCHA for authenticated reporters
+  // and reused later for permission resolution).
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (!captchaValid) {
-    log.warn(
-      { action: "publicIssueReport", ip },
-      "Turnstile CAPTCHA verification failed"
-    );
-    return {
-      error: "CAPTCHA verification failed. Please try again.",
-    };
+  // 4. Verify Turnstile CAPTCHA — only required for anonymous reporters.
+  // Logged-in users skip the Cloudflare round trip entirely.
+  if (!user) {
+    const captchaToken = extractCaptchaToken(formData);
+    const captchaValid = await verifyTurnstileToken(captchaToken ?? "", ip);
+
+    if (!captchaValid) {
+      log.warn(
+        { action: "publicIssueReport", ip },
+        "Turnstile CAPTCHA verification failed"
+      );
+      return {
+        error: "CAPTCHA verification failed. Please try again.",
+      };
+    }
   }
 
   const parsedValue = parsePublicIssueForm(formData);
@@ -156,12 +166,7 @@ export async function submitPublicIssueAction(
     }
   }
 
-  // 3. Resolve reporter
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
+  // 5. Resolve reporter (user was loaded above; reuse it here)
   let reportedBy: string | null = user?.id ?? null;
   log.info(
     { reportedBy, email: user?.email, action: "publicIssueReport" },
@@ -170,7 +175,7 @@ export async function submitPublicIssueAction(
   let reporterName: string | null = null;
   let reporterEmail: string | null = null;
 
-  // 4. Resolve reporter via name/email if not already logged in
+  // 6. Resolve reporter via name/email if not already logged in
   if (!reportedBy) {
     if (email) {
       // Check active user profiles directly to prevent spoofing
@@ -272,7 +277,7 @@ export async function submitPublicIssueAction(
       autoWatchReporter: watchIssue,
     });
 
-    // 5. Link uploaded images
+    // 7. Link uploaded images
     const imagesMetadataStr = formData.get("imagesMetadata");
     if (imagesMetadataStr && typeof imagesMetadataStr === "string") {
       try {

--- a/src/app/(app)/report/unified-report-form.tsx
+++ b/src/app/(app)/report/unified-report-form.tsx
@@ -94,6 +94,12 @@ export function UnifiedReportForm({
 
   const [uploadedImages, setUploadedImages] = useState<ImageMetadata[]>([]);
   const [turnstileToken, setTurnstileToken] = useState("");
+  // CAPTCHA is only required for anonymous reporters. Logged-in users skip it
+  // both client-side (no widget rendered) and server-side (action checks
+  // auth.getUser() before calling verifyTurnstileToken).
+  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
+  const enforceCaptcha =
+    hasTurnstile && process.env.NODE_ENV !== "test" && !userAuthenticated;
 
   // Recent issues panel state
   const [issues, setIssues] = useState<RecentIssueData[]>(initialIssues ?? []);
@@ -582,20 +588,25 @@ export function UnifiedReportForm({
               </div>
             )}
 
-            <input
-              type="hidden"
-              name="cf-turnstile-response"
-              value={turnstileToken}
-            />
-            <TurnstileWidget
-              onVerify={handleTurnstileVerify}
-              onExpire={() => setTurnstileToken("")}
-            />
+            {!userAuthenticated && (
+              <>
+                <input
+                  type="hidden"
+                  name="captchaToken"
+                  value={turnstileToken}
+                />
+                <TurnstileWidget
+                  onVerify={handleTurnstileVerify}
+                  onExpire={() => setTurnstileToken("")}
+                />
+              </>
+            )}
 
             <Button
               type="submit"
               className="w-full bg-primary text-on-primary hover:bg-primary/90 mt-1 h-10 text-sm font-semibold"
               loading={isPending}
+              disabled={isPending || (enforceCaptcha && !turnstileToken)}
             >
               Submit Issue Report
             </Button>

--- a/src/app/(auth)/actions-security.test.ts
+++ b/src/app/(auth)/actions-security.test.ts
@@ -44,7 +44,15 @@ vi.mock("~/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
+// Mock Turnstile — default to passing so existing tests are unaffected.
+// Individual tests can override with mockResolvedValueOnce(false) to test
+// the CAPTCHA-failure branch.
+vi.mock("~/lib/security/turnstile", () => ({
+  verifyTurnstileToken: vi.fn().mockResolvedValue(true),
+}));
+
 import { createClient } from "~/lib/supabase/server";
+import { verifyTurnstileToken } from "~/lib/security/turnstile";
 
 describe("Auth Actions Security - Error Handling", () => {
   beforeEach(() => {
@@ -341,6 +349,69 @@ describe("Auth Actions Security - Error Handling", () => {
       expect(result.message).toBe("Failed to update password");
       expect(result.message).not.toContain("Constraint violation");
     }
+  });
+
+  it("resetPasswordAction should return CAPTCHA error when verification fails", async () => {
+    vi.mocked(verifyTurnstileToken).mockResolvedValueOnce(false);
+
+    const updateUserMock = vi.fn();
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi
+          .fn()
+          .mockResolvedValue({ data: { user: { id: "user-123" } } }),
+        updateUser: updateUserMock,
+        signOut: vi.fn(),
+      },
+    } as any);
+
+    const formData = new FormData();
+    formData.set("password", "NewPassword123!");
+    formData.set("confirmPassword", "NewPassword123!");
+    formData.set("captchaToken", "invalid-token");
+
+    const result = await resetPasswordAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("CAPTCHA");
+      expect(result.message).toContain("Verification failed");
+    }
+    expect(updateUserMock).not.toHaveBeenCalled();
+  });
+
+  it("resetPasswordAction should call updateUser when CAPTCHA verification passes", async () => {
+    vi.mocked(verifyTurnstileToken).mockResolvedValueOnce(true);
+
+    const updateUserMock = vi.fn().mockResolvedValue({ error: null });
+    const signOutMock = vi.fn().mockResolvedValue({ error: null });
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi
+          .fn()
+          .mockResolvedValue({ data: { user: { id: "user-123" } } }),
+        updateUser: updateUserMock,
+        signOut: signOutMock,
+      },
+    } as any);
+
+    const formData = new FormData();
+    formData.set("password", "NewPassword123!");
+    formData.set("confirmPassword", "NewPassword123!");
+    formData.set("captchaToken", "valid-token");
+
+    // resetPasswordAction calls redirect("/login") on success, which throws
+    // a NEXT_REDIRECT error in tests. We don't assert on the return value;
+    // we just confirm the password update was attempted.
+    try {
+      await resetPasswordAction(undefined, formData);
+    } catch {
+      // redirect() throws — expected.
+    }
+
+    expect(updateUserMock).toHaveBeenCalledWith({
+      password: "NewPassword123!",
+    });
   });
 
   it("loginAction should return CAPTCHA error for captcha_failed", async () => {

--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -33,6 +33,7 @@ import {
   extractCaptchaToken,
   getUserMessageForAuthError,
 } from "~/lib/auth/errors";
+import { verifyTurnstileToken } from "~/lib/security/turnstile";
 
 /**
  * Result Types
@@ -64,7 +65,7 @@ export type ForgotPasswordResult = Result<
 
 export type ResetPasswordResult = Result<
   void,
-  "VALIDATION" | "WEAK_PASSWORD" | "SAME_PASSWORD" | "SERVER"
+  "VALIDATION" | "WEAK_PASSWORD" | "SAME_PASSWORD" | "CAPTCHA" | "SERVER"
 >;
 
 /**
@@ -589,6 +590,25 @@ export async function resetPasswordAction(
   const { password } = parsed.data;
 
   try {
+    // Verify Turnstile CAPTCHA. Unlike signUp/signInWithPassword/resetPasswordForEmail,
+    // Supabase's auth.updateUser() does not accept a captchaToken option, so we must
+    // verify the token ourselves before calling it.
+    const captchaToken = extractCaptchaToken(formData);
+    const captchaValid = await verifyTurnstileToken(
+      captchaToken ?? "",
+      await getClientIp()
+    );
+    if (!captchaValid) {
+      log.warn(
+        { action: "reset-password" },
+        "Turnstile CAPTCHA verification failed"
+      );
+      return err(
+        "CAPTCHA",
+        "Verification failed. Please refresh the page and try again."
+      );
+    }
+
     const supabase = await createClient();
 
     // Verify user is authenticated (should be authenticated via reset link)

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import type React from "react";
-import { useActionState, useState } from "react";
+import { useActionState, useCallback, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
 import { PasswordInput } from "~/components/ui/password-input";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { PasswordMismatch } from "~/components/password-mismatch";
 import { PasswordStrength } from "~/components/password-strength";
+import { TurnstileWidget } from "~/components/security/TurnstileWidget";
 import {
   resetPasswordAction,
   type ResetPasswordResult,
@@ -20,6 +21,13 @@ export function ResetPasswordForm(): React.JSX.Element {
   >(resetPasswordAction, undefined);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
+  const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
+
+  const handleTurnstileVerify = useCallback((token: string) => {
+    setTurnstileToken(token);
+  }, []);
 
   return (
     <form action={formAction} className="space-y-4">
@@ -70,8 +78,20 @@ export function ResetPasswordForm(): React.JSX.Element {
         />
       </div>
 
+      <input type="hidden" name="captchaToken" value={turnstileToken} />
+      <TurnstileWidget
+        onVerify={handleTurnstileVerify}
+        onExpire={() => setTurnstileToken("")}
+      />
+
       {/* Submit button */}
-      <Button type="submit" className="w-full" size="lg" loading={isPending}>
+      <Button
+        type="submit"
+        className="w-full"
+        size="lg"
+        loading={isPending}
+        disabled={isPending || (enforceCaptcha && !turnstileToken)}
+      >
         Update Password
       </Button>
     </form>


### PR DESCRIPTION
## Summary

- **Headline change**: `/report` no longer renders a Turnstile widget or runs server-side CAPTCHA verification when the reporter is signed in. The server checks `auth.getUser()` *before* `verifyTurnstileToken()`, so the client-side skip is backed by an authoritative server check.
- **Tightened CAPTCHA coverage**: `/reset-password` now requires CAPTCHA (it was the only password-touching form without one). Verified locally via `verifyTurnstileToken()` because `auth.updateUser()` doesn't accept `captchaToken` in `@supabase/supabase-js@2.103.3`.
- **Normalized report-form wiring**: hidden field renamed `cf-turnstile-response` → `captchaToken` so it shares `extractCaptchaToken()` with the auth forms; submit button now gated on token presence the same way login/signup/forgot-password are.

## Test plan

- [x] `pnpm run check` — 1013/1013 unit tests pass; types/lint/format clean
- [x] 4 new unit tests added (2 reset-password CAPTCHA, 4 report-action CAPTCHA branching)
- [x] `pnpm exec playwright test e2e/full/email-and-notifications.spec.ts --grep "password reset" --project=chromium` — 4/4 pass; new CAPTCHA gate doesn't block the recovery journey
- [x] `pnpm exec playwright test e2e/smoke/public-reporting.spec.ts e2e/smoke/report-form-clear.spec.ts --project=chromium` — 9/9 pass; anonymous CAPTCHA still works AND authenticated bypass works
- [ ] Manual smoke: `/report` while signed in shows no widget and no `challenges.cloudflare.com` network requests
- [ ] Manual smoke: `/reset-password` shows widget, submit disabled until solved, success path lands on `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)