### PR TITLE
chore(hooks): adopt bd v1.0.3 section markers in husky (PP-gc0)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,17 +28,6 @@
         ]
       }
     ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bd prime",
-            "timeout": 10000
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -8,16 +8,15 @@ BRANCH_CHECKOUT=$3
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
-    _bd_exit=$?
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@" || _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run post-checkout "$@"
-    _bd_exit=$?
+    bd hooks run post-checkout "$@" || _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -11,18 +11,18 @@ if command -v bd >/dev/null 2>&1; then
   _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-checkout "$@" || _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
+    if [ "$_bd_exit" -eq 124 ]; then
       echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
     bd hooks run post-checkout "$@" || _bd_exit=$?
   fi
-  if [ $_bd_exit -eq 3 ]; then
+  if [ "$_bd_exit" -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
     _bd_exit=0
   fi
-  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+  if [ "$_bd_exit" -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.3 ---
 

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -3,9 +3,29 @@ set -e
 # Args: previous HEAD, new HEAD, branch flag (1=branch change, 0=file checkout)
 BRANCH_CHECKOUT=$3
 
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
-  bd hooks run post-checkout "$@" || true
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
+# --- END BEADS INTEGRATION v1.0.3 ---
 
 if [ "$BRANCH_CHECKOUT" = "1" ]; then
   if [ -f "supabase/config.toml.template" ]; then

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -8,17 +8,17 @@ if command -v bd >/dev/null 2>&1; then
   _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-merge "$@" || _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
+    if [ "$_bd_exit" -eq 124 ]; then
       echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
     bd hooks run post-merge "$@" || _bd_exit=$?
   fi
-  if [ $_bd_exit -eq 3 ]; then
+  if [ "$_bd_exit" -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
     _bd_exit=0
   fi
-  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+  if [ "$_bd_exit" -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.3 ---

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -5,16 +5,15 @@ set -e
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run post-merge "$@"
-    _bd_exit=$?
+    timeout "$_bd_timeout" bd hooks run post-merge "$@" || _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run post-merge "$@"
-    _bd_exit=$?
+    bd hooks run post-merge "$@" || _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-merge'"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,5 +1,25 @@
 set -e
 
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
-  bd hooks run post-merge "$@" || true
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,10 +10,29 @@ fi
 pnpm exec lint-staged
 pnpm run typecheck
 pnpm run format
+
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+# BD_EXPORT_GIT_ADD=false: prevent beads from force-staging issues.jsonl into commits (PP-2pe).
 if command -v bd >/dev/null 2>&1; then
-  # BD_EXPORT_GIT_ADD=false: prevent beads from force-staging issues.jsonl
-  # at the repo root into every commit. The auto-export still runs (beads
-  # keeps its own copy inside .beads/), but git never sees the file.
-  # See: PP-2pe
-  BD_EXPORT_GIT_ADD=false bd hooks run pre-commit
+  export BD_GIT_HOOK=1
+  export BD_EXPORT_GIT_ADD=false
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,16 +18,15 @@ if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   export BD_EXPORT_GIT_ADD=false
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
-    _bd_exit=$?
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@" || _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run pre-commit "$@"
-    _bd_exit=$?
+    bd hooks run pre-commit "$@" || _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,17 +21,17 @@ if command -v bd >/dev/null 2>&1; then
   _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-commit "$@" || _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
+    if [ "$_bd_exit" -eq 124 ]; then
       echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
     bd hooks run pre-commit "$@" || _bd_exit=$?
   fi
-  if [ $_bd_exit -eq 3 ]; then
+  if [ "$_bd_exit" -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
     _bd_exit=0
   fi
-  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+  if [ "$_bd_exit" -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.3 ---

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,31 @@
 set -e
 
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
-  bd hooks run pre-push "$@" || true
-  # Flush local Dolt commits to DoltHub alongside the git push.
-  # Non-blocking: a transient bd push failure should not abort code push.
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---
+
+# Flush local Dolt commits to DoltHub alongside the git push.
+# Non-blocking: a transient bd push failure should not abort code push.
+if command -v bd >/dev/null 2>&1; then
   bd dolt push --quiet >&2 || echo "Warning: bd dolt push failed (non-fatal)" >&2
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,18 +8,18 @@ if command -v bd >/dev/null 2>&1; then
   _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-push "$@" || _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
+    if [ "$_bd_exit" -eq 124 ]; then
       echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
     bd hooks run pre-push "$@" || _bd_exit=$?
   fi
-  if [ $_bd_exit -eq 3 ]; then
+  if [ "$_bd_exit" -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
     _bd_exit=0
   fi
-  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+  if [ "$_bd_exit" -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.3 ---
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,16 +5,15 @@ set -e
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_exit=0
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$_bd_timeout" bd hooks run pre-push "$@"
-    _bd_exit=$?
+    timeout "$_bd_timeout" bd hooks run pre-push "$@" || _bd_exit=$?
     if [ $_bd_exit -eq 124 ]; then
       echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
       _bd_exit=0
     fi
   else
-    bd hooks run pre-push "$@"
-    _bd_exit=$?
+    bd hooks run pre-push "$@" || _bd_exit=$?
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-push'"


### PR DESCRIPTION
## Summary

- Wrap the bd integration in each husky hook (`pre-commit`, `post-merge`, `pre-push`, `post-checkout`) with bd v1.0.3 section markers (`--- BEGIN BEADS INTEGRATION ---`). PinPoint custom logic (lint-staged, main-branch block, dolt push, worktree setup) lives outside the markers so future `bd hooks install` upgrades preserve it.
- Drop the project-level `bd prime` SessionStart hook from `.claude/settings.json` — the beads plugin's own `plugin.json` already declares this hook, so we were firing it twice per session.
- Refresh `.beads/.gitignore` patterns via `bd doctor --fix` (gitignored, no diff).

## Why

`bd doctor` was reporting:
- ✖ Git Hooks Dolt Compatibility: incompatible (didn't recognize the bare `bd hooks run X` calls)
- ⚠ Git Hooks: outdated (oldest: 0.0.0, current: 1.0.3)

After this change: ✓ 72 passed, 0 errors. The marker-based hooks include bd's full template (timeout handling, exit-code-3 ("database not initialized") graceful skip, version stamp).

## Test plan
- [x] `bd doctor` passes locally (0 errors)
- [x] Pre-commit hook fires lint-staged + typecheck + format + bd integration (verified during this commit)
- [x] Pre-push hook fires bd integration + `bd dolt push` (verified during this push)
- [ ] CI Gate green
- [ ] Verify SessionStart only prints `Beads Workflow Context` once (next session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)