### PR TITLE
fix(e2e): widen password reset link extraction for Supabase format variance (PP-q9r)

### DIFF
--- a/e2e/support/mailpit.ts
+++ b/e2e/support/mailpit.ts
@@ -201,7 +201,15 @@ export class MailpitClient {
   }
 
   /**
-   * Extract password reset link from the latest email for a mailbox
+   * Extract password reset link from the latest email for a mailbox.
+   *
+   * Tries multiple extraction strategies in order:
+   * 1. href attribute in HTML body (covers /auth/v1/verify links)
+   * 2. Any URL containing /auth/v1/verify in the full body (HTML or text)
+   * 3. Any URL containing /auth/callback (newer Supabase formats that embed
+   *    the callback URL directly in the email)
+   *
+   * Logs the full email body and headers on failure so CI flakes are diagnosable.
    */
   async getPasswordResetLink(email: string): Promise<string> {
     const latest =
@@ -220,12 +228,43 @@ export class MailpitClient {
     }
 
     const detail = await this.getMessage(email, latest.ID);
-    const html = (detail.HTML ?? detail.Text ?? "").toString();
-    const match = PASSWORD_RESET_LINK_REGEX.exec(html);
-    if (!match?.[1]) {
-      throw new Error("Password reset link not found in email body");
+    const htmlBody = (detail.HTML ?? "").toString();
+    const textBody = (detail.Text ?? "").toString();
+
+    // Strategy 1: href attribute in HTML containing /auth/v1/verify
+    const hrefMatch = PASSWORD_RESET_LINK_REGEX.exec(htmlBody);
+    if (hrefMatch?.[1]) {
+      return decodeHtmlEntities(hrefMatch[1]);
     }
-    return decodeHtmlEntities(match[1]);
+
+    // Strategy 2: any URL containing /auth/v1/verify in either body
+    const fullBody = htmlBody || textBody;
+    const verifyUrlMatch =
+      /https?:\/\/[^\s"'<>)]*\/auth\/v1\/verify[^\s"'<>)]*/i.exec(fullBody);
+    if (verifyUrlMatch?.[0]) {
+      return decodeHtmlEntities(verifyUrlMatch[0]);
+    }
+
+    // Strategy 3: direct callback URL (newer Supabase versions embed the
+    // redirect_to URL directly with token_hash or code params)
+    const callbackUrlMatch =
+      /https?:\/\/[^\s"'<>)]*\/auth\/callback[^\s"'<>)]*/i.exec(fullBody);
+    if (callbackUrlMatch?.[0]) {
+      return decodeHtmlEntities(callbackUrlMatch[0]);
+    }
+
+    // All strategies failed — log everything so future failures are diagnosable
+    console.error(
+      `[Mailpit] Password reset link not found.\n` +
+        `  Message ID: ${detail.ID}\n` +
+        `  Subject: ${detail.Subject}\n` +
+        `  To: ${detail.To.map((r) => r.Address).join(", ")}\n` +
+        `  Date: ${detail.Date ?? "(unknown)"}\n` +
+        `  HTML body (${htmlBody.length} chars):\n${htmlBody || "(empty)"}\n` +
+        `  Text body (${textBody.length} chars):\n${textBody || "(empty)"}`
+    );
+
+    throw new Error("Password reset link not found in email body");
   }
 
   /**

--- a/e2e/support/mailpit.ts
+++ b/e2e/support/mailpit.ts
@@ -237,31 +237,42 @@ export class MailpitClient {
       return decodeHtmlEntities(hrefMatch[1]);
     }
 
-    // Strategy 2: any URL containing /auth/v1/verify in either body
-    const fullBody = htmlBody || textBody;
+    // Strategy 2: bare URL containing /auth/v1/verify — search both bodies
+    // independently so a non-empty HTML part doesn't hide a text-only link
+    const verifyPattern =
+      /https?:\/\/[^\s"'<>)]*\/auth\/v1\/verify[^\s"'<>)]*/i;
     const verifyUrlMatch =
-      /https?:\/\/[^\s"'<>)]*\/auth\/v1\/verify[^\s"'<>)]*/i.exec(fullBody);
+      verifyPattern.exec(htmlBody) ?? verifyPattern.exec(textBody);
     if (verifyUrlMatch?.[0]) {
       return decodeHtmlEntities(verifyUrlMatch[0]);
     }
 
     // Strategy 3: direct callback URL (newer Supabase versions embed the
     // redirect_to URL directly with token_hash or code params)
+    // Search both bodies independently for the same reason as above.
+    const callbackPattern =
+      /https?:\/\/[^\s"'<>)]*\/auth\/callback[^\s"'<>)]*/i;
     const callbackUrlMatch =
-      /https?:\/\/[^\s"'<>)]*\/auth\/callback[^\s"'<>)]*/i.exec(fullBody);
+      callbackPattern.exec(htmlBody) ?? callbackPattern.exec(textBody);
     if (callbackUrlMatch?.[0]) {
       return decodeHtmlEntities(callbackUrlMatch[0]);
     }
 
-    // All strategies failed — log everything so future failures are diagnosable
+    // All strategies failed — log diagnostics so future CI flakes are diagnosable.
+    // Redact one-time token values to avoid leaking secrets into logs.
+    const redactTokens = (s: string): string =>
+      s
+        .replace(/([?&]token=)[^&"'\s<>)]+/gi, "$1[REDACTED]")
+        .replace(/([?&]token_hash=)[^&"'\s<>)]+/gi, "$1[REDACTED]")
+        .replace(/([?&]code=)[^&"'\s<>)]+/gi, "$1[REDACTED]");
     console.error(
       `[Mailpit] Password reset link not found.\n` +
         `  Message ID: ${detail.ID}\n` +
         `  Subject: ${detail.Subject}\n` +
         `  To: ${detail.To.map((r) => r.Address).join(", ")}\n` +
         `  Date: ${detail.Date ?? "(unknown)"}\n` +
-        `  HTML body (${htmlBody.length} chars):\n${htmlBody || "(empty)"}\n` +
-        `  Text body (${textBody.length} chars):\n${textBody || "(empty)"}`
+        `  HTML body (${htmlBody.length} chars):\n${redactTokens(htmlBody) || "(empty)"}\n` +
+        `  Text body (${textBody.length} chars):\n${redactTokens(textBody) || "(empty)"}`
     );
 
     throw new Error("Password reset link not found in email body");

--- a/e2e/support/mailpit.ts
+++ b/e2e/support/mailpit.ts
@@ -204,10 +204,12 @@ export class MailpitClient {
    * Extract password reset link from the latest email for a mailbox.
    *
    * Tries multiple extraction strategies in order:
-   * 1. href attribute in HTML body (covers /auth/v1/verify links)
-   * 2. Any URL containing /auth/v1/verify in the full body (HTML or text)
-   * 3. Any URL containing /auth/callback (newer Supabase formats that embed
-   *    the callback URL directly in the email)
+   * 1. href attribute in HTML body containing /verify with type=recovery
+   *    (current Supabase GoTrue format — the path is /verify, not
+   *    /auth/v1/verify; type=recovery disambiguates from signup/invite emails)
+   * 2. Any URL containing /verify with type=recovery in either body part
+   * 3. Any URL containing /auth/callback (defensive coverage for future
+   *    format drift where the callback URL appears directly in the email)
    *
    * Logs the full email body and headers on failure so CI flakes are diagnosable.
    */
@@ -231,25 +233,26 @@ export class MailpitClient {
     const htmlBody = (detail.HTML ?? "").toString();
     const textBody = (detail.Text ?? "").toString();
 
-    // Strategy 1: href attribute in HTML containing /auth/v1/verify
+    // Strategy 1: href in HTML containing /verify?...type=recovery
     const hrefMatch = PASSWORD_RESET_LINK_REGEX.exec(htmlBody);
     if (hrefMatch?.[1]) {
       return decodeHtmlEntities(hrefMatch[1]);
     }
 
-    // Strategy 2: bare URL containing /auth/v1/verify — search both bodies
-    // independently so a non-empty HTML part doesn't hide a text-only link
+    // Strategy 2: bare URL containing /verify with type=recovery — search
+    // both bodies independently so a non-empty HTML part doesn't hide a
+    // text-only link
     const verifyPattern =
-      /https?:\/\/[^\s"'<>)]*\/auth\/v1\/verify[^\s"'<>)]*/i;
+      /https?:\/\/[^\s"'<>)]*\/verify\?[^\s"'<>)]*type=recovery[^\s"'<>)]*/i;
     const verifyUrlMatch =
       verifyPattern.exec(htmlBody) ?? verifyPattern.exec(textBody);
     if (verifyUrlMatch?.[0]) {
       return decodeHtmlEntities(verifyUrlMatch[0]);
     }
 
-    // Strategy 3: direct callback URL (newer Supabase versions embed the
-    // redirect_to URL directly with token_hash or code params)
-    // Search both bodies independently for the same reason as above.
+    // Strategy 3: direct callback URL — defensive coverage for future
+    // Supabase formats that embed the /auth/callback URL directly with
+    // token_hash or code params. Search both bodies independently.
     const callbackPattern =
       /https?:\/\/[^\s"'<>)]*\/auth\/callback[^\s"'<>)]*/i;
     const callbackUrlMatch =
@@ -326,7 +329,12 @@ export class MailpitClient {
   }
 }
 
-const PASSWORD_RESET_LINK_REGEX = /href="([^"]*\/auth\/v1\/verify[^"]*)"/i;
+// Match href attributes that point to a /verify URL with type=recovery.
+// Current Supabase GoTrue serves password reset links from /verify (no
+// /auth/v1/ prefix). type=recovery disambiguates from signup/invite emails
+// that also use /verify but with type=signup or type=invite.
+const PASSWORD_RESET_LINK_REGEX =
+  /href="(http[^"]*\/verify\?[^"]*type=recovery[^"]*)"/i;
 
 const decodeHtmlEntities = (text: string): string =>
   text


### PR DESCRIPTION
## Summary

**Iter 2 of PP-q9r** — widens the password reset link extraction regex in `e2e/support/mailpit.ts` to handle Supabase's actual response format (`/verify?token=...&type=recovery&redirect_to=...`) and adds diagnostic logging. Adds defense-in-depth helper improvements that future iterations of the fix will benefit from.

## ⚠️ This PR does NOT unsilence the PP-q9r fixme.

Iter 2 confirmed via #1290's CI run that the regex is now correct, but the underlying test failure is a **flow assumption issue**: `page.goto(resetLink)` lands on `http://127.0.0.1:54321/verify?...&redirect_to=...%2Fauth%2Fcallback%3Fnext%3D%252Freset-password` and never redirects through to `/reset-password`. The PKCE verify endpoint isn't being followed through to the callback in the headless test environment.

The actual fix (iter 3) will need to either:
- Rewrite the test flow to handle the PKCE redirect chain manually
- Or simulate the post-verify state via direct DB token-grant manipulation

That work is **not scoped into this PR**.

## Recommendation

Two reasonable paths:

**Path A — merge as defense-in-depth.** The regex improvement and diagnostic logging are valuable on their own; the next iteration won't have to redo them. Cost: one extra PR in the history for one bead.

**Path B — close and bundle into iter 3.** Wait for iter 3 to be designed and ship the regex + flow fix together. Cost: PP-q9r fixme stays in place a bit longer (already silenced via #1290, so no CI impact).

Tim's earlier decision (excluded this from the morning sweep merge): Path B implicit. Awaiting confirmation.

## Test plan
- [x] CI green (the test is silenced via #1290's fixme, so passing isn't load-bearing here)
- [ ] iter 3 PR uses the new diagnostic logging to confirm flow assumption

## Tracking
- Bead: PP-q9r
- Silenced via: #1290 (skip-PR)
- Iter 3 (TBD): will remove the `test.fixme(true, "PP-q9r — ...")` call in `e2e/full/email-and-notifications.spec.ts:720`