### PR TITLE
chore(e2e): bump actionTimeout to 30s in CI (PP-awg)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
     extraHTTPHeaders: { "x-skip-autologin": "true" },
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    actionTimeout: 10 * 1000,
+    actionTimeout: process.env["CI"] ? 30_000 : 5_000,
     navigationTimeout: 20 * 1000,
   },
 


### PR DESCRIPTION
## Summary

- Bumps `actionTimeout` in `playwright.config.ts` from a flat 10 s to **30 s in CI / 5 s locally**.
- Addresses PP-awg (Layer 1 of Radix portal flake mitigation strategy).
- The previous 10 s budget was tight enough to cause intermittent failures when Radix portals (DropdownMenu, Select) lag on loaded CI runners. This single config change may be sufficient to retire PP-jsh (`machine-details-extended.spec.ts` logout dropdown) and PP-v7g (`status-overhaul.spec.ts` status select) without any per-spec fixes.

## What this is / isn't

- **Is**: a config-level timing buffer for CI variance affecting Radix portal-mounted interactions.
- **Is not**: a fix for any specific test. No spec files were touched.
- **Is not**: a comprehensive flake fix. If sticky flakes remain after 3 monitored CI runs on main, Layer 2 (shared `openAndPick` helper) is next.

## Verification plan

CI passing is sufficient. After merge, monitor next 3 main CI runs for `machine-details-extended.spec.ts` (PP-jsh) and `status-overhaul.spec.ts` (PP-v7g). If both pass consistently → close PP-jsh and PP-v7g. If either still flakes → proceed to Layer 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)