### PR TITLE
docs(agents): edit canonical specs in place, no divergence notes (PP-00s)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,14 +314,19 @@ Some work is well-suited for Claude in Web — the cloud session that runs in a 
 
 ### Keeping specs aligned
 
-When you change UI behavior covered by `.agent/skills/pinpoint-design-bible/SKILL.md` or any
-archetype/spec doc, **edit those documents in place**. Do not append a "divergence note",
-"TODO: spec out of date", or end-of-file disclaimer describing how the implementation now
-differs — that style of accretion drove repeated Copilot/Claude review churn on PR #1270.
+When you change UI behavior covered by a living canonical spec — specifically
+`.agent/skills/pinpoint-design-bible/SKILL.md` and archetype docs under
+`.agent/skills/pinpoint-design-bible/archetypes/` — **edit those documents in place**.
+Do not append a "divergence note", "TODO: spec out of date", or end-of-file disclaimer
+describing how the implementation now differs.
 
-If you find an existing divergence note while making changes, fold its content back into
-the canonical text and delete the note. The spec docs are the single source of truth; if
-implementation has drifted, the fix is to update the spec, not annotate the drift.
+Historical dated artifacts (e.g., `docs/superpowers/specs/<date>-*.md`) are NOT subject to
+this rule — they are design records that should be left as-is.
+
+If you find an existing divergence note in a canonical spec while making changes, fold its
+content back into the canonical text and delete the note. Canonical spec docs are the single
+source of truth; if implementation has drifted, the fix is to update the spec, not annotate
+the drift.
 
 ## Landing the Plane (Session Completion)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,8 +315,7 @@ Some work is well-suited for Claude in Web — the cloud session that runs in a 
 ### Keeping specs aligned
 
 When you change UI behavior covered by a living canonical spec — specifically
-`.agent/skills/pinpoint-design-bible/SKILL.md` and archetype docs under
-`.agent/skills/pinpoint-design-bible/archetypes/` — **edit those documents in place**.
+`.agent/skills/pinpoint-design-bible/SKILL.md` (page/modal archetypes live inside as §5 and §17) — **edit those documents in place**.
 Do not append a "divergence note", "TODO: spec out of date", or end-of-file disclaimer
 describing how the implementation now differs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,17 @@ Some work is well-suited for Claude in Web — the cloud session that runs in a 
 - Designed for efficient LLM consumption
 - Skills provide deep dives on-demand
 
+### Keeping specs aligned
+
+When you change UI behavior covered by `.agent/skills/pinpoint-design-bible/SKILL.md` or any
+archetype/spec doc, **edit those documents in place**. Do not append a "divergence note",
+"TODO: spec out of date", or end-of-file disclaimer describing how the implementation now
+differs — that style of accretion drove repeated Copilot/Claude review churn on PR #1270.
+
+If you find an existing divergence note while making changes, fold its content back into
+the canonical text and delete the note. The spec docs are the single source of truth; if
+implementation has drifted, the fix is to update the spec, not annotate the drift.
+
 ## Landing the Plane (Session Completion)
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.


### PR DESCRIPTION
## Summary
- Adds a **"Keeping specs aligned"** subsection to AGENTS.md section 5 instructing agents to edit canonical spec docs in place rather than appending divergence notes.
- Codifies the lesson from PR #1270 review churn (spec/implementation drift drove Copilot back-and-forth).
- Tells agents that finding an existing divergence note is a signal to fold the content back into canonical text, not preserve the annotation.

Process guidance only — no automation, no code changes.

## Inherited CI failures
`main` is currently red. Inherited failures from main (PP-q9r/PP-e20/PP-jsh/PP-v7g/PP-49m) will appear in CI; not introduced by this PR. See Tim's status comment on PR #1278.

## Test plan
- [x] `pnpm run check` passes (1013 unit tests)
- [x] AGENTS.md still parses cleanly (prettier formatted on commit)
- [ ] CI Gate green

## Related
- Child 6 of epic PP-2on (harden E2E and AI review workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)