### PR TITLE
feat(worktree): auto-configure branch tracking on post-checkout (PP-ozw)

### DIFF
--- a/scripts/tests/test_worktree_setup.py
+++ b/scripts/tests/test_worktree_setup.py
@@ -3,7 +3,6 @@
 import json
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,9 +16,7 @@ from worktree_setup import (
     PortConfig,
     allocate_slot,
     branch_to_project_id,
-    configure_branch_tracking,
     generate_launch_json,
-    get_current_upstream,
     load_manifest,
     merge_env_local,
     parse_env_file,
@@ -27,6 +24,18 @@ from worktree_setup import (
     resolve_brainstorm_server_path,
     save_manifest,
 )
+
+# Testing philosophy for worktree setup
+# ────────────────────────────────────────────────────────────────────────────
+# Worktree setup is infrastructure code: it runs once per worktree, fails
+# benignly (config not generated → fixable manually), and any error surfaces
+# immediately on the next branch switch. We primarily test by running it.
+#
+# Keep unit tests minimal. Focus on logic that's hard to verify by usage —
+# parsing env files, port allocation, ID derivation, JSON manifest correctness.
+# Don't add unit tests for git/subprocess interactions; those tests test mocks
+# more than real behavior, and the integration path (run the post-checkout
+# hook in a real worktree) is faster and more accurate.
 
 
 class TestParseEnvFile:
@@ -529,187 +538,6 @@ class TestBranchToProjectId:
     def test_trailing_special_chars_stripped(self) -> None:
         result = branch_to_project_id("my-feature///")
         assert not result.endswith("-")
-
-
-class TestConfigureBranchTracking:
-    """Unit tests for configure_branch_tracking() and get_current_upstream()."""
-
-    # ---------------------------------------------------------------------------
-    # Helpers
-    # ---------------------------------------------------------------------------
-
-    def _make_completed(
-        self,
-        returncode: int = 0,
-        stdout: str = "",
-        stderr: str = "",
-    ) -> MagicMock:
-        """Build a fake CompletedProcess-like object."""
-        m = MagicMock()
-        m.returncode = returncode
-        m.stdout = stdout
-        m.stderr = stderr
-        return m
-
-    # ---------------------------------------------------------------------------
-    # get_current_upstream
-    # ---------------------------------------------------------------------------
-
-    def test_get_current_upstream_returns_ref_on_success(self, tmp_path: Path) -> None:
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            mock_run.return_value = self._make_completed(
-                returncode=0, stdout="origin/main\n"
-            )
-            result = get_current_upstream("my-branch", tmp_path)
-        assert result == "origin/main"
-
-    def test_get_current_upstream_returns_none_on_failure(self, tmp_path: Path) -> None:
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            mock_run.return_value = self._make_completed(returncode=128, stdout="")
-            result = get_current_upstream("my-branch", tmp_path)
-        assert result is None
-
-    def test_get_current_upstream_returns_none_for_empty_output(
-        self, tmp_path: Path
-    ) -> None:
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            mock_run.return_value = self._make_completed(returncode=0, stdout="")
-            result = get_current_upstream("my-branch", tmp_path)
-        assert result is None
-
-    # ---------------------------------------------------------------------------
-    # configure_branch_tracking: no-op cases
-    # ---------------------------------------------------------------------------
-
-    def test_main_branch_is_skipped(self, tmp_path: Path) -> None:
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            configure_branch_tracking("main", tmp_path)
-        mock_run.assert_not_called()
-
-    def test_master_branch_is_skipped(self, tmp_path: Path) -> None:
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            configure_branch_tracking("master", tmp_path)
-        mock_run.assert_not_called()
-
-    def test_head_is_skipped(self, tmp_path: Path) -> None:
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            configure_branch_tracking("HEAD", tmp_path)
-        mock_run.assert_not_called()
-
-    def test_custom_upstream_is_preserved(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Branch with a non-origin/main, non-origin/<branch> upstream is left alone."""
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            # get_current_upstream returns a custom upstream
-            mock_run.return_value = self._make_completed(
-                returncode=0, stdout="upstream/feat/x\n"
-            )
-            configure_branch_tracking("feat/my-feature", tmp_path)
-        # Only one git call: the @{u} lookup — no set-upstream
-        assert mock_run.call_count == 1
-
-    def test_already_correct_upstream_is_silent(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Branch already tracking origin/<branch>: no further git calls."""
-        with patch("worktree_setup.subprocess.run") as mock_run:
-            # get_current_upstream returns correct upstream
-            mock_run.return_value = self._make_completed(
-                returncode=0, stdout="origin/feat/my-feature\n"
-            )
-            configure_branch_tracking("feat/my-feature", tmp_path)
-        # Only one git call: the @{u} lookup, then remote_check, then early return
-        # (remote exists but upstream is already correct → no set-upstream call)
-        set_upstream_calls = [
-            c for c in mock_run.call_args_list if "--set-upstream-to" in str(c)
-        ]
-        assert len(set_upstream_calls) == 0
-
-    # ---------------------------------------------------------------------------
-    # configure_branch_tracking: upstream repair cases
-    # ---------------------------------------------------------------------------
-
-    def test_no_remote_prints_reminder(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Branch with no origin remote → prints push reminder, no set-upstream."""
-
-        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
-            if "@{u}" in " ".join(args):
-                # get_current_upstream → unset
-                return self._make_completed(returncode=128)
-            # rev-parse --verify → remote does not exist
-            return self._make_completed(returncode=128)
-
-        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
-            configure_branch_tracking("feat/no-remote", tmp_path)
-
-        _, err = capsys.readouterr()
-        assert "git push -u origin feat/no-remote" in err
-        assert "--set-upstream-to" not in err
-
-    def test_stale_origin_main_upstream_is_replaced(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Branch whose upstream is still origin/main gets updated to origin/<branch>."""
-
-        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
-            cmd = " ".join(args)
-            if "@{u}" in cmd:
-                # get_current_upstream → stale
-                return self._make_completed(returncode=0, stdout="origin/main\n")
-            if "refs/remotes/origin" in cmd:
-                # remote exists
-                return self._make_completed(returncode=0, stdout="abc123\n")
-            # set-upstream
-            return self._make_completed(returncode=0)
-
-        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
-            configure_branch_tracking("feat/my-feature", tmp_path)
-
-        _, err = capsys.readouterr()
-        assert "tracks origin/feat/my-feature" in err
-
-    def test_no_upstream_set_is_repaired(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Branch with no upstream configured gets set to origin/<branch>."""
-
-        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
-            cmd = " ".join(args)
-            if "@{u}" in cmd:
-                return self._make_completed(returncode=128)  # no upstream
-            if "refs/remotes/origin" in cmd:
-                return self._make_completed(returncode=0, stdout="abc123\n")
-            return self._make_completed(returncode=0)
-
-        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
-            configure_branch_tracking("feat/new-branch", tmp_path)
-
-        _, err = capsys.readouterr()
-        assert "tracks origin/feat/new-branch" in err
-
-    def test_subprocess_failure_on_set_upstream_warns(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """A failing git branch --set-upstream-to emits a warning and does not crash."""
-
-        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
-            cmd = " ".join(args)
-            if "@{u}" in cmd:
-                return self._make_completed(returncode=128)  # no upstream
-            if "refs/remotes/origin" in cmd:
-                return self._make_completed(returncode=0, stdout="abc123\n")
-            # set-upstream fails
-            return self._make_completed(returncode=1, stderr="fatal: error")
-
-        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
-            configure_branch_tracking("feat/failing-branch", tmp_path)
-
-        _, err = capsys.readouterr()
-        assert "warning" in err.lower()
-        assert "feat/failing-branch" in err
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_worktree_setup.py
+++ b/scripts/tests/test_worktree_setup.py
@@ -1,8 +1,10 @@
 """Unit tests for worktree_setup.py env merging and port allocation."""
 
 import json
+import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -16,7 +18,9 @@ from worktree_setup import (
     PortConfig,
     allocate_slot,
     branch_to_project_id,
+    configure_branch_tracking,
     generate_launch_json,
+    get_current_upstream,
     load_manifest,
     merge_env_local,
     parse_env_file,
@@ -526,6 +530,193 @@ class TestBranchToProjectId:
     def test_trailing_special_chars_stripped(self) -> None:
         result = branch_to_project_id("my-feature///")
         assert not result.endswith("-")
+
+
+class TestConfigureBranchTracking:
+    """Unit tests for configure_branch_tracking() and get_current_upstream()."""
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _make_completed(
+        self,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> MagicMock:
+        """Build a fake CompletedProcess-like object."""
+        m = MagicMock()
+        m.returncode = returncode
+        m.stdout = stdout
+        m.stderr = stderr
+        return m
+
+    # ---------------------------------------------------------------------------
+    # get_current_upstream
+    # ---------------------------------------------------------------------------
+
+    def test_get_current_upstream_returns_ref_on_success(
+        self, tmp_path: Path
+    ) -> None:
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            mock_run.return_value = self._make_completed(
+                returncode=0, stdout="origin/main\n"
+            )
+            result = get_current_upstream("my-branch", tmp_path)
+        assert result == "origin/main"
+
+    def test_get_current_upstream_returns_none_on_failure(
+        self, tmp_path: Path
+    ) -> None:
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            mock_run.return_value = self._make_completed(returncode=128, stdout="")
+            result = get_current_upstream("my-branch", tmp_path)
+        assert result is None
+
+    def test_get_current_upstream_returns_none_for_empty_output(
+        self, tmp_path: Path
+    ) -> None:
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            mock_run.return_value = self._make_completed(returncode=0, stdout="")
+            result = get_current_upstream("my-branch", tmp_path)
+        assert result is None
+
+    # ---------------------------------------------------------------------------
+    # configure_branch_tracking: no-op cases
+    # ---------------------------------------------------------------------------
+
+    def test_main_branch_is_skipped(self, tmp_path: Path) -> None:
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            configure_branch_tracking("main", tmp_path)
+        mock_run.assert_not_called()
+
+    def test_master_branch_is_skipped(self, tmp_path: Path) -> None:
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            configure_branch_tracking("master", tmp_path)
+        mock_run.assert_not_called()
+
+    def test_head_is_skipped(self, tmp_path: Path) -> None:
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            configure_branch_tracking("HEAD", tmp_path)
+        mock_run.assert_not_called()
+
+    def test_custom_upstream_is_preserved(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Branch with a non-origin/main, non-origin/<branch> upstream is left alone."""
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            # get_current_upstream returns a custom upstream
+            mock_run.return_value = self._make_completed(
+                returncode=0, stdout="upstream/feat/x\n"
+            )
+            configure_branch_tracking("feat/my-feature", tmp_path)
+        # Only one git call: the @{u} lookup — no set-upstream
+        assert mock_run.call_count == 1
+
+    def test_already_correct_upstream_is_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Branch already tracking origin/<branch>: no further git calls."""
+        with patch("worktree_setup.subprocess.run") as mock_run:
+            # get_current_upstream returns correct upstream
+            mock_run.return_value = self._make_completed(
+                returncode=0, stdout="origin/feat/my-feature\n"
+            )
+            configure_branch_tracking("feat/my-feature", tmp_path)
+        # Only one git call: the @{u} lookup, then remote_check, then early return
+        # (remote exists but upstream is already correct → no set-upstream call)
+        set_upstream_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "--set-upstream-to" in str(c)
+        ]
+        assert len(set_upstream_calls) == 0
+
+    # ---------------------------------------------------------------------------
+    # configure_branch_tracking: upstream repair cases
+    # ---------------------------------------------------------------------------
+
+    def test_no_remote_prints_reminder(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Branch with no origin remote → prints push reminder, no set-upstream."""
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            if "@{u}" in " ".join(args):
+                # get_current_upstream → unset
+                return self._make_completed(returncode=128)
+            # rev-parse --verify → remote does not exist
+            return self._make_completed(returncode=128)
+
+        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
+            configure_branch_tracking("feat/no-remote", tmp_path)
+
+        _, err = capsys.readouterr()
+        assert "git push -u origin feat/no-remote" in err
+        assert "--set-upstream-to" not in err
+
+    def test_stale_origin_main_upstream_is_replaced(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Branch whose upstream is still origin/main gets updated to origin/<branch>."""
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            cmd = " ".join(args)
+            if "@{u}" in cmd:
+                # get_current_upstream → stale
+                return self._make_completed(returncode=0, stdout="origin/main\n")
+            if "refs/remotes/origin" in cmd:
+                # remote exists
+                return self._make_completed(returncode=0, stdout="abc123\n")
+            # set-upstream
+            return self._make_completed(returncode=0)
+
+        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
+            configure_branch_tracking("feat/my-feature", tmp_path)
+
+        _, err = capsys.readouterr()
+        assert "tracks origin/feat/my-feature" in err
+
+    def test_no_upstream_set_is_repaired(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Branch with no upstream configured gets set to origin/<branch>."""
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            cmd = " ".join(args)
+            if "@{u}" in cmd:
+                return self._make_completed(returncode=128)  # no upstream
+            if "refs/remotes/origin" in cmd:
+                return self._make_completed(returncode=0, stdout="abc123\n")
+            return self._make_completed(returncode=0)
+
+        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
+            configure_branch_tracking("feat/new-branch", tmp_path)
+
+        _, err = capsys.readouterr()
+        assert "tracks origin/feat/new-branch" in err
+
+    def test_subprocess_failure_on_set_upstream_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A failing git branch --set-upstream-to emits a warning and does not crash."""
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            cmd = " ".join(args)
+            if "@{u}" in cmd:
+                return self._make_completed(returncode=128)  # no upstream
+            if "refs/remotes/origin" in cmd:
+                return self._make_completed(returncode=0, stdout="abc123\n")
+            # set-upstream fails
+            return self._make_completed(returncode=1, stderr="fatal: error")
+
+        with patch("worktree_setup.subprocess.run", side_effect=side_effect):
+            configure_branch_tracking("feat/failing-branch", tmp_path)
+
+        _, err = capsys.readouterr()
+        assert "warning" in err.lower()
+        assert "feat/failing-branch" in err
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_worktree_setup.py
+++ b/scripts/tests/test_worktree_setup.py
@@ -1,10 +1,9 @@
 """Unit tests for worktree_setup.py env merging and port allocation."""
 
 import json
-import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -556,9 +555,7 @@ class TestConfigureBranchTracking:
     # get_current_upstream
     # ---------------------------------------------------------------------------
 
-    def test_get_current_upstream_returns_ref_on_success(
-        self, tmp_path: Path
-    ) -> None:
+    def test_get_current_upstream_returns_ref_on_success(self, tmp_path: Path) -> None:
         with patch("worktree_setup.subprocess.run") as mock_run:
             mock_run.return_value = self._make_completed(
                 returncode=0, stdout="origin/main\n"
@@ -566,9 +563,7 @@ class TestConfigureBranchTracking:
             result = get_current_upstream("my-branch", tmp_path)
         assert result == "origin/main"
 
-    def test_get_current_upstream_returns_none_on_failure(
-        self, tmp_path: Path
-    ) -> None:
+    def test_get_current_upstream_returns_none_on_failure(self, tmp_path: Path) -> None:
         with patch("worktree_setup.subprocess.run") as mock_run:
             mock_run.return_value = self._make_completed(returncode=128, stdout="")
             result = get_current_upstream("my-branch", tmp_path)
@@ -627,9 +622,7 @@ class TestConfigureBranchTracking:
         # Only one git call: the @{u} lookup, then remote_check, then early return
         # (remote exists but upstream is already correct → no set-upstream call)
         set_upstream_calls = [
-            c
-            for c in mock_run.call_args_list
-            if "--set-upstream-to" in str(c)
+            c for c in mock_run.call_args_list if "--set-upstream-to" in str(c)
         ]
         assert len(set_upstream_calls) == 0
 

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -512,11 +512,7 @@ def get_branch() -> str:
 
 
 def get_current_upstream(branch: str, worktree_path: Path) -> str | None:
-    """Return the current upstream ref for *branch* (e.g. 'origin/main'), or None.
-
-    Returns None when the branch has no upstream configured or when the git
-    command fails (treated as "unset").
-    """
+    """Return current upstream ref (e.g. 'origin/main') or None if unset."""
     result = subprocess.run(
         [
             "git",
@@ -536,62 +532,47 @@ def get_current_upstream(branch: str, worktree_path: Path) -> str | None:
 
 
 def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
-    """Set local upstream tracking for the worktree branch.
+    """Set the worktree branch's upstream to origin/<branch> if it exists.
 
-    `git worktree add /path -b new-branch origin/main` creates `new-branch`
-    pointing at origin/main but leaves the upstream as origin/main, so later
-    `git pull`/`git push` operate against main. This function fixes that:
-    if origin/<branch> exists, set the upstream to origin/<branch>; otherwise
-    remind the user to run `git push -u origin <branch>` on first push.
-
-    Only updates the upstream when it is currently unset or still points at
-    origin/main or origin/master (the stale default). If the branch already
-    has a custom upstream (e.g. origin/other-branch or upstream/feat/x) the
-    existing tracking is preserved.
-
-    Never auto-pushes (that would create remote branches for throwaway local
-    experiments). Failures are non-fatal — warn and continue.
+    Preserves custom upstreams; only fixes the stale origin/main default that
+    `git worktree add -b` leaves behind. Prints a reminder if no remote ref
+    yet. Failures are non-fatal.
     """
     if branch in ("main", "master", "HEAD"):
         return
 
-    # Check whether the upstream needs to be repaired before doing anything else.
-    current_upstream = get_current_upstream(branch, worktree_path)
-    if current_upstream is not None and current_upstream not in (
-        "origin/main",
-        "origin/master",
-        f"origin/{branch}",
-    ):
-        # Branch already has a non-default, non-stale upstream — leave it alone.
-        return
+    current = get_current_upstream(branch, worktree_path)
+    if current and current not in ("origin/main", "origin/master", f"origin/{branch}"):
+        return  # respect existing custom upstream
 
-    remote_check = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(worktree_path),
-            "rev-parse",
-            "--verify",
-            "--quiet",
-            f"refs/remotes/origin/{branch}",
-        ],
-        capture_output=True,
-        text=True,
+    has_remote = (
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                f"refs/remotes/origin/{branch}",
+            ],
+            capture_output=True,
+        ).returncode
+        == 0
     )
 
-    if remote_check.returncode != 0:
+    if not has_remote:
         print(
-            f"worktree_setup: branch '{branch}' has no remote yet — "
-            f"run `git push -u origin {branch}` after your first commit",
+            f"worktree_setup: '{branch}' has no remote yet — "
+            f"run `git push -u origin {branch}` on first push",
             file=sys.stderr,
         )
         return
 
-    # Skip if already correctly configured.
-    if current_upstream == f"origin/{branch}":
+    if current == f"origin/{branch}":
         return
 
-    set_upstream = subprocess.run(
+    result = subprocess.run(
         [
             "git",
             "-C",
@@ -603,17 +584,12 @@ def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
         capture_output=True,
         text=True,
     )
-
-    if set_upstream.returncode == 0:
-        print(
-            f"worktree_setup: branch '{branch}' tracks origin/{branch}",
-            file=sys.stderr,
-        )
+    if result.returncode == 0:
+        print(f"worktree_setup: '{branch}' tracks origin/{branch}", file=sys.stderr)
     else:
-        stderr = set_upstream.stderr.strip()
         print(
-            f"worktree_setup: warning: failed to set upstream for "
-            f"'{branch}' (exit {set_upstream.returncode}): {stderr}",
+            f"worktree_setup: warning: failed to set upstream for '{branch}' "
+            f"(exit {result.returncode}): {result.stderr.strip()}",
             file=sys.stderr,
         )
 

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -562,9 +562,15 @@ def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
     )
 
     if not has_remote:
+        # Clear the stale origin/main upstream so `git pull` doesn't pull from main.
+        if current in ("origin/main", "origin/master"):
+            subprocess.run(
+                ["git", "-C", str(worktree_path), "branch", "--unset-upstream", branch],
+                capture_output=True,
+            )
         print(
             f"worktree_setup: '{branch}' has no remote yet — "
-            f"run `git push -u origin {branch}` on first push",
+            f"run `git push -u origin {shlex.quote(branch)}` on first push",
             file=sys.stderr,
         )
         return

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -511,6 +511,30 @@ def get_branch() -> str:
     return result.stdout.strip()
 
 
+def get_current_upstream(branch: str, worktree_path: Path) -> str | None:
+    """Return the current upstream ref for *branch* (e.g. 'origin/main'), or None.
+
+    Returns None when the branch has no upstream configured or when the git
+    command fails (treated as "unset").
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(worktree_path),
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            f"{branch}@{{u}}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
 def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
     """Set local upstream tracking for the worktree branch.
 
@@ -520,10 +544,25 @@ def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
     if origin/<branch> exists, set the upstream to origin/<branch>; otherwise
     remind the user to run `git push -u origin <branch>` on first push.
 
+    Only updates the upstream when it is currently unset or still points at
+    origin/main or origin/master (the stale default). If the branch already
+    has a custom upstream (e.g. origin/other-branch or upstream/feat/x) the
+    existing tracking is preserved.
+
     Never auto-pushes (that would create remote branches for throwaway local
     experiments). Failures are non-fatal — warn and continue.
     """
     if branch in ("main", "master", "HEAD"):
+        return
+
+    # Check whether the upstream needs to be repaired before doing anything else.
+    current_upstream = get_current_upstream(branch, worktree_path)
+    if current_upstream is not None and current_upstream not in (
+        "origin/main",
+        "origin/master",
+        f"origin/{branch}",
+    ):
+        # Branch already has a non-default, non-stale upstream — leave it alone.
         return
 
     remote_check = subprocess.run(
@@ -546,6 +585,10 @@ def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
             f"run `git push -u origin {branch}` after your first commit",
             file=sys.stderr,
         )
+        return
+
+    # Skip if already correctly configured.
+    if current_upstream == f"origin/{branch}":
         return
 
     set_upstream = subprocess.run(

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -511,6 +511,70 @@ def get_branch() -> str:
     return result.stdout.strip()
 
 
+def configure_branch_tracking(branch: str, worktree_path: Path) -> None:
+    """Set local upstream tracking for the worktree branch.
+
+    `git worktree add /path -b new-branch origin/main` creates `new-branch`
+    pointing at origin/main but leaves the upstream as origin/main, so later
+    `git pull`/`git push` operate against main. This function fixes that:
+    if origin/<branch> exists, set the upstream to origin/<branch>; otherwise
+    remind the user to run `git push -u origin <branch>` on first push.
+
+    Never auto-pushes (that would create remote branches for throwaway local
+    experiments). Failures are non-fatal — warn and continue.
+    """
+    if branch in ("main", "master", "HEAD"):
+        return
+
+    remote_check = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(worktree_path),
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            f"refs/remotes/origin/{branch}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if remote_check.returncode != 0:
+        print(
+            f"worktree_setup: branch '{branch}' has no remote yet — "
+            f"run `git push -u origin {branch}` after your first commit",
+            file=sys.stderr,
+        )
+        return
+
+    set_upstream = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(worktree_path),
+            "branch",
+            f"--set-upstream-to=origin/{branch}",
+            branch,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if set_upstream.returncode == 0:
+        print(
+            f"worktree_setup: branch '{branch}' tracks origin/{branch}",
+            file=sys.stderr,
+        )
+    else:
+        stderr = set_upstream.stderr.strip()
+        print(
+            f"worktree_setup: warning: failed to set upstream for "
+            f"'{branch}' (exit {set_upstream.returncode}): {stderr}",
+            file=sys.stderr,
+        )
+
+
 def main() -> None:
     worktree_path = Path.cwd().resolve()
 
@@ -523,6 +587,7 @@ def main() -> None:
         return
 
     branch = get_branch()
+    configure_branch_tracking(branch, worktree_path)
     project_id = branch_to_project_id(branch)
     worktree_key = str(worktree_path)
 


### PR DESCRIPTION
## Summary
- Adds `configure_branch_tracking(branch, worktree_path)` to `scripts/worktree_setup.py`, called from `main()` after `get_branch()`.
- If `origin/<branch>` exists: sets local upstream via `git branch --set-upstream-to=origin/<branch>`.
- Otherwise: prints a stderr reminder to run `git push -u origin <branch>` after first commit.
- Skips `main`/`master`/`HEAD`; never auto-pushes; tolerates transient git failures (warn, don't crash).

## Why
`git worktree add /path -b new-branch origin/main` leaves `new-branch`'s upstream as `origin/main`, so later `git pull`/`git push` operate against main. AGENTS.md documents the manual `git push -u origin <branch>` fix but worktree_setup.py never automated it. This PR closes that gap so new worktrees are immediately ready for normal `git pull`/`git push` against the right remote branch.

## Manual verification
- ✅ New local-only branch → reminder printed.
- ✅ Branch with existing remote → upstream set, confirmation printed.
- ✅ `main` / `HEAD` → silently skipped.
- ✅ `pnpm run check` clean (1013 unit tests).
- ✅ `ruff check` and `ruff format --check` pass.

## Inherited CI failures
`main` is currently red. Inherited failures from main (PP-q9r/PP-e20/PP-jsh/PP-v7g/PP-49m) will appear in CI; not introduced by this PR. See Tim's status comment on PR #1278.

## Test plan
- [x] Unit tests pass
- [x] Function tested manually for all four branch-state scenarios
- [ ] CI Gate green
- [ ] Verify on next worktree creation that the reminder/upstream-set message appears in the post-checkout output

## Related
- Child 5 of epic PP-2on
- PP-uc8 / PP-6dp / PP-cao / PP-278 / PP-00s queued as siblings

🤖 Generated with [Claude Code](https://claude.com/claude-code)