### PR TITLE
feat(e2e): browser+Docker preflight in global-setup (PP-cao)

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,4 +1,7 @@
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
+import { existsSync } from "fs";
+
+import { chromium, firefox, webkit, type FullConfig } from "@playwright/test";
 import postgres from "postgres";
 
 function redactUrl(url: string): string {
@@ -11,17 +14,88 @@ function redactUrl(url: string): string {
   }
 }
 
+type BrowserName = "chromium" | "firefox" | "webkit";
+
+const BROWSER_ENGINES: Record<BrowserName, { executablePath(): string }> = {
+  chromium,
+  firefox,
+  webkit,
+};
+
+/**
+ * Verify Playwright browser binaries are installed for every project the
+ * active config will run. Failing fast here turns a cryptic mid-run
+ * `browserType.launch: Executable doesn't exist` into an actionable error.
+ *
+ * Only checks browsers the active config actually needs — CI installs
+ * chromium only, so blanket-checking firefox/webkit would break CI.
+ */
+function checkBrowserBinaries(config: FullConfig): void {
+  const needed = new Set<BrowserName>();
+  for (const project of config.projects) {
+    const name = (project.use.browserName ?? "chromium") as BrowserName;
+    if (name in BROWSER_ENGINES) needed.add(name);
+  }
+
+  const missing: BrowserName[] = [];
+  for (const browser of needed) {
+    try {
+      if (!existsSync(BROWSER_ENGINES[browser].executablePath())) {
+        missing.push(browser);
+      }
+    } catch {
+      missing.push(browser);
+    }
+  }
+
+  if (missing.length > 0) {
+    const names = missing.join(" ");
+    throw new Error(
+      `Missing Playwright browser binaries: ${names}.\n` +
+        `  Install with: pnpm exec playwright install --with-deps ${names}`
+    );
+  }
+}
+
+/**
+ * Verify the Docker daemon is up. Supabase's local stack runs in Docker, so
+ * a missing daemon would surface as confusing Postgres connection failures.
+ * Uses spawnSync (not exec) — no shell, fixed argv, safe.
+ */
+function checkDocker(): void {
+  const result = spawnSync("docker", ["info"], {
+    stdio: "ignore",
+    timeout: 5000,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      "Docker daemon is not running. Supabase's local stack needs it.\n" +
+        "  Start OrbStack: open -a OrbStack\n" +
+        "  Then wait a few seconds and re-run."
+    );
+  }
+}
+
 /**
  * Playwright Global Setup
  *
  * Single orchestrator for test environment readiness.
  * Runs once before all tests. Flow:
- *   1. Pre-flight: verify Supabase and Postgres are reachable
+ *   1. Pre-flight: verify browsers, Docker, Supabase, and Postgres
  *   2. Run migrations (idempotent — handles fresh checkout & post-merge)
  *   3. Fast-reset database (truncate + seed)
  *   4. Full reset fallback if fast-reset fails
  */
-export default async function globalSetup(): Promise<void> {
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  // Browser + Docker checks run regardless of SKIP_SUPABASE_RESET. SKIP only
+  // skips the DB reset/migration/seed; browsers and the docker daemon still
+  // need to be there for tests to launch.
+  console.log("🔍 Checking Playwright browser binaries...");
+  checkBrowserBinaries(config);
+
+  console.log("🔍 Checking Docker daemon...");
+  checkDocker();
+
   if (process.env.SKIP_SUPABASE_RESET === "true") {
     console.log("⏭️  SKIP_SUPABASE_RESET=true, skipping database setup.");
     return;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -67,6 +67,13 @@ function checkDocker(): void {
     stdio: "ignore",
     timeout: 5000,
   });
+  if (result.error?.code === "ENOENT") {
+    throw new Error(
+      "Docker is not installed.\n" +
+        "  Install with: brew install --cask orbstack\n" +
+        "  Or: brew install docker"
+    );
+  }
   if (result.error || result.status !== 0) {
     throw new Error(
       "Docker daemon is not running. Supabase's local stack needs it.\n" +

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -70,14 +70,14 @@ function checkDocker(): void {
   if (result.error?.code === "ENOENT") {
     throw new Error(
       "Docker is not installed.\n" +
-        "  Install with: brew install --cask orbstack\n" +
-        "  Or: brew install docker"
+        "  Install OrbStack, Docker Desktop, or Docker Engine (whichever your platform supports).\n" +
+        "  Mac: brew install --cask orbstack"
     );
   }
   if (result.error || result.status !== 0) {
     throw new Error(
       "Docker daemon is not running. Supabase's local stack needs it.\n" +
-        "  Start OrbStack: open -a OrbStack\n" +
+        "  Start your Docker daemon (e.g., OrbStack, Docker Desktop, Colima, or `systemctl start docker`).\n" +
         "  Then wait a few seconds and re-run."
     );
   }

--- a/src/test/unit/global-setup.test.ts
+++ b/src/test/unit/global-setup.test.ts
@@ -5,16 +5,31 @@ const execSyncMock = vi.fn();
 // spawnSync is used by the Docker preflight check. Default to success.
 const spawnSyncMock = vi.fn(() => ({ status: 0, error: null }));
 
+// existsSync is used by the browser-binary preflight check. Default to true
+// (binary present) so non-browser tests are unaffected.
+const existsSyncMock = vi.fn(() => true);
+
 vi.mock("child_process", () => ({
   execSync: execSyncMock,
   spawnSync: spawnSyncMock,
   default: { execSync: execSyncMock, spawnSync: spawnSyncMock },
 }));
 
+vi.mock("fs", () => ({
+  existsSync: existsSyncMock,
+  default: { existsSync: existsSyncMock },
+}));
+
 // The browser-binaries preflight only inspects projects in the config we
 // pass in. An empty `projects` array therefore disables browser checks for
 // these unit tests, keeping coverage focused on the DB orchestration flow.
 const EMPTY_CONFIG = { projects: [] } as unknown as FullConfig;
+
+// A minimal config with one chromium project, used to exercise the
+// browser-binary preflight with a real (mocked) path check.
+const CHROMIUM_CONFIG = {
+  projects: [{ use: { browserName: "chromium" } }],
+} as unknown as FullConfig;
 
 // Mock postgres client for the pre-flight DB connectivity check
 const endMock = vi.fn();
@@ -44,6 +59,7 @@ describe("e2e/global-setup", () => {
     vi.resetModules();
     execSyncMock.mockReset();
     spawnSyncMock.mockReset().mockReturnValue({ status: 0, error: null });
+    existsSyncMock.mockReset().mockReturnValue(true);
     fetchMock.mockReset().mockResolvedValue({ ok: true });
     sqlTagMock.mockReset().mockResolvedValue([{ "?column?": 1 }]);
     endMock.mockReset();
@@ -59,6 +75,13 @@ describe("e2e/global-setup", () => {
     const setup = await loadSetup();
 
     await setup(EMPTY_CONFIG);
+
+    // Pre-flight: Docker check via spawnSync
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "docker",
+      ["info"],
+      expect.any(Object)
+    );
 
     // Pre-flight: Supabase health check
     expect(fetchMock).toHaveBeenCalledWith(
@@ -145,5 +168,49 @@ describe("e2e/global-setup", () => {
     await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
       "POSTGRES_URL is not set"
     );
+  });
+
+  it("throws daemon-down error when Docker exits with non-zero status", async () => {
+    spawnSyncMock.mockReturnValue({ status: 1, error: null });
+    const setup = await loadSetup();
+
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "Docker daemon is not running"
+    );
+  });
+
+  it("throws not-installed error when Docker returns ENOENT", async () => {
+    const enoent = Object.assign(new Error("spawn docker ENOENT"), {
+      code: "ENOENT",
+    });
+    spawnSyncMock.mockReturnValue({ status: null, error: enoent });
+    const setup = await loadSetup();
+
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "Docker is not installed"
+    );
+  });
+
+  it("throws install hint when a required browser binary is missing", async () => {
+    // existsSync returns false → binary absent → should suggest install
+    existsSyncMock.mockReturnValue(false);
+    const setup = await loadSetup();
+
+    await expect(setup(CHROMIUM_CONFIG)).rejects.toThrow(
+      "pnpm exec playwright install"
+    );
+  });
+
+  it("checks Docker before Supabase health (ordering)", async () => {
+    // Fail Docker so we never reach Supabase; if fetch were called first the
+    // test order would be inverted.
+    spawnSyncMock.mockReturnValue({ status: 1, error: null });
+    const setup = await loadSetup();
+
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "Docker daemon is not running"
+    );
+    // Supabase health check must NOT have been attempted
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/test/unit/global-setup.test.ts
+++ b/src/test/unit/global-setup.test.ts
@@ -1,11 +1,20 @@
+import type { FullConfig } from "@playwright/test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execSyncMock = vi.fn();
+// spawnSync is used by the Docker preflight check. Default to success.
+const spawnSyncMock = vi.fn(() => ({ status: 0, error: null }));
 
 vi.mock("child_process", () => ({
   execSync: execSyncMock,
-  default: { execSync: execSyncMock },
+  spawnSync: spawnSyncMock,
+  default: { execSync: execSyncMock, spawnSync: spawnSyncMock },
 }));
+
+// The browser-binaries preflight only inspects projects in the config we
+// pass in. An empty `projects` array therefore disables browser checks for
+// these unit tests, keeping coverage focused on the DB orchestration flow.
+const EMPTY_CONFIG = { projects: [] } as unknown as FullConfig;
 
 // Mock postgres client for the pre-flight DB connectivity check
 const endMock = vi.fn();
@@ -34,6 +43,7 @@ describe("e2e/global-setup", () => {
   beforeEach(() => {
     vi.resetModules();
     execSyncMock.mockReset();
+    spawnSyncMock.mockReset().mockReturnValue({ status: 0, error: null });
     fetchMock.mockReset().mockResolvedValue({ ok: true });
     sqlTagMock.mockReset().mockResolvedValue([{ "?column?": 1 }]);
     endMock.mockReset();
@@ -48,7 +58,7 @@ describe("e2e/global-setup", () => {
     execSyncMock.mockReturnValue(undefined);
     const setup = await loadSetup();
 
-    await setup();
+    await setup(EMPTY_CONFIG);
 
     // Pre-flight: Supabase health check
     expect(fetchMock).toHaveBeenCalledWith(
@@ -83,7 +93,7 @@ describe("e2e/global-setup", () => {
 
     const setup = await loadSetup();
 
-    await setup();
+    await setup(EMPTY_CONFIG);
 
     expect(execSyncMock).toHaveBeenCalledWith("supabase db reset --yes", {
       stdio: "inherit",
@@ -103,7 +113,7 @@ describe("e2e/global-setup", () => {
     process.env.SKIP_SUPABASE_RESET = "true";
     const setup = await loadSetup();
 
-    await setup();
+    await setup(EMPTY_CONFIG);
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(execSyncMock).not.toHaveBeenCalled();
@@ -113,14 +123,18 @@ describe("e2e/global-setup", () => {
     fetchMock.mockRejectedValue(new Error("fetch failed"));
     const setup = await loadSetup();
 
-    await expect(setup()).rejects.toThrow("Supabase is not reachable");
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "Supabase is not reachable"
+    );
   });
 
   it("throws clear error when Postgres is not reachable", async () => {
     sqlTagMock.mockRejectedValue(new Error("connection refused"));
     const setup = await loadSetup();
 
-    await expect(setup()).rejects.toThrow("Cannot connect to Postgres");
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "Cannot connect to Postgres"
+    );
   });
 
   it("throws clear error when POSTGRES_URL is not set", async () => {
@@ -128,6 +142,8 @@ describe("e2e/global-setup", () => {
     delete process.env.POSTGRES_URL_NON_POOLING;
     const setup = await loadSetup();
 
-    await expect(setup()).rejects.toThrow("POSTGRES_URL is not set");
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "POSTGRES_URL is not set"
+    );
   });
 });


### PR DESCRIPTION
## Summary
Adds two fail-fast checks to `e2e/global-setup.ts` before the existing Supabase/Postgres pre-flight:

1. **`checkBrowserBinaries(config)`** — inspects `config.projects` to derive needed browsers (chromium/firefox/webkit), verifies each binary exists via `existsSync(executablePath())`. On miss, throws with `Install with: pnpm exec playwright install --with-deps <names>`. **Only checks browsers the active config actually needs**, so CI's chromium-only install isn't penalized.
2. **`checkDocker()`** — runs `docker info` via `spawnSync` (no shell, fixed argv) with a 5s timeout. On failure: `Start OrbStack: open -a OrbStack`.

Both checks run regardless of `SKIP_SUPABASE_RESET` — that flag only skips DB reset/migration/seed; browsers and the Docker daemon are still required to launch Playwright.

Replaces cryptic mid-run failures like `browserType.launch: Executable doesn't exist` with clear actionable messages before any spec runs.

Also updates the global-setup unit test to pass a mock `FullConfig` (empty projects array disables the browser check for tests focused on DB orchestration) and mocks `spawnSync` for the Docker check.

## Inherited CI failures
`main` is currently red. Inherited failures from main (PP-q9r/PP-e20/PP-jsh/PP-v7g/PP-49m) will appear in CI; not introduced by this PR. See Tim's status comment on PR #1278.

## Test plan
- [x] `pnpm run check` passes (1013 unit tests, including updated global-setup tests)
- [ ] CI Gate green
- [ ] Manual: rename `~/Library/Caches/ms-playwright/chromium-*` and confirm fail-fast with install hint
- [ ] Manual: stop Docker and confirm fail-fast with OrbStack hint

## Related
- Child 3 of epic PP-2on
- Sibling PRs: #1281 (docs), #1282 (worktree tracking), #1283 (Turnstile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)