### PR TITLE
feat(e2e): isolated all-E2E runner script (PP-6dp)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "e2e:full": "playwright test --config=playwright.config.full.ts --quiet",
     "e2e:full:headed": "playwright test --config=playwright.config.full.ts --headed",
     "e2e:mobile": "playwright test --project='Mobile Chrome'",
+    "e2e:all": "bash scripts/workflow/e2e-all-isolated.sh",
     "db:reset": "npm-run-all db:_restart db:_drop_tables db:migrate test:_generate-schema db:_seed db:_seed-users db:_seed-discord",
     "db:studio": "drizzle-kit studio",
     "db:_restart": "supabase stop && supabase start",

--- a/scripts/workflow/e2e-all-isolated.sh
+++ b/scripts/workflow/e2e-all-isolated.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# scripts/workflow/e2e-all-isolated.sh
+# Run full + smoke + root E2E suites in separate Playwright invocations.
+#
+# Each invocation re-runs e2e/global-setup.ts (which fast-resets the DB),
+# so seeded state from one suite cannot contaminate the next. Replaces the
+# dangerous `pnpm exec playwright test` (no --config=) which picks up every
+# spec under e2e/ in a single process and shares DB state across them.
+#
+# Usage:
+#   bash scripts/workflow/e2e-all-isolated.sh
+#   pnpm run e2e:all
+#
+# On failure, exits with the failing suite's non-zero code and prints
+# which suite failed. Stops at the first failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+run_suite() {
+    local label="$1"
+    shift
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════════"
+    echo "▶ [$label] $*"
+    echo "═══════════════════════════════════════════════════════════════════"
+    "$@"
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo ""
+        echo "❌ [$label] suite failed (exit $rc)"
+        return $rc
+    fi
+}
+
+run_suite "full" pnpm exec playwright test --config=playwright.config.full.ts || exit $?
+run_suite "smoke" pnpm exec playwright test --config=playwright.config.smoke.ts || exit $?
+run_suite "root" pnpm exec playwright test --config=playwright.config.ts e2e/machines-filtering.spec.ts || exit $?
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════════"
+echo "✅ All E2E suites passed (full + smoke + root)"
+echo "═══════════════════════════════════════════════════════════════════"

--- a/scripts/workflow/e2e-all-isolated.sh
+++ b/scripts/workflow/e2e-all-isolated.sh
@@ -14,7 +14,7 @@
 # On failure, exits with the failing suite's non-zero code and prints
 # which suite failed. Stops at the first failure.
 
-set -uo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"


### PR DESCRIPTION
## Summary
Adds `scripts/workflow/e2e-all-isolated.sh` and `pnpm run e2e:all` that runs full + smoke + root specs as **separate Playwright invocations**, each re-running `e2e/global-setup.ts` so DB seed state can't carry over between suites.

Replaces the dangerous `pnpm exec playwright test` (no `--config=`) which picks up every spec under `e2e/` in a single Playwright process and shares mutated DB state across them.

### Sequence
1. `pnpm exec playwright test --config=playwright.config.full.ts`
2. `pnpm exec playwright test --config=playwright.config.smoke.ts`
3. `pnpm exec playwright test --config=playwright.config.ts e2e/machines-filtering.spec.ts` (root specs)

Stops at the first failure with `❌ [<suite>] suite failed (exit N)` so you know which suite broke.

### Permissions
Script committed with mode 644 — invoked via `bash scripts/workflow/e2e-all-isolated.sh` from `package.json` so the executable bit isn't required. If you want to call it directly via `./scripts/workflow/e2e-all-isolated.sh`, run `chmod +x scripts/workflow/e2e-all-isolated.sh && git update-index --chmod=+x scripts/workflow/e2e-all-isolated.sh` and push.

## Inherited CI failures
`main` is currently red. Inherited failures from main (PP-q9r/PP-e20/PP-jsh/PP-v7g/PP-49m) will appear in CI; not introduced by this PR. See Tim's status comment on PR #1278.

**Note:** with those failures still on main, `e2e:all` will exit at suite 1 (`full`) until those land. That's the pre-existing red signal, not a regression of this PR. The orchestration logic itself is verified by the script structure (each suite is its own subprocess invocation of `playwright test`).

## Test plan
- [x] `pnpm run check` passes (1013 unit tests)
- [x] `shellcheck` clean
- [x] `bash -n` syntax check passes
- [ ] Once main is green: `pnpm run e2e:all` exits 0 end-to-end
- [ ] Manual contamination test: mutate state in a `full` spec, confirm `smoke` still passes (proves isolation)

## Related
- Child 2 of epic PP-2on
- Child 4 (PP-278) will document this command in AGENTS.md after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)