### PR TITLE
docs(agents): document e2e:all and warn against raw playwright test (PP-278)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,9 @@ conflicts across worktrees and force-push requirements on open PRs.
 3. **Changed UI components/forms?** → `pnpm run smoke` (~60s)
 4. **Changed auth/permissions/middleware?** → `pnpm run smoke` + targeted full specs
 5. **Changed DB schema/migrations?** → `pnpm run preflight` (full suite)
-6. **NEVER** run `e2e:full` locally unless explicitly asked — that's what CI is for
+6. **NEVER** run `e2e:full` directly during iteration — that's what CI is for
+7. **Doing a final pre-review pass and want everything locally?** → `pnpm run e2e:all` (~10-15 min, runs `full` + `smoke` + root specs in **separate** Playwright invocations with a fresh `global-setup` between them so DB seed state cannot cross-contaminate)
+8. **NEVER** run `pnpm exec playwright test` without `--config=` — that picks up every spec under `e2e/` in a single Playwright process and cross-contaminates seeded state. Use `pnpm run e2e:all` if you actually want everything.
 
 **Key rules for agents:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ conflicts across worktrees and force-push requirements on open PRs.
 5. **Changed DB schema/migrations?** → `pnpm run preflight` (full suite)
 6. **NEVER** run `e2e:full` directly during iteration — that's what CI is for
 7. **Doing a final pre-review pass and want everything locally?** → `pnpm run e2e:all` (~10-15 min, runs `full` + `smoke` + root specs in **separate** Playwright invocations with a fresh `global-setup` between them so DB seed state cannot cross-contaminate)
-8. **NEVER** run `pnpm exec playwright test` without `--config=` — that picks up every spec under `e2e/` in a single Playwright process and cross-contaminates seeded state. Use `pnpm run e2e:all` if you actually want everything.
+8. **NEVER** invoke `pnpm exec playwright test` with no arguments (no spec path, no `--config=`) — the bare command picks up every spec under `e2e/` in a single Playwright process and cross-contaminates seeded state. Targeted invocations like `pnpm exec playwright test e2e/path/to/file.spec.ts --project=chromium` (item 2) are fine. Use `pnpm run e2e:all` if you actually want everything.
 
 **Key rules for agents:**
 


### PR DESCRIPTION
## Summary
Updates AGENTS.md section 4 "Which Tests to Run":

- Reframes item 6 from "NEVER run `e2e:full`" to "NEVER run `e2e:full` directly **during iteration**" — the new `e2e:all` wraps it as part of a legitimate pre-review pass.
- Adds item 7 documenting `pnpm run e2e:all` (introduced in PP-6dp / #1285) for the "want everything locally before review" case, with explicit ~10–15 min runtime and a note that each suite runs in its own Playwright invocation with a fresh `global-setup` between them.
- Adds item 8 warning against `pnpm exec playwright test` without `--config=` — picks up all specs at once and cross-contaminates state. Points to `e2e:all` as the safe alternative.

No code changes.

## Dependency
Depends on **PR #1285 (PP-6dp)** landing first so the referenced `pnpm run e2e:all` script exists. If this lands first, the docs would describe a non-existent command.

## Inherited CI failures
`main` is currently red. Inherited failures from main (PP-q9r/PP-e20/PP-jsh/PP-v7g/PP-49m) will appear in CI; not introduced by this PR. See Tim's status comment on PR #1278.

## Test plan
- [x] `pnpm run check` passes (1013 unit tests)
- [x] No stale `screenshot` references remaining in AGENTS.md / CLAUDE.md / `.agent/skills/` (PR #1278 already cleaned up; verified one remaining match is for Playwright debug screenshots, not the deleted suite)
- [ ] CI Gate green
- [ ] PR #1285 (Child 2) lands before this so the docs are accurate

## Related
- Child 4 of epic PP-2on
- Sibling PRs: #1281, #1282, #1283, #1284, #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)