### PR TITLE
chore(e2e): silence 5 broken specs to restore CI signal (PP-5ra)

### DIFF
--- a/e2e/full/email-and-notifications.spec.ts
+++ b/e2e/full/email-and-notifications.spec.ts
@@ -717,6 +717,10 @@ test.describe("Password Reset Email", () => {
   test("password reset flow - user journey only", async ({
     page,
   }, testInfo) => {
+    test.fixme(
+      true,
+      "PP-q9r — pkce verify URL doesn't redirect to /reset-password; needs iter 3 (test flow assumption is wrong, not regex)"
+    );
     test.setTimeout(40000);
     const testEmail = `reset-e2e-extended-${Date.now()}@example.com`;
     const oldPassword = "OldPassword123!";

--- a/e2e/full/issues-crud-extended.spec.ts
+++ b/e2e/full/issues-crud-extended.spec.ts
@@ -41,6 +41,10 @@ test.describe("Issues System - Extended", () => {
 
   test.describe("Watch Issue Opt-in", () => {
     test("should auto-watch issue by default", async ({ page }) => {
+      test.fixme(
+        true,
+        "PP-49m — strict-mode violation: 2 Unwatch buttons (desktop + mobile dual placement); fix folded into PR #1270"
+      );
       const machineInitials = seededMachines.addamsFamily.initials;
       await page.goto(`/report?machine=${machineInitials}`);
 
@@ -63,6 +67,10 @@ test.describe("Issues System - Extended", () => {
     test("should not auto-watch when checkbox is unchecked", async ({
       page,
     }) => {
+      test.fixme(
+        true,
+        "PP-49m — strict-mode violation: 2 Unwatch buttons (desktop + mobile dual placement); fix folded into PR #1270"
+      );
       const machineInitials = seededMachines.addamsFamily.initials;
       await page.goto(`/report?machine=${machineInitials}`);
 

--- a/e2e/full/machine-details-extended.spec.ts
+++ b/e2e/full/machine-details-extended.spec.ts
@@ -27,6 +27,10 @@ test.describe("Machine Details - Extended", () => {
   test("should show description placeholder for owner", async ({
     page,
   }, testInfo) => {
+    test.fixme(
+      true,
+      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
+    );
     // Login as admin (owner of Medieval Madness)
     await logout(page, testInfo);
     await loginAs(page, testInfo, {
@@ -117,6 +121,10 @@ test.describe("Machine Details - Extended", () => {
   test("should show owner notes to machine owner", async ({
     page,
   }, testInfo) => {
+    test.fixme(
+      true,
+      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
+    );
     // Login as admin (owns Medieval Madness)
     await logout(page, testInfo);
     await loginAs(page, testInfo, {
@@ -143,6 +151,10 @@ test.describe("Machine Details - Extended", () => {
   test("should hide owner requirements from unauthenticated users", async ({
     page,
   }, testInfo) => {
+    test.fixme(
+      true,
+      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
+    );
     // Logout to become unauthenticated
     await logout(page, testInfo);
 
@@ -158,6 +170,10 @@ test.describe("Machine Details - Extended", () => {
   test("should display owner requirements callout on issue page", async ({
     page,
   }, testInfo) => {
+    test.fixme(
+      true,
+      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
+    );
     // First, let's login as admin and set owner requirements on a machine
     await logout(page, testInfo);
     await loginAs(page, testInfo, {

--- a/e2e/full/oauth-connected-accounts.spec.ts
+++ b/e2e/full/oauth-connected-accounts.spec.ts
@@ -29,6 +29,10 @@ test.describe("OAuth + Connected Accounts", () => {
     test("Continue with Discord button on /login redirects to discord.com", async ({
       page,
     }) => {
+      test.fixme(
+        true,
+        "PP-e20 — Discord OAuth not configured in test env; awaiting mock-only fix (no test should reach real Discord)"
+      );
       await page.goto("/login");
       const button = page.getByRole("button", {
         name: /continue with discord/i,
@@ -63,6 +67,10 @@ test.describe("OAuth + Connected Accounts", () => {
     test("Connect Discord from /settings redirects through Discord", async ({
       page,
     }) => {
+      test.fixme(
+        true,
+        "PP-e20 — Discord OAuth not configured in test env; awaiting mock-only fix (no test should reach real Discord)"
+      );
       await page.goto("/settings");
 
       const connectBtn = page.getByRole("button", {

--- a/e2e/full/status-overhaul.spec.ts
+++ b/e2e/full/status-overhaul.spec.ts
@@ -19,6 +19,10 @@ test.describe("Status Overhaul E2E", () => {
   });
 
   test("should create issue and verify all 4 badges", async ({ page }) => {
+    test.fixme(
+      true,
+      "PP-v7g — Radix Select portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
+    );
     const machine = seededMachines.addamsFamily;
 
     // 1. Create Issue


### PR DESCRIPTION
## Why
Main CI has been red for several days due to 5 known-broken E2E specs. Every in-flight PR inherits these failures and looks broken even when its own diff is clean — making CI signal untrustworthy and slowing down all parallel work.

This PR silences the 5 specs via `test.fixme(true, "REASON")` so:
- Main goes green immediately (~10 min after merge)
- PR CI signal becomes trustworthy again
- The 5 broken specs are explicitly counted and tracked, not implicitly subtracted in everyone's head

## Why `test.fixme()` and not `test.skip()` or `test.fail()`?

**`test.fixme()`** marks the test as broken and skips execution. Each call carries a string reason that lives in source code right next to the test, so the bug is visible to anyone reading the spec.

**`test.skip()`** would also skip but loses the "this is broken, fix me" semantic. `fixme()` is more honest about intent.

**`test.fail()`** would run the test and pass CI when it fails, fail CI when it passes — but **two of our five (PP-jsh, PP-v7g) are flaky, not deterministically broken**. They sometimes pass and sometimes time out under CI load. `test.fail()` would fire false-positive failures on the runs where they happened to pass. The other three (PP-q9r, PP-e20, PP-49m) are deterministically broken right now but the cause might shift, so we'd rather not couple to "must always fail."

`test.fixme()` is the right tool for "we know these are broken/flaky, track them explicitly, restore them by removing the fixme as part of the bug-fix PR."

## Trade-off accepted
With `test.fixme()`, if someone accidentally fixes a bug elsewhere that resolves one of these specs, CI won't notice — the test stays skipped. Mitigation: the binding rule below + the grep audit (`rg 'test\.fixme\(true, "PP-' e2e/`) make the count explicit and visible. Each fixme is removed by the PR that fixes its bead, at which point the test runs again on real CI.

## Silenced specs (10 fixme calls across 5 files)
| Spec | Bead | Reason |
|------|------|--------|
| `email-and-notifications.spec.ts` (password reset flow) | [PP-q9r] | pkce verify URL doesn't redirect to /reset-password; needs iter 3 |
| `oauth-connected-accounts.spec.ts:29,63` | [PP-e20] | Discord OAuth not configured in test env; mock-only fix groomed |
| `machine-details-extended.spec.ts` (4 tests using `logout()`) | [PP-jsh] | Radix DropdownMenu portal mount timing; awaiting PP-awg verification |
| `status-overhaul.spec.ts:21` | [PP-v7g] | Radix Select portal mount timing; awaiting PP-awg verification |
| `issues-crud-extended.spec.ts:43,60` | [PP-49m] | Unwatch strict-mode violation; fix folded into #1270 |

## 🚨 BINDING RULE
**Feature PRs do not merge while any `test.fixme(true, "PP-...")` exists in the codebase.**

Each fixme is removed by the PR that fixes its bead. The current count is the explicit CI debt — track it down to zero before resuming feature work.

To audit:
```bash
rg 'test\.fixme\(true, "PP-' e2e/
```

## Test plan
- [x] `pnpm run check` passes locally
- [x] Each fixme lives inside the correct test body
- [ ] CI Gate passes on this PR (the 5 fixmes mean E2E Full Tests skips them rather than fails)
- [ ] Main goes green within 1 run after this lands

## Tracking
- Meta: PP-5ra
- Per-spec: PP-q9r, PP-e20, PP-jsh, PP-v7g, PP-49m