### PR TITLE
test(e2e): verify PP-awg absorption (PP-jsh + PP-v7g)

### DIFF
--- a/e2e/full/machine-details-extended.spec.ts
+++ b/e2e/full/machine-details-extended.spec.ts
@@ -27,10 +27,6 @@ test.describe("Machine Details - Extended", () => {
   test("should show description placeholder for owner", async ({
     page,
   }, testInfo) => {
-    test.fixme(
-      true,
-      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
-    );
     // Login as admin (owner of Medieval Madness)
     await logout(page, testInfo);
     await loginAs(page, testInfo, {
@@ -121,10 +117,6 @@ test.describe("Machine Details - Extended", () => {
   test("should show owner notes to machine owner", async ({
     page,
   }, testInfo) => {
-    test.fixme(
-      true,
-      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
-    );
     // Login as admin (owns Medieval Madness)
     await logout(page, testInfo);
     await loginAs(page, testInfo, {
@@ -151,10 +143,6 @@ test.describe("Machine Details - Extended", () => {
   test("should hide owner requirements from unauthenticated users", async ({
     page,
   }, testInfo) => {
-    test.fixme(
-      true,
-      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
-    );
     // Logout to become unauthenticated
     await logout(page, testInfo);
 
@@ -170,10 +158,6 @@ test.describe("Machine Details - Extended", () => {
   test("should display owner requirements callout on issue page", async ({
     page,
   }, testInfo) => {
-    test.fixme(
-      true,
-      "PP-jsh — Radix DropdownMenu portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
-    );
     // First, let's login as admin and set owner requirements on a machine
     await logout(page, testInfo);
     await loginAs(page, testInfo, {

--- a/e2e/full/status-overhaul.spec.ts
+++ b/e2e/full/status-overhaul.spec.ts
@@ -19,10 +19,6 @@ test.describe("Status Overhaul E2E", () => {
   });
 
   test("should create issue and verify all 4 badges", async ({ page }) => {
-    test.fixme(
-      true,
-      "PP-v7g — Radix Select portal mount timing under CI load; awaiting verification of PP-awg/#1280 absorption"
-    );
     const machine = seededMachines.addamsFamily;
 
     // 1. Create Issue


### PR DESCRIPTION
## Why
PR #1290 silenced 5 broken specs via `test.fixme`. PR #1280 (PP-awg) bumped Playwright's `actionTimeout` from 5s to 30s in CI, hypothesizing it would absorb the Radix portal mount timing variance behind PP-jsh and PP-v7g.

This PR unsilences those 5 tests so CI runs them. The result tells us whether to retire the beads (PP-awg absorbed) or open Layer 2 (per-spec helpers).

## Decision rule
- **All 5 pass**: PP-awg absorbed the variance; merge this PR; close PP-jsh and PP-v7g.
- **Any flake**: revert; file Layer 2 work; the beads stay open.

## Tests unsilenced
- machine-details-extended.spec.ts: 4 tests calling `logout()` (DropdownMenu portal) → PP-jsh
- status-overhaul.spec.ts: 1 test using Status Select → PP-v7g

## Tracking
- PP-awg (already merged): the actionTimeout bump
- PP-jsh, PP-v7g: this PR's verification subjects

## Test plan
- [ ] CI passes E2E Full Tests on first run
- [ ] CI passes E2E Full Tests on a second run (rule out lucky one-shot)
- [ ] If passing: mark ready-for-review and merge