### PR TITLE
feat(workflow): label-gated Supabase branch + scheduled cleanup (PP-pi1)

### DIFF
--- a/.github/workflows/supabase-branch-cleanup.yaml
+++ b/.github/workflows/supabase-branch-cleanup.yaml
@@ -1,0 +1,40 @@
+# Supabase Branch Cleanup
+#
+# Deletes Supabase preview branch DBs for PRs that no longer have the
+# 'preview' label (or whose PR is closed). Runs every 6 hours and can be
+# triggered manually.
+#
+# Required GitHub Secrets (same as supabase-branch-setup.yaml):
+#   SUPABASE_ACCESS_TOKEN - from supabase.com/dashboard/account/tokens (90-day expiry)
+#   SUPABASE_PROJECT_ID   - production project ref (udhesuizjsgxfeotqybn)
+
+name: Supabase Branch Cleanup
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # every 6 hours
+  workflow_dispatch:        # manual trigger
+
+permissions:
+  pull-requests: read
+
+jobs:
+  prune:
+    name: Prune Unlabeled Branches
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}  # zizmor: ignore[secrets-outside-env]
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}  # zizmor: ignore[secrets-outside-env]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # ratchet:actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51  # ratchet:supabase/setup-cli@v1.6.0
+        with:
+          version: latest
+
+      - name: Prune unlabeled branches
+        run: bash scripts/workflow/prune-supabase-branches.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/supabase-branch-setup.yaml
+++ b/.github/workflows/supabase-branch-setup.yaml
@@ -14,7 +14,7 @@ name: Supabase Branch Setup
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     branches: [main]
 
 permissions: read-all  # zizmor: ignore[excessive-permissions]
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   wait-for-branch:
     name: Wait for Supabase Preview
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: ubuntu-latest
     outputs:
       status: ${{ steps.check.outputs.conclusion }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,11 +193,15 @@ conflicts across worktrees and force-push requirements on open PRs.
   - `pinpoint-prod` (Live, Pro plan) - **Real user data. STRICT SAFETY.** Daily backups with 7-day retention.
   - Preview branches are auto-created per PR via Supabase GitHub integration.
 - **Preview Deployments (Supabase Branching)**:
-  - Every PR gets an isolated Supabase branch database (auto-created, auto-deleted on PR close).
-  - The `Supabase Branch Setup` GHA workflow runs Drizzle migrations + seeding on each branch.
-  - Vercel preview deployments connect to branch DBs via the Supabase Vercel integration.
+  - **Default**: PRs do NOT get a usable Supabase branch DB (saves ~$0.32/day per branch).
+  - **To enable**: Add the `preview` label to the PR. Within ~5 min, the `Supabase Branch Setup`
+    GHA workflow runs Drizzle migrations + seed; the Vercel preview becomes functional.
+  - **Cleanup**: The `Supabase Branch Cleanup` cron (every 6h, also manually triggerable) deletes
+    branch DBs for PRs that no longer have `preview` or whose PR is closed.
+  - The Supabase Vercel Marketplace integration still auto-creates the branch DB on PR open, but
+    no migrations/seed run unless `preview` is labeled — making it non-functional by default.
   - Env var fallbacks in `server.ts`/`middleware.ts` handle both PinPoint and integration naming conventions.
-  - Cost: ~$0.32/day per open PR (Micro instance at $0.01344/hr).
+  - Cost model: ~$4.50/day (14 open PRs, all branches) → ~$1/day (3 labeled PRs) typical.
 - **Database Safety**:
   - Local: `db:reset` allowed.
   - Prod: **NEVER** `db:reset`. ONLY `db:migrate`.

--- a/scripts/workflow/prune-supabase-branches.sh
+++ b/scripts/workflow/prune-supabase-branches.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prune Supabase branch DBs for PRs without the 'preview' label.
+# Run by .github/workflows/supabase-branch-cleanup.yaml on cron + manual.
+#
+# Strategy:
+# 1. Get list of open PRs that have the 'preview' label (these stay)
+# 2. List all Supabase preview branches
+# 3. For each branch, find which open PR it corresponds to (via git_branch field)
+# 4. If the PR is NOT in the keep list (or PR is closed/missing), delete the branch
+#
+# Authentication: reads SUPABASE_ACCESS_TOKEN and SUPABASE_PROJECT_ID from env.
+# GH_TOKEN must also be set for `gh` CLI calls.
+
+REPO="${GITHUB_REPOSITORY:-timothyfroehlich/PinPoint}"
+
+# Collect open PR numbers that have the 'preview' label (newline-separated)
+PREVIEW_PRS=$(gh pr list \
+  --repo "$REPO" \
+  --state open \
+  --label preview \
+  --json number \
+  --jq '.[].number' 2>/dev/null || true)
+
+echo "Open PRs with 'preview' label: $(echo "$PREVIEW_PRS" | tr '\n' ' ' | xargs)"
+
+# List all preview branches as JSON. Requires SUPABASE_ACCESS_TOKEN and
+# SUPABASE_PROJECT_ID to be set in the environment.
+ALL_BRANCHES_JSON=$(supabase branches list \
+  --project-ref "$SUPABASE_PROJECT_ID" \
+  --output json 2>&1) || {
+  echo "ERROR: failed to list Supabase branches:" >&2
+  echo "$ALL_BRANCHES_JSON" >&2
+  exit 1
+}
+
+BRANCH_COUNT=$(echo "$ALL_BRANCHES_JSON" | jq 'length')
+echo "Total Supabase preview branches found: $BRANCH_COUNT"
+
+if [[ "$BRANCH_COUNT" -eq 0 ]]; then
+  echo "No preview branches to prune."
+  exit 0
+fi
+
+echo "$ALL_BRANCHES_JSON" | jq -c '.[]' | while IFS= read -r branch; do
+  name=$(echo "$branch" | jq -r '.name')
+  git_branch=$(echo "$branch" | jq -r '.git_branch // empty')
+
+  # Skip production / main branches (they have no git_branch or are named accordingly)
+  if [[ -z "$git_branch" || "$name" == "production" || "$name" == "main" || "$git_branch" == "main" ]]; then
+    echo "SKIP (production/main): $name"
+    continue
+  fi
+
+  # Look up whether an open PR exists for this git branch
+  pr_number=$(gh pr list \
+    --repo "$REPO" \
+    --state open \
+    --head "$git_branch" \
+    --json number \
+    --jq '.[0].number // empty' 2>/dev/null || true)
+
+  if [[ -z "$pr_number" ]]; then
+    # No open PR for this branch — it's closed or was deleted
+    echo "DELETE (PR closed/missing): $name (git branch: $git_branch)"
+    supabase branches delete "$name" \
+      --project-ref "$SUPABASE_PROJECT_ID" \
+      --yes || echo "  WARNING: delete failed for $name (may already be gone)"
+    continue
+  fi
+
+  # Check if this PR number is in the preview keep-list
+  if echo "$PREVIEW_PRS" | grep -qx "$pr_number"; then
+    echo "KEEP: $name (PR #$pr_number has 'preview' label)"
+  else
+    echo "DELETE: $name (PR #$pr_number does not have 'preview' label)"
+    supabase branches delete "$name" \
+      --project-ref "$SUPABASE_PROJECT_ID" \
+      --yes || echo "  WARNING: delete failed for $name"
+  fi
+done
+
+echo "Prune complete."


### PR DESCRIPTION
## Summary

- **Cost savings**: Supabase preview branch DBs are now opt-in via the `preview` label (~$4.50/day → ~$1/day for typical 14-PR workflow)
- Default: PRs open without a functional Supabase branch DB (Supabase Vercel integration still auto-creates the branch, but no migrations/seed run)
- Add `preview` label → `Supabase Branch Setup` runs migrations + seed within ~5 min; Vercel preview becomes functional
- New cron workflow (`Supabase Branch Cleanup`) runs every 6h and deletes branch DBs for PRs without `preview` or with closed PRs

## Files changed

- `.github/workflows/supabase-branch-setup.yaml` — added `labeled`/`unlabeled` triggers; top-level `if: contains(..., 'preview')` gate on `wait-for-branch` job
- `.github/workflows/supabase-branch-cleanup.yaml` — new cron + manual workflow; reuses existing `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROJECT_ID` secrets
- `scripts/workflow/prune-supabase-branches.sh` — deletion logic: lists all Supabase branches via CLI, maps each to a PR via `gh pr list --head`, deletes if PR is closed or missing `preview` label
- `AGENTS.md` — updated Deployment Infrastructure section to document new opt-in flow

## Caveats

1. **Supabase integration still auto-creates the branch DB on PR open** — the marketplace integration runs outside GHA and cannot be gated. The branch DB exists but is empty/not-migrated until the label is applied. The cleanup cron will delete it within 6h if the label is never added.
2. **No `--confirm` flag** — `supabase branches delete` uses `--yes` (global flag per `--help` output). Verified correct.
3. **chmod not needed** — prune script is invoked via `bash scripts/workflow/prune-supabase-branches.sh`, no executable bit required.

## Test plan

- [ ] Open a test PR → confirm `Supabase Branch Setup` is skipped (no `preview` label)
- [ ] Add `preview` label → confirm `Supabase Branch Setup` runs and migrations succeed
- [ ] Remove `preview` label → trigger `Supabase Branch Cleanup` manually (Actions → Supabase Branch Cleanup → Run workflow) → confirm branch is deleted
- [ ] Re-add `preview` label → confirm setup runs again (concurrency cancels any in-flight run)
- [ ] Close a labeled PR → trigger cleanup → confirm branch is deleted

Tracking: PP-pi1