### PR TITLE
fix(perms): add checkPermission to notifications + watcher actions (PP-907)

### DIFF
--- a/src/app/(app)/issues/watcher-actions.ts
+++ b/src/app/(app)/issues/watcher-actions.ts
@@ -6,8 +6,9 @@ import { serverActionError } from "~/lib/observability/report-error";
 import { type Result, ok, err } from "~/lib/result";
 import { toggleIssueWatcher } from "~/services/issues";
 import { db } from "~/server/db";
-import { issues } from "~/server/db/schema";
+import { issues, userProfiles } from "~/server/db/schema";
 import { eq } from "drizzle-orm";
+import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 
 export type ToggleWatcherResult = Result<
   { isWatching: boolean },
@@ -24,6 +25,15 @@ export async function toggleWatcherAction(
 
   if (!user) {
     return err("UNAUTHORIZED", "Unauthorized");
+  }
+
+  const userProfile = await db.query.userProfiles.findFirst({
+    where: eq(userProfiles.id, user.id),
+    columns: { role: true },
+  });
+
+  if (!checkPermission("issues.watch", getAccessLevel(userProfile?.role))) {
+    return err("UNAUTHORIZED", "You do not have permission to watch issues");
   }
 
   try {

--- a/src/app/(app)/issues/watcher-actions.ts
+++ b/src/app/(app)/issues/watcher-actions.ts
@@ -27,16 +27,16 @@ export async function toggleWatcherAction(
     return err("UNAUTHORIZED", "Unauthorized");
   }
 
-  const userProfile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-
-  if (!checkPermission("issues.watch", getAccessLevel(userProfile?.role))) {
-    return err("UNAUTHORIZED", "You do not have permission to watch issues");
-  }
-
   try {
+    const userProfile = await db.query.userProfiles.findFirst({
+      where: eq(userProfiles.id, user.id),
+      columns: { role: true },
+    });
+
+    if (!checkPermission("issues.watch", getAccessLevel(userProfile?.role))) {
+      return err("UNAUTHORIZED", "You do not have permission to watch issues");
+    }
+
     const result = await toggleIssueWatcher({ issueId, userId: user.id });
 
     const issue = await db.query.issues.findFirst({

--- a/src/app/(app)/notifications/actions.ts
+++ b/src/app/(app)/notifications/actions.ts
@@ -26,24 +26,24 @@ export async function markAsReadAction(
     return err("UNAUTHORIZED", "Unauthorized");
   }
 
-  const userProfile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-
-  if (
-    !checkPermission(
-      "notifications.manage_own",
-      getAccessLevel(userProfile?.role)
-    )
-  ) {
-    return err(
-      "UNAUTHORIZED",
-      "You do not have permission to manage notifications"
-    );
-  }
-
   try {
+    const userProfile = await db.query.userProfiles.findFirst({
+      where: eq(userProfiles.id, user.id),
+      columns: { role: true },
+    });
+
+    if (
+      !checkPermission(
+        "notifications.manage_own",
+        getAccessLevel(userProfile?.role)
+      )
+    ) {
+      return err(
+        "UNAUTHORIZED",
+        "You do not have permission to manage notifications"
+      );
+    }
+
     await db
       .delete(notifications)
       .where(
@@ -78,24 +78,24 @@ export async function markAllAsReadAction(): Promise<MarkAsReadResult> {
     return err("UNAUTHORIZED", "Unauthorized");
   }
 
-  const userProfile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-
-  if (
-    !checkPermission(
-      "notifications.manage_own",
-      getAccessLevel(userProfile?.role)
-    )
-  ) {
-    return err(
-      "UNAUTHORIZED",
-      "You do not have permission to manage notifications"
-    );
-  }
-
   try {
+    const userProfile = await db.query.userProfiles.findFirst({
+      where: eq(userProfiles.id, user.id),
+      columns: { role: true },
+    });
+
+    if (
+      !checkPermission(
+        "notifications.manage_own",
+        getAccessLevel(userProfile?.role)
+      )
+    ) {
+      return err(
+        "UNAUTHORIZED",
+        "You do not have permission to manage notifications"
+      );
+    }
+
     await db
       .delete(notifications)
       .where(and(eq(notifications.userId, user.id)));

--- a/src/app/(app)/notifications/actions.ts
+++ b/src/app/(app)/notifications/actions.ts
@@ -3,10 +3,11 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
-import { notifications } from "~/server/db/schema";
+import { notifications, userProfiles } from "~/server/db/schema";
 import { eq, and } from "drizzle-orm";
 import { type Result, ok, err } from "~/lib/result";
 import { serverActionError } from "~/lib/observability/report-error";
+import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 
 export type MarkAsReadResult = Result<
   { success: boolean },
@@ -23,6 +24,23 @@ export async function markAsReadAction(
 
   if (!user) {
     return err("UNAUTHORIZED", "Unauthorized");
+  }
+
+  const userProfile = await db.query.userProfiles.findFirst({
+    where: eq(userProfiles.id, user.id),
+    columns: { role: true },
+  });
+
+  if (
+    !checkPermission(
+      "notifications.manage_own",
+      getAccessLevel(userProfile?.role)
+    )
+  ) {
+    return err(
+      "UNAUTHORIZED",
+      "You do not have permission to manage notifications"
+    );
   }
 
   try {
@@ -58,6 +76,23 @@ export async function markAllAsReadAction(): Promise<MarkAsReadResult> {
 
   if (!user) {
     return err("UNAUTHORIZED", "Unauthorized");
+  }
+
+  const userProfile = await db.query.userProfiles.findFirst({
+    where: eq(userProfiles.id, user.id),
+    columns: { role: true },
+  });
+
+  if (
+    !checkPermission(
+      "notifications.manage_own",
+      getAccessLevel(userProfile?.role)
+    )
+  ) {
+    return err(
+      "UNAUTHORIZED",
+      "You do not have permission to manage notifications"
+    );
   }
 
   try {

--- a/src/lib/permissions/matrix.ts
+++ b/src/lib/permissions/matrix.ts
@@ -384,6 +384,24 @@ export const PERMISSIONS_MATRIX: PermissionCategory[] = [
     ],
   },
   {
+    id: "notifications",
+    label: "Notifications",
+    permissions: [
+      {
+        id: "notifications.manage_own",
+        label: "Manage own notifications",
+        description: "Mark notifications as read or dismiss them",
+        access: {
+          unauthenticated: false,
+          guest: true,
+          member: true,
+          technician: true,
+          admin: true,
+        },
+      },
+    ],
+  },
+  {
     id: "admin",
     label: "Administration",
     permissions: [


### PR DESCRIPTION
## Summary

- Added `notifications.manage_own` permission to the matrix (new `notifications` category) — grants `guest+`, denies unauthenticated. This makes the "manage own notifications" capability auditable via the help page.
- Wired `checkPermission("notifications.manage_own", ...)` into `markAsReadAction` and `markAllAsReadAction` in `src/app/(app)/notifications/actions.ts`.
- Wired `checkPermission("issues.watch", ...)` into `toggleWatcherAction` in `src/app/(app)/issues/watcher-actions.ts` using the **pre-existing** `issues.watch` matrix entry (no new entry needed — it already encoded the policy as guest+).

**Watch-issues policy decision**: `issues.watch` was already in the matrix granting `guest+`. This bead confirms that policy: any authenticated user (guest and above) can watch issues; unauthenticated users cannot. The permission check now enforces this at the action boundary rather than relying solely on `if (\!user)`.

Fixes NON-NEGOTIABLE #14 (all permission checks must use `checkPermission()` from the matrix system).

## Test plan

- [ ] `pnpm run check` passes (unit tests + types + lint + format)
- [ ] Help page at `/help/permissions` renders the new "Notifications" category row with `notifications.manage_own`
- [ ] `markAsReadAction` / `markAllAsReadAction` reject unauthenticated calls with `UNAUTHORIZED`
- [ ] `toggleWatcherAction` rejects unauthenticated calls with `UNAUTHORIZED`
- [ ] Authenticated guest/member/technician/admin can mark notifications and watch issues as before

Closes PP-907

🤖 Generated with [Claude Code](https://claude.com/claude-code)