### PR TITLE
chore(supabase): config polish + lock down handle_new_user (PP-8hz)

### DIFF
--- a/drizzle/0035_lock_handle_new_user.sql
+++ b/drizzle/0035_lock_handle_new_user.sql
@@ -1,0 +1,12 @@
+-- Defense-in-depth: revoke EXECUTE on public.handle_new_user() from
+-- anon and authenticated roles. Migration 0007 created the trigger function
+-- as SECURITY DEFINER with search_path = public (correct), but did not
+-- explicitly restrict callers. This mirrors the pattern established in
+-- migration 0029 for get_discord_config().
+--
+-- handle_new_user() is only ever invoked by the on_auth_user_created trigger
+-- (AFTER INSERT ON auth.users), which runs as the definer regardless. Direct
+-- RPC calls from anon/authenticated serve no legitimate purpose.
+
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM anon, authenticated;

--- a/drizzle/meta/0035_snapshot.json
+++ b/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,1516 @@
+{
+  "id": "bac32b91-2b2c-4f6d-ba6a-d2b3619a509f",
+  "prevId": "0fc7d8d9-6780-46b4-8756-284311d2fb5d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_integration_config": {
+      "name": "discord_integration_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_link": {
+          "name": "invite_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_vault_id": {
+          "name": "bot_token_vault_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_health_status": {
+          "name": "bot_health_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_bot_check_at": {
+          "name": "last_bot_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "discord_integration_config_singleton": {
+          "name": "discord_integration_config_singleton",
+          "value": "id = 'singleton'"
+        },
+        "discord_integration_config_health_check": {
+          "name": "discord_integration_config_health_check",
+          "value": "bot_health_status IN ('unknown', 'healthy', 'degraded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invited_users": {
+      "name": "invited_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "type": "stored",
+            "as": "first_name || ' ' || last_name"
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invite_sent_at": {
+          "name": "invite_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invited_users_email_unique": {
+          "name": "invited_users_email_unique",
+          "columns": ["email"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invited_users_role_check": {
+          "name": "invited_users_role_check",
+          "value": "role IN ('guest', 'member', 'technician', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_comments": {
+      "name": "issue_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_comments_issue_id_created_at": {
+          "name": "idx_issue_comments_issue_id_created_at",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issue_comments_author_id": {
+          "name": "idx_issue_comments_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_comments_issue_id_issues_id_fk": {
+          "name": "issue_comments_issue_id_issues_id_fk",
+          "tableFrom": "issue_comments",
+          "columnsFrom": ["issue_id"],
+          "tableTo": "issues",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_comments_author_id_user_profiles_id_fk": {
+          "name": "issue_comments_author_id_user_profiles_id_fk",
+          "tableFrom": "issue_comments",
+          "columnsFrom": ["author_id"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_system_event_data": {
+          "name": "chk_system_event_data",
+          "value": "NOT \"issue_comments\".\"is_system\" OR \"issue_comments\".\"event_data\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_images": {
+      "name": "issue_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_image_url": {
+          "name": "full_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cropped_image_url": {
+          "name": "cropped_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_blob_pathname": {
+          "name": "full_blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cropped_blob_pathname": {
+          "name": "cropped_blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_images_issue_id": {
+          "name": "idx_issue_images_issue_id",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issue_images_uploaded_by": {
+          "name": "idx_issue_images_uploaded_by",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issue_images_deleted_at": {
+          "name": "idx_issue_images_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_images_issue_id_issues_id_fk": {
+          "name": "issue_images_issue_id_issues_id_fk",
+          "tableFrom": "issue_images",
+          "columnsFrom": ["issue_id"],
+          "tableTo": "issues",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_images_comment_id_issue_comments_id_fk": {
+          "name": "issue_images_comment_id_issue_comments_id_fk",
+          "tableFrom": "issue_images",
+          "columnsFrom": ["comment_id"],
+          "tableTo": "issue_comments",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_images_uploaded_by_user_profiles_id_fk": {
+          "name": "issue_images_uploaded_by_user_profiles_id_fk",
+          "tableFrom": "issue_images",
+          "columnsFrom": ["uploaded_by"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "issue_images_deleted_by_user_profiles_id_fk": {
+          "name": "issue_images_deleted_by_user_profiles_id_fk",
+          "tableFrom": "issue_images",
+          "columnsFrom": ["deleted_by"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_watchers": {
+      "name": "issue_watchers",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_issue_watchers_user_id": {
+          "name": "idx_issue_watchers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_watchers_issue_id_issues_id_fk": {
+          "name": "issue_watchers_issue_id_issues_id_fk",
+          "tableFrom": "issue_watchers",
+          "columnsFrom": ["issue_id"],
+          "tableTo": "issues",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_watchers_user_id_user_profiles_id_fk": {
+          "name": "issue_watchers_user_id_user_profiles_id_fk",
+          "tableFrom": "issue_watchers",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_watchers_issue_id_user_id_pk": {
+          "name": "issue_watchers_issue_id_user_id_pk",
+          "columns": ["issue_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_initials": {
+          "name": "machine_initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'minor'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'intermittent'"
+        },
+        "reported_by": {
+          "name": "reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_reported_by": {
+          "name": "invited_reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_name": {
+          "name": "reporter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_email": {
+          "name": "reporter_email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issues_assigned_to": {
+          "name": "idx_issues_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issues_reported_by": {
+          "name": "idx_issues_reported_by",
+          "columns": [
+            {
+              "expression": "reported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issues_status": {
+          "name": "idx_issues_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issues_created_at": {
+          "name": "idx_issues_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issues_invited_reported_by": {
+          "name": "idx_issues_invited_reported_by",
+          "columns": [
+            {
+              "expression": "invited_reported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issues_severity": {
+          "name": "idx_issues_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_issues_priority": {
+          "name": "idx_issues_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issues_machine_initials_machines_initials_fk": {
+          "name": "issues_machine_initials_machines_initials_fk",
+          "tableFrom": "issues",
+          "columnsFrom": ["machine_initials"],
+          "tableTo": "machines",
+          "columnsTo": ["initials"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issues_reported_by_user_profiles_id_fk": {
+          "name": "issues_reported_by_user_profiles_id_fk",
+          "tableFrom": "issues",
+          "columnsFrom": ["reported_by"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "issues_invited_reported_by_invited_users_id_fk": {
+          "name": "issues_invited_reported_by_invited_users_id_fk",
+          "tableFrom": "issues",
+          "columnsFrom": ["invited_reported_by"],
+          "tableTo": "invited_users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "issues_assigned_to_user_profiles_id_fk": {
+          "name": "issues_assigned_to_user_profiles_id_fk",
+          "tableFrom": "issues",
+          "columnsFrom": ["assigned_to"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_issue_number": {
+          "name": "unique_issue_number",
+          "columns": ["machine_initials", "issue_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reporter_check": {
+          "name": "reporter_check",
+          "value": "(\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NOT NULL AND \"issues\".\"invited_reported_by\" IS NULL AND \"issues\".\"reporter_name\" IS NULL AND \"issues\".\"reporter_email\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NOT NULL AND \"issues\".\"reporter_name\" IS NULL AND \"issues\".\"reporter_email\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NULL AND (\"issues\".\"reporter_name\" IS NOT NULL OR \"issues\".\"reporter_email\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.machine_watchers": {
+      "name": "machine_watchers",
+      "schema": "",
+      "columns": {
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_mode": {
+          "name": "watch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_machine_watchers_user_id": {
+          "name": "idx_machine_watchers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "machine_watchers_machine_id_machines_id_fk": {
+          "name": "machine_watchers_machine_id_machines_id_fk",
+          "tableFrom": "machine_watchers",
+          "columnsFrom": ["machine_id"],
+          "tableTo": "machines",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "machine_watchers_user_id_user_profiles_id_fk": {
+          "name": "machine_watchers_user_id_user_profiles_id_fk",
+          "tableFrom": "machine_watchers",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "machine_watchers_machine_id_user_id_pk": {
+          "name": "machine_watchers_machine_id_user_id_pk",
+          "columns": ["machine_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_issue_number": {
+          "name": "next_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_owner_id": {
+          "name": "invited_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournament_notes": {
+          "name": "tournament_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_requirements": {
+          "name": "owner_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_notes": {
+          "name": "owner_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_status": {
+          "name": "presence_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_the_floor'"
+        }
+      },
+      "indexes": {
+        "idx_machines_owner_id": {
+          "name": "idx_machines_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_machines_invited_owner_id": {
+          "name": "idx_machines_invited_owner_id",
+          "columns": [
+            {
+              "expression": "invited_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_machines_name": {
+          "name": "idx_machines_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "machines_owner_id_user_profiles_id_fk": {
+          "name": "machines_owner_id_user_profiles_id_fk",
+          "tableFrom": "machines",
+          "columnsFrom": ["owner_id"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "machines_invited_owner_id_invited_users_id_fk": {
+          "name": "machines_invited_owner_id_invited_users_id_fk",
+          "tableFrom": "machines",
+          "columnsFrom": ["invited_owner_id"],
+          "tableTo": "invited_users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machines_initials_unique": {
+          "name": "machines_initials_unique",
+          "columns": ["initials"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "initials_check": {
+          "name": "initials_check",
+          "value": "initials ~ '^[A-Z0-9]{2,6}$'"
+        },
+        "owner_check": {
+          "name": "owner_check",
+          "value": "(owner_id IS NULL OR invited_owner_id IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "suppress_own_actions": {
+          "name": "suppress_own_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_assigned": {
+          "name": "email_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_assigned": {
+          "name": "in_app_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notify_on_status_change": {
+          "name": "email_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_notify_on_status_change": {
+          "name": "in_app_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_new_comment": {
+          "name": "email_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_notify_on_new_comment": {
+          "name": "in_app_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_mentioned": {
+          "name": "email_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_mentioned": {
+          "name": "in_app_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notify_on_new_issue": {
+          "name": "email_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_new_issue": {
+          "name": "in_app_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_watch_new_issues_global": {
+          "name": "email_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_watch_new_issues_global": {
+          "name": "in_app_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_enabled": {
+          "name": "discord_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_assigned": {
+          "name": "discord_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_status_change": {
+          "name": "discord_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_notify_on_new_comment": {
+          "name": "discord_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_notify_on_mentioned": {
+          "name": "discord_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_new_issue": {
+          "name": "discord_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_watch_new_issues_global": {
+          "name": "discord_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_dm_blocked_at": {
+          "name": "discord_dm_blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notif_prefs_global_watch_email": {
+          "name": "idx_notif_prefs_global_watch_email",
+          "columns": [
+            {
+              "expression": "email_watch_new_issues_global",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_preferences_user_id_user_profiles_id_fk": {
+          "name": "notification_preferences_user_id_user_profiles_id_fk",
+          "tableFrom": "notification_preferences",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_profiles_id_fk": {
+          "name": "notifications_user_id_user_profiles_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user_profiles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "type": "stored",
+            "as": "first_name || ' ' || last_name"
+          }
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_email_unique": {
+          "name": "user_profiles_email_unique",
+          "columns": ["email"],
+          "nullsNotDistinct": false
+        },
+        "user_profiles_discord_user_id_unique": {
+          "name": "user_profiles_discord_user_id_unique",
+          "columns": ["discord_user_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_profiles_role_check": {
+          "name": "user_profiles_role_check",
+          "value": "role IN ('guest', 'member', 'technician', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1777693414861,
       "tag": "0034_enable_rls_public_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1778293378773,
+      "tag": "0035_lock_handle_new_user",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -15,13 +15,13 @@ import { createClient } from "@supabase/supabase-js";
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Supabase createClient has complex generic return type
 export function createAdminClient() {
   const url =
-    process.env["NEXT_PUBLIC_SUPABASE_URL"] ?? process.env["SUPABASE_URL"];
+    process.env["SUPABASE_URL"] ?? process.env["NEXT_PUBLIC_SUPABASE_URL"];
 
   const serviceRoleKey = process.env["SUPABASE_SERVICE_ROLE_KEY"];
 
   if (!url || !serviceRoleKey) {
     throw new Error(
-      "Missing Supabase admin env vars: set NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL) and SUPABASE_SERVICE_ROLE_KEY."
+      "Missing Supabase admin env vars: set SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) and SUPABASE_SERVICE_ROLE_KEY."
     );
   }
 

--- a/src/lib/supabase/env.ts
+++ b/src/lib/supabase/env.ts
@@ -9,16 +9,16 @@ export function getSupabaseEnv(): SupabaseEnv {
     process.env["NEXT_PUBLIC_SUPABASE_URL"] ?? process.env["SUPABASE_URL"];
 
   // Supabase docs often refer to "publishable" keys, while some integrations still use
-  // "anon" naming. Support both.
+  // "anon" naming. Support both NEXT_PUBLIC_ variants. Non-NEXT_PUBLIC_ variants are
+  // excluded: this helper is used in client bundles and non-prefixed env vars would
+  // never reach the browser.
   const publishableKey =
     process.env["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"] ??
-    process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] ??
-    process.env["SUPABASE_PUBLISHABLE_KEY"] ??
-    process.env["SUPABASE_ANON_KEY"];
+    process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
 
   if (!url || !publishableKey) {
     throw new Error(
-      "Missing Supabase env vars: set NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL) and one of NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_PUBLISHABLE_KEY, or SUPABASE_ANON_KEY."
+      "Missing Supabase env vars: set NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL) and one of NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY."
     );
   }
 

--- a/src/lib/supabase/env.ts
+++ b/src/lib/supabase/env.ts
@@ -9,9 +9,9 @@ export function getSupabaseEnv(): SupabaseEnv {
     process.env["NEXT_PUBLIC_SUPABASE_URL"] ?? process.env["SUPABASE_URL"];
 
   // Supabase docs often refer to "publishable" keys, while some integrations still use
-  // "anon" naming. Support both NEXT_PUBLIC_ variants. Non-NEXT_PUBLIC_ variants are
-  // excluded: this helper is used in client bundles and non-prefixed env vars would
-  // never reach the browser.
+  // "anon" naming. Support both NEXT_PUBLIC_ variants. These are safe-to-expose values;
+  // non-NEXT_PUBLIC_ server-side variants are excluded because they would never be set
+  // in environments where the NEXT_PUBLIC_ names are already available.
   const publishableKey =
     process.env["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"] ??
     process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];

--- a/src/server/db/utils/rls.ts
+++ b/src/server/db/utils/rls.ts
@@ -1,10 +1,13 @@
 /**
  * RLS Context Utilities
  *
- * Provides session context binding for Row Level Security enforcement.
+ * Provides session context binding used by integration tests to simulate
+ * RLS-enforced database contexts.
  *
- * SECURITY: Always use withUserContext for mutations that involve
- * user-scoped data. This ensures RLS policies have proper context.
+ * NOTE: App code does NOT enforce RLS via Drizzle. The Drizzle connection
+ * user has BYPASSRLS, so RLS policies are never evaluated for application
+ * queries. Authorization is handled by checkPermission() in server actions
+ * per NON-NEGOTIABLE #14.
  *
  * Pattern based on September 2024 implementation (commit c52e7732).
  */
@@ -25,7 +28,9 @@ export interface UserContext {
  * - request.user_id: Current user's UUID
  * - request.user_role: Current user's role (admin|member|guest)
  *
- * IMPORTANT: Always wrap mutations in this helper to ensure RLS enforcement.
+ * Used by integration tests to simulate RLS-enforced contexts. App code does NOT enforce
+ * RLS via Drizzle (the connection user has BYPASSRLS); authorization is handled by
+ * checkPermission() in server actions per NON-NEGOTIABLE #14.
  *
  * @example
  * ```typescript

--- a/src/server/db/utils/rls.ts
+++ b/src/server/db/utils/rls.ts
@@ -7,7 +7,7 @@
  * NOTE: App code does NOT enforce RLS via Drizzle. The Drizzle connection
  * user has BYPASSRLS, so RLS policies are never evaluated for application
  * queries. Authorization is handled by checkPermission() in server actions
- * per NON-NEGOTIABLE #14.
+ * (see ~/lib/permissions/helpers).
  *
  * Pattern based on September 2024 implementation (commit c52e7732).
  */
@@ -26,11 +26,11 @@ export interface UserContext {
  *
  * Sets PostgreSQL session variables that RLS policies can check:
  * - request.user_id: Current user's UUID
- * - request.user_role: Current user's role (admin|member|guest)
+ * - request.user_role: Current user's role (see UserRole in ~/lib/types)
  *
  * Used by integration tests to simulate RLS-enforced contexts. App code does NOT enforce
  * RLS via Drizzle (the connection user has BYPASSRLS); authorization is handled by
- * checkPermission() in server actions per NON-NEGOTIABLE #14.
+ * checkPermission() in server actions (see ~/lib/permissions/helpers).
  *
  * @example
  * ```typescript

--- a/src/test/unit/supabase-env.test.ts
+++ b/src/test/unit/supabase-env.test.ts
@@ -11,8 +11,6 @@ describe("getSupabaseEnv", () => {
     delete process.env.SUPABASE_URL;
     delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
     delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-    delete process.env.SUPABASE_PUBLISHABLE_KEY;
-    delete process.env.SUPABASE_ANON_KEY;
   });
 
   it("prefers NEXT_PUBLIC_SUPABASE_URL over SUPABASE_URL", () => {
@@ -23,12 +21,10 @@ describe("getSupabaseEnv", () => {
     expect(getSupabaseEnv().url).toBe("https://public.example");
   });
 
-  it("prefers publishable/anon keys in documented precedence order", () => {
+  it("prefers NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY over NEXT_PUBLIC_SUPABASE_ANON_KEY", () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = "https://public.example";
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_1";
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon_2";
-    process.env.SUPABASE_PUBLISHABLE_KEY = "sb_publishable_3";
-    process.env.SUPABASE_ANON_KEY = "anon_4";
 
     expect(getSupabaseEnv().publishableKey).toBe("sb_publishable_1");
   });
@@ -38,13 +34,6 @@ describe("getSupabaseEnv", () => {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon_2";
 
     expect(getSupabaseEnv().publishableKey).toBe("anon_2");
-  });
-
-  it("falls back to SUPABASE_PUBLISHABLE_KEY when NEXT_PUBLIC keys are not set", () => {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://public.example";
-    process.env.SUPABASE_PUBLISHABLE_KEY = "sb_publishable_3";
-
-    expect(getSupabaseEnv().publishableKey).toBe("sb_publishable_3");
   });
 
   it("throws when missing URL", () => {


### PR DESCRIPTION
## Summary

- **admin.ts**: Reversed URL fallback order to prefer `SUPABASE_URL` over `NEXT_PUBLIC_SUPABASE_URL` — the admin client is `server-only` and the server-side var should take precedence
- **env.ts**: Removed the two dead non-`NEXT_PUBLIC_` fallbacks (`SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_ANON_KEY`) from the publishable key chain — these variables would never reach a client bundle, so the fallbacks were Vercel Marketplace migration cruft
- **rls.ts**: Rewrote misleading JSDoc on `withUserContext` — Drizzle connects as a BYPASSRLS user so RLS is never enforced for app code; this helper exists only for integration tests that simulate RLS contexts
- **migration 0035**: Hand-written `REVOKE ALL ON FUNCTION public.handle_new_user() FROM anon, authenticated` — defense-in-depth lockdown following the same pattern as migration 0029 (`get_discord_config`). The trigger function was created SECURITY DEFINER in migration 0007 but never had explicit EXECUTE revocations.

## Test Plan

- [x] `pnpm run check` passes (116 test files, 1033 tests all green)
- [x] Updated `supabase-env.test.ts` to remove the now-deleted fallback paths
- [ ] `pnpm db:reset` — verify migration 0035 applies and `pnpm db:generate` reports "No schema changes" (requires Supabase running locally; CI will exercise this via Supabase Branch Setup)

Closes PP-8hz

🤖 Generated with [Claude Code](https://claude.com/claude-code)