### PR TITLE
fix(scripts): drop discord_integration_config + trigger functions on db reset (PP-54j)

### DIFF
--- a/scripts/force-db-reset.mjs
+++ b/scripts/force-db-reset.mjs
@@ -32,6 +32,15 @@ const tables = [
   "user_profiles",
   "invited_users",
   "unconfirmed_users",
+  "discord_integration_config",
+];
+
+// Trigger/helper functions in the public schema. CASCADE drops dependent
+// triggers (e.g., handle_new_user's trigger on auth.users), so the auth
+// schema itself stays untouched. Migrations recreate these.
+const functions = [
+  "public.handle_new_user()",
+  "public.get_discord_config()",
 ];
 
 const client = postgres(databaseUrl);
@@ -44,10 +53,16 @@ async function dropTables() {
     await client.unsafe(`DROP TABLE IF EXISTS "${table}" CASCADE;`);
   }
 
+  for (const fn of functions) {
+    // Static function names defined above; CASCADE removes auth.users triggers
+    // that reference handle_new_user without modifying the auth schema itself.
+    await client.unsafe(`DROP FUNCTION IF EXISTS ${fn} CASCADE;`);
+  }
+
   // Drop Drizzle migrations schema to force re-migration
   await client.unsafe(`DROP SCHEMA IF EXISTS drizzle CASCADE;`);
 
-  console.log("✅ Tables dropped.");
+  console.log("✅ Tables and functions dropped.");
 }
 
 dropTables()

--- a/scripts/force-db-reset.mjs
+++ b/scripts/force-db-reset.mjs
@@ -1,9 +1,11 @@
 /**
- * Drops application tables in the local Supabase database.
+ * Drops PinPoint-owned database objects in the local Supabase environment.
  *
  * This script is used by `pnpm run db:reset` (and preflight) to ensure a clean
- * slate before reapplying the Drizzle schema. It intentionally leaves the
- * Supabase auth schema untouched.
+ * slate before reapplying the Drizzle schema. It drops public-schema tables
+ * and trigger-helper functions; the auth.users table and its data remain
+ * intact. (CASCADE on `handle_new_user` does remove our trigger attached to
+ * auth.users — that trigger is PinPoint's, not Supabase's.)
  */
 
 import postgres from "postgres";
@@ -35,9 +37,9 @@ const tables = [
   "discord_integration_config",
 ];
 
-// Trigger/helper functions in the public schema. CASCADE drops dependent
-// triggers (e.g., handle_new_user's trigger on auth.users), so the auth
-// schema itself stays untouched. Migrations recreate these.
+// Trigger/helper functions PinPoint creates in the public schema. CASCADE
+// removes dependent triggers — including handle_new_user's trigger on
+// auth.users, which is ours, not Supabase's. Migrations recreate these.
 const functions = [
   "public.handle_new_user()",
   "public.get_discord_config()",
@@ -45,8 +47,8 @@ const functions = [
 
 const client = postgres(databaseUrl);
 
-async function dropTables() {
-  console.log("🧹 Dropping application tables (public schema)...");
+async function dropApplicationObjects() {
+  console.log("🧹 Dropping application tables and functions (public schema)...");
 
   for (const table of tables) {
     // Use unsafe here only for static table names defined above
@@ -54,20 +56,20 @@ async function dropTables() {
   }
 
   for (const fn of functions) {
-    // Static function names defined above; CASCADE removes auth.users triggers
-    // that reference handle_new_user without modifying the auth schema itself.
+    // Static function names defined above. CASCADE also drops the trigger
+    // PinPoint attached to auth.users (the auth.users table itself stays).
     await client.unsafe(`DROP FUNCTION IF EXISTS ${fn} CASCADE;`);
   }
 
   // Drop Drizzle migrations schema to force re-migration
   await client.unsafe(`DROP SCHEMA IF EXISTS drizzle CASCADE;`);
 
-  console.log("✅ Tables and functions dropped.");
+  console.log("✅ Application objects dropped.");
 }
 
-dropTables()
+dropApplicationObjects()
   .catch((error) => {
-    console.error("❌ Failed to drop tables:", error);
+    console.error("❌ Failed to drop application objects:", error);
     process.exit(1);
   })
   .finally(async () => {


### PR DESCRIPTION
## Summary

Closes PP-54j. Follow-up bug found while shipping PP-8hz (#1309).

- Add `discord_integration_config` to the table list in `scripts/force-db-reset.mjs`.
- Add `DROP FUNCTION IF EXISTS … CASCADE` for `public.handle_new_user()` and `public.get_discord_config()`.

Without these, worktrees whose Docker volume contains rows from a previous schema shape hit `pnpm db:reset` failures: the migrations apply cleanly on a truly empty DB, but the half-emptied state confuses them. CASCADE on the function drops `handle_new_user`'s trigger on `auth.users` (verified in `drizzle/0007_handle_new_user_trigger.sql:104-108`) without touching the auth schema itself, matching the script's existing "intentionally leaves the Supabase auth schema untouched" contract.

## Test plan

- [ ] `pnpm run preflight` passes (no schema changes, function/table names cross-checked against migrations).
- [ ] On a worktree with a stale volume: `pnpm db:reset && pnpm db:reset` — both invocations exit 0 (the acceptance criterion from PP-54j).
- [ ] On a fresh worktree: `pnpm db:reset` still exits 0 (no regression — `IF EXISTS` makes the new statements idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)