### PR TITLE
chore(security): clear pnpm audit gate (PP-3ds)

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,13 @@
       "webpack": ">=5.105.4",
       "brace-expansion": ">=5.0.5",
       "yaml": ">=2.8.3",
-      "uuid": ">=14.0.0"
+      "uuid": ">=14.0.0",
+      "postcss": ">=8.5.10"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-rpr9-rxv7-x643"
+      ]
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   brace-expansion: '>=5.0.5'
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -303,7 +304,7 @@ importers:
         specifier: ^13.1.3
         version: 13.1.3
       postcss:
-        specifier: ^8.5.13
+        specifier: '>=8.5.10'
         version: 8.5.13
       prettier:
         specifier: ^3.8.2
@@ -5552,10 +5553,6 @@ packages:
 
   postal-mime@2.7.4:
     resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
@@ -11855,7 +11852,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.23
       caniuse-lite: 1.0.30001792
-      postcss: 8.4.31
+      postcss: 8.5.13
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
@@ -12122,12 +12119,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postal-mime@2.7.4: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.13:
     dependencies:

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,4 +1,5 @@
 import sanitizeHtml from "sanitize-html";
+import { NON_TEXT_TAGS } from "~/lib/sanitize-html-config";
 
 export function escapeHtml(value: string): string {
   return value
@@ -119,18 +120,7 @@ export function renderMarkdownToHtml(markdown: string): string {
       "hr",
       "a",
     ],
-    // Raw-text elements: when stripped, their text content is dropped (not
-    // re-parsed by the browser). Mitigates GHSA-rpr9-rxv7-x643 (xmp passthrough).
-    nonTextTags: [
-      "script",
-      "style",
-      "textarea",
-      "option",
-      "xmp",
-      "noscript",
-      "noembed",
-      "noframes",
-    ],
+    nonTextTags: [...NON_TEXT_TAGS],
     allowedAttributes: {
       a: ["href", "class", "target", "rel"],
     },

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -119,6 +119,18 @@ export function renderMarkdownToHtml(markdown: string): string {
       "hr",
       "a",
     ],
+    // Raw-text elements: when stripped, their text content is dropped (not
+    // re-parsed by the browser). Mitigates GHSA-rpr9-rxv7-x643 (xmp passthrough).
+    nonTextTags: [
+      "script",
+      "style",
+      "textarea",
+      "option",
+      "xmp",
+      "noscript",
+      "noembed",
+      "noframes",
+    ],
     allowedAttributes: {
       a: ["href", "class", "target", "rel"],
     },

--- a/src/lib/notifications/channels/email-channel.ts
+++ b/src/lib/notifications/channels/email-channel.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import sanitizeHtml from "sanitize-html";
 import { log } from "~/lib/logger";
+import { NON_TEXT_TAGS } from "~/lib/sanitize-html-config";
 import { isInternalAccount } from "~/lib/auth/internal-accounts";
 import { getSiteUrl } from "~/lib/url";
 import type {
@@ -38,18 +39,7 @@ const EMAIL_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     "pre",
     "s",
   ],
-  // Raw-text elements: when stripped, their text content is dropped (not
-  // re-parsed by the browser). Mitigates GHSA-rpr9-rxv7-x643 (xmp passthrough).
-  nonTextTags: [
-    "script",
-    "style",
-    "textarea",
-    "option",
-    "xmp",
-    "noscript",
-    "noembed",
-    "noframes",
-  ],
+  nonTextTags: [...NON_TEXT_TAGS],
   allowedAttributes: {
     a: ["href"],
     span: ["style"],

--- a/src/lib/notifications/channels/email-channel.ts
+++ b/src/lib/notifications/channels/email-channel.ts
@@ -38,6 +38,18 @@ const EMAIL_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     "pre",
     "s",
   ],
+  // Raw-text elements: when stripped, their text content is dropped (not
+  // re-parsed by the browser). Mitigates GHSA-rpr9-rxv7-x643 (xmp passthrough).
+  nonTextTags: [
+    "script",
+    "style",
+    "textarea",
+    "option",
+    "xmp",
+    "noscript",
+    "noembed",
+    "noframes",
+  ],
   allowedAttributes: {
     a: ["href"],
     span: ["style"],

--- a/src/lib/sanitize-html-config.test.ts
+++ b/src/lib/sanitize-html-config.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import sanitizeHtml from "sanitize-html";
+import { NON_TEXT_TAGS } from "./sanitize-html-config";
+
+describe("NON_TEXT_TAGS", () => {
+  const sanitize = (dirty: string): string =>
+    sanitizeHtml(dirty, {
+      allowedTags: ["p", "strong"],
+      nonTextTags: [...NON_TEXT_TAGS],
+    });
+
+  it("covers sanitize-html defaults plus raw-text bypass elements", () => {
+    expect([...NON_TEXT_TAGS]).toEqual([
+      "script",
+      "style",
+      "textarea",
+      "option",
+      "xmp",
+      "noscript",
+      "noembed",
+      "noframes",
+    ]);
+  });
+
+  it.each(["xmp", "noscript", "noembed", "noframes"])(
+    "drops the text content of <%s> instead of leaving it as a re-parseable string",
+    (tag) => {
+      const payload = `<p>Hi</p><${tag}><script>alert(1)</script></${tag}>`;
+      const cleaned = sanitize(payload);
+
+      expect(cleaned).toContain("<p>Hi</p>");
+      expect(cleaned).not.toContain("<script>");
+      expect(cleaned).not.toContain("&lt;script&gt;");
+      expect(cleaned).not.toContain("alert(1)");
+    }
+  );
+
+  it("still drops <script> and <style> content (defaults preserved)", () => {
+    expect(sanitize("<p>a</p><script>alert(1)</script>")).not.toContain(
+      "alert(1)"
+    );
+    expect(sanitize("<p>a</p><style>body{}</style>")).not.toContain("body{}");
+  });
+});

--- a/src/lib/sanitize-html-config.ts
+++ b/src/lib/sanitize-html-config.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared sanitize-html config fragments.
+ *
+ * NON_TEXT_TAGS extends sanitize-html's default `nonTextTags`
+ * (`['script', 'style', 'textarea', 'option']`) with raw-text HTML
+ * elements that pass their content through unparsed by the HTML
+ * parser. When sanitize-html strips a tag listed in `nonTextTags`,
+ * its content is dropped instead of being preserved as text — which
+ * the browser could otherwise re-parse as HTML when the output is
+ * injected back into the DOM.
+ *
+ * Hardens against GHSA-rpr9-rxv7-x643 (sanitize-html xmp passthrough,
+ * CVSS 9.3, no upstream patch as of 2026-05-15) and the broader class
+ * of raw-text-element bypasses (xmp, noscript, noembed, noframes).
+ */
+export const NON_TEXT_TAGS: readonly string[] = [
+  "script",
+  "style",
+  "textarea",
+  "option",
+  "xmp",
+  "noscript",
+  "noembed",
+  "noframes",
+];

--- a/src/lib/tiptap/render.ts
+++ b/src/lib/tiptap/render.ts
@@ -154,6 +154,18 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     "blockquote",
     "hr",
   ],
+  // Raw-text elements: when stripped, their text content is dropped (not
+  // re-parsed by the browser). Mitigates GHSA-rpr9-rxv7-x643 (xmp passthrough).
+  nonTextTags: [
+    "script",
+    "style",
+    "textarea",
+    "option",
+    "xmp",
+    "noscript",
+    "noembed",
+    "noframes",
+  ],
   allowedAttributes: {
     a: ["href", "class", "data-mention-id", "target", "rel"],
     span: ["class"],

--- a/src/lib/tiptap/render.ts
+++ b/src/lib/tiptap/render.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import sanitizeHtml from "sanitize-html";
 import { escapeHtml } from "~/lib/markdown";
+import { NON_TEXT_TAGS } from "~/lib/sanitize-html-config";
 import {
   type ProseMirrorDoc,
   type ProseMirrorMark,
@@ -154,18 +155,7 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     "blockquote",
     "hr",
   ],
-  // Raw-text elements: when stripped, their text content is dropped (not
-  // re-parsed by the browser). Mitigates GHSA-rpr9-rxv7-x643 (xmp passthrough).
-  nonTextTags: [
-    "script",
-    "style",
-    "textarea",
-    "option",
-    "xmp",
-    "noscript",
-    "noembed",
-    "noframes",
-  ],
+  nonTextTags: [...NON_TEXT_TAGS],
   allowedAttributes: {
     a: ["href", "class", "data-mention-id", "target", "rel"],
     span: ["class"],


### PR DESCRIPTION
## Summary

`pnpm audit` (a required CI gate) started failing on every new PR after two CVEs were published in the last ~24h. This PR unblocks the gate.

- **postcss `>=8.5.10` override** — fixes transitive CVE-2026-41305 / GHSA-qx2v-qp2m-jg93 (XSS via unescaped `</style>` in CSS Stringify Output), pulled via `next@16.2.6`. Clean patch bump.
- **sanitize-html audit ignore** — adds GHSA-rpr9-rxv7-x643 (CVSS 9.3, "xmp raw-text passthrough") to `pnpm.auditConfig.ignoreGhsas`. **No upstream patch exists yet.** We're not exploitable: every `sanitize-html` call site (`src/lib/markdown.ts`, `src/lib/tiptap/render.ts`, `src/lib/notifications/channels/email-channel.ts`) uses an explicit positive `allowedTags` list that does not admit `<xmp>`.
- **Defensive hardening** — all three configs now extend `nonTextTags` with `xmp`, `noscript`, `noembed`, `noframes`. With this, content of these raw-text elements is dropped when the tag is stripped, rather than passed back as text where the browser could re-parse it. This hardens us against the entire class of raw-text-element bypasses, not just the published `<xmp>` variant.

Once upstream sanitize-html patches the advisory, the `ignoreGhsas` entry can be removed (track via PP-3ds).

## Test plan

- [x] `pnpm audit --audit-level=moderate` exits 0 (1 critical ignored, 0 unignored) locally.
- [x] `pnpm run check` passes (1034 tests).
- [ ] CI Gate green (will be verified by checks below).
- [ ] After merge: rebase #1322 (Dependabot minor-patch group) and confirm its `pnpm audit` job goes green.

Closes PP-3ds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)