### PR TITLE
chore(e2e): delete Send Test DM E2E block (class-J, PP-dgc)

### DIFF
--- a/e2e/full/discord-dm-preferences.spec.ts
+++ b/e2e/full/discord-dm-preferences.spec.ts
@@ -156,38 +156,4 @@ test.describe("Discord DM preferences (integration enabled)", () => {
       await setUserDiscordId(memberId, null);
     }
   });
-
-  test("Linked user can click 'Send test DM' and gets feedback", async ({
-    page,
-  }, testInfo) => {
-    // NON_NEGOTIABLE #11: every clickable UI element must be exercised in
-    // E2E. The button triggers a real call to Discord with the test fake
-    // token, so the result will be a failure — but the form must render
-    // a result paragraph rather than hang or crash.
-    //
-    // The section gates `showTestDm` on `canReceiveDiscordDms` (the mirror
-    // column), which is exactly what the dispatcher reads at delivery time.
-    // setUserDiscordId is sufficient to flip the gate.
-    await setUserDiscordId(memberId, "test-discord-id-test-dm");
-
-    try {
-      await loginAs(page, testInfo, {
-        email: memberEmail,
-        password: "TestPassword123",
-      });
-      await page.goto("/settings");
-
-      const button = page.getByRole("button", { name: "Send test DM" });
-      await expect(button).toBeVisible();
-      await button.click();
-
-      // Either success or one of the REASON_COPY failure messages should
-      // surface. The fake bot token makes failure (transient) the most
-      // likely outcome — but we don't depend on the specific reason.
-      const resultMessage = page.getByRole("status");
-      await expect(resultMessage).toBeVisible({ timeout: 15_000 });
-    } finally {
-      await setUserDiscordId(memberId, null);
-    }
-  });
 });


### PR DESCRIPTION
## Summary

Wave 0a of the E2E audit cleanup (PP-dgc / parent PP-xm1). Deletes lines 160–192 of `e2e/full/discord-dm-preferences.spec.ts` — the `"Linked user can click 'Send test DM' and gets feedback"` block — because it is a confirmed Rule #17 (Test What We Own) class-J violation.

## Rule #17 violation rationale

The deleted block clicked "Send test DM" which triggered `testDiscordDmAction` → `sendDm()` in `src/lib/discord/client.ts` → unconditional `fetch("https://discord.com/api/v10/users/@me/channels")` against Discord's **production** API with an e2e-fake bot token. The spec explicitly relied on Discord returning a non-200 to exercise the error-rendering path — meaning it depended on live third-party API behavior.

Class-J self-check diagnostic: *"If this ran against production with real credentials, would the same code pass?"* → **No.** Confirmed violation.

Reference: audit row 1 in [`docs/testing/e2e-audit-2026-05.md`](../blob/main/docs/testing/e2e-audit-2026-05.md) (Class-J Violations Inventory).

## Replacement test already exists

`src/server/actions/test-discord-dm-action.test.ts` covers all branches at the SDK boundary with `sendDm` mocked:

- `not_authenticated`
- `not_linked`
- `not_configured`
- `ok`
- `blocked`
- `rate_limited`
- `transient`

No new test needed.

## Rule #17 two-layer self-check

- **Layer 1** (`rg 'https?://' e2e/full/discord-dm-preferences.spec.ts`) → 0 results. Spec contains no URLs.
- **Layer 2** (`rg 'https?://' src/lib/ src/server/actions/`) → the `discord.com` hostname appears only in `src/lib/discord/client.ts` as the `DISCORD_API` constant, reachable exclusively via `sendDm()`. None of the 4 remaining spec blocks call `sendDm()` or `testDiscordDmAction` — they exercise page rendering, Discord column visibility, and per-event preference toggle + save (`saveNotificationPreferences`). No class-J exposure remains.

## Other 4 blocks retained

1. "Discord column is hidden when integration is disabled"
2. "Linked user without integration enabled still sees no Discord column"
3. "Unlinked user sees Discord column with Link CTA and disabled main switch"
4. "Linked user toggles Discord per-event preference and value persists across reload"

(Audit row 24 flags block #2 as a future delete candidate but that's a separate bead — out of scope here.)

## Test plan

- [x] `pnpm run check` — green (116 files, 1034 tests)
- [x] `pnpm exec playwright test e2e/full/discord-dm-preferences.spec.ts --project=chromium` — green (7 passed: 3 auth-setup + 4 remaining blocks, 20.8s)
- [x] Rule #17 Layer 1 grep — clean
- [x] Rule #17 Layer 2 grep — clean (no remaining live-Discord call path triggered by this spec)

## Expected CI failure

`pnpm audit` is expected to fail on this PR due to pre-existing sanitize-html + postcss advisories being addressed separately in PR #1323. This is the **only** acceptable red check.

Closes PP-dgc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)