### PR TITLE
chore(e2e): delete inert image-upload smoke test 1 + Vercel Blob routing verified local (PP-013)

### DIFF
--- a/e2e/smoke/image-upload.spec.ts
+++ b/e2e/smoke/image-upload.spec.ts
@@ -21,55 +21,6 @@ test.describe("Image Upload Reporting", () => {
     });
   });
 
-  test("should upload image and persist it to issue", async ({ page }) => {
-    // 1. Prepare
-    await page.goto("/report");
-    const select = page.getByTestId("machine-select");
-    await select.selectOption({ index: 1 });
-    await expect(page).toHaveURL(/machine=/);
-
-    // 2. Fill Form
-    const issueTitle = `${IMAGE_UPLOAD_PREFIX} ${Date.now()}`;
-    await fillReportForm(page, {
-      title: issueTitle,
-      description: "Testing image persistence.",
-      includePriority: false,
-    });
-
-    // 3. Upload Image
-    // Use a test PNG from fixtures (2.3KB) that meets the 1KB minimum validation requirement
-    const testImagePath = join(__dirname, "..", "fixtures", "test-image.png");
-
-    await page.setInputFiles(
-      'input[data-testid="image-upload-input"]',
-      testImagePath
-    );
-
-    // 4. Verify Preview appears
-    // The preview card has a generic "Issue image" alt text or the filename
-    // Verify preview
-    await expect(page.getByText("Image uploaded successfully")).toBeVisible();
-    await expect(
-      page.getByRole("img", { name: "test-image.png" })
-    ).toBeVisible();
-
-    // 5. Submit
-    await page.getByRole("button", { name: "Submit Issue Report" }).click();
-
-    // 6. Verify Success & Navigation
-    // Anonymous user goes to success page, then we can click the link to view the issue if we were logged in,
-    // but here we are anonymous. The success page doesn't link to the issue for anonymous users for privacy/security
-    // (unless we change that flow, but currently it doesn't).
-
-    // Wait, the action redirects:
-    // "Redirect logic: 2. Anonymous users go to success page"
-    await expect(page).toHaveURL("/report/success");
-
-    // To verify persistence, we need to login as an admin or verify via DB/API.
-    // Or we can modify the test to login first.
-    // Let's login first to get redirected to the issue page directly.
-  });
-
   test("authenticated user should see uploaded image on issue page", async ({
     page,
   }, testInfo) => {


### PR DESCRIPTION
## Summary

Wave 0c of the E2E audit cleanup (`docs/testing/e2e-audit-2026-05.md` row 3). Two-part task:

### Part B (investigation — surfaced first, gated Part A's scope)

**Vercel Blob image uploads do NOT reach production in E2E runs.** Routing is gated by `shouldUseMockBlobStorage()` in [`src/lib/blob/client.ts:7-18`](../blob/main/src/lib/blob/client.ts#L7-L18), which returns `true` (→ local-filesystem mock at `public/uploads/`) when either:

1. `process.env["MOCK_BLOB_STORAGE"] === "true"`, or
2. `NODE_ENV !== "production"` AND `BLOB_READ_WRITE_TOKEN` is absent.

`.github/workflows/ci.yml` sets `MOCK_BLOB_STORAGE: "true"` explicitly on all five E2E job steps (Smoke Chromium ~L604, Smoke Mobile Chrome ~L685, Full Chromium ~L766, Comprehensive Smoke ~L852, Comprehensive Full ~L864). When mock is active, the `@vercel/blob` SDK's `put()` is never called and no HTTP request leaves the host — the file is written to disk and a `localhost:PORT/uploads/...` URL is returned. Locally, the second branch trips the same fallback since `.env.local` has no `BLOB_READ_WRITE_TOKEN`.

**Verdict:** test 2 ("authenticated user should see uploaded image on issue page") is NOT a class-J violation. It's a genuine class-F multi-step journey (login → report form → upload → redirect → timeline image → lightbox) that exercises `uploadIssueImage` server action + DB write + `revalidatePath` against the local mock — exactly the right layer. **KEEP test 2.**

### Part A (delete-inert)

Removed test 1 ("should upload image and persist it to issue") from `e2e/smoke/image-upload.spec.ts`. The test submitted as an anonymous user, landed on `/report/success`, and then explicitly admitted in a comment that it could not verify persistence without being logged in — inert by design. Class-B coverage already lives in `src/server/actions/images.test.ts`.

## Test plan

- [x] `pnpm run check` — 116 files, 1034 tests passing
- [x] `pnpm exec playwright test e2e/smoke/image-upload.spec.ts --project=chromium` — 4/4 passing (3 auth-setup + retained test 2)
- [ ] CI green (note: `pnpm audit` failure expected, fixed by separate PR #1323 — do not bump deps in this PR)

Closes PP-013
Audit row: `docs/testing/e2e-audit-2026-05.md` row 3

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>