### PR TITLE
fix(ci): switch paths-filter to some+negative patterns for docs-only skip (PP-r5v)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ concurrency:
 
 jobs:
   # Detect which files changed to skip expensive jobs for docs-only changes.
-  # Uses predicate-quantifier: 'every' with a negative filter so that code=true
-  # unless EVERY changed file is docs-only. New/unknown directories default to
+  # Uses predicate-quantifier: 'some' with negative patterns so that has_code=true
+  # when ANY changed file is NOT docs-only. New/unknown directories default to
   # running full CI — the safe failure mode.
   changes:
     name: Detect Changes
@@ -39,16 +39,17 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # ratchet:dorny/paths-filter@v4.0.1
         with:
-          predicate-quantifier: "every"
+          predicate-quantifier: "some"
           filters: |
-            docs_only:
-              - 'docs/**'
-              - '**/*.md'
-              - '.beads/**'
-              - '.agent/**'
-              - '.claude/**'
-              - 'LICENSE'
-              - '.gitignore'
+            has_code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!.beads/**'
+              - '!.agent/**'
+              - '!.claude/**'
+              - '!LICENSE'
+              - '!.gitignore'
       # Separate filter for dependency changes using default "some" quantifier
       # so deps=true when ANY changed file is a dependency file (not ALL).
       - id: deps-filter
@@ -61,10 +62,11 @@ jobs:
       - name: Determine code changes
         id: set-code
         run: |
-          if [ "${{ steps.filter.outputs.docs_only }}" = "true" ]; then
-            echo "code=false" >> "$GITHUB_OUTPUT"
-          else
+          has_code="${{ steps.filter.outputs.has_code }}"
+          if [ "$has_code" = "true" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
           fi
   # Setup job caches dependencies for reuse by other jobs
   setup:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,10 @@ jobs:
               - 'pnpm-lock.yaml'
       - name: Determine code changes
         id: set-code
+        env:
+          HAS_CODE: ${{ steps.filter.outputs.has_code }}
         run: |
-          has_code="${{ steps.filter.outputs.has_code }}"
-          if [ "$has_code" = "true" ]; then
+          if [ "$HAS_CODE" = "true" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fixes `dorny/paths-filter` never triggering the `docs_only` skip on docs-only PRs
- Root cause: `predicate-quantifier: every` with positive-only patterns is logically impossible to satisfy — the filter always returned false
- Fix (Option 1 from PP-r5v): switch to `predicate-quantifier: some` and rename filter to `has_code` with negative patterns (`!docs/**`, `!**/*.md`, etc.) — fires `true` if ANY changed file is NOT a doc file
- Also moved `steps.filter.outputs.has_code` expression into an env variable in `set-code` to satisfy the zizmor security linter (no untrusted-input injection risk here, but cleaner style)

## Test plan
- [ ] Docs-only PR (only `*.md` / `.agent/**` changes): `setup` job should be skipped, CI Gate passes via skipped path
- [ ] Mixed PR (docs + source): full CI runs as normal
- [ ] Pure source PR: full CI runs as normal
- [ ] CI Gate green on this PR itself (source change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)