### PR TITLE
fix(PP-8mq): clear rich-text editor after comment submit

### DIFF
--- a/e2e/full/comment-actions.spec.ts
+++ b/e2e/full/comment-actions.spec.ts
@@ -157,16 +157,20 @@ test.describe.serial("Comment Edit and Delete", () => {
       await loginAs(page, testInfo);
       await page.goto(issueUrl);
 
+      const resetCheckText = "Temporary comment for reset check";
       const commentEditor = page.getByLabel("Comment", { exact: true });
       await expect(commentEditor).toBeVisible({ timeout: 10000 });
       await commentEditor.click();
-      await page.keyboard.type("Temporary comment for reset check");
+      await page.keyboard.type(resetCheckText);
 
       await page.getByRole("button", { name: "Add Comment" }).click();
 
-      // Wait for the toast / timeline update to confirm submit succeeded
+      // Scope to the timeline to confirm the comment was persisted and rendered,
+      // not just that the text exists in the editor before clear
       await expect(
-        page.getByText("Temporary comment for reset check")
+        page
+          .locator('[data-testid^="timeline-item-"]')
+          .filter({ hasText: resetCheckText })
       ).toBeVisible({ timeout: 10000 });
 
       // The ProseMirror contenteditable should be empty after reset

--- a/e2e/full/comment-actions.spec.ts
+++ b/e2e/full/comment-actions.spec.ts
@@ -151,6 +151,28 @@ test.describe.serial("Comment Edit and Delete", () => {
       await page.keyboard.press("Escape");
     });
 
+    test("editor body is empty after successful comment submit", async ({
+      page,
+    }, testInfo) => {
+      await loginAs(page, testInfo);
+      await page.goto(issueUrl);
+
+      const commentEditor = page.getByLabel("Comment", { exact: true });
+      await expect(commentEditor).toBeVisible({ timeout: 10000 });
+      await commentEditor.click();
+      await page.keyboard.type("Temporary comment for reset check");
+
+      await page.getByRole("button", { name: "Add Comment" }).click();
+
+      // Wait for the toast / timeline update to confirm submit succeeded
+      await expect(
+        page.getByText("Temporary comment for reset check")
+      ).toBeVisible({ timeout: 10000 });
+
+      // The ProseMirror contenteditable should be empty after reset
+      await expect(commentEditor).toHaveText("", { timeout: 5000 });
+    });
+
     test("author can edit their own comment", async ({ page }, testInfo) => {
       await loginAs(page, testInfo);
       await page.goto(issueUrl);

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -167,7 +167,10 @@ export const RichTextEditor = forwardRef<
     ref,
     () => ({
       clear: () => {
-        editor?.commands.clearContent(true);
+        // clearContent(false) avoids firing onUpdate, which would call onChange()
+        // with an empty-paragraph doc and overwrite the null state already set
+        // by the caller (AddCommentForm's success effect calling setComment(null)).
+        editor?.commands.clearContent(false);
       },
       focus: () => {
         editor?.commands.focus();

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -1,7 +1,12 @@
 // src/components/editor/RichTextEditor.tsx
 "use client";
 
-import React, { useMemo, useEffect } from "react";
+import React, {
+  useMemo,
+  useEffect,
+  useImperativeHandle,
+  forwardRef,
+} from "react";
 import {
   useEditor,
   EditorContent,
@@ -19,6 +24,11 @@ import { EditorToolbar } from "./EditorToolbar";
 import { type ProseMirrorDoc } from "~/lib/tiptap/types";
 import { cn } from "~/lib/utils";
 
+export interface RichTextEditorHandle {
+  clear: () => void;
+  focus: () => void;
+}
+
 interface RichTextEditorProps {
   content: ProseMirrorDoc | null;
   onChange: (doc: ProseMirrorDoc) => void;
@@ -30,16 +40,22 @@ interface RichTextEditorProps {
   ariaLabel?: string | undefined;
 }
 
-export function RichTextEditor({
-  content,
-  onChange,
-  mentionsEnabled = false,
-  placeholder = "Write something...",
-  compact = false,
-  disabled = false,
-  className,
-  ariaLabel,
-}: RichTextEditorProps): React.JSX.Element {
+export const RichTextEditor = forwardRef<
+  RichTextEditorHandle,
+  RichTextEditorProps
+>(function RichTextEditor(
+  {
+    content,
+    onChange,
+    mentionsEnabled = false,
+    placeholder = "Write something...",
+    compact = false,
+    disabled = false,
+    className,
+    ariaLabel,
+  }: RichTextEditorProps,
+  ref
+) {
   const extensions = useMemo(() => {
     const list: AnyExtension[] = [
       StarterKit.configure({
@@ -147,6 +163,19 @@ export function RichTextEditor({
     },
   });
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      clear: () => {
+        editor?.commands.clearContent(true);
+      },
+      focus: () => {
+        editor?.commands.focus();
+      },
+    }),
+    [editor]
+  );
+
   // Sync external content changes (e.g. when restoring draft from localStorage)
   // We only set it if the editor is currently empty to prevent overwriting user input
   useEffect(() => {
@@ -167,4 +196,4 @@ export function RichTextEditor({
       <EditorContent editor={editor} />
     </div>
   );
-}
+});

--- a/src/components/editor/RichTextEditorDynamic.tsx
+++ b/src/components/editor/RichTextEditorDynamic.tsx
@@ -7,6 +7,8 @@
  */
 import dynamic from "next/dynamic";
 
+export type { RichTextEditorHandle } from "~/components/editor/RichTextEditor";
+
 export const RichTextEditor = dynamic(
   () =>
     import("~/components/editor/RichTextEditor").then(

--- a/src/components/issues/AddCommentForm.test.tsx
+++ b/src/components/issues/AddCommentForm.test.tsx
@@ -15,6 +15,31 @@ vi.mock("~/app/(app)/issues/actions", () => ({
   addCommentAction: vi.fn(),
 }));
 
+// Mock the dynamic RichTextEditor so tests don't require a DOM/TipTap runtime.
+// The mock exposes the imperative handle (clear, focus) via forwardRef so that
+// AddCommentForm's editorRef wiring works correctly.
+// Uses an async factory to avoid the hoisting constraint that prevents top-level
+// variable access inside synchronous vi.mock() factories.
+vi.mock("~/components/editor/RichTextEditorDynamic", async () => {
+  const { forwardRef, useImperativeHandle } = await import("react");
+  interface Handle {
+    clear: () => void;
+    focus: () => void;
+  }
+  return {
+    RichTextEditor: forwardRef<Handle>(function MockRichTextEditor(
+      _props: unknown,
+      ref
+    ) {
+      useImperativeHandle(ref, () => ({
+        clear: vi.fn(),
+        focus: vi.fn(),
+      }));
+      return null;
+    }),
+  };
+});
+
 // Mock useActionState
 const mockUseActionState = vi.fn();
 

--- a/src/components/issues/AddCommentForm.tsx
+++ b/src/components/issues/AddCommentForm.tsx
@@ -12,7 +12,10 @@ import { ImageUploadButton } from "~/components/images/ImageUploadButton";
 import { ImageGallery } from "~/components/images/ImageGallery";
 import { BLOB_CONFIG } from "~/lib/blob/config";
 import { type ImageMetadata } from "~/types/images";
-import { RichTextEditor } from "~/components/editor/RichTextEditorDynamic";
+import {
+  RichTextEditor,
+  type RichTextEditorHandle,
+} from "~/components/editor/RichTextEditorDynamic";
 import { type ProseMirrorDoc } from "~/lib/tiptap/types";
 
 interface AddCommentFormProps {
@@ -23,6 +26,7 @@ export function AddCommentForm({
   issueId,
 }: AddCommentFormProps): React.JSX.Element {
   const formRef = useRef<HTMLFormElement>(null);
+  const editorRef = useRef<RichTextEditorHandle>(null);
   const [state, formAction, isPending] = useActionState<
     AddCommentResult | undefined,
     FormData
@@ -36,6 +40,8 @@ export function AddCommentForm({
       formRef.current?.reset();
       setUploadedImages([]);
       setComment(null);
+      editorRef.current?.clear();
+      editorRef.current?.focus();
     }
   }, [state]);
 
@@ -52,6 +58,7 @@ export function AddCommentForm({
         value={JSON.stringify(uploadedImages)}
       />
       <RichTextEditor
+        ref={editorRef}
         content={comment}
         onChange={setComment}
         mentionsEnabled={true}


### PR DESCRIPTION
## Summary

- Adds `RichTextEditorHandle` interface with `clear()` and `focus()` methods exported from `RichTextEditor.tsx`
- Converts `RichTextEditor` to use `forwardRef` so consumers can hold an imperative ref
- `AddCommentForm` acquires an `editorRef` and calls `clear()` + `focus()` in the success effect so the TipTap editor visually resets after submit and focus returns to the editor for the next comment
- Unit test mock updated to stub the imperative handle so existing tests continue passing
- E2E assertion added to `comment-actions.spec.ts`: after a successful submit, the editor body must be empty

Fixes PP-8mq.

## Test plan
- [ ] `pnpm run check` passes (types, lint, unit tests) ✅ done
- [ ] E2E: `editor body is empty after successful comment submit` test in `comment-actions.spec.ts`
- [ ] Existing comment-actions E2E suite does not regress (serial describe uses shared issue — new test fits in the chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)