### PR TITLE
feat(test): collapse public-routes-audit into middleware.test.ts unit coverage (PP-x6nb)

### DIFF
--- a/e2e/full/public-routes-audit.spec.ts
+++ b/e2e/full/public-routes-audit.spec.ts
@@ -1,193 +1,42 @@
 /**
- * Smoke Test: Public Routes Audit
+ * E2E Tests: Public Routes — Class-A Residuals
  *
- * Verifies key user-facing public routes are accessible to unauthenticated
- * users without redirecting to /login. API endpoints and auth callbacks are
- * covered by unit tests in middleware.test.ts rather than E2E.
+ * The bulk of this spec (17 DOWNGRADE-integration blocks) was retired to
+ * src/lib/supabase/middleware.test.ts publicRoutes/protectedRoutes arrays
+ * (PP-x6nb). Only the two class-A cases that require a real browser remain:
  *
- * This is the definitive test for the public access audit (PinPoint-kh6).
- * Individual route behavior is tested in other spec files; this file
- * focuses solely on "can an unauthenticated user reach this page?"
+ *   1. /m/new redirects to /login — page-level protection (server component
+ *      redirect), NOT middleware. middleware.test.ts explicitly defers this to
+ *      E2E (see the "Note" comment in that file's protectedRoutes section).
+ *
+ *   2. machine detail "Report Issue" button navigates to /report — genuine
+ *      multi-step click-through (button click → cross-page navigation) that
+ *      cannot be captured by a unit/integration test.
+ *
+ * One block ("about page links to privacy and terms") was DELETE-redundant:
+ * about-page.spec.ts already verifies those links, and middleware.test.ts
+ * covers /about, /privacy, /terms as public routes.
  */
 
 import { test, expect } from "@playwright/test";
-import { seededMachines, seededIssues } from "../support/constants";
+import { seededMachines } from "../support/constants";
 
-test.describe("Public Routes Audit", () => {
-  test.describe("Static public pages", () => {
-    test("/ (landing page) loads without login", async ({ page }) => {
-      await page.goto("/");
-      await expect(page).toHaveURL("/");
-      await expect(
-        page.getByRole("heading", { name: /Welcome to PinPoint/i })
-      ).toBeVisible();
-    });
-
-    test("/about loads without login", async ({ page }) => {
-      await page.goto("/about");
-      await expect(page).toHaveURL("/about");
-      await expect(
-        page.getByRole("heading", { name: "About PinPoint" })
-      ).toBeVisible();
-    });
-
-    test("/privacy loads without login", async ({ page }) => {
-      await page.goto("/privacy");
-      await expect(page).toHaveURL("/privacy");
-      await expect(
-        page.getByRole("heading", { name: "Privacy Policy" })
-      ).toBeVisible();
-    });
-
-    test("/terms loads without login", async ({ page }) => {
-      await page.goto("/terms");
-      await expect(page).toHaveURL("/terms");
-      await expect(
-        page.getByRole("heading", { name: "Terms of Service" })
-      ).toBeVisible();
-    });
-
-    test("/help loads without login", async ({ page }) => {
-      await page.goto("/help");
-      await expect(page).toHaveURL("/help");
-      await expect(page.getByRole("heading", { name: "Help" })).toBeVisible();
-    });
-
-    test("/help/permissions loads without login", async ({ page }) => {
-      await page.goto("/help/permissions");
-      await expect(page).toHaveURL("/help/permissions");
-      await expect(
-        page.getByRole("heading", { name: /Roles & Permissions/i })
-      ).toBeVisible();
-    });
-
-    test("/dashboard loads without login", async ({ page }) => {
-      await page.goto("/dashboard");
-      await expect(page).toHaveURL("/dashboard");
-      await expect(page.getByTestId("quick-stats")).toBeVisible();
-    });
+test.describe("Public Routes — Class-A Residuals", () => {
+  test("/m/new redirects to login (page-level protection)", async ({
+    page,
+  }) => {
+    await page.goto("/m/new");
+    await expect(page).toHaveURL(/\/login/);
   });
 
-  test.describe("Machine routes (public read access)", () => {
-    test("/m (machines list) loads without login", async ({ page }) => {
-      await page.goto("/m");
-      await expect(page).toHaveURL(/\/m(?:\?.*)?$/);
-      await expect(
-        page.getByRole("heading", { name: "Machines" })
-      ).toBeVisible();
-    });
+  test("machine detail Report Issue button navigates without login wall", async ({
+    page,
+  }) => {
+    const machine = seededMachines.medievalMadness;
+    await page.goto(`/m/${machine.initials}`);
 
-    test("/m/[initials] (machine detail) loads without login", async ({
-      page,
-    }) => {
-      const machine = seededMachines.medievalMadness;
-      await page.goto(`/m/${machine.initials}`);
-      await expect(page).toHaveURL(`/m/${machine.initials}`);
-      await expect(
-        page.getByRole("heading", { name: machine.name })
-      ).toBeVisible();
-    });
-
-    test("/m/[initials]/i/[num] (issue detail) loads without login", async ({
-      page,
-    }) => {
-      const issue = seededIssues.AFM[0];
-      await page.goto(`/m/AFM/i/${issue.num}`);
-      await expect(page).toHaveURL(`/m/AFM/i/${issue.num}`);
-      // Issue title should be visible
-      await expect(
-        page.getByRole("heading", { name: issue.title })
-      ).toBeVisible();
-    });
-  });
-
-  test.describe("Report route (public)", () => {
-    test("/report loads without login", async ({ page }) => {
-      await page.goto("/report");
-      await expect(page).toHaveURL(/\/report/);
-      // Report form should be visible
-      await expect(
-        page.getByRole("heading", { name: /report/i })
-      ).toBeVisible();
-    });
-  });
-
-  test.describe("Auth routes (public by nature)", () => {
-    test("/login loads without redirect loop", async ({ page }) => {
-      await page.goto("/login");
-      await expect(page).toHaveURL("/login");
-    });
-
-    test("/signup loads without redirect loop", async ({ page }) => {
-      await page.goto("/signup");
-      await expect(page).toHaveURL("/signup");
-    });
-  });
-
-  test.describe("Issues route (public read access)", () => {
-    test("/issues loads without login", async ({ page }) => {
-      await page.goto("/issues");
-      await expect(page).toHaveURL(/\/issues(?:\?.*)?$/);
-      await expect(
-        page.getByRole("heading", { name: "All Issues" })
-      ).toBeVisible();
-    });
-  });
-
-  test.describe("Protected routes redirect to login", () => {
-    test("/settings redirects to login", async ({ page }) => {
-      await page.goto("/settings");
-      await expect(page).toHaveURL(/\/login/);
-    });
-
-    test("/admin/users redirects to login", async ({ page }) => {
-      await page.goto("/admin/users");
-      await expect(page).toHaveURL(/\/login/);
-    });
-
-    test("/m/new redirects to login", async ({ page }) => {
-      await page.goto("/m/new");
-      await expect(page).toHaveURL(/\/login/);
-    });
-  });
-
-  test.describe("Cross-page navigation without login", () => {
-    test("navigating from privacy to help works without login wall", async ({
-      page,
-    }) => {
-      await page.goto("/privacy");
-      await expect(page).toHaveURL("/privacy");
-
-      // Navigate directly to help (verifying route is public)
-      await page.goto("/help");
-      await expect(page).toHaveURL("/help");
-      await expect(page.getByRole("heading", { name: "Help" })).toBeVisible();
-    });
-
-    test("about page links to privacy and terms without login wall", async ({
-      page,
-    }) => {
-      await page.goto("/about");
-
-      // Click Privacy Policy link
-      await page.getByRole("link", { name: "Privacy Policy" }).click();
-      await expect(page).toHaveURL("/privacy");
-
-      // Go back and click Terms of Service
-      await page.goto("/about");
-      await page.getByRole("link", { name: "Terms of Service" }).click();
-      await expect(page).toHaveURL("/terms");
-    });
-
-    test("machine detail Report Issue button navigates without login wall", async ({
-      page,
-    }) => {
-      const machine = seededMachines.medievalMadness;
-      await page.goto(`/m/${machine.initials}`);
-
-      // Click Report Issue button
-      await page.getByTestId("machine-report-issue").click();
-      await expect(page).toHaveURL(/\/report/);
-    });
+    // Click Report Issue button
+    await page.getByTestId("machine-report-issue").click();
+    await expect(page).toHaveURL(/\/report/);
   });
 });

--- a/src/lib/supabase/middleware.test.ts
+++ b/src/lib/supabase/middleware.test.ts
@@ -205,6 +205,7 @@ describe("updateSession public route access", () => {
     "/about",
     "/help",
     "/help/permissions",
+    "/whats-new",
     "/privacy",
     "/terms",
     "/api/health",


### PR DESCRIPTION
## Summary

Per the [2026-05 E2E audit](docs/testing/e2e-audit-2026-05.md) row 4 (P1, Wave 1a), `e2e/full/public-routes-audit.spec.ts` had 20 test blocks. 18 collapse into existing `src/lib/supabase/middleware.test.ts` unit coverage. 2 genuine class-A multi-step blocks remain in E2E.

**Totals:** 17 DOWNGRADE-integration + 2 KEEP + 1 DELETE-redundant = 20. Matches the audit doc verdict exactly.

**CI savings:** ~18 browser starts per CI run dropped. Spec shrinks from 193 lines → 42 lines.

## Per-block classification

| # | Block | Verdict | Replacement |
|---|---|---|---|
| 1 | `/` loads without login | DOWNGRADE | middleware.test.ts publicRoutes `/` |
| 2 | `/about` loads | DOWNGRADE | publicRoutes `/about` |
| 3 | `/privacy` loads | DOWNGRADE | publicRoutes `/privacy` |
| 4 | `/terms` loads | DOWNGRADE | publicRoutes `/terms` |
| 5 | `/help` loads | DOWNGRADE | publicRoutes `/help` |
| 6 | `/help/permissions` loads | DOWNGRADE | publicRoutes `/help/permissions` (already present) |
| 7 | `/dashboard` loads | DOWNGRADE | publicRoutes `/dashboard` |
| 8 | `/m` loads | DOWNGRADE | publicRoutes `/m` |
| 9 | `/m/[initials]` loads | DOWNGRADE | publicRoutes `/m/TAF` |
| 10 | `/m/[initials]/i/[num]` loads | DOWNGRADE | publicRoutes `/m/AFM/i/42` |
| 11 | `/report` loads | DOWNGRADE | publicRoutes `/report` |
| 12 | `/login` loads | DOWNGRADE | publicRoutes `/login` |
| 13 | `/signup` loads | DOWNGRADE | publicRoutes `/signup` |
| 14 | `/issues` loads | DOWNGRADE | publicRoutes `/issues` |
| 15 | `/settings` redirects | DOWNGRADE | protectedRoutes `/settings` |
| 16 | `/admin/users` redirects | DOWNGRADE | protectedRoutes `/admin/users` |
| 17 | `/m/new` redirects | **KEEP** | Page-level redirect (server component), NOT middleware. middleware.test.ts has an inline comment explicitly deferring this case to E2E. |
| 18 | privacy → help (no click, 2 goto()s) | DOWNGRADE | both routes already covered |
| 19 | about → privacy/terms (link clicks) | **DELETE-redundant** | `about-page.spec.ts` already asserts those links are visible; middleware covers public access; click-through adds no class-A value |
| 20 | machine → Report Issue (button click) | **KEEP** | Genuine class-A: button click triggers cross-page navigation; cannot be tested below E2E |

## middleware.test.ts additions

Single `+1` line: `"/whats-new"` added to the `publicRoutes` `it.each` array. `/help/permissions` was already there. `protectedRoutes` array already covered `/settings` and `/admin/users`. Test count for the `"updateSession public route access"` describe block: 20 → 21 `it.each` iterations.

## Files changed

- `e2e/full/public-routes-audit.spec.ts`: +31 / -181 (deleted 18 blocks, kept 2, rewrote header docblock)
- `src/lib/supabase/middleware.test.ts`: +1 / -0

## Test plan

- [x] `pnpm run check` green (1041 tests, 117 files, 20.48s)
- [x] `pnpm exec playwright test e2e/full/public-routes-audit.spec.ts --project=chromium --list` enumerates the 2 KEEP tests cleanly
- [ ] CI green (Playwright run in CI environment without local orphan-container collision)

Closes PP-x6nb. Parent epic: PP-xm1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)