### PR TITLE
docs: changelog week of May 11, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 89, "lastUpdated": "2026-04-06" }
+{ "totalEntries": 92, "lastUpdated": "2026-05-15" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,18 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## May 11, 2026
+
+### New Features
+
+- **Issue Detail Page Updates** — Machine status, severity, priority, and other details now appear inline on the issue page; on mobile, the comment box is pinned to the bottom of the screen so you can reply without scrolling back up
+
+### Bug Fixes
+
+- After posting a comment, the text editor now automatically clears and refocuses so you can immediately start typing the next one without any extra clicks
+- Signing out now ends your session on all devices at once; deleting your account immediately revokes all active sessions everywhere
+
+---
+
 ## April 6, 2026
 
 ### New Features


### PR DESCRIPTION
## Summary

Weekly user-facing changelog entry for the week of May 11, 2026. Covers 3 merged PRs out of 26 total (the rest were deps, CI, tests, and internal infra).

### New Features (1 bullet)
- **Issue Detail Page Updates** — inline metadata + sticky mobile composer (#1270)

### Bug Fixes (2 bullets)
- Rich-text editor clears and refocuses after comment submit (#1328)
- Global logout (all devices) + revoke-all-sessions on account delete (#1306)

### Filtered out (not user-facing)
- #1327 CI paths-filter fix
- #1322, #1320, #1314, #1311, #1310, #1305, #1304, #1299, #1298, #1300, #1297 — dependency updates
- #1323 pnpm audit gate / security overrides
- #1317 testing doctrine docs
- #1315, #1313, #1291, #1302 — E2E/test fixes and cleanup
- #1312 db-reset script fix
- #1309 Supabase internal config
- #1308 permissions enforcement (internal, no visible behavior change for authenticated users)
- #1303 docs-only

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoZ2Peh3uYRCkGfd4VfBsY)_