### PR TITLE
fix(security): suppress reporter email in pino log + bestEffort for Discord DM (PP-klu8)

### DIFF
--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -169,7 +169,7 @@ export async function submitPublicIssueAction(
   // 5. Resolve reporter (user was loaded above; reuse it here)
   let reportedBy: string | null = user?.id ?? null;
   log.info(
-    { reportedBy, email: user?.email, action: "publicIssueReport" },
+    { reportedBy, hasEmail: !!user?.email, action: "publicIssueReport" },
     "Resolving reporter for public issue"
   );
   let reporterName: string | null = null;

--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -278,8 +278,10 @@ export async function createNotification(
       if (r.status === "rejected") {
         // Channel.deliver() is expected to catch its own errors and return
         // {ok:false}. A rejection here means a bug — log at error level and report to Sentry.
+        // bestEffort: true because notification fan-out is a post-commit side-effect;
+        // failures here do not affect the primary user-facing action.
         reportError(r.reason, {
-          bestEffort: false,
+          bestEffort: true,
           action: "notifications.dispatch.fanout",
         });
       }


### PR DESCRIPTION
## Summary

Two small, isolated security-review backfill fixes (Issue #1340 / PP-klu8).

### Fix 1 — Pino email log (`src/app/(app)/report/actions.ts:172`)

**Before:** `{ reportedBy, email: user?.email, action: "publicIssueReport" }`
**After:** `{ reportedBy, hasEmail: !!user?.email, action: "publicIssueReport" }`

Pino currently logs to stdout only, but a future Sentry transport (we already route some errors there) would forward raw log objects including the `email` field. Pre-empting the latent leak now by replacing the raw email value with a boolean presence flag.

No existing tests assert on the `email` log field (confirmed by reading `src/app/(app)/report/actions.test.ts`), so no test updates needed.

### Fix 2 — `bestEffort` flag in notification dispatch (`src/lib/notifications/dispatch.ts:282`)

**Before:** `bestEffort: false`
**After:** `bestEffort: true`

The rejection handler in `createNotification`'s fan-out loop fires when `channel.deliver()` throws instead of returning `{ok: false}`. The comment notes this "means a bug." However, notification delivery is a post-commit side-effect — failures here do not affect the primary user-facing action. Marking as `bestEffort: true` is consistent with how `src/services/issues.ts` handles notification-related `reportError` calls throughout the codebase.

**Important scoping note:** `bestEffort: true` does NOT suppress Sentry capture — the error is still reported to both Sentry and the structured log. It only adds a routing tag so alert rules can treat best-effort failures differently from primary-path failures. This is the correct granularity for notification fan-out errors.

The Discord channel adapter (`src/lib/notifications/channels/discord-channel.ts`) already handles all expected failures internally (429 → `rate_limited`, blocked → `permanent`, network error → `transient`) without throwing, so they never reach the rejection path. Any rejection in the fan-out loop is a genuine unexpected bug regardless of channel — the `bestEffort` flag is the right lever to tune alert routing without silencing the errors.

No new tests added: the change is a context-tag adjustment to an already-tested error reporting path.

Closes #1340
Closes PP-klu8

🤖 Generated with [Claude Code](https://claude.com/claude-code)