### PR TITLE
fix(settings): clear password inputs after successful change-password save (PP-cy0)

### DIFF
--- a/e2e/full/change-password.spec.ts
+++ b/e2e/full/change-password.spec.ts
@@ -58,6 +58,13 @@ test.describe("Change Password", () => {
 
     await expect(form.getByRole("button", { name: "Saved!" })).toBeVisible();
 
+    // --- Verify password inputs are cleared after successful save ---
+    await expect(page.locator('input[name="currentPassword"]')).toHaveValue("");
+    await expect(page.locator('input[name="newPassword"]')).toHaveValue("");
+    await expect(page.locator('input[name="confirmNewPassword"]')).toHaveValue(
+      ""
+    );
+
     // --- Verify new password works ---
     await logout(page, testInfo);
 

--- a/src/app/(app)/settings/change-password-section.tsx
+++ b/src/app/(app)/settings/change-password-section.tsx
@@ -24,8 +24,15 @@ export function ChangePasswordSection(): React.JSX.Element {
     }
   }, [state]);
 
-  // Reset key to force re-render on cancel
+  // Reset key to force re-render on cancel or successful save
   const [resetKey, setResetKey] = useState(0);
+
+  // Clear password inputs after successful save by remounting the form
+  useEffect(() => {
+    if (state?.ok) {
+      setResetKey((k) => k + 1);
+    }
+  }, [state]);
 
   return (
     <form


### PR DESCRIPTION
## Summary

Password inputs in the change-password form remained populated in the DOM after a successful save — a security smell where cleartext credentials linger for shoulder-surfing, screen capture, and browser-extension scraping.

- **Fix**: Added a `useEffect` in `ChangePasswordSection` that watches `state.ok` and increments the form's `resetKey` on success. Incrementing `resetKey` remounts the form subtree, which resets all three uncontrolled password inputs (`currentPassword`, `newPassword`, `confirmNewPassword`) to empty. The `Saved!` button continues to appear because `showFeedback` is driven independently and is untouched by this change.
- **Error path**: Only `state.ok === true` triggers the reset. Failed submissions leave inputs populated so the user can correct their input.
- **E2E**: Added three `toHaveValue('')` assertions immediately after the `Saved!` button assertion in `e2e/full/change-password.spec.ts`.

Closes PP-cy0

## Test plan

- [x] `pnpm run check` passes (1060 unit tests)
- [x] `pnpm exec playwright test e2e/full/change-password.spec.ts --project=chromium` — 5/5 passed locally including the new input-clearing assertions
- [ ] CI `CI Gate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)