### PR TITLE
chore(infra): stop generating Turnstile test keys in .env.local (PP-5fb)

### DIFF
--- a/scripts/tests/test_worktree_setup.py
+++ b/scripts/tests/test_worktree_setup.py
@@ -199,17 +199,17 @@ class TestMergeEnvLocal:
         assert "INBUCKET_SMTP_PORT=58325" in result
         assert "MAILPIT_SMTP_PORT=58325" in result
 
-    def test_turnstile_keys_are_commented_out(
+    def test_turnstile_keys_are_absent(
         self, tmp_path: Path, port_config: PortConfig
     ) -> None:
         result = merge_env_local(tmp_path, port_config)
 
-        # Keys must appear as commented-out lines so the widget doesn't render in local dev.
-        assert "# NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA" in result
-        assert "# TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA" in result
-        # Must NOT appear as active (uncommented) env vars.
-        assert "\nNEXT_PUBLIC_TURNSTILE_SITE_KEY=" not in result
-        assert "\nTURNSTILE_SECRET_KEY=" not in result
+        # Turnstile keys must not appear at all — not even commented out.
+        # The application already handles unset keys gracefully:
+        # - Client (TurnstileWidget): if (!siteKey) return null
+        # - Server (turnstile.ts): if (!secretKey && !production) return true
+        assert "NEXT_PUBLIC_TURNSTILE_SITE_KEY" not in result
+        assert "TURNSTILE_SECRET_KEY" not in result
 
 
 class TestManagedKeys:
@@ -232,8 +232,7 @@ class TestManagedKeys:
             "DEV_AUTOLOGIN_PASSWORD",
             "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
             "SUPABASE_SERVICE_ROLE_KEY",
-            "NEXT_PUBLIC_TURNSTILE_SITE_KEY",
-            "TURNSTILE_SECRET_KEY",
+            "UNSUBSCRIBE_SIGNING_SECRET",
         }
         assert MANAGED_ENV_KEYS == expected_managed
 

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -60,8 +60,6 @@ MANAGED_ENV_KEYS = {
     "DEV_AUTOLOGIN_PASSWORD",
     "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
     "SUPABASE_SERVICE_ROLE_KEY",
-    "NEXT_PUBLIC_TURNSTILE_SITE_KEY",
-    "TURNSTILE_SECRET_KEY",
     "UNSUBSCRIBE_SIGNING_SECRET",
 }
 
@@ -322,11 +320,6 @@ def format_env_file(
         f"NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY={managed_values['NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY']}",
         f"SUPABASE_SERVICE_ROLE_KEY={managed_values['SUPABASE_SERVICE_ROLE_KEY']}",
         "",
-        "# Turnstile keys are commented out for local dev so the widget doesn't render.",
-        "# To test CAPTCHA UI locally, uncomment these. Production sets them via Vercel env.",
-        f"# NEXT_PUBLIC_TURNSTILE_SITE_KEY={managed_values['NEXT_PUBLIC_TURNSTILE_SITE_KEY']}",
-        f"# TURNSTILE_SECRET_KEY={managed_values['TURNSTILE_SECRET_KEY']}",
-        "",
         "# Unsubscribe-link HMAC signing secret (local-dev placeholder).",
         "# Production uses a real `openssl rand -hex 32` value set in Vercel env.",
         f"UNSUBSCRIBE_SIGNING_SECRET={managed_values['UNSUBSCRIBE_SIGNING_SECRET']}",
@@ -440,8 +433,6 @@ def merge_env_local(worktree_path: Path, port_config: PortConfig) -> str:
         "DEV_AUTOLOGIN_PASSWORD": "TestPassword123",
         "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY": LOCAL_SUPABASE_PUBLISHABLE_KEY,
         "SUPABASE_SERVICE_ROLE_KEY": LOCAL_SUPABASE_SERVICE_ROLE_KEY,
-        "NEXT_PUBLIC_TURNSTILE_SITE_KEY": "1x00000000000000000000AA",
-        "TURNSTILE_SECRET_KEY": "1x0000000000000000000000000000000AA",
         # Unsubscribe-link HMAC signing secret. Falls back to a placeholder
         # only when no real value is set; preserves any developer-set value
         # so chmod-+w / edit / regenerate doesn't overwrite it.


### PR DESCRIPTION
## Summary

This PR fixes PP-uc8 at the source rather than via the `dev:e2e` workaround introduced in #1283.

**Root cause**: `scripts/worktree_setup.py` was writing Cloudflare test keys (`1x00000...`) into every worktree's `.env.local`. Even commented-out, this was more complexity than necessary.

**The fix**: Remove the Turnstile entries from `worktree_setup.py` entirely. The application already handles unset keys gracefully:
- Client (`TurnstileWidget.tsx`): `if (!siteKey) return null` — widget simply doesn't render
- Server (`src/lib/security/turnstile.ts`): `if (!secretKey && !production) return true` — verification is skipped with a warn log

This eliminates the special carve-out, the commented-out Cloudflare key noise in `.env.local`, and the underlying cause of PP-uc8.

**Note**: PR #1283 was already merged before this PR was created, so there is nothing to close.

**Testing Turnstile locally**: If you need to test CAPTCHA UI, set the env vars via shell override or temporarily `chmod +w .env.local` and add them manually. Production continues to use real keys set in Vercel.

Also fixes a pre-existing test gap where `UNSUBSCRIBE_SIGNING_SECRET` was missing from the managed-keys completeness test (added in PP-7xt but the test wasn't updated).

Closes PP-5fb

🤖 Generated with [Claude Code](https://claude.com/claude-code)