### PR TITLE
docs(agents): add worktree-dispatch safety rules (PP-484c)

### DIFF
--- a/.agent/skills/pinpoint-dispatch-e2e-teammate/SKILL.md
+++ b/.agent/skills/pinpoint-dispatch-e2e-teammate/SKILL.md
@@ -35,7 +35,7 @@ Customize: remove Copilot line for trivial changes, add task-specific items.
 ## Step 2: Dispatch the Subagent
 
 ```
-Task(
+Agent(
   subagent_type: "general-purpose",
   model: "sonnet",
   isolation: "worktree",

--- a/.agent/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agent/skills/pinpoint-orchestrator/SKILL.md
@@ -103,9 +103,9 @@ Present options to user. Before proceeding, verify tasks are independent:
 
 > **Known bug — team_name**: `isolation: "worktree"` is silently ignored when `team_name` is set. For Agent Teams, create worktrees manually with `git worktree add`.
 >
-> **Known bug — dispatch-from-nested-worktree** (anthropics/claude-code#47548): Dispatching `Agent(isolation: "worktree")` from inside a non-primary worktree (e.g., `.claude/worktrees/agent-*`) silently switches the parent worktree's branch to the subagent's new branch. Fires at N=1. **Always dispatch from the main checkout.**
+> **Known bug — dispatch-from-linked-worktree** (anthropics/claude-code#47548): Dispatching `Agent(isolation: "worktree")` from inside a linked (non-primary) worktree, e.g. `.claude/worktrees/agent-*`, silently switches the parent worktree's branch to the subagent's new branch. Fires at N=1. **Always dispatch from the main worktree** — the original clone where `.git/` is a directory.
 >
-> **Known bug — parallel-batch race** (anthropics/claude-code#47266): Sending 3+ `Agent(isolation: "worktree")` calls in a single message causes a `.git/config.lock` race — 2 of 3 typically fail. **Limit to N≤2 `isolation: "worktree"` calls per message.** If you need 3+, serialize: dispatch 2, wait for them to start, then dispatch the rest.
+> **Known bug — parallel-batch race** (anthropics/claude-code#47266): Parallel `Agent(isolation: "worktree")` calls in one message can race on `.git/config.lock`. Upstream reproducer is N=3 with 2 of 3 failing; we have no evidence N=2 is reliably safe. **Serialize: one `Agent(isolation: "worktree")` call per message.** Dispatch, confirm the new `.claude/worktrees/agent-*` directory appeared, then dispatch the next.
 
 Manual worktree creation is for the lead's own use or Agent Teams worktree setup:
 
@@ -120,7 +120,7 @@ git worktree add ../pinpoint-worktrees/<branch-name> -b <branch-name>
 ### Option A: Standalone Subagents (Primary)
 
 ```
-Task(
+Agent(
   subagent_type: "general-purpose",
   model: "sonnet",
   isolation: "worktree",
@@ -151,7 +151,7 @@ git worktree add ../pinpoint-worktrees/feat-<branch-name> -b feat/<branch-name>
 ```
 
 ```
-Task(
+Agent(
   subagent_type: "general-purpose",
   model: "sonnet",
   team_name: "pinpoint-<summary>",
@@ -292,14 +292,14 @@ If a subagent can't be resumed (GC'd), spawn a new one on the same branch.
 
 ## Error Recovery
 
-| Problem                                 | Fix                                                                                                     |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Subagent fails to create PR             | Check output, verify worktree state, resume with context                                                |
-| Permission denied on worktree           | Add paths to `.claude/settings.json`, restart session                                                   |
-| Worktree creation fails                 | `supabase stop` (current worktree only — **never** `--all`), then re-create with `git worktree add`     |
-| Agent Teams isolation broken            | Known bug. Use standalone subagents (Option A) instead                                                  |
-| `.git/config.lock` race on N≥3 dispatch | anthropics/claude-code#47266. Serialize: dispatch ≤2, wait, then dispatch rest                          |
-| Parent branch flips after dispatch      | anthropics/claude-code#47548. You dispatched from a nested worktree. Always dispatch from main checkout |
-| Hooks fire from wrong directory         | Hooks skip for non-worktree CWD. Safeword: `touch .claude-hook-bypass`                                  |
-| Session dies with active team           | `rm -rf ~/.claude/teams/<name> ~/.claude/tasks/<name>`                                                  |
-| Husky post-checkout hook fails          | Check `.husky/post-checkout` for merge conflict markers                                                 |
+| Problem                                      | Fix                                                                                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Subagent fails to create PR                  | Check output, verify worktree state, resume with context                                                                               |
+| Permission denied on worktree                | Add paths to `.claude/settings.json`, restart session                                                                                  |
+| Worktree creation fails                      | `supabase stop` (current worktree only — **never** `--all`), then re-create with `git worktree add`                                    |
+| Agent Teams isolation broken                 | Known bug. Use standalone subagents (Option A) instead                                                                                 |
+| `.git/config.lock` race on parallel dispatch | anthropics/claude-code#47266. Serialize: one `Agent(isolation: "worktree")` per message, confirm worktree appeared, then dispatch next |
+| Parent branch flips after dispatch           | anthropics/claude-code#47548. You dispatched from a linked worktree. Always dispatch from the main worktree                            |
+| Hooks fire from wrong directory              | Hooks skip for non-worktree CWD. Safeword: `touch .claude-hook-bypass`                                                                 |
+| Session dies with active team                | `rm -rf ~/.claude/teams/<name> ~/.claude/tasks/<name>`                                                                                 |
+| Husky post-checkout hook fails               | Check `.husky/post-checkout` for merge conflict markers                                                                                |

--- a/.agent/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agent/skills/pinpoint-orchestrator/SKILL.md
@@ -101,7 +101,11 @@ Present options to user. Before proceeding, verify tasks are independent:
 
 `isolation: "worktree"` handles creation automatically. The Husky `post-checkout` hook runs `scripts/worktree_setup.py` to allocate ports and generate configs.
 
-> **Known bug**: `isolation: "worktree"` is silently ignored when `team_name` is set. For Agent Teams, create worktrees manually with `git worktree add`.
+> **Known bug — team_name**: `isolation: "worktree"` is silently ignored when `team_name` is set. For Agent Teams, create worktrees manually with `git worktree add`.
+>
+> **Known bug — dispatch-from-nested-worktree** (anthropics/claude-code#47548): Dispatching `Agent(isolation: "worktree")` from inside a non-primary worktree (e.g., `.claude/worktrees/agent-*`) silently switches the parent worktree's branch to the subagent's new branch. Fires at N=1. **Always dispatch from the main checkout.**
+>
+> **Known bug — parallel-batch race** (anthropics/claude-code#47266): Sending 3+ `Agent(isolation: "worktree")` calls in a single message causes a `.git/config.lock` race — 2 of 3 typically fail. **Limit to N≤2 `isolation: "worktree"` calls per message.** If you need 3+, serialize: dispatch 2, wait for them to start, then dispatch the rest.
 
 Manual worktree creation is for the lead's own use or Agent Teams worktree setup:
 
@@ -288,12 +292,14 @@ If a subagent can't be resumed (GC'd), spawn a new one on the same branch.
 
 ## Error Recovery
 
-| Problem                         | Fix                                                                                                 |
-| ------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Subagent fails to create PR     | Check output, verify worktree state, resume with context                                            |
-| Permission denied on worktree   | Add paths to `.claude/settings.json`, restart session                                               |
-| Worktree creation fails         | `supabase stop` (current worktree only — **never** `--all`), then re-create with `git worktree add` |
-| Agent Teams isolation broken    | Known bug. Use standalone subagents (Option A) instead                                              |
-| Hooks fire from wrong directory | Hooks skip for non-worktree CWD. Safeword: `touch .claude-hook-bypass`                              |
-| Session dies with active team   | `rm -rf ~/.claude/teams/<name> ~/.claude/tasks/<name>`                                              |
-| Husky post-checkout hook fails  | Check `.husky/post-checkout` for merge conflict markers                                             |
+| Problem                                 | Fix                                                                                                     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Subagent fails to create PR             | Check output, verify worktree state, resume with context                                                |
+| Permission denied on worktree           | Add paths to `.claude/settings.json`, restart session                                                   |
+| Worktree creation fails                 | `supabase stop` (current worktree only — **never** `--all`), then re-create with `git worktree add`     |
+| Agent Teams isolation broken            | Known bug. Use standalone subagents (Option A) instead                                                  |
+| `.git/config.lock` race on N≥3 dispatch | anthropics/claude-code#47266. Serialize: dispatch ≤2, wait, then dispatch rest                          |
+| Parent branch flips after dispatch      | anthropics/claude-code#47548. You dispatched from a nested worktree. Always dispatch from main checkout |
+| Hooks fire from wrong directory         | Hooks skip for non-worktree CWD. Safeword: `touch .claude-hook-bypass`                                  |
+| Session dies with active team           | `rm -rf ~/.claude/teams/<name> ~/.claude/tasks/<name>`                                                  |
+| Husky post-checkout hook fails          | Check `.husky/post-checkout` for merge conflict markers                                                 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,8 +314,10 @@ For multiple independent tasks, use worktree-isolated subagents.
 
 - DON'T use Agent Teams as default — standalone subagents have working worktree isolation
 - DON'T forget to check Copilot comments before merging
+- DON'T dispatch `isolation: "worktree"` subagents from inside a nested worktree — see "Worktree Dispatch Safety" in CLAUDE.md
+- DON'T dispatch 3+ `isolation: "worktree"` subagents in one message — see "Worktree Dispatch Safety" in CLAUDE.md
 
-See `pinpoint-orchestrator` skill for the full workflow.
+See `pinpoint-orchestrator` skill for the full workflow and known-bug details.
 
 ### Claude in Web Candidates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,8 +314,8 @@ For multiple independent tasks, use worktree-isolated subagents.
 
 - DON'T use Agent Teams as default — standalone subagents have working worktree isolation
 - DON'T forget to check Copilot comments before merging
-- DON'T dispatch `isolation: "worktree"` subagents from inside a nested worktree — see "Worktree Dispatch Safety" in CLAUDE.md
-- DON'T dispatch 3+ `isolation: "worktree"` subagents in one message — see "Worktree Dispatch Safety" in CLAUDE.md
+- DON'T dispatch `Agent(isolation: "worktree")` from a linked (non-primary) worktree — see "Worktree Dispatch Safety" in CLAUDE.md
+- DON'T fire 2+ `Agent(isolation: "worktree")` calls in a single message — serialize them, see "Worktree Dispatch Safety" in CLAUDE.md
 
 See `pinpoint-orchestrator` skill for the full workflow and known-bug details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,11 @@
 
 ### Worktree Dispatch Safety
 
-Two upstream Claude Code bugs require active enforcement when the user asks you to dispatch subagents with `isolation: "worktree"`:
+Two upstream Claude Code bugs require active enforcement when the user asks you to dispatch subagents via `Agent(isolation: "worktree")`. "Main worktree" below means the original repository clone — the worktree where `.git/` is a directory, not a file pointing into `.git/worktrees/`. It is **not** about being on the `main` branch.
 
-1. **Dispatch only from the main checkout.** If your CWD is inside `.claude/worktrees/agent-*` or any non-primary worktree, **refuse and explain**: upstream bug [anthropics/claude-code#47548](https://github.com/anthropics/claude-code/issues/47548) silently switches the parent worktree's branch to the subagent's new branch when dispatched from a nested worktree — even at N=1. Tell the user you need to switch back to the main checkout first, or ask whether they want to accept the risk.
+1. **Dispatch only from the main worktree.** If your CWD is inside `.claude/worktrees/agent-*` or any other linked (non-primary) worktree, **refuse and explain**: upstream bug [anthropics/claude-code#47548](https://github.com/anthropics/claude-code/issues/47548) silently switches the parent worktree's branch to the subagent's new branch when dispatched from a linked worktree — even at N=1. Tell the user you need to switch back to the main worktree first, or ask whether they want to accept the risk.
 
-2. **Limit to N≤2 `isolation: "worktree"` calls per message.** N≥3 in a single parallel batch hits a `.git/config.lock` race ([anthropics/claude-code#47266](https://github.com/anthropics/claude-code/issues/47266)) — 2 of 3 typically fail. If the user requests 3+, push back: offer to serialize (dispatch 2, wait for them to start, then dispatch the rest), or explain the risk.
+2. **Serialize: one `isolation: "worktree"` Agent call per message.** Two or more parallel `Agent(isolation: "worktree")` calls in a single message can race on `.git/config.lock` ([anthropics/claude-code#47266](https://github.com/anthropics/claude-code/issues/47266)) — the upstream reproducer is N=3 with 2 of 3 failing, and we have no evidence that N=2 is reliably safe. Dispatch one, confirm its worktree appeared on disk, then dispatch the next. If the user asks for 2+ in one message, push back: explain the race, offer to serialize.
 
 If the user explicitly overrides ("yes, do it anyway"), proceed. These rules require push-back + explanation, not silent compliance.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,15 @@
   the actual issue, stop and ask the user for guidance.
 - For simple PRs (< 5 files changed), do not spawn more than 2 sub-agents.
 - Do not over-engineer or spawn excessive parallel agents for straightforward tasks.
+
+### Worktree Dispatch Safety
+
+Two upstream Claude Code bugs require active enforcement when the user asks you to dispatch subagents with `isolation: "worktree"`:
+
+1. **Dispatch only from the main checkout.** If your CWD is inside `.claude/worktrees/agent-*` or any non-primary worktree, **refuse and explain**: upstream bug [anthropics/claude-code#47548](https://github.com/anthropics/claude-code/issues/47548) silently switches the parent worktree's branch to the subagent's new branch when dispatched from a nested worktree — even at N=1. Tell the user you need to switch back to the main checkout first, or ask whether they want to accept the risk.
+
+2. **Limit to N≤2 `isolation: "worktree"` calls per message.** N≥3 in a single parallel batch hits a `.git/config.lock` race ([anthropics/claude-code#47266](https://github.com/anthropics/claude-code/issues/47266)) — 2 of 3 typically fail. If the user requests 3+, push back: offer to serialize (dispatch 2, wait for them to start, then dispatch the rest), or explain the risk.
+
+If the user explicitly overrides ("yes, do it anyway"), proceed. These rules require push-back + explanation, not silent compliance.
+
+See `pinpoint-orchestrator` skill Phase 2 for the full technical record.


### PR DESCRIPTION
## Summary

- Adds **Worktree Dispatch Safety** section to `CLAUDE.md` with push-back rules for the two open upstream bugs
- Expands `pinpoint-orchestrator` SKILL.md Phase 2 known-bugs block with `#47548` and `#47266` entries; adds two Error Recovery table rows
- Adds cross-reference anti-pattern bullets in `AGENTS.md` Parallel Subagent Workflow

## Upstream bugs addressed

- [anthropics/claude-code#47548](https://github.com/anthropics/claude-code/issues/47548) — dispatching `isolation: "worktree"` from a non-primary worktree silently switches the parent branch to the subagent's new branch (N=1 is enough to trigger)
- [anthropics/claude-code#47266](https://github.com/anthropics/claude-code/issues/47266) — 3+ `isolation: "worktree"` calls in a single message race on `.git/config.lock`; 2 of 3 typically fail

## Context

Discovered during PP-46z investigation; empirically confirmed during PP-cvh coordination (Claude-Spinner, Claude-Slingshot, Claude-Plunger).

## Test plan

- [x] `pnpm run check` passes
- [ ] Human review: tone matches existing CLAUDE.md/AGENTS.md style
- [ ] Human review: rules are actionable and not redundant

🤖 Generated with [Claude Code](https://claude.com/claude-code)