### PR TITLE
feat(workflow): extract PR gates to shared helper + add claude-merge.sh (PP-d4bf)

### DIFF
--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# scripts/workflow/_pr-gates.sh
+# Shared PR gate functions sourced by label-ready.sh and claude-merge.sh.
+# Each function prints informative output and returns 0 (pass) or 1 (fail).
+#
+# Usage: source this file, then call gate functions:
+#   check_ci <PR>
+#   check_copilot_currency <PR> [force]
+#   check_unresolved_threads <PR> [force]
+#   check_no_merge_conflict <PR>
+#
+# Pass "true" as the second arg to force-bypass gates that support it.
+
+# ---------------------------------------------------------------------------
+# check_ci <PR>
+# Verifies all CI checks have completed and passed (ignoring codecov/* checks).
+# Returns 0 if all checks succeeded, 1 if any failed, pending, or no checks.
+# ---------------------------------------------------------------------------
+check_ci() {
+    local PR="$1"
+    local checks total failed pending failed_names
+
+    checks=$(gh pr checks "$PR" --json name,state 2>&1) || {
+        echo "FAIL: Could not fetch CI checks for PR #${PR}."
+        return 1
+    }
+    total=$(echo "$checks" | jq 'length')
+    failed=$(echo "$checks" | jq '[.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.state != "CANCELLED") and (.state != "SKIPPED") and (.name | startswith("codecov/") | not))] | length')
+    pending=$(echo "$checks" | jq '[.[] | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING")] | length')
+
+    if [ "$total" -eq 0 ]; then
+        echo "WAIT: No CI checks reported yet."
+        return 1
+    fi
+
+    if [ "$pending" -gt 0 ]; then
+        echo "WAIT: ${pending} checks still running."
+        return 1
+    fi
+
+    if [ "$failed" -gt 0 ]; then
+        failed_names=$(echo "$checks" | jq -r '.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.state != "CANCELLED") and (.state != "SKIPPED") and (.name | startswith("codecov/") | not)) | "\(.name) (\(.state))"' | paste -sd ", ")
+        echo "FAIL: ${failed} checks failed: ${failed_names}"
+        return 1
+    fi
+
+    echo "CI: All checks passed."
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# check_copilot_currency <PR> [force]
+# Verifies the latest Copilot review covers the head commit (PP-pny0 logic).
+# If force="true", skips the check and returns 0.
+# Returns 0 (pass/warn/skip) or 1 (WAIT: review pending within threshold).
+# ---------------------------------------------------------------------------
+COPILOT_CURRENCY_THRESHOLD=600  # seconds; elapsed >= threshold → WARN and proceed
+
+check_copilot_currency() {
+    local PR="$1"
+    local force="${2:-false}"
+    local reviews_json latest_review head_sha head_date head_epoch now_epoch elapsed head_date_noz
+
+    if [ "$force" = "true" ]; then
+        return 0
+    fi
+
+    # Paginate to cover long-running PRs with >30 review cycles. Run jq on the
+    # merged output (not via --jq) so sort_by/last operates across all pages.
+    # Distinguish API failure from "no Copilot reviews": failure exits 1 per
+    # scripts/workflow/AGENTS.md ("label-ready must fail closed on Copilot
+    # API errors unless --force").
+    if ! reviews_json=$(gh api --paginate "repos/timothyfroehlich/PinPoint/pulls/${PR}/reviews" 2>/dev/null); then
+        echo "FAIL: Could not query Copilot reviews from GitHub API. Use --force to override."
+        return 1
+    fi
+    latest_review=$(echo "$reviews_json" | jq -r '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | sort_by(.submitted_at) | last | .submitted_at // empty')
+
+    if [ -n "$latest_review" ]; then
+        if ! head_sha=$(gh api "repos/timothyfroehlich/PinPoint/pulls/${PR}" --jq '.head.sha // empty' 2>/dev/null); then
+            echo "FAIL: Could not fetch PR head SHA from GitHub API. Use --force to override."
+            return 1
+        fi
+        if [ -n "$head_sha" ]; then
+            if ! head_date=$(gh api "repos/timothyfroehlich/PinPoint/commits/${head_sha}" --jq '.commit.committer.date // empty' 2>/dev/null); then
+                echo "FAIL: Could not fetch head commit metadata from GitHub API. Use --force to override."
+                return 1
+            fi
+
+            if [ -n "$head_date" ] && [[ "$head_date" > "$latest_review" ]]; then
+                # Head commit is newer than last Copilot review — compute elapsed seconds.
+                # Both macOS (BSD date -jf) and Linux (GNU date -d) need TZ=UTC to parse
+                # the trailing Z as UTC rather than the local timezone.
+                if date --version >/dev/null 2>&1; then
+                    # GNU date (Linux)
+                    head_epoch=$(TZ=UTC date -d "$head_date" +%s 2>/dev/null) || head_epoch=0
+                    now_epoch=$(date +%s)
+                else
+                    # BSD date (macOS) — strip trailing Z, parse with explicit TZ=UTC
+                    head_date_noz="${head_date%Z}"
+                    head_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%S" "$head_date_noz" +%s 2>/dev/null) || head_epoch=0
+                    now_epoch=$(date +%s)
+                fi
+
+                if [ "$head_epoch" -gt 0 ]; then
+                    elapsed=$(( now_epoch - head_epoch ))
+                    if [ "$elapsed" -lt "$COPILOT_CURRENCY_THRESHOLD" ]; then
+                        echo "WAIT: Copilot review pending for ${elapsed}s since push (threshold: ${COPILOT_CURRENCY_THRESHOLD}s). Use --force to override."
+                        return 1
+                    else
+                        echo "WARN: Copilot review not received after ${elapsed}s — proceeding."
+                    fi
+                else
+                    echo "WARN: Could not parse head commit date '${head_date}' — skipping currency check."
+                fi
+            elif [ -n "$head_date" ]; then
+                echo "Copilot: review is current."
+            else
+                echo "WARN: Could not fetch head commit date — skipping currency check."
+            fi
+        else
+            echo "WARN: Could not fetch head SHA — skipping currency check."
+        fi
+    else
+        # No Copilot reviews at all — some PRs legitimately skip (e.g. Dependabot).
+        echo "Copilot: no reviews found — skipping currency check."
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# check_unresolved_threads <PR> [force]
+# Verifies there are 0 unresolved Copilot review threads (via GraphQL).
+# If force="true", warns instead of blocking.
+# Returns 0 (pass or forced) or 1 (unresolved threads present).
+# ---------------------------------------------------------------------------
+check_unresolved_threads() {
+    local PR="$1"
+    local force="${2:-false}"
+    local copilot_count
+
+    # shellcheck disable=SC2016
+    copilot_count=$(gh api graphql -f query="
+  {
+    repository(owner: \"timothyfroehlich\", name: \"PinPoint\") {
+      pullRequest(number: $PR) {
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+            comments(first: 1) {
+              nodes { author { login } }
+            }
+          }
+        }
+      }
+    }
+  }" --jq '
+  [.data.repository.pullRequest.reviewThreads.nodes[]
+   | select(.isResolved == false)
+   | select(.comments.nodes | length > 0)
+   | .comments.nodes[0] as $comment
+   | select(
+       $comment.author.login == "copilot-pull-request-reviewer"
+       or $comment.author.login == "copilot-pull-request-reviewer[bot]"
+     )]
+   | length' 2>/dev/null) || {
+        echo "FAIL: Could not fetch Copilot threads (API error). Use --force to skip."
+        return 1
+    }
+
+    if [ "$copilot_count" -gt 0 ] && [ "$force" = "false" ]; then
+        echo "BLOCK: ${copilot_count} unresolved Copilot thread(s). Use --force to label anyway."
+        return 1
+    fi
+
+    if [ "$copilot_count" -gt 0 ]; then
+        echo "WARN: ${copilot_count} unresolved Copilot thread(s) (--force used)."
+    else
+        echo "Copilot: 0 unresolved threads."
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# check_no_merge_conflict <PR>
+# Verifies the PR is mergeable (not CONFLICTING). BEHIND is allowed.
+# Retries up to 30s if GitHub returns UNKNOWN (still computing).
+# Returns 0 (MERGEABLE or BEHIND) or 1 (CONFLICTING or timeout).
+# ---------------------------------------------------------------------------
+check_no_merge_conflict() {
+    local PR="$1"
+    local mergeable elapsed=0 interval=5
+
+    while [ "$elapsed" -le 30 ]; do
+        mergeable=$(gh pr view "$PR" --json mergeable --jq '.mergeable' 2>/dev/null) || {
+            echo "FAIL: Could not fetch mergeable status for PR #${PR}."
+            return 1
+        }
+
+        case "$mergeable" in
+            MERGEABLE)
+                echo "Merge: no conflicts."
+                return 0
+                ;;
+            CONFLICTING)
+                echo "BLOCK: PR has merge conflicts. Resolve and re-push before merging."
+                return 1
+                ;;
+            UNKNOWN)
+                if [ "$elapsed" -eq 0 ]; then
+                    echo "Merge: GitHub still computing merge status, waiting..."
+                fi
+                sleep "$interval"
+                elapsed=$(( elapsed + interval ))
+                ;;
+            *)
+                echo "WARN: Unexpected mergeable status '${mergeable}' — skipping conflict check."
+                return 0
+                ;;
+        esac
+    done
+
+    echo "FAIL: Timed out waiting for GitHub to compute merge status. Re-run or use --force."
+    return 1
+}

--- a/scripts/workflow/claude-merge.sh
+++ b/scripts/workflow/claude-merge.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# scripts/workflow/claude-merge.sh
+# Re-evaluates all PR gates at merge time and squash-merges if they pass.
+# On gate failure, removes the ready-for-review label (it can no longer be trusted).
+#
+# Usage:
+#   ./scripts/workflow/claude-merge.sh 918                # Check gates and merge
+#   ./scripts/workflow/claude-merge.sh 918 --dry-run       # Show what would happen without acting
+#   ./scripts/workflow/claude-merge.sh 918 --force         # Bypass all gates and merge
+#
+# Gate summary (see _pr-gates.sh for full logic):
+#   check_ci              — all CI checks SUCCESS
+#   check_copilot_currency — last Copilot review covers head commit (PP-pny0)
+#   check_unresolved_threads — 0 unresolved Copilot threads
+#   check_no_merge_conflict  — PR is not CONFLICTING
+#
+# Authorship check (not bypassable by --force — separate safety):
+#   PR must be authored by the current gh CLI user.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/workflow/_pr-gates.sh
+source "${SCRIPT_DIR}/_pr-gates.sh"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <PR_NUMBER> [--dry-run] [--force]"
+    exit 1
+fi
+
+PR=$1
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number must be numeric (e.g. '945'); received '$PR'."
+    exit 1
+fi
+shift
+
+FORCE=false
+DRY_RUN=false
+
+for arg in "$@"; do
+    case $arg in
+        --force) FORCE=true ;;
+        --dry-run) DRY_RUN=true ;;
+        *) echo "Error: unknown option '$arg'."; echo "Usage: $0 <PR_NUMBER> [--dry-run] [--force]"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Authorship check — not bypassable by --force (separate safety concern)
+# ---------------------------------------------------------------------------
+current_user=$(gh api user --jq .login 2>/dev/null) || {
+    echo "FAIL: Could not determine current GitHub user. Check 'gh auth status'."
+    exit 1
+}
+pr_author=$(gh pr view "$PR" --json author --jq .author.login 2>/dev/null) || {
+    echo "FAIL: Could not fetch PR #${PR} author."
+    exit 1
+}
+
+if [ "$current_user" != "$pr_author" ]; then
+    echo "REFUSE: claude-merge only operates on your own PRs."
+    echo "  PR #${PR} was authored by '${pr_author}', but current user is '${current_user}'."
+    exit 1
+fi
+
+# Get PR title for display
+pr_title=$(gh pr view "$PR" --json title --jq .title 2>/dev/null) || pr_title="(unknown)"
+echo "PR #${PR}: ${pr_title}"
+echo "Author: ${pr_author} (matches current user)"
+
+# ---------------------------------------------------------------------------
+# Run all four gates
+# ---------------------------------------------------------------------------
+gates_passed=true
+gate_failures=()
+
+if ! check_ci "$PR"; then
+    gates_passed=false
+    pr_url=$(gh pr view "$PR" --json url --jq .url 2>/dev/null || echo "")
+    gate_failures+=("CI is red — see ${pr_url}")
+fi
+
+if ! check_copilot_currency "$PR" "$FORCE"; then
+    gates_passed=false
+    gate_failures+=("Copilot is reviewing the latest commit — re-run in ~3min, or use --force")
+fi
+
+if ! check_unresolved_threads "$PR" "$FORCE"; then
+    gates_passed=false
+    pr_url=$(gh pr view "$PR" --json url --jq .url 2>/dev/null || echo "")
+    gate_failures+=("Unresolved Copilot threads — address at ${pr_url}/files")
+fi
+
+if ! check_no_merge_conflict "$PR"; then
+    gates_passed=false
+    gate_failures+=("Merge conflict — resolve and re-push (git fetch origin && git merge origin/main)")
+fi
+
+# ---------------------------------------------------------------------------
+# Handle gate failure
+# ---------------------------------------------------------------------------
+if [ "$gates_passed" = "false" ]; then
+    echo ""
+    echo "GATES FAILED — PR #${PR} is not ready to merge."
+    for hint in "${gate_failures[@]}"; do
+        echo "  - ${hint}"
+    done
+
+    if [ "$DRY_RUN" = "false" ]; then
+        # Remove ready-for-review label if present (squelch error if already absent)
+        current_labels=$(gh pr view "$PR" --json labels --jq '[.labels[].name]' 2>/dev/null || echo "[]")
+        if echo "$current_labels" | jq -e 'index("ready-for-review") != null' >/dev/null 2>&1; then
+            gh pr edit "$PR" --remove-label "ready-for-review" >/dev/null 2>&1 || true
+            echo "Removed ready-for-review label (label can no longer be trusted)."
+        fi
+    else
+        echo "(DRY RUN: would remove ready-for-review label if present)"
+    fi
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# All gates passed — merge or dry-run
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" = "true" ]; then
+    echo ""
+    echo "DRY RUN: All gates passed. Would run:"
+    echo "  gh pr merge ${PR} --squash --delete-branch"
+else
+    echo ""
+    echo "All gates passed. Merging PR #${PR}..."
+    gh pr merge "$PR" --squash --delete-branch
+    echo "Merged."
+fi

--- a/scripts/workflow/label-ready.sh
+++ b/scripts/workflow/label-ready.sh
@@ -9,15 +9,17 @@
 #   ./scripts/workflow/label-ready.sh 918 --force             # Label even with Copilot comments
 #   ./scripts/workflow/label-ready.sh 918 --dry-run           # Show what would happen
 #
-# Copilot review currency gate (PP-pny0):
-#   After CI passes, verifies the latest Copilot review covers the head commit.
-#   - head newer than last review AND elapsed < 600s → exit 1 (WAIT)
-#   - head newer than last review AND elapsed >= 600s → WARN and proceed
-#   - review is current (review timestamp >= head commit timestamp) → proceed
-#   - no Copilot reviews at all → proceed (some PRs legitimately skip Copilot)
-#   - --force bypasses this gate
+# Gate summary (see _pr-gates.sh for full logic):
+#   check_ci              — all CI checks SUCCESS
+#   check_copilot_currency — last Copilot review covers head commit (PP-pny0)
+#   check_unresolved_threads — 0 unresolved Copilot threads
+#   check_no_merge_conflict  — PR is not CONFLICTING
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/workflow/_pr-gates.sh
+source "${SCRIPT_DIR}/_pr-gates.sh"
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <PR_NUMBER> [--cleanup] [--force] [--dry-run]"
@@ -57,135 +59,25 @@ if [ "$is_draft" = "true" ]; then
     exit 1
 fi
 
-# Check CI
-checks=$(gh pr checks "$PR" --json name,state 2>&1) || { echo "FAIL: Could not fetch CI checks for PR #${PR}."; exit 1; }
-total=$(echo "$checks" | jq 'length')
-failed=$(echo "$checks" | jq '[.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.state != "CANCELLED") and (.state != "SKIPPED") and (.name | startswith("codecov/") | not))] | length')
-pending=$(echo "$checks" | jq '[.[] | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING")] | length')
+# Run all four gates (--force bypasses currency and thread checks)
+gates_passed=true
 
-if [ "$total" -eq 0 ]; then
-    echo "WAIT: No CI checks reported yet."
+check_ci "$PR" || gates_passed=false
+
+if [ "$gates_passed" = "true" ]; then
+    check_copilot_currency "$PR" "$FORCE" || gates_passed=false
+fi
+
+if [ "$gates_passed" = "true" ]; then
+    check_unresolved_threads "$PR" "$FORCE" || gates_passed=false
+fi
+
+if [ "$gates_passed" = "true" ]; then
+    check_no_merge_conflict "$PR" || gates_passed=false
+fi
+
+if [ "$gates_passed" = "false" ]; then
     exit 1
-fi
-
-if [ "$pending" -gt 0 ]; then
-    echo "WAIT: ${pending} checks still running."
-    exit 1
-fi
-
-if [ "$failed" -gt 0 ]; then
-    failed_names=$(echo "$checks" | jq -r '.[] | select((.state != "SUCCESS") and (.state != "IN_PROGRESS") and (.state != "QUEUED") and (.state != "PENDING") and (.state != "CANCELLED") and (.state != "SKIPPED") and (.name | startswith("codecov/") | not)) | "\(.name) (\(.state))"' | paste -sd ", ")
-    echo "FAIL: ${failed} checks failed: ${failed_names}"
-    exit 1
-fi
-
-echo "CI: All checks passed."
-
-# Gate: Copilot review currency (PP-pny0)
-# Verifies the latest Copilot review covers the current head commit.
-# ISO 8601 timestamps from GitHub are always UTC (Z suffix), so string
-# comparison is lexicographically correct (same logic as copilot-comments.sh).
-COPILOT_CURRENCY_THRESHOLD=600  # seconds; elapsed >= threshold → WARN and proceed
-
-if [ "$FORCE" = "false" ]; then
-    # Paginate to cover long-running PRs with >30 review cycles. Run jq on the
-    # merged output (not via --jq) so sort_by/last operates across all pages.
-    # Distinguish API failure from "no Copilot reviews": failure exits 1 per
-    # scripts/workflow/AGENTS.md ("label-ready must fail closed on Copilot
-    # API errors unless --force").
-    if ! reviews_json=$(gh api --paginate "repos/timothyfroehlich/PinPoint/pulls/${PR}/reviews" 2>/dev/null); then
-        echo "FAIL: Could not query Copilot reviews from GitHub API. Use --force to override."
-        exit 1
-    fi
-    latest_review=$(echo "$reviews_json" | jq -r '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | sort_by(.submitted_at) | last | .submitted_at // empty')
-
-    if [ -n "$latest_review" ]; then
-        if ! head_sha=$(gh api "repos/timothyfroehlich/PinPoint/pulls/${PR}" --jq '.head.sha // empty' 2>/dev/null); then
-            echo "FAIL: Could not fetch PR head SHA from GitHub API. Use --force to override."
-            exit 1
-        fi
-        if [ -n "$head_sha" ]; then
-            if ! head_date=$(gh api "repos/timothyfroehlich/PinPoint/commits/${head_sha}" --jq '.commit.committer.date // empty' 2>/dev/null); then
-                echo "FAIL: Could not fetch head commit metadata from GitHub API. Use --force to override."
-                exit 1
-            fi
-
-            if [ -n "$head_date" ] && [[ "$head_date" > "$latest_review" ]]; then
-                # Head commit is newer than last Copilot review — compute elapsed seconds.
-                # Both macOS (BSD date -jf) and Linux (GNU date -d) need TZ=UTC to parse
-                # the trailing Z as UTC rather than the local timezone.
-                if date --version >/dev/null 2>&1; then
-                    # GNU date (Linux)
-                    head_epoch=$(TZ=UTC date -d "$head_date" +%s 2>/dev/null) || head_epoch=0
-                    now_epoch=$(date +%s)
-                else
-                    # BSD date (macOS) — strip trailing Z, parse with explicit TZ=UTC
-                    head_date_noz="${head_date%Z}"
-                    head_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%S" "$head_date_noz" +%s 2>/dev/null) || head_epoch=0
-                    now_epoch=$(date +%s)
-                fi
-
-                if [ "$head_epoch" -gt 0 ]; then
-                    elapsed=$(( now_epoch - head_epoch ))
-                    if [ "$elapsed" -lt "$COPILOT_CURRENCY_THRESHOLD" ]; then
-                        echo "WAIT: Copilot review pending for ${elapsed}s since push (threshold: ${COPILOT_CURRENCY_THRESHOLD}s). Use --force to override."
-                        exit 1
-                    else
-                        echo "WARN: Copilot review not received after ${elapsed}s — proceeding."
-                    fi
-                else
-                    echo "WARN: Could not parse head commit date '${head_date}' — skipping currency check."
-                fi
-            elif [ -n "$head_date" ]; then
-                echo "Copilot: review is current."
-            else
-                echo "WARN: Could not fetch head commit date — skipping currency check."
-            fi
-        else
-            echo "WARN: Could not fetch head SHA — skipping currency check."
-        fi
-    else
-        # No Copilot reviews at all — some PRs legitimately skip (e.g. Dependabot).
-        echo "Copilot: no reviews found — skipping currency check."
-    fi
-fi
-
-# Check Copilot comments (unresolved threads only via GraphQL)
-# shellcheck disable=SC2016
-copilot_count=$(gh api graphql -f query="
-  {
-    repository(owner: \"timothyfroehlich\", name: \"PinPoint\") {
-      pullRequest(number: $PR) {
-        reviewThreads(first: 100) {
-          nodes {
-            isResolved
-            comments(first: 1) {
-              nodes { author { login } }
-            }
-          }
-        }
-      }
-    }
-  }" --jq '
-  [.data.repository.pullRequest.reviewThreads.nodes[]
-   | select(.isResolved == false)
-   | select(.comments.nodes | length > 0)
-   | .comments.nodes[0] as $comment
-   | select(
-       $comment.author.login == "copilot-pull-request-reviewer"
-       or $comment.author.login == "copilot-pull-request-reviewer[bot]"
-     )]
-   | length' 2>/dev/null) || { echo "FAIL: Could not fetch Copilot threads (API error). Use --force to skip."; exit 1; }
-
-if [ "$copilot_count" -gt 0 ] && [ "$FORCE" = "false" ]; then
-    echo "BLOCK: ${copilot_count} unresolved Copilot thread(s). Use --force to label anyway."
-    exit 1
-fi
-
-if [ "$copilot_count" -gt 0 ]; then
-    echo "WARN: ${copilot_count} unresolved Copilot thread(s) (--force used)."
-else
-    echo "Copilot: 0 unresolved threads."
 fi
 
 # Label


### PR DESCRIPTION
## Summary

- Extracts the four PR gate checks (CI, Copilot currency, unresolved threads, merge conflict) from `label-ready.sh` into a new sourced helper `scripts/workflow/_pr-gates.sh`. Single source of truth — both `label-ready.sh` and `claude-merge.sh` call the same functions.
- Adds a new `check_no_merge_conflict` gate: blocks on `CONFLICTING`, retries up to 30s on `UNKNOWN`, allows `BEHIND`. Wired into both label-ready and claude-merge.
- Adds `scripts/workflow/claude-merge.sh`: re-evaluates all four gates at merge time, removes the `ready-for-review` label on gate failure (the label is the user's click-merge contract — stale = gone), squash-merges on success. Supports `--dry-run` and `--force`. Authorship check is not bypassable by `--force`.

Closes PP-d4bf. See PP-4t3n for audit context.

## Verification trace

| Scenario | Command | Result |
|---|---|---|
| Source clean | `bash _pr-gates.sh && echo "sourced clean"` | `sourced clean` |
| check_ci | `check_ci 1342` | `CI: All checks passed.` |
| check_copilot_currency | `check_copilot_currency 1326 false` | `Copilot: no reviews found — skipping currency check.` |
| check_unresolved_threads | `check_unresolved_threads 1342 false` | `Copilot: 0 unresolved threads.` |
| label-ready --dry-run | `label-ready.sh 1342 --dry-run` | CI/currency/threads passed; merge gate UNKNOWN timeout (expected: merged PRs never become MERGEABLE) |
| claude-merge --dry-run | `claude-merge.sh 1342 --dry-run` | Authorship matched; same gate results; printed "would remove ready-for-review label if present" |

Merged PRs return `UNKNOWN` for `mergeable` indefinitely — the merge-conflict gate correctly times out on them. For open/active PRs, `MERGEABLE` resolves immediately and `CONFLICTING` blocks fast.

## Test plan

- [ ] `pnpm run check` passes (shellcheck clean for all three scripts)
- [ ] `bash scripts/workflow/_pr-gates.sh && echo "sourced clean"` — no side effects
- [ ] `claude-merge.sh --dry-run <open-PR>` against an active open PR shows gate results without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)