### PR TITLE
feat(header): reorder nav and restyle Report button

### DIFF
--- a/.agent/skills/pinpoint-design-bible/SKILL.md
+++ b/.agent/skills/pinpoint-design-bible/SKILL.md
@@ -221,8 +221,8 @@ Use shadcn defaults: `CardHeader` (px-6 pt-6 pb-3), `CardContent` (px-6 pb-6). O
 
 ### AppHeader (always rendered, two-tier responsive)
 
-- **Wide desktop (>= lg):** Logo, APC logo, nav links (icon+text), spacer, Report Issue (icon+text), HelpMenu, NotificationList, UserMenu.
-- **Tablet (md–lg):** Logo, nav links (icon-only), spacer, Report Issue (icon-only), HelpMenu, NotificationList, UserMenu. APC logo hidden.
+- **Wide desktop (>= lg):** Logo, APC logo, nav links (Dashboard, Machines, Issues — icon+text), spacer, Report Issue button (secondary variant, icon+text), HelpMenu, NotificationList, UserMenu.
+- **Tablet (md–lg):** Logo, nav links (Dashboard, Machines, Issues — icon-only), spacer, Report button (secondary variant, icon + "Report" label), HelpMenu, NotificationList, UserMenu. APC logo hidden.
 - **Mobile (< md):** Logo, spacer, NotificationList, UserMenu. Nav links and Report Issue use `hidden md:flex`.
 - **Unauthenticated:** NotificationList + UserMenu replaced by Sign In / Sign Up buttons.
 - **Admin link:** Inside UserMenu dropdown (role-gated, not a top-level nav item).
@@ -235,7 +235,7 @@ Use shadcn defaults: `CardHeader` (px-6 pt-6 pb-3), `CardContent` (px-6 pb-6). O
 
 ### BottomTabBar (mobile only, `md:hidden`)
 
-- **Primary tabs:** Dashboard, Issues, Machines, Report Issue.
+- **Primary tabs:** Dashboard, Machines, Issues, Report Issue. Order matches the desktop `AppHeader` because `BottomTabBar` spreads the same `NAV_ITEMS` array.
 - **More tab:** Opens `Sheet` (bottom drawer) with Feedback, What's New, Help, About, Admin (role-gated).
 
 ### Shared rules
@@ -307,7 +307,7 @@ Before building something new, check if one of these already exists:
 | :------------------------------------ | :---------------------------------------------------------------------------------------------- |
 | `AppHeader`                           | Two-tier responsive header. Icon-only nav at `md:`, icon+text at `lg:`. APC logo at `lg:` only. |
 | `HelpMenu`                            | Dropdown with Feedback, What's New, Help, About. Badge dot for unread changelog.                |
-| `BottomTabBar`                        | Mobile tab bar (`md:hidden`). Dashboard, Issues, Machines, Report, More.                        |
+| `BottomTabBar`                        | Mobile tab bar (`md:hidden`). Dashboard, Machines, Issues, Report, More.                        |
 | `IssueBadgeGrid`                      | Status/severity/priority/frequency display                                                      |
 | `IssueBadge`                          | Individual status badge with color                                                              |
 | `IssueCard`                           | Issue summary card (normal/compact)                                                             |

--- a/src/components/layout/AppHeader.test.tsx
+++ b/src/components/layout/AppHeader.test.tsx
@@ -150,6 +150,21 @@ describe("AppHeader", () => {
       expect(screen.getByTestId("nav-machines")).toHaveAttribute("href", "/m");
     });
 
+    it("renders nav links in Dashboard, Machines, Issues order", () => {
+      render(<AppHeader {...defaultAuthProps} />);
+
+      const mainNav = screen.getByRole("navigation", { name: "main" });
+      const navTestIds = Array.from(
+        mainNav.querySelectorAll("[data-testid^='nav-']")
+      ).map((el) => el.getAttribute("data-testid"));
+
+      expect(navTestIds).toEqual([
+        "nav-dashboard",
+        "nav-machines",
+        "nav-issues",
+      ]);
+    });
+
     it("uses issuesPath for the Issues link", () => {
       render(
         <AppHeader {...defaultAuthProps} issuesPath="/issues?status=open" />

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -31,8 +31,8 @@ interface AppHeaderProps {
 /**
  * Unified application header that replaces Sidebar + MobileHeader.
  *
- * Desktop (>= lg): Logo, APC logo, nav links (icon+text), Report Issue (icon+text), HelpMenu, auth.
- * Tablet (md–lg): Logo, nav links (icon-only), Report Issue (icon-only), HelpMenu, auth.
+ * Desktop (>= lg): Logo, APC logo, nav links (icon+text), Report Issue button (icon+"Report Issue"), HelpMenu, auth.
+ * Tablet (md–lg): Logo, nav links (icon-only), Report button (icon+"Report"), HelpMenu, auth.
  * Mobile (< md): Logo, auth. Nav handled by BottomTabBar.
  */
 export function AppHeader({
@@ -124,13 +124,16 @@ export function AppHeader({
       <div className="hidden md:flex items-center gap-2">
         <Button
           asChild
-          variant="ghost"
           size="sm"
-          className="text-muted-foreground hover:text-primary gap-2"
+          variant="secondary"
+          className="gap-2"
           data-testid="nav-report-issue"
         >
           <Link href="/report" aria-label="Report Issue">
             <AlertCircle className="size-4 shrink-0" aria-hidden="true" />
+            <span className="lg:hidden" aria-hidden="true">
+              Report
+            </span>
             <span className="hidden lg:inline" aria-hidden="true">
               Report Issue
             </span>

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -9,6 +9,6 @@ export interface NavItem {
 
 export const NAV_ITEMS = [
   { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-  { title: "Issues", href: "/issues", icon: AlertTriangle },
   { title: "Machines", href: "/m", icon: Gamepad2 },
+  { title: "Issues", href: "/issues", icon: AlertTriangle },
 ] as const satisfies readonly NavItem[];


### PR DESCRIPTION
## Summary

- Swap top-nav order to **Dashboard → Machines → Issues** (Machines and Issues positions exchanged).
- Restyle the **Report Issue** action as a `variant="secondary"` button (teal) so it matches the landing-page "Report an Issue" CTA and reads as a clear button instead of a ghost text link.
- Add a responsive label: shows **"Report"** between `md` and `lg`, expands to **"Report Issue"** at `lg+`. Icon stays visible at both sizes; `aria-label="Report Issue"` is preserved so screen readers always announce the full action.

## Files

- `src/components/layout/nav-config.ts` — reorder `NAV_ITEMS`.
- `src/components/layout/AppHeader.tsx` — drop `variant="ghost"` + muted color, add `variant="secondary"`, swap-label pattern (`lg:hidden` / `hidden lg:inline`), update header comment.

## Design notes

- Per design bible §1, secondary teal (`#2dd4bf`) is a canonical palette token — applied via the `variant="secondary"` shadcn variant, not raw `teal-*` classes.
- Per design bible §4 / commandment #16, label visibility is a viewport-breakpoint decision (page-chrome structure), so `lg:` is the right layer — no container queries needed for the header.
- The `<span className="lg:hidden">Report</span>` / `<span className="hidden lg:inline">Report Issue</span>` pattern keeps the markup static (no JS resize logic) and matches the existing nav-link label pattern on lines 115–117.

## Testing

- `pnpm run check` (types + lint + format + unit tests) — passing locally (1093 tests, 0 failures).
- `src/components/layout/AppHeader.test.tsx` — 16/16 passing; testids and link targets unaffected by visual reordering.
- Manual: verified `Report` label at tablet width, `Report Issue` at desktop width via dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)