### PR TITLE
fix(worktree): cap Supabase project_id at 40 chars + hash-suffix long branches (PP-xwm)

### DIFF
--- a/scripts/tests/test_worktree_setup.py
+++ b/scripts/tests/test_worktree_setup.py
@@ -1,6 +1,7 @@
 """Unit tests for worktree_setup.py env merging and port allocation."""
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -544,11 +545,52 @@ class TestBranchToProjectId:
     def test_long_branch_name_truncated(self) -> None:
         long_name = "a" * 100
         result = branch_to_project_id(long_name)
-        assert len(result) <= 50
+        assert len(result) <= 40
 
     def test_trailing_special_chars_stripped(self) -> None:
         result = branch_to_project_id("my-feature///")
         assert not result.endswith("-")
+
+    def test_long_branch_uses_hash_suffix(self) -> None:
+        # The branch from PP-xwm casework that triggered Docker overflow.
+        long_branch = "feat/e2e-cleanup-admin-discord-downgrade-PP-t8o"
+        result = branch_to_project_id(long_branch)
+        assert len(result) == 40
+        assert result.startswith("pinpoint-feat-e2e-cleanup-admin")
+        # 8-char hex hash suffix joined by a single "-"
+        assert re.match(r"^pinpoint-.{22}-[0-9a-f]{8}$", result), result
+
+    def test_long_branch_hash_is_deterministic(self) -> None:
+        long_branch = "feat/some-very-long-branch-name-that-exceeds-the-cap"
+        assert branch_to_project_id(long_branch) == branch_to_project_id(long_branch)
+
+    def test_long_branches_with_common_prefix_get_distinct_ids(self) -> None:
+        # Same first N chars but different tail → hash must disambiguate.
+        a = branch_to_project_id("feat/very-long-shared-prefix-branch-alpha")
+        b = branch_to_project_id("feat/very-long-shared-prefix-branch-beta")
+        assert a != b
+
+    def test_long_branch_no_trailing_hyphen_after_truncation(self) -> None:
+        # Construct a branch where the 31-char readable portion would end
+        # exactly on a hyphen — rstrip must clean it before joining the hash.
+        long_branch = "feat-aaaaaaaaaaaaaaaaaaaaa-bbb-cc"
+        result = branch_to_project_id(long_branch)
+        assert "--" not in result
+        assert len(result) <= 40
+
+    def test_boundary_40_char_branch_no_hash(self) -> None:
+        # Exactly 31 char sanitized → "pinpoint-" + 31 = 40 chars, no hash.
+        branch = "a" * 31
+        result = branch_to_project_id(branch)
+        assert result == f"pinpoint-{'a' * 31}"
+        assert len(result) == 40
+
+    def test_boundary_41_char_branch_uses_hash(self) -> None:
+        # 32 char sanitized → "pinpoint-" + 32 = 41 chars, hash applied.
+        branch = "a" * 32
+        result = branch_to_project_id(branch)
+        assert len(result) == 40
+        assert re.match(r"^pinpoint-a{22}-[0-9a-f]{8}$", result), result
 
 
 if __name__ == "__main__":

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -8,19 +8,16 @@ and removes the git worktree. One argument: the worktree path.
 
 import fcntl
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
 
+# Reuse the project-id derivation from worktree_setup so cleanup targets the
+# same container/volume names that setup created. (Python auto-adds this
+# script's directory to sys.path when invoked as `python3 worktree_cleanup.py`.)
+from worktree_setup import branch_to_project_id  # noqa: E402
+
 MANIFEST_PATH = Path.home() / ".config" / "pinpoint" / "worktree-slots.json"
-
-
-def branch_to_project_id(branch_name: str) -> str:
-    """Convert a branch name to a valid Supabase project ID."""
-    project_id = re.sub(r"[^a-z0-9-]", "-", branch_name.lower())
-    project_id = re.sub(r"-+", "-", f"pinpoint-{project_id}").strip("-")
-    return project_id[:50]
 
 
 def deallocate_slot(worktree_path: str) -> None:

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -234,8 +234,14 @@ def get_existing_slot(worktree_path: str) -> int | None:
 # fit Docker's 63-char container name limit. The longest active service prefix
 # observed in practice is `supabase_inbucket_` (18 chars); `supabase_edge_runtime_`
 # (22 chars) is a future risk. Capping project_id at 40 leaves headroom for
-# either, and the leading `pinpoint-` (9 chars) leaves 31 readable chars for
-# the branch portion.
+# either.
+#
+# For short branches whose sanitized form fits in 40 chars, the whole readable
+# name is preserved (e.g., "pinpoint-main"). For long branches, the readable
+# portion is truncated to MAX_READABLE_LEN (31) and an 8-char hash is appended;
+# of those 31 chars the leading "pinpoint-" consumes 9, leaving up to 22 chars
+# of branch text (potentially fewer after rstrip("-") trims a truncation that
+# landed on a hyphen).
 MAX_PROJECT_ID_LEN = 40
 HASH_SUFFIX_LEN = 8
 # +1 for the "-" separator joining the readable part to the hash.

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -8,6 +8,7 @@ Not a CLI tool — no argparse, no subcommands. Operates on $PWD.
 """
 
 import fcntl
+import hashlib
 import json
 import os
 import re
@@ -229,11 +230,35 @@ def get_existing_slot(worktree_path: str) -> int | None:
 # =============================================================================
 
 
+# Supabase container names follow `supabase_<service>_<project_id>` and must
+# fit Docker's 63-char container name limit. The longest active service prefix
+# observed in practice is `supabase_inbucket_` (18 chars); `supabase_edge_runtime_`
+# (22 chars) is a future risk. Capping project_id at 40 leaves headroom for
+# either, and the leading `pinpoint-` (9 chars) leaves 31 readable chars for
+# the branch portion.
+MAX_PROJECT_ID_LEN = 40
+HASH_SUFFIX_LEN = 8
+# +1 for the "-" separator joining the readable part to the hash.
+MAX_READABLE_LEN = MAX_PROJECT_ID_LEN - HASH_SUFFIX_LEN - 1
+
+
 def branch_to_project_id(branch_name: str) -> str:
-    """Convert a branch name to a valid Supabase project ID."""
-    project_id = re.sub(r"[^a-z0-9-]", "-", branch_name.lower())
-    project_id = re.sub(r"-+", "-", f"pinpoint-{project_id}").strip("-")
-    return project_id[:50]
+    """Convert a branch name to a valid Supabase project ID.
+
+    Short branches keep their full readable name (e.g., "main" → "pinpoint-main").
+    Long branches are truncated and suffixed with an 8-char sha256 hash of the
+    original branch name, preserving uniqueness across worktrees on different
+    long branches that share a common prefix.
+
+    Cap is 40 chars; see MAX_PROJECT_ID_LEN comment above for why.
+    """
+    sanitized = re.sub(r"[^a-z0-9-]", "-", branch_name.lower())
+    full = re.sub(r"-+", "-", f"pinpoint-{sanitized}").strip("-")
+    if len(full) <= MAX_PROJECT_ID_LEN:
+        return full
+    digest = hashlib.sha256(branch_name.encode("utf-8")).hexdigest()[:HASH_SUFFIX_LEN]
+    readable = full[:MAX_READABLE_LEN].rstrip("-")
+    return f"{readable}-{digest}"
 
 
 def generate_config_toml(worktree_path: Path, port_config: PortConfig) -> str:


### PR DESCRIPTION
## Summary

Long feature branch names produced project_ids that, combined with Supabase's `supabase_<service>_<project_id>` container naming, exceeded Docker's 63-char container name limit and got truncated mid-token (often leaving a trailing hyphen). Result: hostname resolution failed in those worktrees and Supabase wouldn't start. Bit a Wave 0b teammate on 2026-05-15 with branch `feat/e2e-cleanup-admin-discord-downgrade-PP-t8o`.

## Fix

- Cap sanitized project_id at **40 chars** (was 50). Longest active Supabase prefix is `supabase_inbucket_` (18); `supabase_edge_runtime_` (22) is a future risk — 40 keeps us safe against either against Docker's 63-char limit.
- For branches whose sanitized form would exceed 40 chars: append an 8-char sha256 hash of the original branch name to keep the readable prefix while guaranteeing uniqueness across worktrees on different long branches that share a common prefix.
- `rstrip("-")` at the truncation boundary prevents trailing-hyphen container names even when the cut lands on a token boundary.

## Migration

- Short branches (≤31 readable chars): unchanged behavior, no migration.
- Long branches: project_id changes from a possibly-broken truncated form to a deterministic readable+hash form. These worktrees were already broken (Supabase wouldn't start), so there's nothing to lose; the next config regeneration produces a working container name.

## Test plan

- [x] 6 new pytest cases: hash-suffix for long branches, deterministic hashing, distinct IDs for common-prefix long branches, no trailing hyphens after truncation, exact 40/41-char boundary
- [x] Existing `<= 50` assertion tightened to `<= 40`
- [x] All 47 `test_worktree_setup.py` tests pass
- [x] `pnpm run check` clean (ruff included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)