### PR TITLE
fix(worktree-hook): use cwd/name from real WorktreeCreate payload (PP-pno7)

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -22,6 +22,17 @@
 #     "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/worktree-create.sh"
 #   No positional args are passed; all input comes from the JSON payload on stdin.
 #
+# Stdin payload fields (verified empirically via diagnostic dump, PP-pno7, 2026-05-16):
+#   {
+#     "session_id":        "<uuid>",
+#     "transcript_path":   "<path to .jsonl>",
+#     "cwd":               "<repo root absolute path>",   ← used as BASE_PATH
+#     "hook_event_name":   "WorktreeCreate",
+#     "name":              "agent-<hex>"                   ← used as worktree dir name + branch
+#   }
+#   The hook derives `BRANCH = worktree-${name}` to match Claude Code's native
+#   pre-hook naming convention (e.g., `worktree-agent-a20a236fe97a6d41c`).
+#
 # Platform: macOS uses /usr/bin/lockf (ships with macOS, backed by flock(2)).
 #   Linux uses flock(1) from util-linux. Detected at runtime.
 #
@@ -49,19 +60,22 @@ print(payload.get('$1') or '')
 " || exit $?
 }
 
-BASE_PATH=$(parse_field base_path)
-BRANCH=$(parse_field branch)
-ISOLATION_ID=$(parse_field isolation_id)
+BASE_PATH=$(parse_field cwd)
+NAME=$(parse_field name)
 
-if [ -z "$BASE_PATH" ] || [ -z "$BRANCH" ]; then
-  echo "worktree-create.sh: missing base_path or branch in hook input" >&2
+if [ -z "$BASE_PATH" ] || [ -z "$NAME" ]; then
+  echo "worktree-create.sh: missing cwd or name in hook input" >&2
   exit 1
 fi
 
-WORKTREE_PATH="${BASE_PATH}/.claude/worktrees/${ISOLATION_ID:-$BRANCH}"
+# Match Claude Code's pre-hook native naming so existing tooling (cleanup hook,
+# worktree manifest, orchestrator skill) continues to recognize the worktree.
+BRANCH="worktree-${NAME}"
+WORKTREE_PATH="${BASE_PATH}/.claude/worktrees/${NAME}"
 
-# Branch names commonly contain `/` (e.g. `feat/foo`); ensure the parent dir
-# under .claude/worktrees/ exists before `git worktree add` tries to write.
+# Ensure the parent directory exists before `git worktree add` tries to write.
+# (Claude Code's `name` is currently a flat `agent-<hex>` slug with no slashes,
+# but mkdir -p is cheap insurance against future name conventions.)
 mkdir -p "$(dirname "$WORKTREE_PATH")"
 
 # --- Lock file: ~/.config/pinpoint/worktree-add.lock ---
@@ -136,7 +150,7 @@ do_worktree_add() {
   done
 
   echo "worktree-create.sh: FAILED to create worktree after $max_retries attempts" >&2
-  echo "  base_path=$BASE_PATH  branch=$BRANCH  target=$WORKTREE_PATH" >&2
+  echo "  cwd=$BASE_PATH  branch=$BRANCH  target=$WORKTREE_PATH" >&2
   echo "  Last error: $last_stderr" >&2
   return 1
 }


### PR DESCRIPTION
## Summary

- The PP-bg45 hook (PR #1360, shipped today) parsed stdin JSON for `base_path` / `branch` / `isolation_id` — but Claude Code's actual `WorktreeCreate` payload uses `cwd` / `name`. Every `Agent(isolation: \"worktree\")` dispatch fail-closed with `missing base_path or branch in hook input`.
- Fixes the parse to use `cwd` (BASE_PATH) and `name` (worktree dir), and derives `BRANCH = worktree-${name}` to match Claude Code's native pre-hook convention (visible in `git worktree list` as `worktree-agent-<hex>`).
- Adds the empirically-verified payload schema to the hook's header comment so future maintainers don't repeat the guess.

## Why CI didn't catch this in #1360

CI never runs `Agent(isolation: \"worktree\")`. The hook's runtime contract is between the script and Claude Code — neither linting nor unit tests exercise it. Verified the actual payload by inserting a temporary `tee` to `/tmp/pp-pno7-payload.log` before the parse, then triggering a real dispatch.

Captured payload:
\`\`\`json
{
  \"session_id\": \"<uuid>\",
  \"transcript_path\": \"<.jsonl>\",
  \"cwd\": \"/Users/froeht/Code/PinPoint\",
  \"hook_event_name\": \"WorktreeCreate\",
  \"name\": \"agent-ab48ff9f071ef42c8\"
}
\`\`\`

## Test plan

- [x] Diagnostic capture of real Claude Code stdin payload
- [ ] **After CI green, exhaustive local testing in main worktree:**
  - [ ] Single \`Agent(isolation: \"worktree\")\` dispatch from main — verify worktree directory created, branch named \`worktree-agent-<hex>\`, subagent starts cleanly
  - [ ] Parallel N=3 dispatches — verify flock serializes (no \`.git/config.lock\` errors), all 3 worktrees created with distinct names
  - [ ] Malformed payload (manually pipe \`echo '{}' | bash worktree-create.sh\`) — verify fail-closed with new error message
  - [ ] Cleanup hook still works against worktrees created via fixed hook (\`scripts/worktree_cleanup.py\` calls into \`worktree_setup.branch_to_project_id\` — unchanged contract)
  - [ ] \`pnpm run check\` passes

## Out of scope (separate beads to file)

- Pre-existing SC2323 style finding on \`ms_to_sleep_args\` — unrelated to my changes, not in scope here.
- Adding \`.claude/hooks/\` to \`pnpm run check\`'s shellcheck scan path. Currently scans \`scripts/\`, \`.agent/skills/\`, \`.devcontainer/\` only — this gap is what allowed #1360 to ship with a runtime-incompatible parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)