### PR TITLE
fix(forms): three small form-correctness cleanups (PP-rwy)

### DIFF
--- a/src/app/(app)/m/[initials]/i/[issueNumber]/assign-issue-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/assign-issue-form.tsx
@@ -89,8 +89,7 @@ export function AssignIssueForm({
   );
 
   return (
-    <form action={formAction}>
-      <input type="hidden" name="issueId" value={issueId} />
+    <div>
       {permissionState.allowed ? (
         picker
       ) : (
@@ -102,6 +101,6 @@ export function AssignIssueForm({
       {state && !state.ok && (
         <p className="text-sm text-destructive">{state.message}</p>
       )}
-    </form>
+    </div>
   );
 }

--- a/src/app/(app)/settings/delete-account-section.tsx
+++ b/src/app/(app)/settings/delete-account-section.tsx
@@ -68,7 +68,16 @@ export function DeleteAccountSection({
         </div>
       )}
 
-      <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (!open) {
+            setConfirmText("");
+            setReassignTo("__unassigned__");
+          }
+        }}
+      >
         <AlertDialogTrigger asChild>
           <Button
             variant="destructive"
@@ -175,14 +184,7 @@ export function DeleteAccountSection({
             </AlertDialogHeader>
 
             <AlertDialogFooter className="gap-2 sm:gap-0">
-              <AlertDialogCancel
-                onClick={() => {
-                  setConfirmText("");
-                  setIsOpen(false);
-                }}
-              >
-                Keep Account
-              </AlertDialogCancel>
+              <AlertDialogCancel>Keep Account</AlertDialogCancel>
               <Button
                 type="submit"
                 variant="destructive"

--- a/src/components/issues/cells/IssueEditableCell.tsx
+++ b/src/components/issues/cells/IssueEditableCell.tsx
@@ -39,6 +39,7 @@ interface EditableCellProps {
  * Shows loading state during updates
  */
 export function IssueEditableCell({
+  issue,
   field,
   config,
   options,
@@ -81,7 +82,7 @@ export function IssueEditableCell({
             >
               <opt.icon className={cn("h-3.5 w-3.5", opt.iconColor)} />
               <span className="flex-1">{opt.label}</span>
-              {opt.label === config.label && (
+              {opt.value === issue[field as keyof typeof issue] && (
                 <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
               )}
             </DropdownMenuItem>

--- a/src/components/issues/cells/IssueEditableCell.tsx
+++ b/src/components/issues/cells/IssueEditableCell.tsx
@@ -14,9 +14,11 @@ import {
 } from "~/components/ui/dropdown-menu";
 import type { IssueListItem } from "~/lib/types";
 
+type EditableField = "status" | "priority" | "severity";
+
 interface EditableCellProps {
   issue: IssueListItem;
-  field: string;
+  field: EditableField;
   config: {
     label: string;
     icon: LucideIcon;
@@ -82,7 +84,7 @@ export function IssueEditableCell({
             >
               <opt.icon className={cn("h-3.5 w-3.5", opt.iconColor)} />
               <span className="flex-1">{opt.label}</span>
-              {opt.value === issue[field as keyof typeof issue] && (
+              {opt.value === issue[field] && (
                 <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
               )}
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary

- **delete-account-section**: Reset `confirmText` and `reassignTo` in `onOpenChange`'s close branch, so outside-click dismissal doesn't leak stale state on reopen. Previously only the explicit Cancel `onClick` reset state; now any close path resets it.
- **assign-issue-form**: Remove vestigial `<form>` wrapper. Real submission goes through the `onAssign` callback which builds `FormData` manually and calls `formAction` directly. The form wrapper had no `assignedToId` hidden input so native submit would send incomplete data. No progressive-enhancement consumer exists.
- **IssueEditableCell**: Change active-option checkmark from `opt.label === config.label` to `opt.value === issue[field]`. Label comparison is fragile (two statuses could share a label); value comparison against the actual issue field is correct.

## Test plan

- [x] `pnpm run check` passes (1136 tests, typecheck, lint, format all green)
- [ ] CI Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)