### PR TITLE
docs: changelog week of May 18, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 108, "lastUpdated": "2026-05-15" }
+{ "totalEntries": 116, "lastUpdated": "2026-05-17" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,23 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## May 18, 2026
+
+### New Features
+
+- **Move Issue to Another Machine** — Admins, technicians, and machine owners can now reassign an issue to a different machine using the "More actions" menu on the issue page; the issue keeps its full comment and timeline history
+- **Updated Navigation** — The navigation bar now reads Dashboard → Machines → Issues (in that order), and the "Report Issue" action appears as a distinct teal button so it's easy to find on any page
+
+### Bug Fixes
+
+- Notification emails for the same issue now group into a single thread in Gmail, Apple Mail, and Outlook instead of arriving as separate messages
+- When a status, priority, severity, or frequency change fails to save, the dropdown now resets to its previous value instead of showing the failed selection
+- Editing an issue title inline no longer discards your typed text when you move focus away after a failed save
+- Notification preference switches now correctly show the saved state after saving changes, without requiring a page refresh
+- Password fields on the Change Password page are now cleared automatically after a successful save so your credentials don't linger on screen
+- Relative timestamps (like "2 hours ago") on the Issues list and Notifications page no longer flicker when the page first loads
+
+---
+
 ## May 11, 2026
 
 ### New Features


### PR DESCRIPTION
## Changelog entry: week of May 18, 2026

Adds the weekly user-facing changelog entry for PRs merged May 10–17, 2026. The May 11 entry was already published (PR #1336 merged May 16), so this covers the remaining user-facing changes shipped after that cut-off.

## What's in the entry

**New Features (2)**
- Move Issue to Another Machine — users can now reassign an issue via the "More actions" menu (#1274)
- Updated Navigation — Dashboard → Machines → Issues order + teal "Report Issue" button (#1356)

**Bug Fixes (6)**
- Notification emails for the same issue now thread in Gmail/Apple Mail/Outlook (#1354)
- Inline status/priority/severity/frequency dropdowns reset to previous value on failed save (#1350)
- Editing an issue title inline no longer drops typed text when focus moves away after a failed save (#1358)
- Notification preference switches correctly reflect saved state after saving (#1358)
- Change Password form clears all three password fields after a successful save (#1345)
- Relative timestamps on Issues list and Notifications page no longer flicker on page load (#1344)

## Excluded (non-user-facing)
CI/workflow tooling (#1355, #1361, #1360, #1359, #1352, #1327, #1331), dependency bumps (#1342, #1322, #1316, #1311), test-only refactors (many), docs/infra (#1353, #1330, #1346, #1307, #1312, #1323), already captured in May 11 entry (#1328), internal logging fix (#1341), accessibility-internal hydration fix (#1329 — span→button, no visible change for mouse users).

Note: `totalEntries` updated from 108 → 116 (8 new bullets); `lastUpdated` updated to 2026-05-17.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUwaXBx21rFCABVYsCLszQ)_