### PR TITLE
fix(workflow): drop --delete-branch from merge-pr.sh (PP-hma4)

### DIFF
--- a/.agent/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agent/skills/pinpoint-pr-workflow/SKILL.md
@@ -240,7 +240,7 @@ Script emits structured status tokens:
 
 On any FAIL: script removes `ready-for-review` label if present (the label's contract is "click-merge-without-thinking"; if a gate fails at merge time, that contract is broken). Exit 1.
 
-On all PASS: script captures head SHA, calls `gh pr merge <PR> --squash --delete-branch --match-head-commit=<sha>`. TOCTOU-safe — if a new commit lands between gate check and merge, GitHub rejects the merge (`--match-head-commit` mismatch).
+On all PASS: script captures head SHA, calls `gh pr merge <PR> --squash --match-head-commit=<sha>`. TOCTOU-safe — if a new commit lands between gate check and merge, GitHub rejects the merge (`--match-head-commit` mismatch). Branch deletion is handled by the repo's auto-delete-branches setting, not by the merge command — passing `--delete-branch` from a worktree fails local cleanup because main is held by the root checkout.
 
 ### 4.3 Escape hatches
 
@@ -269,7 +269,7 @@ If you absolutely need to bypass the hook (e.g., merge-pr.sh itself is broken an
 
 ```bash
 touch .claude-merge-bypass
-gh pr merge <PR> --squash --delete-branch
+gh pr merge <PR> --squash
 ```
 
 The sentinel is single-use — deleted on the next merge attempt. Document in commit message WHY you bypassed.

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -121,7 +121,9 @@ echo "RESULT: all gates passed"
 
 # Build merge args. --admin invokes admin-merge mode on GitHub, which overrides
 # branch-protection rules (failed required checks, missing reviews, etc.).
-MERGE_ARGS=(--squash --delete-branch --match-head-commit="$PR_HEAD_SHA")
+# Branch deletion is handled by the repo's auto-delete setting — passing --delete-branch
+# from a worktree fails the local cleanup step because main is held by the root checkout.
+MERGE_ARGS=(--squash --match-head-commit="$PR_HEAD_SHA")
 if [ "$BYPASS_REQS" = "true" ]; then
   MERGE_ARGS+=(--admin)
 fi


### PR DESCRIPTION
## Summary

- `gh pr merge --delete-branch` performs local-side cleanup that includes a `git checkout main`, which always fails from a worktree because `main` is held by the root checkout. The actual GitHub merge succeeds before this cleanup runs — making the failure cosmetic but noisy.
- GitHub-side branch deletion is handled by the repo's auto-delete-branches setting, so `--delete-branch` was redundant here.
- Surfaced on the merge of PR #1366 (PP-d4bf) when `merge-pr.sh` ran for the first time outside of `--dry-run`.

## Changes

- `scripts/workflow/merge-pr.sh` — remove `--delete-branch` from `MERGE_ARGS`, add a one-line comment explaining the why.
- `.agent/skills/pinpoint-pr-workflow/SKILL.md` — update Phase 4.2 description + Phase 4.4 bypass example to match.

## Test Plan

- [x] `shellcheck scripts/workflow/merge-pr.sh` clean
- [x] No remaining `--delete-branch` references in canonical code (`scripts/workflow/`, `.agent/skills/pinpoint-pr-workflow/`); the matches that remain are the new explanatory comments.
- [ ] Next merge via `merge-pr.sh` proceeds without the "main is already used by worktree" error.

Closes PP-hma4. Followup to #1366 (PP-d4bf).