### PR TITLE
fix(e2e): clean-slate loginAs + generic openDropdownMenu helper (PP-j3b)

### DIFF
--- a/e2e/full/issues-reassign-machine.spec.ts
+++ b/e2e/full/issues-reassign-machine.spec.ts
@@ -13,6 +13,7 @@ import {
   submitFormAndWaitForRedirect,
 } from "../support/page-helpers.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
+import { openDropdownMenu } from "../support/actions.js";
 
 // Prefix shared across all tests in this file; cleaned up in afterEach by title
 // prefix so cleanup works regardless of URL pattern (issues now live at
@@ -58,8 +59,8 @@ test.describe("Issue reassignment", () => {
 
       await createIssueOnMachine(page, fromInitials, issueTitle);
 
-      // Open the kebab menu in the page header.
-      await page.getByTestId("issue-actions-menu-trigger").click();
+      // Open the kebab menu in the page header using the retry-on-race helper.
+      await openDropdownMenu(page.getByTestId("issue-actions-menu-trigger"));
       await page.getByTestId("issue-actions-menu-reassign").click();
 
       // Pick the destination machine in the AlertDialog combobox.

--- a/e2e/support/actions.ts
+++ b/e2e/support/actions.ts
@@ -1,4 +1,9 @@
-import { expect, type Page, type TestInfo } from "@playwright/test";
+import {
+  expect,
+  type Locator,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
 
 import { TEST_USERS } from "./constants.js";
 
@@ -37,9 +42,19 @@ export async function loginAs(
   // Wait for the UI to settle into either "ready to login" or "already logged in"
   await expect(emailInput.or(menu)).toBeVisible();
 
-  // If already logged in, we must log out first to ensure we are the correct user
+  // If already logged in, clear client state directly instead of driving the
+  // UI logout flow. This eliminates the entire "user-menu-signout not visible"
+  // flake class that affects tests switching identities mid-suite.
+  // PinPoint auth lives exclusively in HTTP cookies (no createBrowserClient /
+  // no indexedDB usage), so clearCookies() is the authoritative reset.
+  // localStorage + sessionStorage are cleared as hygiene (RichTextEditor
+  // drafts, report-form drafts).
   if (await menu.isVisible()) {
-    await logout(page, testInfo);
+    await page.context().clearCookies();
+    await page.evaluate(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
     await page.goto("/login");
     await expect(emailInput).toBeVisible();
   }
@@ -147,28 +162,40 @@ export async function logout(page: Page, _testInfo: TestInfo): Promise<void> {
 }
 
 /**
- * Click the user-menu trigger and confirm it actually opened. Retries once
- * if the first click loses to a focus/overlay race (common right after a form
- * submit that leaves an editor focused).
+ * Click a Radix dropdown trigger and confirm it actually opened. Retries once
+ * if the first click loses to a focus/overlay race.
+ *
+ * Radix sets `aria-expanded="true"` on the trigger once the dropdown is open.
+ * We assert that before proceeding so a click intercepted by an overlay (e.g.
+ * a freshly-focused ProseMirror editor) surfaces as a clear "dropdown never
+ * opened" failure rather than a missing-item failure downstream.
  */
-async function openUserMenu(
-  userMenu: ReturnType<typeof visibleUserMenu>
-): Promise<void> {
-  await userMenu.click();
+export async function openDropdownMenu(trigger: Locator): Promise<void> {
+  await trigger.click();
   try {
-    await expect(userMenu).toHaveAttribute("aria-expanded", "true", {
+    await expect(trigger).toHaveAttribute("aria-expanded", "true", {
       timeout: 3000,
     });
     return;
   } catch {
     // One retry — the first click sometimes loses to a focus race (e.g. a
     // ProseMirror editor still holding focus right after a form submit).
-    await userMenu.click();
+    await trigger.click();
     await expect(
-      userMenu,
-      "User menu did not open after two click attempts. aria-expanded never became 'true' — the click is likely being intercepted by an overlay (modal, editor focus trap, etc.)."
+      trigger,
+      "Dropdown trigger did not open after two click attempts. aria-expanded never became 'true' — the click is likely being intercepted by an overlay (modal, editor focus trap, etc.)."
     ).toHaveAttribute("aria-expanded", "true", { timeout: 3000 });
   }
+}
+
+/**
+ * Click the user-menu trigger and confirm it actually opened. Delegates to
+ * the generic openDropdownMenu helper.
+ */
+async function openUserMenu(
+  userMenu: ReturnType<typeof visibleUserMenu>
+): Promise<void> {
+  await openDropdownMenu(userMenu);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Lever A**: Replace the UI logout dance in `loginAs()` with direct client-state clearing (`context.clearCookies()` + `window.localStorage/sessionStorage.clear()`). Eliminates the "user-menu-signout not visible" flake class for tests that switch identities mid-suite. PinPoint auth lives exclusively in HTTP cookies (no `createBrowserClient`, no IndexedDB), so `clearCookies()` is the authoritative reset. The post-login `page.reload()` cookie-rotation settlement and the exported `logout()` helper are both kept untouched — the latter is still exercised by `auth-flows.spec.ts:114` as a user-facing UI test.
- **Lever D.1**: Extract `openUserMenu`'s aria-expanded retry pattern into a new exported `openDropdownMenu(trigger: Locator)` helper. Refactor `openUserMenu` to delegate to it. Apply `openDropdownMenu` to the issue kebab menu trigger in `issues-reassign-machine.spec.ts` — the same Radix dropdown click race that PR #1362 patched for the user menu, now surfacing on the kebab menu on Mobile Chrome.

**`/login` redirect sanity check**: The middleware marks `/login` as a public route and does NOT redirect authenticated users away from it — only unauthenticated users are redirected away from protected routes. So the pre-clear `page.goto("/login")` inside `loginAs()` lands on the login page as expected, and `await expect(emailInput).toBeVisible()` settles correctly in all cases.

## Test Plan

- [x] `pnpm run check` clean (125 test files, 1137 tests passing)
- [x] `e2e/full/rich-text.spec.ts:18` on Chromium × 3 — 3/3 passed
- [x] `e2e/full/machine-details-extended.spec.ts:38` on Mobile Chrome × 3 — 3/3 passed
- [x] `e2e/full/issues-reassign-machine.spec.ts:52` on Mobile Chrome × 3 — 3/3 passed

## Related Issues

Part 1 of 2 for PP-j3b flake remediation (see plan in `.claude/plans/do-a-full-planning-inherited-meadow.md`). PR 2 ships Levers B + C (AddCommentForm focus refactor + auth-flows audit row 34 deletion) independently.