### PR TITLE
fix(shellcheck): extend check:linters scan to .claude/hooks/ and fix SC2323

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -110,7 +110,7 @@ fi
 ms_to_sleep_args() {
   local ms=$1
   local secs=$((ms / 1000))
-  local frac=$(( (ms % 1000) ))
+  local frac=$(( ms % 1000 ))
   # Format as "N.NNN" for sleep (POSIX sleep accepts decimal on macOS/GNU)
   printf '%d.%03d' "$secs" "$frac"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "db:reset-to-empty": "node --env-file=.env.local scripts/reset-to-empty.mjs",
     "check:config": "python3 scripts/check-config-drift.py > /dev/null",
     "check:migrations": "drizzle-kit check",
-    "check:linters": "yamllint .github/workflows/ && actionlint $(find .github/workflows \\( -name '*.yml' -o -name '*.yaml' \\) ! -name '*.lock.yml') && ruff check scripts/ && ruff format --check scripts/ && find scripts/ .devcontainer/ -name '*.sh' -print0 | xargs -0 shellcheck && zizmor --min-severity low --format plain $(find .github/workflows \\( -name '*.yml' -o -name '*.yaml' \\) ! -name '*.lock.yml') && ratchet lint .github/workflows/ci.yml .github/workflows/supabase-branch-setup.yaml",
+    "check:linters": "yamllint .github/workflows/ && actionlint $(find .github/workflows \\( -name '*.yml' -o -name '*.yaml' \\) ! -name '*.lock.yml') && ruff check scripts/ && ruff format --check scripts/ && find scripts/ .devcontainer/ .claude/hooks/ -name '*.sh' -print0 | xargs -0 shellcheck && zizmor --min-severity low --format plain $(find .github/workflows \\( -name '*.yml' -o -name '*.yaml' \\) ! -name '*.lock.yml') && ratchet lint .github/workflows/ci.yml .github/workflows/supabase-branch-setup.yaml",
     "audit:role-checks": "bash scripts/audit/no-hardcoded-role-checks.sh",
     "check:behind-main": "bash scripts/check-behind-main.sh",
     "check": "npm-run-all --silent --parallel typecheck lint test format:fix check:linters audit:role-checks check:behind-main",


### PR DESCRIPTION
## Summary

- Extends the `shellcheck` `find` path in the `check:linters` script (`package.json`) to include `.claude/hooks/` so hook shell scripts are linted in CI going forward
- Fixes SC2323 style warning in `ms_to_sleep_args` in `.claude/hooks/worktree-create.sh`: removes redundant parentheses inside `$(( ))` (`$(( (ms % 1000) ))` → `$(( ms % 1000 ))`)

Closes PP-vpdc.

## Test plan

- [x] `pnpm run check:linters` passes cleanly with the new path included
- [x] `shellcheck .claude/hooks/*.sh` reports no findings after the SC2323 fix
- [x] CI Gate green