### PR TITLE
chore(machines): isolate tabbed layout via (tabs) route group (PP-qjnc)

### DIFF
--- a/src/app/(app)/m/[initials]/(tabs)/layout.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/layout.tsx
@@ -4,7 +4,7 @@ import { PageContainer } from "~/components/layout/PageContainer";
 import { MachineDetailHeader } from "~/components/machines/MachineDetailHeader";
 import { MachineTabStrip } from "~/components/machines/MachineTabStrip";
 import { deriveMachineStatus } from "~/lib/machines/status";
-import { getMachineForLayout } from "./_data";
+import { getMachineForLayout } from "../_data";
 
 export default async function MachineDetailLayout({
   children,

--- a/src/app/(app)/m/[initials]/(tabs)/maintenance/page.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/maintenance/page.tsx
@@ -6,8 +6,8 @@ import { db } from "~/server/db";
 import { userProfiles } from "~/server/db/schema";
 import { WatchMachineButton } from "~/components/machines/WatchMachineButton";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/index";
-import { IssuesExpando } from "../issues-expando";
-import { getMachineForLayout } from "../_data";
+import { IssuesExpando } from "~/app/(app)/m/[initials]/issues-expando";
+import { getMachineForLayout } from "~/app/(app)/m/[initials]/_data";
 
 /**
  * Machine Maintenance Tab (/m/[initials]/maintenance)

--- a/src/app/(app)/m/[initials]/(tabs)/page.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/page.tsx
@@ -12,19 +12,19 @@ import { MachinePresenceBadge } from "~/components/machines/MachinePresenceBadge
 import { formatDate } from "~/lib/dates";
 import { headers } from "next/headers";
 import { resolveRequestUrl } from "~/lib/url";
-import { EditButtonWithTooltip } from "./edit-button-tooltip";
-import { EditMachineDialog } from "./update-machine-form";
-import { QrCodeDialog } from "./qr-code-dialog";
+import { EditButtonWithTooltip } from "../edit-button-tooltip";
+import { EditMachineDialog } from "../update-machine-form";
+import { QrCodeDialog } from "../qr-code-dialog";
 import { buildMachineReportUrl } from "~/lib/machines/report-url";
 import { generateQrPngDataUrl } from "~/lib/machines/qr";
-import { MachineTextFields } from "./machine-text-fields";
+import { MachineTextFields } from "../machine-text-fields";
 import {
   getAccessLevel,
   checkPermission,
   getPermissionDeniedReason,
   type OwnershipContext,
 } from "~/lib/permissions/index";
-import { getMachineForLayout } from "./_data";
+import { getMachineForLayout } from "../_data";
 
 /**
  * Machine Info Tab (default route for /m/[initials]/)


### PR DESCRIPTION
## Summary

Fixes the layout inheritance bug filed in [PP-qjnc](https://github.com/timothyfroehlich/PinPoint/issues/PP-qjnc) (flagged by Copilot during PR #1365 review).

- Moves `layout.tsx`, `page.tsx`, and `maintenance/page.tsx` into a new `(tabs)/` route group under `src/app/(app)/m/[initials]/`
- The `i/[issueNumber]/` route is outside `(tabs)/` and no longer inherits `MachineDetailHeader` + `MachineTabStrip`
- URLs are unchanged — Next.js route groups are URL-invisible
- Updates all relative imports: single-level refs use `../`, the two-level ref in `maintenance/page.tsx` uses `~/app/(app)/m/[initials]/` path aliases (required by the `no-restricted-imports` lint rule)

**Before**: Issue detail at `/m/[initials]/i/[num]` inherited the outer `PageContainer size="standard"` + `MachineDetailHeader` + `MachineTabStrip`, causing double `PageContainer` nesting, ~40px extra padding, and a tab strip rendering with no active state.

**After**: Issue detail renders without that chrome. Info and Service tabs (`/m/[initials]/` and `/m/[initials]/maintenance`) continue to render with the full tabbed layout.

## Follow-up

PP-a8po is the next bead on this surface (EditMachineDialog prop shape) — out of scope here.

## Test plan

- [ ] `pnpm run check` passes (types, lint, format, unit tests)
- [ ] CI Gate passes
- [ ] Visit `/m/[initials]/` — MachineDetailHeader + tab strip render correctly
- [ ] Visit `/m/[initials]/maintenance` — MachineDetailHeader + tab strip render correctly
- [ ] Visit `/m/[initials]/i/[num]` — no MachineDetailHeader, no tab strip, no double padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)