### PR TITLE
test(users): admin email-visibility integration tests (PP-1fyt)

### DIFF
--- a/src/test/integration/invited_users.test.ts
+++ b/src/test/integration/invited_users.test.ts
@@ -599,8 +599,9 @@ describe("Invited Users Integration", () => {
 
   // Rule #12 (admin half): admins MUST be able to see real email addresses.
   // The admin user-listing page calls getUnifiedUsers({ includeEmails: true }).
-  // This test ensures the returned values are actual email strings — not null,
-  // undefined, or any redacted form.
+  // These tests assert that the `email` field is present in each returned user
+  // and equals the value that was seeded — confirming the field is not omitted
+  // (which would happen if called without includeEmails: true).
   describe("Admin email visibility (Rule #12 admin half)", () => {
     it("should return real email addresses for active users when includeEmails is true", async () => {
       const db = await getTestDb();
@@ -621,7 +622,7 @@ describe("Invited Users Integration", () => {
       const user = users.find((u) => u.id === userId);
 
       expect(user).toBeDefined();
-      // The email must be the real string — not null, not undefined, not redacted.
+      // The email field must be present and equal the seeded value.
       expect(user?.email).toBe(userEmail);
     });
 
@@ -643,7 +644,7 @@ describe("Invited Users Integration", () => {
       const user = users.find((u) => u.id === invited.id);
 
       expect(user).toBeDefined();
-      // The email must be the real string — not null, not undefined, not redacted.
+      // The email field must be present and equal the seeded value.
       expect(user?.email).toBe(invitedEmail);
     });
   });

--- a/src/test/integration/invited_users.test.ts
+++ b/src/test/integration/invited_users.test.ts
@@ -596,4 +596,55 @@ describe("Invited Users Integration", () => {
     expect(prefs?.emailNotifyOnNewIssue).toBe(true);
     expect(prefs?.inAppNotifyOnNewIssue).toBe(false);
   });
+
+  // Rule #12 (admin half): admins MUST be able to see real email addresses.
+  // The admin user-listing page calls getUnifiedUsers({ includeEmails: true }).
+  // This test ensures the returned values are actual email strings — not null,
+  // undefined, or any redacted form.
+  describe("Admin email visibility (Rule #12 admin half)", () => {
+    it("should return real email addresses for active users when includeEmails is true", async () => {
+      const db = await getTestDb();
+
+      const userId = "00000000-0000-0000-0000-000000000090";
+      const userEmail = "admin-visible@example.com";
+
+      await db.insert(authUsers).values({ id: userId, email: userEmail });
+      await db.insert(userProfiles).values({
+        id: userId,
+        email: userEmail,
+        firstName: "Visible",
+        lastName: "Admin",
+        role: "member",
+      });
+
+      const users = await getUnifiedUsers({ includeEmails: true });
+      const user = users.find((u) => u.id === userId);
+
+      expect(user).toBeDefined();
+      // The email must be the real string — not null, not undefined, not redacted.
+      expect(user?.email).toBe(userEmail);
+    });
+
+    it("should return real email addresses for invited users when includeEmails is true", async () => {
+      const db = await getTestDb();
+
+      const invitedEmail = "invited-admin-visible@example.com";
+      const [invited] = await db
+        .insert(invitedUsers)
+        .values({
+          firstName: "InvitedVisible",
+          lastName: "Admin",
+          email: invitedEmail,
+          role: "member",
+        })
+        .returning();
+
+      const users = await getUnifiedUsers({ includeEmails: true });
+      const user = users.find((u) => u.id === invited.id);
+
+      expect(user).toBeDefined();
+      // The email must be the real string — not null, not undefined, not redacted.
+      expect(user?.email).toBe(invitedEmail);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds two integration tests for the admin half of Non-Negotiable Rule #12 (email privacy)
- Tests assert that `getUnifiedUsers({ includeEmails: true })` — the call made by the admin user-listing page (`/admin/users`) — returns real email strings for both active users (`userProfiles`) and invited users (`invitedUsers`)
- Test layer: integration (PGlite), bug class E (permission-conditional data exposure), per the pinpoint-testing skill decision tree

## Test plan

- [x] `pnpm test:integration -- invited_users` passes (128 tests)
- [x] `pnpm run check` passes (1137 tests, all green)
- [x] New tests live in `src/test/integration/invited_users.test.ts` under a dedicated `describe("Admin email visibility (Rule #12 admin half)")` block

Closes PP-1fyt (admin half) — lead closes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)