### PR TITLE
fix(e2e): Mobile Chrome Sheet-locator + nav + owner-picker residuals (PP-j3b followup)

### DIFF
--- a/e2e/full/machine-owner-picker.spec.ts
+++ b/e2e/full/machine-owner-picker.spec.ts
@@ -24,11 +24,30 @@ import { STORAGE_STATE } from "../support/auth-state.js";
 const testMachines = new Set<string>();
 const testEmails = new Set<string>();
 
-/** Open the owner picker popover. */
+/** Open the owner picker popover and wait for it to be interactive. */
 async function openOwnerPicker(page: Page) {
   await page.getByTestId("owner-select").click();
-  // Wait for the popover content to be visible (checkbox is a reliable anchor)
-  await expect(page.getByLabel(/Show guests and invited users/i)).toBeVisible();
+  // Wait for the search input to be visible — it's a reliable sign the
+  // popover is fully open and interactive.
+  await expect(page.getByPlaceholder("Search users...")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+/**
+ * Select a guest user by name using the search input.
+ *
+ * Searching bypasses the "Show guests and invited users" checkbox filter
+ * (per OwnerSelect: when query is non-empty, all matching users are shown).
+ * This is more robust on mobile viewports where the checkbox+list scroll
+ * interaction can miss clicks on CommandItem elements.
+ */
+async function selectGuestUserBySearch(page: Page, name: string) {
+  const searchInput = page.getByPlaceholder("Search users...");
+  await searchInput.fill(name);
+  const list = page.locator("[data-slot=command-list]");
+  await expect(list.getByText(name)).toBeVisible({ timeout: 5000 });
+  await list.getByText(name).click();
 }
 
 test.describe("Machine Owner Picker — promote-dialog journeys (PP-6oi)", () => {
@@ -59,16 +78,10 @@ test.describe("Machine Owner Picker — promote-dialog journeys (PP-6oi)", () =>
     await page.getByLabel(/Initials/i).fill(machineInitials);
     await page.getByLabel(/Machine Name/i).fill(`Owner Picker Test ${testId}`);
 
-    // Open picker and reveal guests
+    // Open picker and select guest via search (search bypasses the
+    // "Show guests" checkbox filter — more robust on mobile viewports).
     await openOwnerPicker(page);
-    const checkbox = page.getByLabel(/Show guests and invited users/i);
-    await checkbox.click();
-    await expect(checkbox).toBeChecked();
-
-    // Select the Guest User from the command list
-    const list = page.locator("[data-slot=command-list]");
-    await expect(list.getByText("Guest User")).toBeVisible();
-    await list.getByText("Guest User").click();
+    await selectGuestUserBySearch(page, "Guest User");
 
     // Owner trigger should show "Guest User" selected
     await expect(page.getByTestId("owner-select")).toContainText("Guest User");
@@ -111,16 +124,10 @@ test.describe("Machine Owner Picker — promote-dialog journeys (PP-6oi)", () =>
       .getByLabel(/Machine Name/i)
       .fill(`Owner Picker Confirm ${testId}`);
 
-    // Open picker and reveal guests
+    // Open picker and select guest via search (search bypasses the
+    // "Show guests" checkbox filter — more robust on mobile viewports).
     await openOwnerPicker(page);
-    const checkbox = page.getByLabel(/Show guests and invited users/i);
-    await checkbox.click();
-    await expect(checkbox).toBeChecked();
-
-    // Select Guest User
-    const list = page.locator("[data-slot=command-list]");
-    await expect(list.getByText("Guest User")).toBeVisible();
-    await list.getByText("Guest User").click();
+    await selectGuestUserBySearch(page, "Guest User");
 
     // Verify selection
     await expect(page.getByTestId("owner-select")).toContainText("Guest User");

--- a/e2e/full/rich-text.spec.ts
+++ b/e2e/full/rich-text.spec.ts
@@ -124,20 +124,42 @@ test.describe("Rich Text and Mentions", () => {
 
     await expect(page).toHaveURL(new RegExp(`/m/${machine.initials}/i/1`));
 
+    // On mobile (md: breakpoint hidden), AddCommentForm lives inside the
+    // StickyCommentComposer Sheet — open it before interacting with the editor.
+    // The inline form is hidden (hidden md:flex) on mobile; scope locators to
+    // the open dialog to avoid resolving to the hidden inline ProseMirror.
+    await page.waitForLoadState("domcontentloaded");
+    const sheetTrigger = page.getByRole("button", { name: "Add a comment" });
+    const isOnMobile = await sheetTrigger
+      .isVisible({ timeout: 3000 })
+      .catch(() => false);
+    if (isOnMobile) {
+      await sheetTrigger.click();
+      await page
+        .getByRole("dialog", { name: "Add a comment" })
+        .waitFor({ state: "visible", timeout: 5000 });
+    }
+
+    const commentForm = isOnMobile
+      ? page.getByRole("dialog", { name: "Add a comment" })
+      : page.getByTestId("issue-comment-form");
+
     // Add rich text comment
-    const editor = page.locator(".ProseMirror").last();
+    const editor = commentForm.locator(".ProseMirror");
+    await editor.waitFor({ state: "visible", timeout: 15000 });
     await editor.click();
     await page.keyboard.type("This is a ");
 
     // Test toolbar button (Commandment #11)
-    await page.click('button[aria-label="Toggle italic"]');
+    await commentForm.getByRole("button", { name: "Toggle italic" }).click();
     await page.keyboard.type("rich text");
-    await page.click('button[aria-label="Toggle italic"]');
+    await commentForm.getByRole("button", { name: "Toggle italic" }).click();
     await page.keyboard.type(" comment.");
 
-    await page.click('button:has-text("Add Comment")');
+    await commentForm.getByRole("button", { name: "Add Comment" }).click();
 
-    // Verify rendered comment
+    // Verify rendered comment — after submit, the Sheet closes on mobile
+    // and the comment appears in the timeline below.
     const lastComment = page.locator(".prose").last();
     await expect(lastComment.locator("em")).toContainText("rich text");
   });

--- a/e2e/smoke/navigation.spec.ts
+++ b/e2e/smoke/navigation.spec.ts
@@ -129,6 +129,12 @@ test.describe("Bottom Tab Bar (mobile only)", () => {
     await expect(moreButton).toBeVisible();
     await moreButton.click();
 
+    // Wait for the Sheet to fully animate open before asserting on children.
+    // The Sheet is a Radix Dialog portal — scope assertions to the dialog
+    // so they resolve even if the surrounding page has shifted layout.
+    const moreSheet = page.getByRole("dialog");
+    await moreSheet.waitFor({ state: "visible", timeout: 5000 });
+
     // Sheet should open with secondary nav items
     await expect(page.getByTestId("more-sheet-help")).toBeVisible();
     await expect(page.getByTestId("more-sheet-whats-new")).toBeVisible();
@@ -151,6 +157,10 @@ test.describe("Bottom Tab Bar (mobile only)", () => {
 
     const moreButton = page.getByRole("button", { name: /more options/i });
     await moreButton.click();
+
+    // Wait for Sheet to animate open before asserting on children.
+    const moreSheet = page.getByRole("dialog");
+    await moreSheet.waitFor({ state: "visible", timeout: 5000 });
 
     // User Management should be visible for admin role
     await expect(page.getByTestId("more-sheet-admin")).toBeVisible();

--- a/e2e/smoke/navigation.spec.ts
+++ b/e2e/smoke/navigation.spec.ts
@@ -135,10 +135,11 @@ test.describe("Bottom Tab Bar (mobile only)", () => {
     const moreSheet = page.getByRole("dialog");
     await moreSheet.waitFor({ state: "visible", timeout: 5000 });
 
-    // Sheet should open with secondary nav items
-    await expect(page.getByTestId("more-sheet-help")).toBeVisible();
-    await expect(page.getByTestId("more-sheet-whats-new")).toBeVisible();
-    await expect(page.getByTestId("more-sheet-about")).toBeVisible();
+    // Sheet should open with secondary nav items.
+    // Scope to the dialog so locators are anchored to the Sheet portal content.
+    await expect(moreSheet.getByTestId("more-sheet-help")).toBeVisible();
+    await expect(moreSheet.getByTestId("more-sheet-whats-new")).toBeVisible();
+    await expect(moreSheet.getByTestId("more-sheet-about")).toBeVisible();
   });
 
   test("More sheet shows User Management only for admin users", async ({
@@ -162,8 +163,9 @@ test.describe("Bottom Tab Bar (mobile only)", () => {
     const moreSheet = page.getByRole("dialog");
     await moreSheet.waitFor({ state: "visible", timeout: 5000 });
 
-    // User Management should be visible for admin role
-    await expect(page.getByTestId("more-sheet-admin")).toBeVisible();
+    // User Management should be visible for admin role.
+    // Scope to the dialog so locators are anchored to the Sheet portal content.
+    await expect(moreSheet.getByTestId("more-sheet-admin")).toBeVisible();
     await expect(page.getByTestId("more-sheet-admin")).toHaveAttribute(
       "href",
       "/admin/users"


### PR DESCRIPTION
## Summary

Three Mobile Chrome E2E failures left over after PRs #1372 and #1377 merged as part of the PP-j3b flake remediation plan.

- **rich-text.spec.ts:108** (`allows adding comments with rich text`) — applies the same Sheet-locator pattern already in `form-resets.spec.ts:231-280`: detect mobile via "Add a comment" trigger visibility, open the Sheet, then scope all ProseMirror/toolbar/submit button locators to the dialog container instead of using `.last()` on the page.

- **navigation.spec.ts:117** (`More tab opens a sheet with secondary nav links`) — adds `waitFor({ state: "visible" })` on the Radix Sheet dialog before asserting on `more-sheet-*` testid children; the 30s timeout was caused by asserting before the Sheet animation completes. Also fixes the admin-role variant in the same describe block.

- **machine-owner-picker.spec.ts:48/98** (`promote dialog appears`, both Mobile Chrome and Mobile Safari) — replaces the checkbox+scroll+click interaction with a search-input approach. `OwnerSelect` shows all matching users when the search query is non-empty (bypasses the "Show guests" filter), so typing "Guest User" makes the CommandItem reliably clickable on small mobile viewports without needing to scroll.

## Test plan

- [ ] `pnpm exec playwright test e2e/full/rich-text.spec.ts --project="Mobile Chrome" --repeat-each=5` — zero failures
- [ ] `pnpm exec playwright test e2e/smoke/navigation.spec.ts --project="Mobile Chrome" --repeat-each=5` — zero failures
- [ ] `pnpm exec playwright test e2e/full/machine-owner-picker.spec.ts --project="Mobile Chrome" --repeat-each=3` — zero failures
- [ ] `pnpm run check` — clean (already confirmed locally)
- [ ] CI Gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)