### PR TITLE
fix(e2e): bump Sheet waitFor timeout 5s→10s on Mobile Chrome (PP-e8rf)

### DIFF
--- a/e2e/full/form-resets.spec.ts
+++ b/e2e/full/form-resets.spec.ts
@@ -243,7 +243,7 @@ test.describe("CREATE form resets", () => {
       // Wait for the Sheet to fully animate open before interacting.
       await page
         .getByRole("dialog", { name: "Add a comment" })
-        .waitFor({ state: "visible", timeout: 5000 });
+        .waitFor({ state: "visible", timeout: 10000 });
     }
 
     const commentForm = isOnMobile

--- a/e2e/full/rich-text.spec.ts
+++ b/e2e/full/rich-text.spec.ts
@@ -137,7 +137,7 @@ test.describe("Rich Text and Mentions", () => {
       await sheetTrigger.click();
       await page
         .getByRole("dialog", { name: "Add a comment" })
-        .waitFor({ state: "visible", timeout: 5000 });
+        .waitFor({ state: "visible", timeout: 10000 });
     }
 
     const commentForm = isOnMobile


### PR DESCRIPTION
## Summary

Bumps the Radix Sheet `waitFor` timeout from 5s to 10s in two Mobile Chrome E2E specs to absorb CI runner latency on top of the ~500ms Sheet open animation.

- `e2e/full/form-resets.spec.ts:246` — comment Sheet open in CREATE form resets
- `e2e/full/rich-text.spec.ts:140` — comment Sheet open in rich text/mentions flow
- Mechanical timeout bump only — no other logic touched, no other timeouts in these files modified

## Context

This is residual CI-runner-latency tightening for **PP-e8rf** (Cluster A of the PP-j3b Mobile Chrome triage). The lever-shipped structural fixes from PP-j3b (#1372, #1377, #1378) are working as intended — this PR addresses only the timing budget for the Sheet open animation on the CI runner.

Clusters B/C (PP-pvbq, PP-aouu) are separate beads and out of scope here.

## Test plan

- [x] `pnpm run check` clean (1137 unit tests pass, lint/types/format/yamllint/actionlint/ruff/shellcheck all green)
- [ ] CI: Mobile Chrome E2E (form-resets + rich-text) stable across reruns

🤖 Generated with [Claude Code](https://claude.com/claude-code)