### PR TITLE
docs(skill): codify Dependabot back-to-back rebase rule (PR workflow §4.5)

### DIFF
--- a/.agent/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agent/skills/pinpoint-pr-workflow/SKILL.md
@@ -274,6 +274,28 @@ gh pr merge <PR> --squash
 
 The sentinel is single-use — deleted on the next merge attempt. Document in commit message WHY you bypassed.
 
+### 4.5 Dependabot PRs: rebase before merging back-to-back
+
+When two or more Dependabot PRs that both touch `pnpm-lock.yaml` (or any lockfile) are open simultaneously, merging them in succession without rebasing the second-and-later PRs can silently break the lockfile.
+
+**The trap:** each Dependabot PR's lockfile diff adds entries in slightly different alphabetical zones based on its own snapshot of main. After the first PR merges, git's textual three-way merge of the second PR doesn't see a conflict because the additions live in non-overlapping line ranges — but both PRs may add the _same_ transitive dep (e.g., `brace-expansion@5.0.6`). The squash-merge produces a lockfile with a duplicated mapping key, which `pnpm install --frozen-lockfile` rejects with `ERR_PNPM_BROKEN_LOCKFILE`. Every new PR's `Setup Dependencies` then fails until main is fixed.
+
+**Why `rebase-strategy: auto` in `.github/dependabot.yml` doesn't save you:** "auto" means Dependabot rebases when _the dependency version_ is out of date, not when _the lockfile region_ has shifted under it. Two independent Dependabot PRs against the same main can both stay "current" by Dependabot's definition while their lockfile diffs collide on merge.
+
+**Rule:** when merging the first of two or more Dependabot PRs that both touch a lockfile, comment `@dependabot rebase` on each remaining Dependabot PR before merging it. Dependabot regenerates the lockfile against post-first-merge main and the duplicate is deduped automatically. Wait for the rebased CI to pass before invoking `merge-pr.sh` on the second PR.
+
+**Casework:** 2026-05-19 — PRs #1379 and #1381 each added `brace-expansion@5.0.6:` to `packages:` independently. Both merged within ~1 minute. Main's `Setup Dependencies` broke until PR #1383 shipped a manual dedup.
+
+**Quick triage check before merging the second of two open Dependabot PRs:**
+
+```bash
+# Does the second PR's branch share a lockfile baseline with current main?
+gh pr view <second_pr> --json baseRefOid --jq .baseRefOid
+git rev-parse origin/main
+```
+
+If `baseRefOid` is older than `origin/main`, request a rebase first.
+
 ---
 
 ## MCP gotchas reference

--- a/.agent/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agent/skills/pinpoint-pr-workflow/SKILL.md
@@ -284,17 +284,18 @@ When two or more Dependabot PRs that both touch `pnpm-lock.yaml` (or any lockfil
 
 **Rule:** when merging the first of two or more Dependabot PRs that both touch a lockfile, comment `@dependabot rebase` on each remaining Dependabot PR before merging it. Dependabot regenerates the lockfile against post-first-merge main and the duplicate is deduped automatically. Wait for the rebased CI to pass before invoking `merge-pr.sh` on the second PR.
 
-**Casework:** 2026-05-19 — PRs #1379 and #1381 each added `brace-expansion@5.0.6:` to `packages:` independently. Both merged within ~1 minute. Main's `Setup Dependencies` broke until PR #1383 shipped a manual dedup.
+**Casework:** 2026-05-19 — PRs #1379 and #1381 each added `brace-expansion@5.0.6:` to `packages:` independently. Both merged within ~1 minute. Main's `Setup Dependencies` broke until a manual dedup of `pnpm-lock.yaml` was bundled into PR #1383 (commit `505a1475`) alongside that PR's primary E2E locator fix.
 
 **Quick triage check before merging the second of two open Dependabot PRs:**
 
 ```bash
-# Does the second PR's branch share a lockfile baseline with current main?
-gh pr view <second_pr> --json baseRefOid --jq .baseRefOid
-git rev-parse origin/main
+# How many commits is the PR's branch behind origin/main?
+# behind_by > 0 means the PR's lockfile snapshot predates current main.
+pr_branch=$(gh pr view <second_pr> --json headRefName --jq .headRefName)
+gh api "repos/{owner}/{repo}/compare/main...$pr_branch" --jq '.behind_by'
 ```
 
-If `baseRefOid` is older than `origin/main`, request a rebase first.
+If `behind_by > 0`, comment `@dependabot rebase` on the PR and wait for the rebased CI to pass before invoking `merge-pr.sh`. Do not use `gh pr view --json baseRefOid` for this — `baseRefOid` is the base branch's current SHA at query time, so it always equals `origin/main` and cannot detect a stale PR head.
 
 ---
 

--- a/.agent/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agent/skills/pinpoint-pr-workflow/SKILL.md
@@ -284,7 +284,7 @@ When two or more Dependabot PRs that both touch `pnpm-lock.yaml` (or any lockfil
 
 **Rule:** when merging the first of two or more Dependabot PRs that both touch a lockfile, comment `@dependabot rebase` on each remaining Dependabot PR before merging it. Dependabot regenerates the lockfile against post-first-merge main and the duplicate is deduped automatically. Wait for the rebased CI to pass before invoking `merge-pr.sh` on the second PR.
 
-**Casework:** 2026-05-19 — PRs #1379 and #1381 each added `brace-expansion@5.0.6:` to `packages:` independently. Both merged within ~1 minute. Main's `Setup Dependencies` broke until a manual dedup of `pnpm-lock.yaml` was bundled into PR #1383 (commit `505a1475`) alongside that PR's primary E2E locator fix.
+**Casework:** 2026-05-19 — PRs #1379 and #1381 each added `brace-expansion@5.0.6:` to `packages:` independently. Both merged within ~1 minute. Main's `Setup Dependencies` broke until a manual dedup of `pnpm-lock.yaml` was bundled into PR #1383 alongside that PR's primary E2E locator fix.
 
 **Quick triage check before merging the second of two open Dependabot PRs:**
 


### PR DESCRIPTION
## Summary

Adds §4.5 to the `pinpoint-pr-workflow` skill documenting the back-to-back Dependabot PR lockfile-collision trap and the mitigation rule.

**The trap (casework: PRs #1379 + #1381 → broken main → manual dedup bundled into PR #1383):** when two Dependabot PRs both touch `pnpm-lock.yaml` and add the same transitive dep in non-overlapping line ranges, git's textual three-way merge of the second PR sees no conflict — but the squash-merge produces a duplicated YAML mapping key. `pnpm install --frozen-lockfile` then rejects the lockfile with `ERR_PNPM_BROKEN_LOCKFILE`, and every subsequent PR's `Setup Dependencies` job fails until main is fixed.

**Why `rebase-strategy: auto` in `.github/dependabot.yml` doesn't catch it:** "auto" rebases when the dep version is out of date, not when the lockfile region has shifted under the PR. Two independent Dependabot PRs can both stay "current" by Dependabot's definition while their lockfile diffs collide on merge.

**The rule:** when merging the first of two-or-more Dependabot PRs that both touch a lockfile, comment `@dependabot rebase` on each remaining Dependabot PR before merging it. Dependabot regenerates the lockfile against post-first-merge main and the duplicate is deduped automatically. Wait for the rebased CI to pass before invoking `merge-pr.sh` on the second PR.

The new section also includes a triage check (`gh api compare/main...<pr_branch> --jq .behind_by`) so the next agent can confirm whether the second PR's branch is stale before merging. The check explicitly warns against using `gh pr view --json baseRefOid`, which returns the base ref's current SHA at query time and therefore cannot detect a stale PR head.

## Test plan

- [x] Markdown-only change; pre-commit hooks (prettier, typecheck, format) ran clean
- [x] Verified §4.5 lands between §4.4 and the `---` / MCP gotchas heading
- [x] Addressed Copilot review feedback (2026-05-19): corrected casework wording so PR #1383 is described as the E2E locator fix that bundled the lockfile dedup, and replaced the broken `baseRefOid` triage check with the GitHub compare API's `behind_by` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)