### PR TITLE
fix(ci): use predicate-quantifier 'every' so docs-only PRs skip e2e (PP-r5v)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,19 @@ concurrency:
 
 jobs:
   # Detect which files changed to skip expensive jobs for docs-only changes.
-  # Uses predicate-quantifier: 'some' with negative patterns so that has_code=true
-  # when ANY changed file is NOT docs-only. New/unknown directories default to
-  # running full CI — the safe failure mode.
+  # Uses predicate-quantifier: 'every' with a positive '**' plus negative
+  # exclusions. A changed file counts as "code" only when it matches every
+  # pattern — i.e. it matches '**' (always) AND is NOT under any excluded
+  # path. `has_code` is true if at least one changed file is "code". A
+  # docs-only PR (only excluded paths touched) produces has_code=false and
+  # downstream expensive jobs cascade-skip via `setup`'s `if:` gate. New /
+  # unknown directories default to running full CI — the safe failure mode.
+  #
+  # Why 'every' and not 'some': under 'some', the positive '**' matches every
+  # file by itself, short-circuiting the negative exclusions and forcing
+  # has_code=true on every PR. PR #1327 / PP-r5v shipped 'some' and the
+  # filter never fired (e.g. PR #1386, a single .agent/skills/*.md change,
+  # still ran the full E2E suite).
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
@@ -39,7 +49,7 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # ratchet:dorny/paths-filter@v4.0.1
         with:
-          predicate-quantifier: "some"
+          predicate-quantifier: "every"
           filters: |
             has_code:
               - '**'
@@ -47,6 +57,7 @@ jobs:
               - '!**/*.md'
               - '!.beads/**'
               - '!.agent/**'
+              - '!.agents/**'
               - '!.claude/**'
               - '!LICENSE'
               - '!.gitignore'


### PR DESCRIPTION
## Summary
- PR #1327 attempted to fix PP-r5v by switching the `changes` filter to `predicate-quantifier: "some"` plus `**` + negative patterns. Under dorny/paths-filter that's a no-op: `some` means "match if ANY pattern matches" and `**` matches every file, so `has_code` is always `true` and every docs-only PR runs the full E2E suite.
- Switch the quantifier to `every`. A file counts as "code" only when it matches `**` AND none of the negative exclusions hit. Docs-only PRs evaluate `has_code=false` and downstream jobs cascade-skip via `setup`'s existing `if: needs.changes.outputs.code == 'true'` gate.
- Adds `!.agents/**` to the exclusion set (the inbound Antigravity harness directory, alongside the existing `.agent/`, `.claude/`, `.beads/` entries).

## Evidence the current filter is broken
- PR #1386 (single file: `.agent/skills/pinpoint-pr-workflow/SKILL.md`) ran Build, Integration Tests, E2E Smoke (Chromium + Mobile Chrome), E2E Full Chromium, and Supabase Integration Tests. Detect Changes log: `Filter has_code = true`.
- PR #1389 (single file: `.claude/settings.json`) — same.

## What does not change
- Always-runs jobs (`linters`, `gitleaks`) still run on every PR.
- `CI Gate` aggregator logic is unchanged: Tier-1 must succeed, Tier-2 path-filtered jobs may be `success`/`skipped`/`cancelled`.
- Mixed PRs (docs + source) still run everything — any non-excluded file flips `has_code` to true.
- New/unknown directories still default to running full CI (safe failure mode).

## Test plan
- [x] `yamllint .github/workflows/ci.yml` clean
- [x] `actionlint .github/workflows/ci.yml` clean
- [x] `zizmor --min-severity low` clean
- [ ] This PR touches `ci.yml` itself, so `has_code=true` and the full CI suite runs — confirms nothing else broke.
- [ ] Next docs-only PR after merge should show all path-filtered jobs as `skipped` while `linters`, `gitleaks`, and `CI Gate` pass.

## Closes
- PP-r5v