### PR TITLE
feat(workflow): huddle rotation — daily bead hierarchy + bootstrap + migration (PP-m4ki)

### DIFF
--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -1,24 +1,37 @@
 ---
 name: pinpoint-huddle
-description: Inter-session coordination via PP-cvh comments injected by SessionStart, UserPromptSubmit, and (throttled) PostToolUse hooks. Use when you see a huddle identity announcement, an injected PP-cvh comments block, want to register a session name, want to tune the PostToolUse throttle, or want to understand how parallel Claude sessions coordinate without re-injecting their own posts.
+description: Inter-session coordination via daily/monthly beads injected by SessionStart, UserPromptSubmit, and (throttled) PostToolUse hooks. Manages bootstrap, daily rotation, identity registration, and self-filter. Use when you see a huddle identity announcement, a rotation-needed notice, injected coordination comments, or want to post an update for other sessions to read.
 ---
 
 # pinpoint-huddle
 
-> **Use when:** you see a huddle SessionStart announcement or want to understand
-> the inter-session coordination system. Triggers on "huddle", "PP-cvh",
-> "coordination bead", "identity announcement", "rotation needed".
+> **Use when:** you see a huddle SessionStart announcement, a rotation-needed notice, or want to understand the inter-session coordination system. Triggers on "huddle", "coordination bead", "identity announcement", "rotation needed", "bootstrap".
 
-The huddle system is a context-efficient channel between parallel Claude Code
-sessions working on PinPoint. Each session learns what other sessions did
-recently, posts its own updates, and filters out its own echoes — all without
-consuming thousands of tokens at every session start.
+The huddle system is a context-efficient channel between parallel sessions working on PinPoint. Each session learns what other sessions did recently, posts its own updates, and filters out its own echoes — all without consuming thousands of tokens at every session start.
 
 ## What you'll see at session start
 
-The `huddle-session-start.sh` hook (registered in project-level
-`.claude/settings.json`) fires when your session opens. It outputs one of two
-blocks into your context:
+The `huddle-session-start.sh` hook fires when your session opens. It outputs one of these blocks:
+
+### Bootstrap needed (system not initialized)
+
+    ## ⚠️ Huddle not bootstrapped
+
+    The huddle coordination system is not set up yet. ...
+
+    To bootstrap, run:
+        bash scripts/hooks/huddle-bootstrap.sh
+
+Run the command, then start or resume your session normally. Bootstrap is idempotent — safe to re-run.
+
+### Rotation needed (day has rolled)
+
+    ## ⚠️ Huddle rotation needed
+
+    The active coordination bead points to date <STORED_DATE>, but today is <NOW_DATE>.
+    Before continuing, dispatch the rotation subagent ...
+
+**Stop and dispatch the rotation subagent before continuing your work.** See the "Rotation" section below for the exact dispatch.
 
 ### Identity announcement (you're registered)
 
@@ -27,143 +40,213 @@ blocks into your context:
     Your session_id: `<UUID>`
     Registered as: **Claude-<Name>** (self-filter active for your own posts)
 
-    If this scrolls out of context later, recall your name with:
-        bash scripts/hooks/huddle-whoami.sh whoami <UUID>
+You're ready. Sign your huddle comments with `—<YourName>` (em-dash + your full registered name).
 
-You're ready. The poll hook (next section) will filter out comments you
-yourself posted. Sign your PP-cvh comments with `—Claude-<YourName>` (em-dash,
-canonical).
-
-### Registration needed (you're new)
+### Registration needed (you're new or pruned)
 
     ## Huddle identity — registration needed
 
     Your session_id: `<UUID>`
+    ...
 
-    When you receive your first user prompt, derive a short descriptive name
-    for yourself from what you're being asked to do. ...
-
-Read the full notice, derive a name from your first user prompt, and register:
+Read the full notice, derive a name from your first prompt, and register:
 
     bash scripts/hooks/huddle-whoami.sh register <YourName> <session_id>
 
 **Naming rules:**
 
-- Short, descriptive of the work (CamelCase, ASCII, under ~20 chars)
-- Examples: `WorktreeHookFix`, `TestAudit`, `DesignBible`, `DocsSync`, `RotationDesign`
-- DO NOT use bead IDs or PR numbers (they don't help Tim recognize sessions)
-- DO NOT use generic labels like `Worker1`
+- Format: `<Harness>-<Topic>` (CamelCase, ASCII, under ~30 chars)
+- Examples: `Claude-WorktreeHookFix`, `Antigravity-TestAudit`, `Codex-DesignBible`
+- DO NOT use bead IDs, PR numbers, or generic labels like `Worker1`
 - If the name's taken, the helper suggests variations; pick one and retry
+
+### Recent activity summary (follows identity)
+
+After the identity block, session-start injects this month's coordination summary and the descriptions of the N most-recent daily beads (default N=5). This is the context that replaced the old PP-cvh comment dump — ~300 tokens vs ~5,000.
+
+## Bootstrap
+
+The huddle system must be bootstrapped once per local clone before it activates. If you see the "not bootstrapped" notice at session start, run:
+
+    bash scripts/hooks/huddle-bootstrap.sh
+
+This creates:
+
+- A root epic bead (permanent — never closes)
+- Today's daily bead (child of root — accepts coordination comments)
+- This month's monthly bead (child of root — collects daily summaries)
+- `.agents/huddle/config.json` with the root bead ID
+- Root bead notes JSON with pointers (§4.2 schema)
+
+Re-running is safe — it's a no-op if already bootstrapped, printing current state.
+
+**Historical archive:** PP-cvh contains coordination activity prior to bootstrap. It stays open as a read-only reference; no one writes there after bootstrap runs.
+
+## Rotation
+
+When the `today_bead.date` in root notes doesn't match today's local date, hooks emit a "rotation needed" notice. **You must dispatch a rotation subagent before continuing your work.**
+
+### Rotation subagent dispatch
+
+Use this `Agent` call (adjust model as appropriate):
+
+```javascript
+Agent({
+  subagent_type: "claude",
+  model: "claude-sonnet-4-5",
+  prompt: `
+You are the huddle rotation subagent. Your job is to rotate the daily coordination bead.
+
+**Phase A — run the shell script:**
+
+  output=$(bash scripts/hooks/huddle-rotate.sh)
+  echo "$output"
+
+Parse the output for key=value lines:
+- OLD_TODAY=<id>       — yesterday's daily bead to summarize + close
+- OLD_MONTHLY=<id>     — last month's monthly bead (only present if month rolled)
+- OLD_MONTH=<name>     — the month label (e.g. "2026-05") of the old monthly
+- NEW_TODAY=<id>       — today's fresh daily bead (now active)
+- NEW_MONTHLY=<id>     — current monthly bead
+- ROTATION_DATE=<date> — the rotation date
+
+If the script exits 0 with no output, a peer already rotated — exit immediately
+with "No-op: peer rotated first."
+
+**Phase B — LLM summarization (only if OLD_TODAY is present):**
+
+1. Fetch OLD_TODAY's comments:
+     bd comments <OLD_TODAY> --json
+
+2. Write a tight categorized summary into OLD_TODAY's description:
+   - Categories (omit empty ones): Merged/Ships, In-flight, Discoveries, Blockers
+   - ~30-50 tokens per category; bullet list per category
+   - Run: bd update <OLD_TODAY> --description "<summary>"
+
+3. Archive raw comments into OLD_TODAY's notes (JSON array for forensics):
+   - Format: [{"author":"...","created_at":"...","text":"..."},...]
+   - Run: bd update <OLD_TODAY> --notes '<json-array>'
+
+4. Close OLD_TODAY:
+     bd close <OLD_TODAY>
+
+5. If month rolled (OLD_MONTHLY present):
+   a. Read OLD_MONTHLY's comments or collect recent daily descriptions for that month
+   b. Write monthly rollup summary into OLD_MONTHLY's description
+   c. Close OLD_MONTHLY: bd close <OLD_MONTHLY>
+
+6. Prune stale session names (§8.4 of the design spec):
+   a. Read .agents/huddle/session-names.json
+   b. For each {session_id: name} entry, scan the last 14 days of huddle content
+      (today's bead + recent daily archives + monthly summaries) for sign-offs
+      matching "—<name>" or "—Claude-<name>"
+   c. Evict entries with no match in 14 days
+   d. Write the pruned map back to session-names.json
+
+After phase B, report: "Rotation complete. OLD_TODAY=<id> closed. NEW_TODAY=<id> active."
+`,
+});
+```
+
+The subagent acquires a file lock in phase A. If a peer session already rotated, phase A exits immediately — safe to dispatch even if you're unsure.
 
 ## What you'll see during normal work
 
 The `huddle-poll.sh` hook fires from two events:
 
 - **`UserPromptSubmit`** — always polls before each user turn (unthrottled).
-- **`PostToolUse`** — polls at most once every `HUDDLE_THROTTLE_SECONDS`
-  seconds (default 180 = 3 min). Most tool calls hit a fast-path skip
-  (~10–30 ms wall clock) — the bd/jq slow path only runs at the throttle
-  cadence. This closes the gap for orchestrator-style sessions that go long
-  stretches between user prompts.
+- **`PostToolUse`** — polls at most once every `HUDDLE_THROTTLE_SECONDS` seconds (default 180 = 3 min).
 
-When the hook finds new comments since this worktree's last cursor, it injects
-them as a system-reminder block:
+When the hook finds new comments since this worktree's last cursor, it injects them:
 
-    ## New PP-cvh coordination comments (N)
+    ## New huddle coordination comments (N)
 
     **<author>** (<timestamp>):
     <comment text>
     ...
 
-Comments signed by your own session (matching `—Claude-<YourName>` or
-`—<YourName>`) are filtered out — you won't see your own posts re-injected.
-
-If nothing's new, no block appears (zero tokens).
+Comments signed by your own session (matching `—<YourName>` or `—Claude-<YourName>`) are filtered out — you won't see your own posts re-injected.
 
 ### Throttle override
 
-To change the PostToolUse throttle interval, edit `.claude/settings.json`
-and update `HUDDLE_THROTTLE_SECONDS=180` on the PostToolUse hook command line.
-Lower means more frequent polling — e.g. `60` for once-per-minute. **Setting
-the value to `0` (or removing the env var) makes the script poll on every
-tool call**, which is heavy bd load — useful for debugging only. To stop
-PostToolUse polling entirely, remove the entire PostToolUse entry from
-`.claude/settings.json` (UserPromptSubmit polling continues regardless).
-
-Subagent sessions (`Agent({...})` dispatches) are skipped on both events
-without writing the throttle marker, so a subagent's tool calls don't
-advance its parent agent's throttle clock.
+Edit `.claude/settings.json` and update `HUDDLE_THROTTLE_SECONDS=180` on the PostToolUse hook command line. Setting it to `0` polls on every tool call — useful for debugging only. To stop PostToolUse polling entirely, remove the entire PostToolUse entry from `.claude/settings.json` (UserPromptSubmit polling continues regardless).
 
 ## How to post coordination updates
 
-Use `bd comments add PP-cvh "..."` with your sign-off. Example:
+Post to today's active bead. To find today's bead ID, check what the session-start hook reported, or look up via:
 
-    bd comments add PP-cvh "Merged PR #1361 (PP-pno7 worktree hook fix). Sync main if you have active branches. —Claude-Slingshot"
+    bd show $(jq -r '.root_bead_id' ~/.agents/huddle/config.json) --json | jq -r '.[0].notes | fromjson | .today_bead.id'
+
+Then post:
+
+    bd comments add <TODAY_BEAD_ID> "Your update here. —<YourName>"
 
 Things worth posting:
 
-- A PR you merged ("Merged PR #N (bead X). Sync main if you have active branches.")
-- A PR you opened ("Opened PR #N (bead X): brief title.")
-- A bead you filed for a non-obvious finding ("Filed PP-XXXX: <finding>.")
+- A PR you merged ("Merged PR #N (PP-xxx). Sync main if you have active branches.")
+- A PR you opened ("Opened PR #N (PP-xxx): brief title.")
+- A bead you filed for a non-obvious finding ("Filed PP-xxx: <finding>.")
 - A coordination need ("Working on file Y in branch Z; flag if conflict.")
 
 Things NOT worth posting:
 
 - Every single commit
 - Internal debugging chatter
-- "I started working on X" (only post merge/discovery; agents read each
-  other's outputs after the fact, not real-time)
+- "I started working on X" (only post merge/discovery)
+
+Sign with `—<YourFullRegisteredName>` (em-dash + your registered name). The self-filter matches this suffix to suppress your own echoes.
 
 ## Scripts
 
-| Script                                   | Trigger                                    | Purpose                                                |
-| ---------------------------------------- | ------------------------------------------ | ------------------------------------------------------ |
-| `scripts/hooks/huddle-poll.sh`           | UserPromptSubmit + PostToolUse (throttled) | Inject new PP-cvh comments since last_seen             |
-| `scripts/hooks/huddle-session-start.sh`  | SessionStart                               | Identity announcement; rotation check (currently stub) |
-| `scripts/hooks/huddle-whoami.sh`         | manual                                     | Register/lookup/list/discover session→name mappings    |
-| `scripts/hooks/huddle-rotation-check.sh` | sourced by both hooks                      | Date-compare for daily rotation (stub in PR #1357)     |
-| `scripts/hooks/huddle-lib.sh`            | sourced by all hooks                       | Shared helpers (state-dir resolver)                    |
+| Script                                   | Trigger                                    | Purpose                                                             |
+| ---------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
+| `scripts/hooks/huddle-bootstrap.sh`      | manual (one-time)                          | Init root epic + daily + monthly + config.json                      |
+| `scripts/hooks/huddle-rotate.sh`         | rotation subagent                          | Phase A: atomic create-and-pointer-update; outputs OLD/NEW bead IDs |
+| `scripts/hooks/huddle-poll.sh`           | UserPromptSubmit + PostToolUse (throttled) | Inject new today_bead comments since last_seen                      |
+| `scripts/hooks/huddle-session-start.sh`  | SessionStart                               | Bootstrap notice, rotation notice, identity, summary injection      |
+| `scripts/hooks/huddle-whoami.sh`         | manual                                     | Register/lookup/list/discover session→name mappings                 |
+| `scripts/hooks/huddle-rotation-check.sh` | sourced by both hooks                      | Date-compare: returns 0 if today_bead.date < today                  |
+| `scripts/hooks/huddle-lib.sh`            | sourced by all hooks                       | Shared helpers (state-dir resolver)                                 |
 
-## State files (all under `<main-worktree>/.claude/huddle/`)
+## State files
 
-The state directory is shared across all linked worktrees of the same clone
-(resolved via `git rev-parse --git-common-dir`). `.claude/huddle/` is
-git-ignored so the state stays machine-local.
+All under `<main-worktree>/.agents/huddle/` (shared across all linked worktrees via `git rev-parse --git-common-dir`). Git-ignored — machine-local.
 
-| File                    | Purpose                                                      |
-| ----------------------- | ------------------------------------------------------------ |
-| `session-names.json`    | `{session_id: name}` map (canonical)                         |
-| `last-seen-<path-hash>` | Per-checkout poll cursor (most-recent injected `created_at`) |
-| `rotation.lock`         | flock target (rotation PR only)                              |
-| `config.json`           | Root bead ID + schema version (rotation PR only)             |
+| File                    | Purpose                                                 |
+| ----------------------- | ------------------------------------------------------- |
+| `config.json`           | `{"root_bead_id": "PP-xxx"}` — written by bootstrap     |
+| `session-names.json`    | `{session_id: name}` map (canonical for self-filter)    |
+| `last-seen-<path-hash>` | Per-checkout poll cursor (newest injected `created_at`) |
+| `rotation.lock`         | flock/lockf target for rotation serialization           |
 
 Plus one per-worktree file outside the shared state dir:
 
-| File                                            | Purpose                                                                   |
-| ----------------------------------------------- | ------------------------------------------------------------------------- |
-| `$CLAUDE_PROJECT_DIR/.claude/.huddle-last-poll` | Throttle marker (epoch seconds) for PostToolUse; gates the fast-path skip |
+| File                                            | Purpose                                                   |
+| ----------------------------------------------- | --------------------------------------------------------- |
+| `$CLAUDE_PROJECT_DIR/.agents/.huddle-last-poll` | Throttle marker (epoch seconds) for PostToolUse fast-path |
+
+## Bead hierarchy
+
+```
+Huddle Root  (epic, never closes)                   ── PP-XXXX
+  notes JSON: today_bead, monthly_bead, recent_dailies, settings, last_rotation
+  │
+  ├── Daily 2026-05-20  ── PP-AAAA  (open; receives coordination comments today)
+  ├── Daily 2026-05-19  ── PP-CCCC  (closed; summary in description, archive in notes)
+  │     ... older dailies ...
+  │
+  ├── Monthly 2026-05   ── PP-BBBB  (open until month rolls)
+  └── Monthly 2026-04   ── PP-EEEE  (closed; rollup summary)
+```
 
 ## Self-filter rules
 
-- Comments are filtered out by exact suffix match on the **em-dash** form: either `—Claude-<YourName>` (canonical, em-dash + "Claude-" + name) or `—<YourName>` (shorthand).
-- The em-dash (U+2014) distinguishes from hyphen-minus: `—Claude-Spinner` does NOT end with `—Spinner` because the byte preceding "Spinner" is a hyphen-minus in "Claude-Spinner", not an em-dash. So no false positives.
-- If your name's mapping gets pruned (the rotation PR adds a 14-day inactivity prune) and your own past posts start re-injecting, just re-register: `bash scripts/hooks/huddle-whoami.sh register <Name> <session_id>`.
+- Comments are filtered by exact suffix match: `—<YourName>` (shorthand) or `—Claude-<YourName>` (canonical).
+- The em-dash (U+2014) distinguishes from hyphen-minus — no false positives between `—Claude-Spinner` and `—Spinner`.
+- If your name gets pruned (14-day inactivity) and your own past posts start re-injecting, re-register: `bash scripts/hooks/huddle-whoami.sh register <Name> <session_id>`.
 
 ## Subagent sessions
 
-Subagent sessions (any `Agent({...})` dispatch) are skipped entirely. Detection:
-`transcript_path` contains `/subagents/<agent-id>.jsonl`. Both hooks exit 0
-without output for subagents. Subagents shouldn't register names or post on
-PP-cvh — they're ephemeral.
+Subagent sessions (`Agent({...})` dispatches) are skipped entirely. Detection: `transcript_path` contains `/subagents/`. Both hooks exit 0 without output. Subagents should not register names or post coordination updates — they're ephemeral.
 
-## What this PR (foundation) doesn't yet include
-
-- **Daily rotation:** PP-cvh remains the single coordination bead. The follow-up
-  rotation PR adds daily summary beads, monthly rollups, and a rotation
-  subagent that runs at the first session of a new local day.
-- **Stale name pruning:** the 14-day name-freeing happens during rotation; not
-  yet active.
-- **Bootstrap:** the huddle root bead doesn't exist yet because rotation isn't
-  shipped. PP-cvh acts as the implicit root.
-
-Full design at `docs/superpowers/specs/2026-05-17-huddle-system-design.md`.
+Full design: `docs/superpowers/specs/2026-05-17-huddle-system-design.md`.

--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -173,9 +173,10 @@ Edit `.claude/settings.json` and update `HUDDLE_THROTTLE_SECONDS=180` on the Pos
 
 ## How to post coordination updates
 
-Post to today's active bead. To find today's bead ID, check what the session-start hook reported, or look up via:
+Post to today's active bead. To find today's bead ID, check what the session-start hook reported, or look up via (huddle state lives at `<main-worktree>/.agents/huddle/`, resolved via `git rev-parse --git-common-dir` — `huddle-lib.sh` itself uses the same lookup):
 
-    bd show $(jq -r '.root_bead_id' ~/.agents/huddle/config.json) --json | jq -r '.[0].notes | fromjson | .today_bead.id'
+    HUDDLE_DIR="$(dirname "$(git rev-parse --git-common-dir)")/.agents/huddle"
+    bd show "$(jq -r '.root_bead_id' "$HUDDLE_DIR/config.json")" --json | jq -r '.[0].notes | fromjson | .today_bead.id'
 
 Then post:
 

--- a/docs/superpowers/plans/2026-05-20-huddle-rotation.md
+++ b/docs/superpowers/plans/2026-05-20-huddle-rotation.md
@@ -1,0 +1,1203 @@
+# Huddle Rotation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement daily bead rotation for the huddle coordination system — creating `huddle-bootstrap.sh`, a real `huddle-rotation-check.sh`, and `huddle-rotate.sh` (phase A shell only); wire existing hooks to use the new bead hierarchy instead of hardcoded PP-cvh; update SKILL.md and spec paths.
+
+**Architecture:** Bootstrap creates a root epic + today's daily + this month's monthly in the bd database, writes `.agents/huddle/config.json` with the root bead ID, and stores a JSON notes blob on the root bead that tracks active bead pointers. Rotation (phase A) acquires a flock/lockf lock, re-checks the date inside the lock, creates new daily/monthly beads atomically by updating root notes, then exits — the LLM-driven summarization (phase B) is documented as a subagent dispatch template in SKILL.md rather than implemented as shell. Both existing hooks (`huddle-poll.sh` and `huddle-session-start.sh`) are updated to read `today_bead.id` from config rather than hardcoding PP-cvh.
+
+**Tech Stack:** Bash (set -euo pipefail, shellcheck), `jq` for JSON, `bd` CLI (beads issue tracker), `flock`/`lockf` (platform-detected, same pattern as `worktree-create.sh`), `python3` for JSON parsing in hooks (already used), `pnpm run check` (shellcheck included).
+
+---
+
+## File Map
+
+| Action  | Path                                                        | Responsibility                                                                                                           |
+| ------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Create  | `scripts/hooks/huddle-bootstrap.sh`                         | One-time idempotent init: root epic + daily + monthly + config.json                                                      |
+| Create  | `scripts/hooks/huddle-rotate.sh`                            | Phase A atomic rotation (shell only): lock → recheck → create beads → update root notes → pointer comments               |
+| Replace | `scripts/hooks/huddle-rotation-check.sh`                    | Real date-compare: reads config.json + root notes, returns 0 if rotation needed                                          |
+| Modify  | `scripts/hooks/huddle-poll.sh`                              | Replace hardcoded `PP-cvh` with `today_bead.id` from config; add bootstrap-not-ready fast path                           |
+| Modify  | `scripts/hooks/huddle-session-start.sh`                     | Insert bootstrap-needed branch before identity; add summary injection step                                               |
+| Modify  | `.agents/skills/pinpoint-huddle/SKILL.md`                   | Document bootstrap, rotation, rotation subagent dispatch template, update state paths, remove "not yet included" section |
+| Modify  | `docs/superpowers/specs/2026-05-17-huddle-system-design.md` | Replace all `.claude/huddle/` with `.agents/huddle/`                                                                     |
+
+---
+
+## Task 1: Replace huddle-rotation-check.sh stub with real implementation
+
+**Files:**
+
+- Replace: `scripts/hooks/huddle-rotation-check.sh`
+
+The real implementation reads `config.json` → `root_bead_id`, then reads the root bead's notes JSON via `bd show <root> --json`, extracts `today_bead.date`, and compares to `$(date +%F)`. Returns 0 (rotation needed) if they differ; 1 if they match. If config.json is missing or root bead is unreachable, returns 1 (no rotation needed) so hooks degrade gracefully.
+
+- [ ] **Step 1.1: Write the new huddle-rotation-check.sh**
+
+Write the following content to `scripts/hooks/huddle-rotation-check.sh` (replacing the stub entirely):
+
+```bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# huddle-rotation-check.sh — shared helper sourced by huddle-poll.sh and
+# huddle-session-start.sh. Defines a single function `huddle_rotation_needed`
+# that returns 0 if a coordination-bead rotation is needed, 1 otherwise.
+#
+# Design: reads <STATE_DIR>/config.json for root_bead_id, then reads the root
+# bead's notes JSON via `bd show <root> --json`, extracts today_bead.date, and
+# compares to $(date +%F) (local date). Returns 0 if mismatch (rotation
+# needed), 1 if match (no rotation needed) or if config is missing/unreadable
+# (hooks degrade gracefully — only SessionStart emits the user-visible notice).
+#
+# Called as:
+#   source "$(dirname "$0")/huddle-rotation-check.sh"
+#   if huddle_rotation_needed; then
+#     # emit rotation notice
+#   fi
+#
+# Requires huddle-lib.sh to already be sourced (STATE_DIR must be set by the
+# caller before sourcing this file, OR this file sources the lib itself if
+# STATE_DIR is unset).
+
+# Ensure STATE_DIR is set. If the caller already sourced huddle-lib.sh and
+# set STATE_DIR, we skip re-sourcing. Otherwise we source the lib ourselves.
+# shellcheck disable=SC2317  # function is sourced and called by callers
+huddle_rotation_needed() {
+  local state_dir config_file root_id root_json today_bead_date today
+
+  # Resolve state dir (re-use caller's STATE_DIR if already set)
+  if [[ -n "${STATE_DIR:-}" ]]; then
+    state_dir="$STATE_DIR"
+  else
+    local lib_script
+    lib_script="$(dirname "${BASH_SOURCE[0]}")/huddle-lib.sh"
+    [[ -f "$lib_script" ]] || return 1
+    # shellcheck source=huddle-lib.sh disable=SC1091
+    source "$lib_script"
+    state_dir=$(huddle_state_dir) || return 1
+  fi
+
+  config_file="$state_dir/config.json"
+  [[ -f "$config_file" ]] || return 1  # not bootstrapped → no rotation needed
+
+  root_id=$(jq -r '.root_bead_id // ""' "$config_file" 2>/dev/null)
+  [[ -n "$root_id" ]] || return 1
+
+  # Fetch the root bead's notes JSON. bd show outputs a JSON array; we pick
+  # the first element's `notes` field. If bd is unavailable or notes is empty,
+  # fail open (return 1 = no rotation needed).
+  root_json=$(bd show "$root_id" --json 2>/dev/null) || return 1
+  today_bead_date=$(printf '%s' "$root_json" | jq -r '.[0].notes // "" | if . == "" then "" else (fromjson? // {}) | .today_bead.date // "" end' 2>/dev/null) || return 1
+  [[ -n "$today_bead_date" ]] || return 1
+
+  today=$(date +%F)
+  if [[ "$today_bead_date" != "$today" ]]; then
+    return 0  # rotation needed
+  fi
+  return 1  # up to date
+}
+```
+
+- [ ] **Step 1.2: Run shellcheck on the new script**
+
+```bash
+shellcheck scripts/hooks/huddle-rotation-check.sh
+```
+
+Expected: no errors or warnings.
+
+- [ ] **Step 1.3: Verify pnpm run check passes**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass (shellcheck runs as part of the check suite).
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add scripts/hooks/huddle-rotation-check.sh
+git commit -m "feat(workflow): implement real huddle-rotation-check.sh (PP-m4ki)"
+```
+
+---
+
+## Task 2: Write huddle-bootstrap.sh
+
+**Files:**
+
+- Create: `scripts/hooks/huddle-bootstrap.sh`
+
+Bootstrap is idempotent: re-running on an already-bootstrapped repo prints status and exits 0 without creating duplicate beads.
+
+Flow:
+
+1. Source `huddle-lib.sh`, resolve `STATE_DIR`.
+2. Check if `config.json` already exists. If yes, verify the root bead is still open → print status and exit 0.
+3. Create root epic: `bd create -t epic --title "Huddle coordination root" --description "..."` — capture ID.
+4. Create today's daily bead as child: `bd create -t task --parent <root> --title "Huddle daily $(date +%F)"` — capture ID.
+5. Create this month's monthly bead as child: `bd create -t task --parent <root> --title "Huddle monthly $(date +%Y-%m)"` — capture ID.
+6. Build notes JSON (schema per §4.2 of the spec) and write it to the root bead: `bd update <root> --notes '<json>'`.
+7. Write `config.json`: `{"schema_version":1,"root_bead_id":"<root>"}`.
+8. Print success summary.
+
+- [ ] **Step 2.1: Write huddle-bootstrap.sh**
+
+```bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# huddle-bootstrap.sh — one-time initialization of the huddle coordination system.
+#
+# Creates:
+#   - root epic bead (open forever, never closes)
+#   - today's first daily bead (child of root)
+#   - this month's first monthly bead (child of root)
+#   - <STATE_DIR>/config.json with root_bead_id
+#   - root bead notes JSON (§4.2 schema)
+#
+# Idempotent: re-running on an already-bootstrapped project prints status and
+# exits 0 without creating duplicate beads.
+#
+# Usage: bash scripts/hooks/huddle-bootstrap.sh
+
+set -euo pipefail
+
+# --- Dependency check ---
+for dep in jq bd python3; do
+  command -v "$dep" >/dev/null 2>&1 || {
+    printf 'huddle-bootstrap.sh: %s not found — please install it\n' "$dep" >&2
+    exit 1
+  }
+done
+
+# --- State directory ---
+LIB_SCRIPT="$(dirname "$0")/huddle-lib.sh"
+if [[ ! -f "$LIB_SCRIPT" ]]; then
+  printf 'huddle-bootstrap.sh: huddle-lib.sh not found at %s\n' "$LIB_SCRIPT" >&2
+  exit 1
+fi
+# shellcheck source=huddle-lib.sh disable=SC1091
+source "$LIB_SCRIPT"
+STATE_DIR=$(huddle_state_dir) || {
+  printf 'huddle-bootstrap.sh: not inside a git checkout; cannot resolve huddle state dir\n' >&2
+  exit 1
+}
+mkdir -p "$STATE_DIR"
+
+CONFIG_FILE="$STATE_DIR/config.json"
+
+# --- Idempotency check ---
+if [[ -f "$CONFIG_FILE" ]]; then
+  ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+  if [[ -n "$ROOT_ID" ]]; then
+    # Verify root bead still exists and is open
+    ROOT_STATUS=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].status // "missing"' 2>/dev/null || echo "missing")
+    if [[ "$ROOT_STATUS" != "missing" ]]; then
+      printf 'Huddle already bootstrapped.\n'
+      printf '  Root bead: %s (status: %s)\n' "$ROOT_ID" "$ROOT_STATUS"
+      NOTES_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+      if [[ -n "$NOTES_JSON" ]]; then
+        TODAY_BEAD=$(printf '%s' "$NOTES_JSON" | python3 -c "import sys,json; n=json.load(sys.stdin); print(n.get('today_bead',{}).get('id','unknown'))" 2>/dev/null || echo "unknown")
+        MONTHLY_BEAD=$(printf '%s' "$NOTES_JSON" | python3 -c "import sys,json; n=json.load(sys.stdin); print(n.get('monthly_bead',{}).get('id','unknown'))" 2>/dev/null || echo "unknown")
+        printf '  Today daily: %s\n' "$TODAY_BEAD"
+        printf '  Monthly:     %s\n' "$MONTHLY_BEAD"
+      fi
+      exit 0
+    fi
+    printf 'Warning: root bead %s is missing or inaccessible; re-bootstrapping.\n' "$ROOT_ID"
+  fi
+fi
+
+TODAY=$(date +%F)
+MONTH=$(date +%Y-%m)
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+printf 'Bootstrapping huddle coordination system...\n'
+
+# --- Create root epic ---
+printf '  Creating root epic...\n'
+ROOT_DESCRIPTION="Huddle coordination root — the permanent parent bead for all daily and monthly coordination beads.
+
+This bead never closes. Daily beads (children) are created each day; monthly beads (children) are created each month. After rotation, daily beads carry a categorized summary of the day's coordination activity in their description and a raw archive in their notes field.
+
+Historical archive: PP-cvh contains coordination activity prior to $(date +%Y-%m-%d).
+
+State is stored in this bead's notes field as JSON (schema v1); use \`bd show <this-id> --json\` to inspect."
+ROOT_ID=$(bd create -t epic \
+  --title "Huddle coordination root" \
+  --description "$ROOT_DESCRIPTION" \
+  --silent)
+printf '  Root epic:     %s\n' "$ROOT_ID"
+
+# --- Create today's daily bead ---
+printf '  Creating today'\''s daily bead...\n'
+TODAY_ID=$(bd create -t task \
+  --parent "$ROOT_ID" \
+  --title "Huddle daily $TODAY" \
+  --description "Active coordination bead for $TODAY. Agents post updates here with their sign-off (e.g. —Claude-WorktreeFix). At midnight rotation, this bead gets a categorized summary in its description and a raw archive in its notes, then closes." \
+  --silent)
+printf '  Today daily:   %s\n' "$TODAY_ID"
+
+# --- Create this month's monthly bead ---
+printf '  Creating monthly bead...\n'
+MONTHLY_ID=$(bd create -t task \
+  --parent "$ROOT_ID" \
+  --title "Huddle monthly $MONTH" \
+  --description "Monthly coordination summary for $MONTH. Receives aggregated summaries of each day's daily bead when that daily closes." \
+  --silent)
+printf '  Monthly:       %s\n' "$MONTHLY_ID"
+
+# --- Build and write root notes JSON ---
+printf '  Writing root bead notes JSON...\n'
+NOTES_JSON=$(python3 -c "
+import json, sys
+notes = {
+    'schema_version': 1,
+    'today_bead': {'id': sys.argv[1], 'date': sys.argv[2]},
+    'monthly_bead': {'id': sys.argv[3], 'month': sys.argv[4]},
+    'recent_dailies': [{'id': sys.argv[1], 'date': sys.argv[2]}],
+    'settings': {
+        'n_dailies_to_inject': 5,
+        'day_boundary_tz': 'local',
+        'stale_name_cutoff_days': 14
+    },
+    'last_rotation': sys.argv[5]
+}
+print(json.dumps(notes))
+" "$TODAY_ID" "$TODAY" "$MONTHLY_ID" "$MONTH" "$NOW")
+
+bd update "$ROOT_ID" --notes "$NOTES_JSON"
+
+# --- Write config.json ---
+printf '  Writing config.json...\n'
+python3 -c "
+import json, sys
+config = {'schema_version': 1, 'root_bead_id': sys.argv[1]}
+print(json.dumps(config, indent=2))
+" "$ROOT_ID" > "$CONFIG_FILE"
+
+printf '\nBootstrap complete!\n'
+printf '  Config:    %s\n' "$CONFIG_FILE"
+printf '  Root:      %s\n' "$ROOT_ID"
+printf '  Today:     %s (%s)\n' "$TODAY_ID" "$TODAY"
+printf '  Monthly:   %s (%s)\n' "$MONTHLY_ID" "$MONTH"
+printf '\nHooks will now use the new bead hierarchy. PP-cvh remains open as historical archive.\n'
+printf 'Run `bash scripts/hooks/huddle-whoami.sh register <YourName> <session_id>` to register yourself.\n'
+```
+
+Save this to `scripts/hooks/huddle-bootstrap.sh`.
+
+- [ ] **Step 2.2: Run shellcheck**
+
+```bash
+shellcheck scripts/hooks/huddle-bootstrap.sh
+```
+
+Expected: no errors or warnings.
+
+- [ ] **Step 2.3: Smoke-test idempotency (dry run without a real bd)**
+
+Run the script with `--dry-run` understanding that it will actually call `bd create` in a real environment. Instead, verify the script structure parses correctly:
+
+```bash
+bash -n scripts/hooks/huddle-bootstrap.sh
+```
+
+Expected: no syntax errors (bash -n parses without executing).
+
+- [ ] **Step 2.4: Run pnpm run check**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add scripts/hooks/huddle-bootstrap.sh
+git commit -m "feat(workflow): add huddle-bootstrap.sh idempotent init (PP-m4ki)"
+```
+
+---
+
+## Task 3: Write huddle-rotate.sh (phase A — shell atomic only)
+
+**Files:**
+
+- Create: `scripts/hooks/huddle-rotate.sh`
+
+Phase A performs the atomic shell work: acquire lock, re-check date inside lock, create new beads, update root notes, post pointer comments, print old bead IDs to stdout. Phase B (LLM summarization) is NOT done in this script — it is dispatched separately as a subagent and documented in SKILL.md Task 7.
+
+Lock strategy (same platform-detection pattern as `scripts/hooks/worktree-create.sh`): detect `lockf` (macOS) or `flock` (Linux) and use whichever is available, 60s timeout.
+
+- [ ] **Step 3.1: Check worktree-create.sh for the exact lock pattern to copy**
+
+```bash
+grep -A 20 'lockf\|flock' scripts/hooks/worktree-create.sh | head -40
+```
+
+This shows the exact platform-detection pattern used by PP-bg45. Copy that pattern into rotate.sh.
+
+- [ ] **Step 3.2: Write huddle-rotate.sh**
+
+```bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# huddle-rotate.sh — daily coordination bead rotation (phase A: shell atomic).
+#
+# Phase A (this script) does the atomic shell work:
+#   1. Acquire lock on <STATE_DIR>/rotation.lock (60s timeout)
+#   2. Re-check date inside lock (exit 0 if peer already rotated)
+#   3. Create new daily bead (+ monthly if month rolled) under root
+#   4. Atomically update root notes JSON with new pointers
+#   5. Post "→ continued in <new-bead>" comments on old beads (best-effort)
+#   6. Print OLD_TODAY_ID (and OLD_MONTHLY_ID if rolled) to stdout
+#
+# Phase B (LLM summarization, closing, name-prune) is done by the dispatching
+# subagent after reading phase A stdout. Template in SKILL.md §7.2 (rotation
+# subagent dispatch).
+#
+# Crash-safety: steps 1-4 are the "make consistent" path. If the process dies
+# between step 4 and step 6, root notes already point to new beads — system is
+# consistent. Old bead has no summary, but the next rotation's subagent can
+# back-fill it before proceeding.
+#
+# Usage:
+#   output=$(bash scripts/hooks/huddle-rotate.sh)
+#   OLD_TODAY_ID=$(printf '%s\n' "$output" | grep '^OLD_TODAY=' | cut -d= -f2)
+#   OLD_MONTHLY_ID=$(printf '%s\n' "$output" | grep '^OLD_MONTHLY=' | cut -d= -f2)
+#
+# Exits 0 (no-op) if rotation is not needed (peer already rotated inside lock).
+
+set -euo pipefail
+
+for dep in jq bd python3; do
+  command -v "$dep" >/dev/null 2>&1 || {
+    printf 'huddle-rotate.sh: %s not found\n' "$dep" >&2
+    exit 1
+  }
+done
+
+LIB_SCRIPT="$(dirname "$0")/huddle-lib.sh"
+[[ -f "$LIB_SCRIPT" ]] || { printf 'huddle-rotate.sh: huddle-lib.sh not found\n' >&2; exit 1; }
+# shellcheck source=huddle-lib.sh disable=SC1091
+source "$LIB_SCRIPT"
+STATE_DIR=$(huddle_state_dir) || { printf 'huddle-rotate.sh: not in a git checkout\n' >&2; exit 1; }
+
+CONFIG_FILE="$STATE_DIR/config.json"
+[[ -f "$CONFIG_FILE" ]] || { printf 'huddle-rotate.sh: not bootstrapped — run huddle-bootstrap.sh first\n' >&2; exit 1; }
+
+ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+[[ -n "$ROOT_ID" ]] || { printf 'huddle-rotate.sh: config.json missing root_bead_id\n' >&2; exit 1; }
+
+LOCK_FILE="$STATE_DIR/rotation.lock"
+
+# Platform-detected locking (same pattern as worktree-create.sh PP-bg45).
+# lockf(1) on macOS, flock(1) on Linux. Both provide exclusive lock with timeout.
+if command -v lockf >/dev/null 2>&1; then
+  # macOS: lockf -t <timeout> <file> <cmd> [args...]
+  _run_locked() {
+    lockf -t 60 "$LOCK_FILE" bash -c "$1"
+  }
+elif command -v flock >/dev/null 2>&1; then
+  # Linux: flock -x -w <timeout> <file> <cmd> [args...]
+  _run_locked() {
+    flock -x -w 60 "$LOCK_FILE" bash -c "$1"
+  }
+else
+  printf 'huddle-rotate.sh: neither lockf nor flock found — cannot safely rotate\n' >&2
+  exit 1
+fi
+
+# The rotation body runs inside the lock. We pass it as a here-string through
+# bash -c so the lock covers the entire operation atomically.
+# Variables needed inside the locked body are exported first.
+export ROOT_ID STATE_DIR CONFIG_FILE
+
+ROTATION_OUTPUT=$(_run_locked '
+set -euo pipefail
+
+# Re-check date inside the lock (idempotency: peer may have rotated first)
+ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || exit 0
+NOTES_STR=$(printf "%s" "$ROOT_JSON" | jq -r ".[0].notes // \"\"" 2>/dev/null) || exit 0
+[[ -n "$NOTES_STR" ]] || { printf "huddle-rotate.sh: root bead has no notes — was bootstrap run?\n" >&2; exit 1; }
+
+TODAY_BEAD_DATE=$(printf "%s" "$NOTES_STR" | python3 -c "
+import sys, json
+n = json.load(sys.stdin)
+print(n.get(\"today_bead\", {}).get(\"date\", \"\"))
+" 2>/dev/null) || exit 0
+
+TODAY=$(date +%F)
+if [[ "$TODAY_BEAD_DATE" == "$TODAY" ]]; then
+  # Peer already rotated — no-op
+  exit 0
+fi
+
+# Parse current pointers from notes
+OLD_TODAY_ID=$(printf "%s" "$NOTES_STR" | python3 -c "
+import sys, json
+n = json.load(sys.stdin)
+print(n.get(\"today_bead\", {}).get(\"id\", \"\"))
+" 2>/dev/null)
+OLD_MONTHLY_ID=$(printf "%s" "$NOTES_STR" | python3 -c "
+import sys, json
+n = json.load(sys.stdin)
+print(n.get(\"monthly_bead\", {}).get(\"id\", \"\"))
+" 2>/dev/null)
+OLD_MONTH=$(printf "%s" "$NOTES_STR" | python3 -c "
+import sys, json
+n = json.load(sys.stdin)
+print(n.get(\"monthly_bead\", {}).get(\"month\", \"\"))
+" 2>/dev/null)
+RECENT_DAILIES=$(printf "%s" "$NOTES_STR" | python3 -c "
+import sys, json
+n = json.load(sys.stdin)
+print(json.dumps(n.get(\"recent_dailies\", [])))
+" 2>/dev/null)
+SETTINGS=$(printf "%s" "$NOTES_STR" | python3 -c "
+import sys, json
+n = json.load(sys.stdin)
+print(json.dumps(n.get(\"settings\", {\"n_dailies_to_inject\": 5, \"day_boundary_tz\": \"local\", \"stale_name_cutoff_days\": 14})))
+" 2>/dev/null)
+
+CURRENT_MONTH=$(date +%Y-%m)
+MONTH_ROLLED=0
+if [[ "$OLD_MONTH" != "$CURRENT_MONTH" ]]; then
+  MONTH_ROLLED=1
+fi
+
+# Create new daily bead (orphan — not live until root notes updated)
+NEW_TODAY_ID=$(bd create -t task \
+  --parent "$ROOT_ID" \
+  --title "Huddle daily $TODAY" \
+  --description "Active coordination bead for $TODAY. Agents post updates here. At midnight rotation this bead gets a categorized summary and closes." \
+  --silent)
+
+NEW_MONTHLY_ID="$OLD_MONTHLY_ID"
+if [[ "$MONTH_ROLLED" -eq 1 ]]; then
+  NEW_MONTHLY_ID=$(bd create -t task \
+    --parent "$ROOT_ID" \
+    --title "Huddle monthly $CURRENT_MONTH" \
+    --description "Monthly coordination summary for $CURRENT_MONTH. Receives aggregated summaries of daily beads when they close." \
+    --silent)
+fi
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Build new recent_dailies: prepend new today entry, cap at 20
+NEW_RECENT=$(python3 -c "
+import sys, json
+existing = json.loads(sys.argv[1])
+new_entry = {\"id\": sys.argv[2], \"date\": sys.argv[3]}
+combined = [new_entry] + existing
+print(json.dumps(combined[:20]))
+" "$RECENT_DAILIES" "$NEW_TODAY_ID" "$TODAY")
+
+# Build new notes JSON
+NEW_NOTES=$(python3 -c "
+import sys, json
+notes = {
+    \"schema_version\": 1,
+    \"today_bead\": {\"id\": sys.argv[1], \"date\": sys.argv[2]},
+    \"monthly_bead\": {\"id\": sys.argv[3], \"month\": sys.argv[4]},
+    \"recent_dailies\": json.loads(sys.argv[5]),
+    \"settings\": json.loads(sys.argv[6]),
+    \"last_rotation\": sys.argv[7]
+}
+print(json.dumps(notes))
+" "$NEW_TODAY_ID" "$TODAY" "$NEW_MONTHLY_ID" "$CURRENT_MONTH" "$NEW_RECENT" "$SETTINGS" "$NOW")
+
+# ATOMIC: update root pointers — after this, system is consistent
+bd update "$ROOT_ID" --notes "$NEW_NOTES"
+
+# Post continuation comments on old beads (best-effort: failures do not abort)
+if [[ -n "$OLD_TODAY_ID" ]]; then
+  bd comments add "$OLD_TODAY_ID" "→ continued in $NEW_TODAY_ID (rotation $(date +%F))" 2>/dev/null || true
+fi
+if [[ "$MONTH_ROLLED" -eq 1 ]] && [[ -n "$OLD_MONTHLY_ID" ]]; then
+  bd comments add "$OLD_MONTHLY_ID" "→ continued in $NEW_MONTHLY_ID (month rolled to $CURRENT_MONTH)" 2>/dev/null || true
+fi
+
+# Output old bead IDs for phase B (LLM summarization)
+printf "OLD_TODAY=%s\n" "$OLD_TODAY_ID"
+if [[ "$MONTH_ROLLED" -eq 1 ]]; then
+  printf "OLD_MONTHLY=%s\n" "$OLD_MONTHLY_ID"
+  printf "OLD_MONTH=%s\n" "$OLD_MONTH"
+fi
+printf "NEW_TODAY=%s\n" "$NEW_TODAY_ID"
+printf "NEW_MONTHLY=%s\n" "$NEW_MONTHLY_ID"
+printf "ROTATION_DATE=%s\n" "$TODAY"
+')
+
+# Print phase A output to stdout (phase B subagent reads this)
+printf '%s\n' "$ROTATION_OUTPUT"
+```
+
+Save to `scripts/hooks/huddle-rotate.sh`.
+
+- [ ] **Step 3.3: Run shellcheck**
+
+```bash
+shellcheck scripts/hooks/huddle-rotate.sh
+```
+
+Expected: no errors or warnings. If shellcheck complains about variables inside the `bash -c` heredoc body (passed as a string literal), those are in a string — they're intentional. Address any real issues.
+
+- [ ] **Step 3.4: Verify bash syntax**
+
+```bash
+bash -n scripts/hooks/huddle-rotate.sh
+```
+
+Expected: no syntax errors.
+
+- [ ] **Step 3.5: Run pnpm run check**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add scripts/hooks/huddle-rotate.sh
+git commit -m "feat(workflow): add huddle-rotate.sh phase-A atomic rotation (PP-m4ki)"
+```
+
+---
+
+## Task 4: Update huddle-poll.sh to read today_bead from config
+
+**Files:**
+
+- Modify: `scripts/hooks/huddle-poll.sh`
+
+Two changes:
+
+1. After state-dir resolution, check if `config.json` exists. If not, exit 0 silently (SessionStart handles the user-visible bootstrap notice).
+2. Replace `bd comments PP-cvh --json` (line ~204) with: read `today_bead.id` from `config.json` → root notes, then `bd comments <today_bead_id> --json`.
+3. Update the "rotation needed" output branch to emit the full §7.2 template (not the stub placeholder).
+4. Update the comment at the top of the output block from `## New PP-cvh coordination comments (N)` to `## New huddle coordination comments (N)` (removing the hardcoded PP-cvh reference).
+
+- [ ] **Step 4.1: Read the current huddle-poll.sh to identify the exact lines to change**
+
+Re-read `scripts/hooks/huddle-poll.sh` lines 144–260 to confirm exact text before editing.
+
+- [ ] **Step 4.2: Replace the hardcoded PP-cvh fetch and add bootstrap check**
+
+After the `STATE_DIR` resolution and `mkdir -p "$STATE_DIR"` block (around line 182), add a bootstrap check:
+
+```bash
+# --- Bootstrap check ---
+# If config.json is missing, the system hasn't been bootstrapped yet.
+# Exit silently — huddle-session-start.sh emits the user-visible bootstrap notice.
+CONFIG_FILE="$STATE_DIR/config.json"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  exit 0
+fi
+ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+if [[ -z "$ROOT_ID" ]]; then
+  exit 0
+fi
+```
+
+Then replace the rotation needed output (around line 149–156) with the full §7.2 template:
+
+```bash
+  if huddle_rotation_needed; then
+    STORED_DATE=""
+    if [[ -f "$CONFIG_FILE" ]]; then
+      NOTES_STR=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+      if [[ -n "$NOTES_STR" ]]; then
+        STORED_DATE=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('date', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+      fi
+    fi
+    NOW_DATE=$(date +%F)
+    printf '## ⚠️ Huddle rotation needed\n\n'
+    printf 'The active coordination bead points to date %s, but today is %s.\n' "$STORED_DATE" "$NOW_DATE"
+    printf 'Before continuing, dispatch the rotation subagent.\n\n'
+    printf 'See .agents/skills/pinpoint-huddle/SKILL.md for the dispatch template.\n'
+    exit 0
+  fi
+```
+
+Then replace the hardcoded `bd comments PP-cvh --json` line (~line 204) and update the output header:
+
+Old line:
+
+```bash
+COMMENTS_JSON="$(bd comments PP-cvh --json 2>/dev/null)" || { exit 0; }
+```
+
+New — read `today_bead.id` from root notes:
+
+```bash
+# Read today_bead.id from root notes
+ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || { exit 0; }
+NOTES_STR=$(printf '%s' "$ROOT_JSON" | jq -r '.[0].notes // ""' 2>/dev/null) || { exit 0; }
+[[ -n "$NOTES_STR" ]] || { exit 0; }
+TODAY_BEAD_ID=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null) || { exit 0; }
+[[ -n "$TODAY_BEAD_ID" ]] || { exit 0; }
+
+COMMENTS_JSON="$(bd comments "$TODAY_BEAD_ID" --json 2>/dev/null)" || { exit 0; }
+```
+
+And update the output header (line ~256):
+Old:
+
+```bash
+printf '## New PP-cvh coordination comments (%d)\n\n' "$COUNT"
+```
+
+New:
+
+```bash
+printf '## New huddle coordination comments (%d)\n\n' "$COUNT"
+```
+
+- [ ] **Step 4.3: Run shellcheck**
+
+```bash
+shellcheck scripts/hooks/huddle-poll.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 4.4: Run pnpm run check**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add scripts/hooks/huddle-poll.sh
+git commit -m "feat(workflow): wire huddle-poll.sh to today_bead from config (PP-m4ki)"
+```
+
+---
+
+## Task 5: Update huddle-session-start.sh with bootstrap-needed branch and summary injection
+
+**Files:**
+
+- Modify: `scripts/hooks/huddle-session-start.sh`
+
+Three changes:
+
+1. After subagent skip and before the rotation check, add a bootstrap-needed branch: if `config.json` is missing (or `root_bead_id` is blank), emit the §7.1 "bootstrap needed" notice and exit.
+2. Replace the rotation needed stub output (lines ~81-87) with the full §7.2 template (matching what huddle-poll.sh uses).
+3. After the identity announcement (before the final `exit 0`), add summary injection (§5.1 step 5): read `monthly_bead.id` and `recent_dailies` from root notes, fetch their descriptions, emit them as context. Suppressed if `source == "compact"` (already suppressed via the early-exit at line ~113).
+
+- [ ] **Step 5.1: Locate the exact insertion points**
+
+Re-read `scripts/hooks/huddle-session-start.sh`. The bootstrap-needed block goes right after `mkdir -p "$STATE_DIR"` (line 49) and before the rotation check (line 75).
+
+- [ ] **Step 5.2: Add bootstrap-needed branch**
+
+After the `mkdir -p "$STATE_DIR"` line (line 49), insert:
+
+```bash
+# --- Bootstrap check ---
+CONFIG_FILE="$STATE_DIR/config.json"
+ROOT_ID=""
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '## ⚠️ Huddle not bootstrapped\n\n'
+  printf 'The huddle coordination system is not set up yet. It maintains a daily bead\n'
+  printf 'for agents to coordinate on, summarizes each day'\''s chatter into ~50-token\n'
+  printf 'digests so it stays cheap to read, and rotates at local midnight.\n\n'
+  printf 'To bootstrap, run:\n'
+  printf '    bash scripts/hooks/huddle-bootstrap.sh\n\n'
+  printf 'That creates the root bead, today'\''s daily, this month'\''s monthly, and writes\n'
+  MAIN_ROOT=$(git rev-parse --git-common-dir 2>/dev/null | xargs -I{} dirname {} 2>/dev/null || echo "<main-worktree>")
+  printf '%s/.agents/huddle/config.json with the IDs. Re-running is safe.\n' "$MAIN_ROOT"
+  exit 0
+fi
+ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+if [[ -z "$ROOT_ID" ]]; then
+  # Corrupt config — treat as not bootstrapped
+  printf '## ⚠️ Huddle not bootstrapped\n\n'
+  printf 'config.json exists but has no root_bead_id. Re-run:\n'
+  printf '    bash scripts/hooks/huddle-bootstrap.sh\n'
+  exit 0
+fi
+```
+
+- [ ] **Step 5.3: Replace rotation-needed stub with full template**
+
+Replace lines ~81-87:
+
+```bash
+    # Real "rotation needed" output lands in the follow-up PR. For now this
+    # branch is unreachable (stub returns 1).
+    printf '## ⚠️ Huddle rotation needed\n\n'
+    printf 'See docs/superpowers/specs/2026-05-17-huddle-system-design.md §7.2\n'
+    exit 0
+```
+
+With:
+
+```bash
+    STORED_DATE=""
+    NOTES_STR=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+    if [[ -n "$NOTES_STR" ]]; then
+      STORED_DATE=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('date', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+    fi
+    NOW_DATE=$(date +%F)
+    printf '## ⚠️ Huddle rotation needed\n\n'
+    printf 'The active coordination bead points to date %s, but today is %s.\n' "$STORED_DATE" "$NOW_DATE"
+    printf 'Before continuing, dispatch the rotation subagent — it will summarize\n'
+    printf 'the previous day, create today'\''s bead, update pointers, and post\n'
+    printf '"continued in" markers on closed beads.\n\n'
+    printf 'Dispatch template in .agents/skills/pinpoint-huddle/SKILL.md.\n'
+    exit 0
+```
+
+- [ ] **Step 5.4: Add summary injection after identity block**
+
+After the closing `fi` of the identity block (after line ~151 where the `else` branch ends, before the final `exit 0`), add:
+
+```bash
+# --- Summary injection (§5.1 step 5) ---
+# Inject monthly summary + N most-recent daily bead descriptions.
+# Suppressed on compact (already returned early above).
+# Fails open: any bd error exits silently, not noisily.
+ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || { exit 0; }
+NOTES_STR=$(printf '%s' "$ROOT_JSON" | jq -r '.[0].notes // ""' 2>/dev/null) || { exit 0; }
+if [[ -z "$NOTES_STR" ]]; then
+  exit 0
+fi
+
+N_DAILIES=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('settings', {}).get('n_dailies_to_inject', 5))
+except Exception:
+    print(5)
+" 2>/dev/null || echo "5")
+
+MONTHLY_BEAD_ID=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('monthly_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+RECENT_DAILIES=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    items = n.get('recent_dailies', [])
+    for item in items:
+        print(item.get('id', '') + '\t' + item.get('date', ''))
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+
+# Only emit the summary block if we have something to show
+HAS_CONTENT=0
+
+if [[ -n "$MONTHLY_BEAD_ID" ]]; then
+  MONTHLY_DESC=$(bd show "$MONTHLY_BEAD_ID" --json 2>/dev/null | jq -r '.[0].description // ""' 2>/dev/null || echo "")
+  if [[ -n "$MONTHLY_DESC" && "$MONTHLY_DESC" != "null" ]]; then
+    HAS_CONTENT=1
+  fi
+fi
+
+if [[ -n "$RECENT_DAILIES" ]]; then
+  # Quick check — if we can read at least one daily, we have content
+  FIRST_ID=$(printf '%s\n' "$RECENT_DAILIES" | head -1 | cut -f1)
+  if [[ -n "$FIRST_ID" ]]; then
+    HAS_CONTENT=1
+  fi
+fi
+
+if [[ "$HAS_CONTENT" -eq 0 ]]; then
+  exit 0
+fi
+
+printf '\n## Huddle recent activity\n\n'
+
+if [[ -n "$MONTHLY_BEAD_ID" && -n "${MONTHLY_DESC:-}" && "$MONTHLY_DESC" != "null" ]]; then
+  MONTHLY_TITLE=$(bd show "$MONTHLY_BEAD_ID" --json 2>/dev/null | jq -r '.[0].title // ""' 2>/dev/null || echo "Monthly summary")
+  printf '### %s\n\n%s\n\n' "$MONTHLY_TITLE" "$MONTHLY_DESC"
+fi
+
+if [[ -n "$RECENT_DAILIES" ]]; then
+  DAILY_COUNT=0
+  while IFS=$'\t' read -r daily_id daily_date; do
+    [[ -z "$daily_id" ]] && continue
+    [[ "$DAILY_COUNT" -ge "$N_DAILIES" ]] && break
+    DAILY_DESC=$(bd show "$daily_id" --json 2>/dev/null | jq -r '.[0].description // ""' 2>/dev/null || echo "")
+    if [[ -n "$DAILY_DESC" && "$DAILY_DESC" != "null" ]]; then
+      printf '### Daily %s (%s)\n\n%s\n\n' "$daily_date" "$daily_id" "$DAILY_DESC"
+    fi
+    DAILY_COUNT=$(( DAILY_COUNT + 1 ))
+  done <<< "$RECENT_DAILIES"
+fi
+```
+
+- [ ] **Step 5.5: Run shellcheck**
+
+```bash
+shellcheck scripts/hooks/huddle-session-start.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 5.6: Verify bash syntax**
+
+```bash
+bash -n scripts/hooks/huddle-session-start.sh
+```
+
+Expected: no syntax errors.
+
+- [ ] **Step 5.7: Run pnpm run check**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 5.8: Commit**
+
+```bash
+git add scripts/hooks/huddle-session-start.sh
+git commit -m "feat(workflow): bootstrap-needed + summary injection in session-start (PP-m4ki)"
+```
+
+---
+
+## Task 6: Update the spec — replace .claude/huddle/ with .agents/huddle/
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-05-17-huddle-system-design.md`
+
+The spec was written before PR #1390 moved state from `.claude/huddle/` to `.agents/huddle/`. Replace all occurrences. Also update §8.1 mapping storage path (`.claude/huddle/session-names.json` → `.agents/huddle/session-names.json`).
+
+- [ ] **Step 6.1: Find all occurrences of the old path**
+
+```bash
+grep -n '\.claude/huddle' docs/superpowers/specs/2026-05-17-huddle-system-design.md
+```
+
+This shows every line that needs updating.
+
+- [ ] **Step 6.2: Replace all occurrences (use rg/sed or Edit tool)**
+
+Replace every instance of `.claude/huddle/` with `.agents/huddle/` in the spec file. Also update the §2 state list which says `<main-worktree>/.claude/huddle/` → `<main-worktree>/.agents/huddle/`.
+
+Also: update §4.3 header from `(<main-worktree>/.claude/huddle/config.json)` to `(<main-worktree>/.agents/huddle/config.json)`.
+
+Also update §7.1 bootstrap notice template (which has the config path in example text) to use `.agents/huddle/config.json`.
+
+- [ ] **Step 6.3: Verify no .claude/huddle references remain**
+
+```bash
+grep -c '\.claude/huddle' docs/superpowers/specs/2026-05-17-huddle-system-design.md
+```
+
+Expected: `0`.
+
+- [ ] **Step 6.4: Run pnpm run check**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-17-huddle-system-design.md
+git commit -m "docs(spec): update huddle spec paths .claude/ -> .agents/ (PP-m4ki)"
+```
+
+---
+
+## Task 7: Update SKILL.md with bootstrap, rotation, and dispatch template
+
+**Files:**
+
+- Modify: `.agents/skills/pinpoint-huddle/SKILL.md`
+
+Rewrite the SKILL.md to reflect the full implemented system. Key additions:
+
+1. Update description/frontmatter to remove PP-cvh references and mention the bead hierarchy.
+2. Add a "Bootstrap" section: when to run it, what it creates, idempotency.
+3. Add a "Rotation subagent dispatch" section (§7.2 template): exact `Agent({...})` call pattern, what the subagent should do for phase B (summarize old bead → write description → write notes → close → prune names).
+4. Update "Scripts" table to include the two new scripts.
+5. Update "State files" table — change `.claude/huddle/` to `.agents/huddle/`.
+6. Update "How to post coordination updates" to use `today_bead.id` from config instead of `PP-cvh`.
+7. Remove the "What this PR doesn't yet include" section.
+
+- [ ] **Step 7.1: Write the updated SKILL.md**
+
+Write the full updated content. Key sections:
+
+**Frontmatter** — update description to mention daily rotation and root bead hierarchy.
+
+**Bootstrap section** (new, after "What you'll see at session start"):
+
+```markdown
+## Bootstrap
+
+The huddle system must be bootstrapped once per local clone before it activates.
+If you see the "not bootstrapped" notice at session start, run:
+
+    bash scripts/hooks/huddle-bootstrap.sh
+
+This creates:
+
+- A root epic bead (permanent — never closes)
+- Today's daily bead (child of root — accepts coordination comments)
+- This month's monthly bead (child of root — collects daily summaries)
+- `.agents/huddle/config.json` with the root bead ID
+
+Re-running is safe — it's a no-op if already bootstrapped.
+```
+
+**Rotation needed section** (new, after "What you'll see at session start"):
+
+````markdown
+## Rotation needed
+
+When the `today_bead.date` in root notes doesn't match today's local date, hooks
+emit a "rotation needed" notice. **You must dispatch a rotation subagent before
+continuing your work.** Use this exact dispatch:
+
+    Agent({
+      subagent_type: "claude",
+      model: "claude-sonnet-4-5",
+      prompt: "<see §7.2 template below>"
+    })
+
+### Rotation subagent prompt template (§7.2)
+
+Paste this as the subagent's `prompt`:
+
+---
+
+You are the huddle rotation subagent. Your job is to rotate the daily coordination bead.
+
+**Phase A (run the shell script):**
+
+```bash
+output=$(bash scripts/hooks/huddle-rotate.sh)
+echo "$output"
+```
+````
+
+Parse the output for:
+
+- `OLD_TODAY=<id>` — yesterday's daily bead
+- `OLD_MONTHLY=<id>` — last month's monthly bead (only if month rolled)
+- `NEW_TODAY=<id>` — today's fresh daily bead
+- `NEW_MONTHLY=<id>` — current monthly bead
+
+If the script exits 0 with no output, a peer already rotated — exit immediately (rotation was a no-op).
+
+**Phase B (LLM summarization — do this only if phase A produced OLD_TODAY):**
+
+1. Fetch OLD_TODAY's comments: `bd comments <OLD_TODAY> --json`
+2. Write a tight categorized summary into OLD_TODAY's description:
+   - Categories: Merged/Ships, In-flight, Discoveries, Blockers
+   - ~30-50 tokens per category; omit empty categories
+   - Format: markdown bullet list per category
+   - Run: `bd update <OLD_TODAY> --description "<summary>"`
+3. Archive raw comments into OLD_TODAY's notes (for forensics):
+   - Format: JSON array of {author, created_at, text}
+   - Run: `bd update <OLD_TODAY> --notes '<json-array>'`
+4. Close OLD_TODAY: `bd close <OLD_TODAY>`
+5. If month rolled (OLD_MONTHLY present):
+   - Fetch OLD_MONTHLY's comments (or read recent daily descriptions for the month)
+   - Write monthly summary into OLD_MONTHLY's description
+   - Close OLD_MONTHLY: `bd close <OLD_MONTHLY>`
+6. Prune stale session names (§8.4):
+   - Read `.agents/huddle/session-names.json`
+   - For each entry, scan the last 14 days of huddle content for `—<name>` or `—Claude-<name>`
+   - Evict entries with no match in 14 days; write the pruned map back
+
+## After phase B, report: "Rotation complete. OLD_TODAY=<id> closed. NEW_TODAY=<id> active."
+
+````
+
+**Scripts table** — add `huddle-bootstrap.sh` and `huddle-rotate.sh` rows.
+
+**State files** — change `.claude/huddle/` → `.agents/huddle/` throughout.
+
+**How to post** — update from `bd comments add PP-cvh "..."` to:
+```markdown
+Use `bd comments add <today_bead_id> "..."` with your sign-off. To find today's bead ID:
+    bd show $(jq -r '.root_bead_id' "$(bash scripts/hooks/huddle-lib.sh | ...)")
+````
+
+Or simpler: hook output already shows the today_bead ID at rotation time.
+
+Remove the "What this PR doesn't yet include" section entirely.
+
+- [ ] **Step 7.2: Run pnpm run check**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add .agents/skills/pinpoint-huddle/SKILL.md
+git commit -m "docs(skill): update pinpoint-huddle SKILL.md with rotation lifecycle (PP-m4ki)"
+```
+
+---
+
+## Task 8: Final integration check and PR open
+
+**Files:** None (verification + PR)
+
+- [ ] **Step 8.1: Run the full check suite**
+
+```bash
+pnpm run check
+```
+
+Expected: all checks pass including shellcheck on all modified/created scripts.
+
+- [ ] **Step 8.2: Verify shellcheck on all new/modified scripts**
+
+```bash
+shellcheck scripts/hooks/huddle-bootstrap.sh \
+           scripts/hooks/huddle-rotate.sh \
+           scripts/hooks/huddle-rotation-check.sh \
+           scripts/hooks/huddle-poll.sh \
+           scripts/hooks/huddle-session-start.sh
+```
+
+Expected: no errors.
+
+- [ ] **Step 8.3: Verify spec paths updated**
+
+```bash
+grep -c '\.claude/huddle' docs/superpowers/specs/2026-05-17-huddle-system-design.md
+```
+
+Expected: `0`.
+
+- [ ] **Step 8.4: Verify SKILL.md no longer mentions PP-cvh as the active bead**
+
+```bash
+grep 'PP-cvh' .agents/skills/pinpoint-huddle/SKILL.md
+```
+
+Expected: any remaining references should be in the historical archive context only (e.g. "PP-cvh contains activity prior to..."), not as the active coordination target.
+
+- [ ] **Step 8.5: Open PR via pinpoint-pr-workflow skill**
+
+Use the `pinpoint-pr-workflow` skill to push the branch, open the PR, and start CI monitoring.
+
+PR title: `feat(workflow): huddle rotation — daily bead hierarchy + bootstrap (PP-m4ki)`
+
+PR body should summarize:
+
+- Implements `huddle-bootstrap.sh` (idempotent init: root epic + daily + monthly + config.json)
+- Implements `huddle-rotate.sh` phase A (atomic shell: lock + recheck + create beads + update root notes)
+- Replaces `huddle-rotation-check.sh` stub with real date-compare
+- Wires `huddle-poll.sh` and `huddle-session-start.sh` to read `today_bead.id` from config instead of hardcoded PP-cvh
+- Adds summary injection to session-start (monthly desc + N recent daily descs)
+- Updates `SKILL.md` with bootstrap + rotation subagent dispatch template
+- Updates spec paths from `.claude/huddle/` to `.agents/huddle/`
+
+- [ ] **Step 8.6: After CI green + Copilot review, merge via gate enforcer**
+
+```bash
+bash scripts/workflow/merge-pr.sh <PR_NUMBER>
+```
+
+- [ ] **Step 8.7: After merge, post PP-cvh merge notice**
+
+```bash
+# Register as rotation implementer if not already
+bash scripts/hooks/huddle-whoami.sh register Claude-RotationImpl <session_id>
+
+# Post merge notice to today's bead (or PP-cvh until bootstrap runs post-merge)
+bd comments add PP-cvh "Merged PR #<N> (PP-m4ki): huddle rotation — daily bead hierarchy, bootstrap, phase-A rotate, hooks wired to config. Bootstrap with \`bash scripts/hooks/huddle-bootstrap.sh\`. —Claude-RotationImpl"
+```
+
+- [ ] **Step 8.8: Close PP-m4ki**
+
+```bash
+bd close PP-m4ki
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement                                                                                   | Task                                                      |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `huddle-bootstrap.sh` — create root + daily + monthly + config.json, idempotent                    | Task 2                                                    |
+| `huddle-rotation-check.sh` — real date compare                                                     | Task 1                                                    |
+| `huddle-rotate.sh` — phase A atomic (lock + recheck + create + update pointers + pointer comments) | Task 3                                                    |
+| `huddle-rotate.sh` — phase B via subagent template in SKILL.md                                     | Task 7                                                    |
+| `huddle-poll.sh` — replace PP-cvh with today_bead.id from config                                   | Task 4                                                    |
+| `huddle-session-start.sh` — bootstrap-needed branch (§7.1)                                         | Task 5                                                    |
+| `huddle-session-start.sh` — summary injection (§5.1 step 5)                                        | Task 5                                                    |
+| SKILL.md — document bootstrap, rotation, dispatch template                                         | Task 7                                                    |
+| Spec paths `.claude/` → `.agents/`                                                                 | Task 6                                                    |
+| PP-cvh stays open as historical archive (no close)                                                 | Task 8 step 8.7 (comment only)                            |
+| shellcheck clean                                                                                   | Tasks 1–5 step N.3, Task 8 step 8.2                       |
+| pnpm run check passes                                                                              | All tasks                                                 |
+| Migration: new root carries "historical archive" pointer                                           | Task 2 (bootstrap creates root description with the text) |
+
+All acceptance criteria from PP-m4ki are covered.
+
+**Notes on phase B (LLM summarization):**
+Per the bead description's "Script-vs-LLM responsibility split", phase B (summarize old bead, archive, close, name-prune) cannot be done in shell. Task 3 outputs OLD_TODAY/OLD_MONTHLY IDs on stdout; the dispatch template in Task 7 tells the rotation subagent what to do with them. This is the correct split.
+
+**Concurrency and crash-safety:**
+
+- Lock acquisition is 60s timeout (same as spec §6 step 1)
+- Re-check inside lock prevents double rotation (§9.4)
+- Phase A exits if root notes say today_bead.date is already today
+- If crash between step 4 and 6 of phase A: root notes are consistent (new bead is live); old bead lacks pointer comment only — next rotation will still see the old bead closed without summary and can back-fill (spec §9.5)

--- a/docs/superpowers/specs/2026-05-17-huddle-system-design.md
+++ b/docs/superpowers/specs/2026-05-17-huddle-system-design.md
@@ -34,13 +34,13 @@ All scripts use the `huddle-` prefix:
 - `huddle-rotation-check.sh` — shared helper sourced by both hooks
 - `huddle-whoami.sh` — agent identity helper
 
-All state lives in `<main-worktree>/.claude/huddle/` (project-scoped,
+All state lives in `<main-worktree>/.agents/huddle/` (project-scoped,
 git-ignored, shared across linked worktrees via `git rev-parse --git-common-dir`):
 
-- `<main-worktree>/.claude/huddle/config.json` — local config, holds root bead ID
-- `<main-worktree>/.claude/huddle/session-names.json` — session_id → name mapping
-- `<main-worktree>/.claude/huddle/last-seen-<path-hash>` — per-checkout poll cursor
-- `<main-worktree>/.claude/huddle/rotation.lock` — flock target for rotation
+- `<main-worktree>/.agents/huddle/config.json` — local config, holds root bead ID
+- `<main-worktree>/.agents/huddle/session-names.json` — session_id → name mapping
+- `<main-worktree>/.agents/huddle/last-seen-<path-hash>` — per-checkout poll cursor
+- `<main-worktree>/.agents/huddle/rotation.lock` — flock target for rotation
 
 ## 3. Plugin Packaging
 
@@ -56,11 +56,11 @@ Agents see plugin docs as a skill they can invoke; humans manage it via
 `enabledPlugins` in `~/.claude/settings.json`. The plugin is installed at
 project level via `scripts/hooks/` (already part of the PinPoint repo) and
 referenced from project `.claude/settings.json`. State lives in
-`<main-worktree>/.claude/huddle/` so it's project-scoped, not user-scoped — a
+`<main-worktree>/.agents/huddle/` so it's project-scoped, not user-scoped — a
 clone of PinPoint boots the system without writing to the user's home dir.
 
 The PinPoint-specific bd issue identifiers (the rolling daily/monthly beads)
-are stored in `<main-worktree>/.claude/huddle/config.json`, so the same plugin
+are stored in `<main-worktree>/.agents/huddle/config.json`, so the same plugin
 code works for any project that bootstraps its own huddle root.
 
 ## 4. System Architecture
@@ -110,7 +110,7 @@ Parent-child links via `bd dep add <child> <root> --type parent-child`.
   ~20 entries to bound size). Hooks read this directly without bd queries.
 - `last_rotation`: timestamp of the last successful rotation, for diagnostics.
 
-### 4.3 Local config file (`<main-worktree>/.claude/huddle/config.json`)
+### 4.3 Local config file (`<main-worktree>/.agents/huddle/config.json`)
 
 ```json
 {
@@ -179,7 +179,7 @@ Single source of truth for the detection logic.
 
 Invoked by the rotation subagent (dispatched by the lead agent when the
 rotation notice fires). Acquires the flock at
-`<main-worktree>/.claude/huddle/rotation.lock` (same `lockf(1)` / `flock(1)`
+`<main-worktree>/.agents/huddle/rotation.lock` (same `lockf(1)` / `flock(1)`
 platform-detection pattern as PP-bg45's worktree-create.sh), then performs
 the rotation. See §6 for the rotation flow.
 
@@ -188,7 +188,7 @@ the rotation. See §6 for the rotation flow.
 One-time initialization. Idempotent — re-running on an already-bootstrapped
 project is a no-op that prints status. Creates the root epic, today's first
 daily bead, this month's monthly bead, writes
-`<main-worktree>/.claude/huddle/config.json`, and initializes the root's notes
+`<main-worktree>/.agents/huddle/config.json`, and initializes the root's notes
 JSON.
 
 ### 5.6 `huddle-whoami.sh`
@@ -209,7 +209,7 @@ lead agent dispatches a single rotation subagent. The subagent runs
 `huddle-rotate.sh`, which:
 
 1. **Acquire lock** via `lockf -t 60` (macOS) or `flock -x -w 60` (Linux) on
-   `<main-worktree>/.claude/huddle/rotation.lock`. 60s allows the slowest case
+   `<main-worktree>/.agents/huddle/rotation.lock`. 60s allows the slowest case
    (LLM-driven summarization of a long day's chatter) to complete without
    spurious timeouts from a peer's concurrent rotation attempt.
 2. **Re-check date** inside the lock. If rotation is no longer needed (a
@@ -255,7 +255,7 @@ To bootstrap, run:
     bash scripts/hooks/huddle-bootstrap.sh
 
 That creates the root bead, today's daily, this month's monthly, and writes
-<main-worktree>/.claude/huddle/config.json with the IDs. Re-running the script
+<main-worktree>/.agents/huddle/config.json with the IDs. Re-running the script
 is safe — it's a no-op if already bootstrapped.
 ```
 
@@ -328,7 +328,7 @@ of those help Tim track who's doing what. The name describes the WORK.
 
 ### 8.1 Mapping storage
 
-`<main-worktree>/.claude/huddle/session-names.json` — JSON map of `{session_id:
+`<main-worktree>/.agents/huddle/session-names.json` — JSON map of `{session_id:
 name}`. Persists across restarts and compactions because it's a regular file.
 The canonical lookup for both the SessionStart hook (announcement) and the
 poll hook (self-filter).

--- a/scripts/hooks/huddle-bootstrap.sh
+++ b/scripts/hooks/huddle-bootstrap.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# huddle-bootstrap.sh — one-time initialization of the huddle coordination system.
+#
+# Creates:
+#   - root epic bead (open forever, never closes)
+#   - today's first daily bead (child of root)
+#   - this month's first monthly bead (child of root)
+#   - <STATE_DIR>/config.json with root_bead_id
+#   - root bead notes JSON (§4.2 schema from huddle system design spec)
+#
+# Idempotent: re-running on an already-bootstrapped project prints status and
+# exits 0 without creating duplicate beads.
+#
+# Usage: bash scripts/hooks/huddle-bootstrap.sh
+
+set -euo pipefail
+
+# --- Dependency check ---
+for dep in jq bd python3; do
+  command -v "$dep" >/dev/null 2>&1 || {
+    printf 'huddle-bootstrap.sh: %s not found — please install it\n' "$dep" >&2
+    exit 1
+  }
+done
+
+# --- State directory ---
+LIB_SCRIPT="$(dirname "$0")/huddle-lib.sh"
+if [[ ! -f "$LIB_SCRIPT" ]]; then
+  printf 'huddle-bootstrap.sh: huddle-lib.sh not found at %s\n' "$LIB_SCRIPT" >&2
+  exit 1
+fi
+# shellcheck source=huddle-lib.sh disable=SC1091
+source "$LIB_SCRIPT"
+STATE_DIR=$(huddle_state_dir) || {
+  printf 'huddle-bootstrap.sh: not inside a git checkout; cannot resolve huddle state dir\n' >&2
+  exit 1
+}
+mkdir -p "$STATE_DIR"
+
+CONFIG_FILE="$STATE_DIR/config.json"
+
+# --- Idempotency check ---
+if [[ -f "$CONFIG_FILE" ]]; then
+  ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+  if [[ -n "$ROOT_ID" ]]; then
+    # Verify root bead still exists and is accessible
+    ROOT_STATUS=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].status // "missing"' 2>/dev/null || echo "missing")
+    if [[ "$ROOT_STATUS" != "missing" ]]; then
+      printf 'Huddle already bootstrapped.\n'
+      printf '  Root bead: %s (status: %s)\n' "$ROOT_ID" "$ROOT_STATUS"
+      NOTES_STR=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+      if [[ -n "$NOTES_STR" ]]; then
+        TODAY_BEAD=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('id', 'unknown'))
+except Exception:
+    print('unknown')
+" 2>/dev/null || echo "unknown")
+        MONTHLY_BEAD=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('monthly_bead', {}).get('id', 'unknown'))
+except Exception:
+    print('unknown')
+" 2>/dev/null || echo "unknown")
+        printf '  Today daily: %s\n' "$TODAY_BEAD"
+        printf '  Monthly:     %s\n' "$MONTHLY_BEAD"
+      fi
+      exit 0
+    fi
+    printf 'Warning: root bead %s is missing or inaccessible; re-bootstrapping.\n' "$ROOT_ID"
+  fi
+fi
+
+TODAY=$(date +%F)
+MONTH=$(date +%Y-%m)
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+printf 'Bootstrapping huddle coordination system...\n'
+
+# --- Create root epic ---
+printf '  Creating root epic...\n'
+ROOT_DESCRIPTION="Huddle coordination root — the permanent parent bead for all daily and monthly coordination beads.
+
+This bead never closes. Daily beads (children) are created each day; monthly beads (children) are created each month. After rotation, daily beads carry a categorized summary of the day's coordination activity in their description and a raw archive in their notes field.
+
+Historical archive: PP-cvh contains coordination activity prior to $TODAY.
+
+State is stored in this bead's notes field as JSON (schema v1); use \`bd show <this-id> --json\` to inspect."
+
+ROOT_ID=$(bd create -t epic \
+  --title "Huddle coordination root" \
+  --description "$ROOT_DESCRIPTION" \
+  --silent)
+printf '  Root epic:     %s\n' "$ROOT_ID"
+
+# --- Create today's daily bead ---
+printf '  Creating today'\''s daily bead...\n'
+TODAY_ID=$(bd create -t task \
+  --parent "$ROOT_ID" \
+  --title "Huddle daily $TODAY" \
+  --description "Active coordination bead for $TODAY. Agents post updates here with their sign-off (e.g. —Claude-WorktreeFix). At midnight rotation, this bead gets a categorized summary in its description and a raw archive in its notes, then closes." \
+  --silent)
+printf '  Today daily:   %s\n' "$TODAY_ID"
+
+# --- Create this month's monthly bead ---
+printf '  Creating monthly bead...\n'
+MONTHLY_ID=$(bd create -t task \
+  --parent "$ROOT_ID" \
+  --title "Huddle monthly $MONTH" \
+  --description "Monthly coordination summary for $MONTH. Receives aggregated summaries of each day's daily bead when that daily closes." \
+  --silent)
+printf '  Monthly:       %s\n' "$MONTHLY_ID"
+
+# --- Build and write root notes JSON ---
+printf '  Writing root bead notes JSON...\n'
+NOTES_JSON=$(python3 -c "
+import json, sys
+notes = {
+    'schema_version': 1,
+    'today_bead': {'id': sys.argv[1], 'date': sys.argv[2]},
+    'monthly_bead': {'id': sys.argv[3], 'month': sys.argv[4]},
+    'recent_dailies': [{'id': sys.argv[1], 'date': sys.argv[2]}],
+    'settings': {
+        'n_dailies_to_inject': 5,
+        'day_boundary_tz': 'local',
+        'stale_name_cutoff_days': 14
+    },
+    'last_rotation': sys.argv[5]
+}
+print(json.dumps(notes))
+" "$TODAY_ID" "$TODAY" "$MONTHLY_ID" "$MONTH" "$NOW")
+
+bd update "$ROOT_ID" --notes "$NOTES_JSON"
+
+# --- Write config.json ---
+printf '  Writing config.json...\n'
+python3 -c "
+import json, sys
+config = {'schema_version': 1, 'root_bead_id': sys.argv[1]}
+print(json.dumps(config, indent=2))
+" "$ROOT_ID" > "$CONFIG_FILE"
+
+printf '\nBootstrap complete!\n'
+printf '  Config:    %s\n' "$CONFIG_FILE"
+printf '  Root:      %s\n' "$ROOT_ID"
+printf '  Today:     %s (%s)\n' "$TODAY_ID" "$TODAY"
+printf '  Monthly:   %s (%s)\n' "$MONTHLY_ID" "$MONTH"
+printf '\nHooks will now use the new bead hierarchy. PP-cvh remains open as historical archive.\n'
+# shellcheck disable=SC2016  # backticks are literal Markdown, not command substitution
+printf 'Run `bash scripts/hooks/huddle-whoami.sh register <YourName> <session_id>` to register yourself.\n'

--- a/scripts/hooks/huddle-poll.sh
+++ b/scripts/hooks/huddle-poll.sh
@@ -141,20 +141,6 @@ esac
 mkdir -p "$(dirname "$POLL_FILE")" 2>/dev/null || true
 date +%s > "$POLL_FILE" 2>/dev/null || true
 
-# --- Rotation check (stub in PR #1357; real check in follow-up rotation PR) ---
-ROTATION_CHECK_SCRIPT="$(dirname "$0")/huddle-rotation-check.sh"
-if [[ -f "$ROTATION_CHECK_SCRIPT" ]]; then
-  # shellcheck source=huddle-rotation-check.sh disable=SC1091
-  source "$ROTATION_CHECK_SCRIPT"
-  if huddle_rotation_needed; then
-    # Real "rotation needed" output lands in the follow-up PR. For now this
-    # branch is unreachable (stub returns 1).
-    printf '## ⚠️ Huddle rotation needed\n\n'
-    printf 'See docs/superpowers/specs/2026-05-17-huddle-system-design.md §7.2\n'
-    exit 0
-  fi
-fi
-
 SESSION_ID=""
 if [[ -n "$INPUT" ]]; then
   SESSION_ID=$(
@@ -182,6 +168,45 @@ source "$LIB_SCRIPT"
 STATE_DIR=$(huddle_state_dir) || exit 0
 mkdir -p "$STATE_DIR"
 
+# --- Bootstrap check ---
+# If config.json is missing, the system hasn't been bootstrapped yet.
+# Exit silently — huddle-session-start.sh emits the user-visible bootstrap notice.
+CONFIG_FILE="$STATE_DIR/config.json"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  exit 0
+fi
+ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+if [[ -z "$ROOT_ID" ]]; then
+  exit 0
+fi
+
+# --- Rotation check ---
+ROTATION_CHECK_SCRIPT="$(dirname "$0")/huddle-rotation-check.sh"
+if [[ -f "$ROTATION_CHECK_SCRIPT" ]]; then
+  # shellcheck source=huddle-rotation-check.sh disable=SC1091
+  source "$ROTATION_CHECK_SCRIPT"
+  if huddle_rotation_needed; then
+    STORED_DATE=""
+    NOTES_STR_ROT=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+    if [[ -n "$NOTES_STR_ROT" ]]; then
+      STORED_DATE=$(printf '%s' "$NOTES_STR_ROT" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('date', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+    fi
+    NOW_DATE=$(date +%F)
+    printf '## ⚠️ Huddle rotation needed\n\n'
+    printf 'The active coordination bead points to date %s, but today is %s.\n' "$STORED_DATE" "$NOW_DATE"
+    printf 'Before continuing, dispatch the rotation subagent.\n\n'
+    printf 'See .agents/skills/pinpoint-huddle/SKILL.md for the dispatch template.\n'
+    exit 0
+  fi
+fi
+
 # Derive a per-checkout key from the worktree root (not the hook's CWD).
 # Earlier versions hashed `pwd -P`, but that varied if the hook fired from a
 # subdirectory of the checkout (e.g. `cd src/` then triggering a UserPromptSubmit
@@ -200,8 +225,21 @@ else
   LAST_SEEN="0"
 fi
 
-# Fetch all PP-cvh comments as JSON
-COMMENTS_JSON="$(bd comments PP-cvh --json 2>/dev/null)" || { exit 0; }
+# Resolve today_bead.id from root notes, then fetch its comments
+ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || { exit 0; }
+NOTES_STR=$(printf '%s' "$ROOT_JSON" | jq -r '.[0].notes // ""' 2>/dev/null) || { exit 0; }
+[[ -n "$NOTES_STR" ]] || { exit 0; }
+TODAY_BEAD_ID=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+[[ -n "$TODAY_BEAD_ID" ]] || { exit 0; }
+
+COMMENTS_JSON="$(bd comments "$TODAY_BEAD_ID" --json 2>/dev/null)" || { exit 0; }
 
 # Resolve self agent name. Priority order:
 #   1. <STATE_DIR>/session-names.json[session_id] (canonical)
@@ -253,7 +291,7 @@ NEWEST="$(printf '%s' "$NEW_COMMENTS" | jq -r '.[-1].created_at')"
 printf '%s' "$NEWEST" > "$STATE_FILE"
 
 # Emit formatted block — becomes <system-reminder> content
-printf '## New PP-cvh coordination comments (%d)\n\n' "$COUNT"
+printf '## New huddle coordination comments (%d)\n\n' "$COUNT"
 printf '%s' "$NEW_COMMENTS" | jq -r '.[] | "**\(.author)** (\(.created_at)):\n\(.text)\n"'
 
 exit 0

--- a/scripts/hooks/huddle-rotate.sh
+++ b/scripts/hooks/huddle-rotate.sh
@@ -72,24 +72,40 @@ fi
 do_rotation() {
   set -euo pipefail
 
-  # Re-check date inside the lock (idempotency: a peer may have rotated first)
+  # Re-check date inside the lock (idempotency: a peer may have rotated first).
+  # Reserve `exit 0` for the explicit "already up to date" case below. Anything
+  # else (bd unreachable, root bead unreadable, notes corrupted) is a hard error
+  # — silently `exit 0` here would make a caller treat a broken state as
+  # "successful no-op" and skip a required rotation.
   local root_json notes_str today_bead_date today
-  root_json=$(bd show "$ROOT_ID" --json 2>/dev/null) || exit 0
-  notes_str=$(printf '%s' "$root_json" | jq -r '.[0].notes // ""' 2>/dev/null) || exit 0
+  if ! root_json=$(bd show "$ROOT_ID" --json 2>&1); then
+    printf 'huddle-rotate.sh: failed to fetch root bead %s: %s\n' "$ROOT_ID" "$root_json" >&2
+    exit 1
+  fi
+  if ! notes_str=$(printf '%s' "$root_json" | jq -r '.[0].notes // ""' 2>&1); then
+    printf 'huddle-rotate.sh: failed to parse root bead JSON: %s\n' "$notes_str" >&2
+    exit 1
+  fi
   [[ -n "$notes_str" ]] || {
     printf 'huddle-rotate.sh: root bead has no notes — was huddle-bootstrap.sh run?\n' >&2
     exit 1
   }
 
   today=$(date +%F)
-  today_bead_date=$(printf '%s' "$notes_str" | python3 -c "
+  # today_bead.date is a required field; if it's missing or parse fails, the
+  # notes JSON is corrupted and proceeding would overwrite root pointers based
+  # on an empty-string compare. Fail clearly instead.
+  if ! today_bead_date=$(printf '%s' "$notes_str" | python3 -c "
 import sys, json
-try:
-    n = json.loads(sys.stdin.read())
-    print(n.get('today_bead', {}).get('date', ''))
-except Exception:
-    print('')
-" 2>/dev/null || echo "")
+n = json.loads(sys.stdin.read())
+d = n.get('today_bead', {}).get('date', '')
+if not d:
+    raise SystemExit('today_bead.date missing or empty in root notes')
+print(d)
+" 2>&1); then
+    printf 'huddle-rotate.sh: %s\n' "$today_bead_date" >&2
+    exit 1
+  fi
 
   if [[ "$today_bead_date" == "$today" ]]; then
     # Peer already rotated — no-op, exit silently

--- a/scripts/hooks/huddle-rotate.sh
+++ b/scripts/hooks/huddle-rotate.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# huddle-rotate.sh — daily coordination bead rotation, phase A (shell atomic).
+#
+# Phase A (this script) performs the atomic shell work:
+#   1. Acquire exclusive lock on <STATE_DIR>/rotation.lock (60s timeout)
+#   2. Re-check date inside the lock (exit 0 if peer already rotated)
+#   3. Create new daily bead (+ monthly if month rolled) under root
+#   4. Atomically update root notes JSON with new pointers
+#   5. Post "→ continued in <new-bead>" comments on old beads (best-effort)
+#   6. Print phase-B handoff variables to stdout
+#
+# Phase B (LLM summarization, old-bead archiving, closing, name-prune) is
+# performed by the dispatching subagent after reading phase A stdout.
+# Dispatch template: .agents/skills/pinpoint-huddle/SKILL.md §rotation.
+#
+# Crash-safety: steps 1-4 are the "make consistent" path. If the process dies
+# between step 4 and step 5, root notes already point to the new beads — the
+# system is consistent. Old bead has no summary, but the next rotation subagent
+# can back-fill it before proceeding with the current rotation.
+#
+# Usage:
+#   output=$(bash scripts/hooks/huddle-rotate.sh)
+#   # parse key=value lines:
+#   OLD_TODAY_ID=$(printf '%s\n' "$output" | grep '^OLD_TODAY=' | cut -d= -f2-)
+#   OLD_MONTHLY_ID=$(printf '%s\n' "$output" | grep '^OLD_MONTHLY=' | cut -d= -f2-)
+#   NEW_TODAY_ID=$(printf '%s\n' "$output" | grep '^NEW_TODAY=' | cut -d= -f2-)
+#   NEW_MONTHLY_ID=$(printf '%s\n' "$output" | grep '^NEW_MONTHLY=' | cut -d= -f2-)
+#
+# Exits 0 with no output if rotation is not needed (peer already rotated).
+
+set -euo pipefail
+
+for dep in jq bd python3; do
+  command -v "$dep" >/dev/null 2>&1 || {
+    printf 'huddle-rotate.sh: %s not found\n' "$dep" >&2
+    exit 1
+  }
+done
+
+LIB_SCRIPT="$(dirname "$0")/huddle-lib.sh"
+[[ -f "$LIB_SCRIPT" ]] || { printf 'huddle-rotate.sh: huddle-lib.sh not found\n' >&2; exit 1; }
+# shellcheck source=huddle-lib.sh disable=SC1091
+source "$LIB_SCRIPT"
+STATE_DIR=$(huddle_state_dir) || { printf 'huddle-rotate.sh: not in a git checkout\n' >&2; exit 1; }
+
+CONFIG_FILE="$STATE_DIR/config.json"
+[[ -f "$CONFIG_FILE" ]] || {
+  printf 'huddle-rotate.sh: not bootstrapped — run huddle-bootstrap.sh first\n' >&2
+  exit 1
+}
+
+ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+[[ -n "$ROOT_ID" ]] || { printf 'huddle-rotate.sh: config.json missing root_bead_id\n' >&2; exit 1; }
+
+LOCK_FILE="$STATE_DIR/rotation.lock"
+
+# Platform-detected locking — same pattern as .claude/hooks/worktree-create.sh (PP-bg45).
+# lockf(1) on macOS (ships with the OS), flock(1) on Linux (util-linux).
+LOCK_TOOL=""
+if command -v lockf >/dev/null 2>&1; then
+  LOCK_TOOL="macos"
+elif command -v flock >/dev/null 2>&1; then
+  LOCK_TOOL="linux"
+else
+  printf 'huddle-rotate.sh: neither lockf nor flock found — cannot safely rotate\n' >&2
+  exit 1
+fi
+
+# The rotation body runs as an exported function so the lock covers the entire
+# atomic operation. Variables needed inside are exported below.
+do_rotation() {
+  set -euo pipefail
+
+  # Re-check date inside the lock (idempotency: a peer may have rotated first)
+  local root_json notes_str today_bead_date today
+  root_json=$(bd show "$ROOT_ID" --json 2>/dev/null) || exit 0
+  notes_str=$(printf '%s' "$root_json" | jq -r '.[0].notes // ""' 2>/dev/null) || exit 0
+  [[ -n "$notes_str" ]] || {
+    printf 'huddle-rotate.sh: root bead has no notes — was huddle-bootstrap.sh run?\n' >&2
+    exit 1
+  }
+
+  today=$(date +%F)
+  today_bead_date=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('date', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+  if [[ "$today_bead_date" == "$today" ]]; then
+    # Peer already rotated — no-op, exit silently
+    exit 0
+  fi
+
+  # Parse current pointers from notes
+  local old_today_id old_monthly_id old_month recent_dailies settings current_month
+  old_today_id=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+  old_monthly_id=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('monthly_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+  old_month=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('monthly_bead', {}).get('month', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+  recent_dailies=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(json.dumps(n.get('recent_dailies', [])))
+except Exception:
+    print('[]')
+" 2>/dev/null || echo "[]")
+  settings=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    default = {'n_dailies_to_inject': 5, 'day_boundary_tz': 'local', 'stale_name_cutoff_days': 14}
+    print(json.dumps(n.get('settings', default)))
+except Exception:
+    print('{\"n_dailies_to_inject\":5,\"day_boundary_tz\":\"local\",\"stale_name_cutoff_days\":14}')
+" 2>/dev/null || echo '{"n_dailies_to_inject":5,"day_boundary_tz":"local","stale_name_cutoff_days":14}')
+
+  current_month=$(date +%Y-%m)
+  local month_rolled=0
+  if [[ "$old_month" != "$current_month" ]]; then
+    month_rolled=1
+  fi
+
+  # Create new daily bead (orphan until root notes are updated)
+  local new_today_id
+  new_today_id=$(bd create -t task \
+    --parent "$ROOT_ID" \
+    --title "Huddle daily $today" \
+    --description "Active coordination bead for $today. Agents post updates here. At midnight rotation this bead gets a categorized summary and closes." \
+    --silent)
+
+  local new_monthly_id="$old_monthly_id"
+  if [[ "$month_rolled" -eq 1 ]]; then
+    new_monthly_id=$(bd create -t task \
+      --parent "$ROOT_ID" \
+      --title "Huddle monthly $current_month" \
+      --description "Monthly coordination summary for $current_month. Receives aggregated summaries of daily beads when they close." \
+      --silent)
+  fi
+
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Build new recent_dailies: prepend today's entry, cap at 20
+  local new_recent
+  new_recent=$(python3 -c "
+import sys, json
+existing = json.loads(sys.argv[1])
+new_entry = {'id': sys.argv[2], 'date': sys.argv[3]}
+combined = [new_entry] + existing
+print(json.dumps(combined[:20]))
+" "$recent_dailies" "$new_today_id" "$today")
+
+  # Build new notes JSON
+  local new_notes
+  new_notes=$(python3 -c "
+import sys, json
+notes = {
+    'schema_version': 1,
+    'today_bead': {'id': sys.argv[1], 'date': sys.argv[2]},
+    'monthly_bead': {'id': sys.argv[3], 'month': sys.argv[4]},
+    'recent_dailies': json.loads(sys.argv[5]),
+    'settings': json.loads(sys.argv[6]),
+    'last_rotation': sys.argv[7]
+}
+print(json.dumps(notes))
+" "$new_today_id" "$today" "$new_monthly_id" "$current_month" "$new_recent" "$settings" "$now")
+
+  # ATOMIC: update root notes — after this the system is consistent
+  bd update "$ROOT_ID" --notes "$new_notes"
+
+  # Post continuation comments on old beads (best-effort: failures do not abort)
+  if [[ -n "$old_today_id" ]]; then
+    bd comments add "$old_today_id" "→ continued in $new_today_id (rotation $today)" 2>/dev/null || true
+  fi
+  if [[ "$month_rolled" -eq 1 ]] && [[ -n "$old_monthly_id" ]]; then
+    bd comments add "$old_monthly_id" "→ continued in $new_monthly_id (month rolled to $current_month)" 2>/dev/null || true
+  fi
+
+  # Output phase-B handoff on stdout (key=value format, one per line)
+  printf 'OLD_TODAY=%s\n' "$old_today_id"
+  if [[ "$month_rolled" -eq 1 ]]; then
+    printf 'OLD_MONTHLY=%s\n' "$old_monthly_id"
+    printf 'OLD_MONTH=%s\n' "$old_month"
+  fi
+  printf 'NEW_TODAY=%s\n' "$new_today_id"
+  printf 'NEW_MONTHLY=%s\n' "$new_monthly_id"
+  printf 'ROTATION_DATE=%s\n' "$today"
+}
+
+export -f do_rotation
+export ROOT_ID STATE_DIR CONFIG_FILE
+
+# Acquire exclusive lock and run the rotation body
+case "$LOCK_TOOL" in
+  macos)
+    # lockf -k: keep lock file (prevents delete/recreate races).
+    # -t 60: wait up to 60s (longer than PP-bg45's 30s because rotation
+    # includes bd creates, not just git worktree add).
+    lockf -k -t 60 "$LOCK_FILE" bash -c 'do_rotation'
+    ;;
+  linux)
+    # flock -x: exclusive lock; -w 60: wait up to 60s.
+    flock -x -w 60 "$LOCK_FILE" bash -c 'do_rotation'
+    ;;
+esac

--- a/scripts/hooks/huddle-rotation-check.sh
+++ b/scripts/hooks/huddle-rotation-check.sh
@@ -1,21 +1,14 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
 # huddle-rotation-check.sh — shared helper sourced by huddle-poll.sh and
 # huddle-session-start.sh. Defines a single function `huddle_rotation_needed`
 # that returns 0 if a coordination-bead rotation is needed, 1 otherwise.
 #
-# This file is a STUB in PR #1357 (the foundation PR). It always returns 1
-# ("no rotation needed") because rotation isn't implemented yet — PP-cvh is
-# still the single coordination bead. The real date-compare logic lands in
-# the follow-up rotation PR, at which point this stub is replaced with the
-# implementation described in §5.3 of:
-#   docs/superpowers/specs/2026-05-17-huddle-system-design.md
-#
-# Design intent for the eventual real implementation:
-#   - source huddle-lib.sh; resolve STATE_DIR via huddle_state_dir
-#   - Read <STATE_DIR>/config.json for root_bead_id
-#   - bd show <root> --json to extract today_bead.date from notes
-#   - Compare to $(date +%F) (local date)
-#   - Return 0 if mismatch (rotation needed), 1 if match (no rotation needed)
+# Design: reads <STATE_DIR>/config.json for root_bead_id, then reads the root
+# bead's notes JSON via `bd show <root> --json`, extracts today_bead.date, and
+# compares to $(date +%F) (local date). Returns 0 if mismatch (rotation
+# needed), 1 if match (no rotation needed) or if config is missing/unreadable
+# (hooks degrade gracefully — only SessionStart emits the user-visible notice).
 #
 # Calling pattern in both hooks:
 #   source "$(dirname "$0")/huddle-rotation-check.sh"
@@ -23,10 +16,53 @@
 #     # emit "rotation needed" notice and skip subsequent steps
 #   fi
 #
-# Until the real implementation lands, this stub keeps the hooks running
-# the existing polling/identity logic unchanged.
+# Requires huddle-lib.sh to be sourced before calling, OR resolves the lib
+# itself if STATE_DIR is not yet set. Both hooks source this file after
+# sourcing huddle-lib.sh, so the fast path (STATE_DIR already set) is normal.
 
 # shellcheck disable=SC2317  # function is sourced and called by callers
 huddle_rotation_needed() {
-  return 1
+  local state_dir config_file root_id root_json notes_str today_bead_date today
+
+  # Resolve state dir — re-use caller's STATE_DIR if already set, otherwise
+  # source huddle-lib.sh to compute it.
+  if [[ -n "${STATE_DIR:-}" ]]; then
+    state_dir="$STATE_DIR"
+  else
+    local lib_script
+    lib_script="$(dirname "${BASH_SOURCE[0]}")/huddle-lib.sh"
+    [[ -f "$lib_script" ]] || return 1
+    # shellcheck source=huddle-lib.sh disable=SC1091
+    source "$lib_script"
+    state_dir=$(huddle_state_dir) || return 1
+  fi
+
+  config_file="$state_dir/config.json"
+  [[ -f "$config_file" ]] || return 1  # not bootstrapped → no rotation needed
+
+  root_id=$(jq -r '.root_bead_id // ""' "$config_file" 2>/dev/null)
+  [[ -n "$root_id" ]] || return 1
+
+  # Fetch the root bead's notes JSON. bd show outputs a JSON array; we pick
+  # the first element's `notes` field (a JSON string). If bd is unavailable,
+  # notes is empty, or notes fails to parse, fail open (return 1).
+  root_json=$(bd show "$root_id" --json 2>/dev/null) || return 1
+  notes_str=$(printf '%s' "$root_json" | jq -r '.[0].notes // ""' 2>/dev/null) || return 1
+  [[ -n "$notes_str" ]] || return 1
+
+  today_bead_date=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('date', ''))
+except Exception:
+    print('')
+" 2>/dev/null) || return 1
+  [[ -n "$today_bead_date" ]] || return 1
+
+  today=$(date +%F)
+  if [[ "$today_bead_date" != "$today" ]]; then
+    return 0  # rotation needed
+  fi
+  return 1  # up to date
 }

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -48,6 +48,31 @@ STATE_DIR=$(huddle_state_dir) || exit 0
 NAMES_JSON="$STATE_DIR/session-names.json"
 mkdir -p "$STATE_DIR"
 
+# --- Bootstrap check ---
+# If config.json is missing, emit the user-visible bootstrap notice and exit.
+# This is the only hook that emits the notice; huddle-poll.sh exits silently.
+CONFIG_FILE="$STATE_DIR/config.json"
+ROOT_ID=""
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  MAIN_ROOT=$(dirname "$(git rev-parse --git-common-dir 2>/dev/null || echo ".")" 2>/dev/null || echo "<main-worktree>")
+  printf '## ⚠️ Huddle not bootstrapped\n\n'
+  printf 'The huddle coordination system is not set up yet. It maintains a daily bead\n'
+  printf 'for agents to coordinate on, summarizes each day'\''s chatter into ~50-token\n'
+  printf 'digests so it stays cheap to read, and rotates at local midnight.\n\n'
+  printf 'To bootstrap, run:\n'
+  printf '    bash scripts/hooks/huddle-bootstrap.sh\n\n'
+  printf 'That creates the root bead, today'\''s daily, this month'\''s monthly, and writes\n'
+  printf '%s/.agents/huddle/config.json with the IDs. Re-running is safe.\n' "$MAIN_ROOT"
+  exit 0
+fi
+ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
+if [[ -z "$ROOT_ID" ]]; then
+  printf '## ⚠️ Huddle not bootstrapped\n\n'
+  printf 'config.json exists but has no root_bead_id. Re-run:\n'
+  printf '    bash scripts/hooks/huddle-bootstrap.sh\n'
+  exit 0
+fi
+
 # Read stdin JSON (best-effort; never fail SessionStart on parse errors)
 INPUT=""
 if [[ ! -t 0 ]]; then
@@ -72,16 +97,31 @@ case "$TRANSCRIPT_PATH" in
   *) ;;
 esac
 
-# --- Rotation check (stub in PR #1357; real check in follow-up rotation PR) ---
+# --- Rotation check ---
 ROTATION_CHECK_SCRIPT="$(dirname "$0")/huddle-rotation-check.sh"
 if [[ -f "$ROTATION_CHECK_SCRIPT" ]]; then
   # shellcheck source=huddle-rotation-check.sh disable=SC1091
   source "$ROTATION_CHECK_SCRIPT"
   if huddle_rotation_needed; then
-    # Real "rotation needed" output lands in the follow-up PR. For now this
-    # branch is unreachable (stub returns 1).
+    STORED_DATE=""
+    NOTES_STR_ROT=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+    if [[ -n "$NOTES_STR_ROT" ]]; then
+      STORED_DATE=$(printf '%s' "$NOTES_STR_ROT" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('date', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+    fi
+    NOW_DATE=$(date +%F)
     printf '## ⚠️ Huddle rotation needed\n\n'
-    printf 'See docs/superpowers/specs/2026-05-17-huddle-system-design.md §7.2\n'
+    printf 'The active coordination bead points to date %s, but today is %s.\n' "$STORED_DATE" "$NOW_DATE"
+    printf 'Before continuing, dispatch the rotation subagent — it will summarize\n'
+    printf 'the previous day, create today'\''s bead, update pointers, and post\n'
+    printf '"continued in" markers on closed beads.\n\n'
+    printf 'Dispatch template in .agents/skills/pinpoint-huddle/SKILL.md.\n'
     exit 0
   fi
 fi
@@ -103,7 +143,7 @@ except Exception:
   )" || { SESSION_ID=""; SOURCE=""; }
 fi
 
-# If we have no session_id, silently exit — the user's PP-cvh participation is optional.
+# If we have no session_id, silently exit — huddle participation is optional.
 if [[ -z "$SESSION_ID" ]]; then
   exit 0
 fi
@@ -149,6 +189,75 @@ else
   printf 'If the name is taken, the helper suggests variations.\n'
   # shellcheck disable=SC2016  # backticks are literal Markdown
   printf 'Full reference: `.agents/skills/pinpoint-huddle/SKILL.md`\n'
+fi
+
+# --- Summary injection (§5.1 step 5) ---
+# Inject monthly summary description + N most-recent daily bead descriptions.
+# Suppressed on compact (already returned early above via SOURCE check).
+# Fails open: any bd error exits silently without noise.
+ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || { exit 0; }
+NOTES_STR=$(printf '%s' "$ROOT_JSON" | jq -r '.[0].notes // ""' 2>/dev/null) || { exit 0; }
+if [[ -z "$NOTES_STR" ]]; then
+  exit 0
+fi
+
+N_DAILIES=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('settings', {}).get('n_dailies_to_inject', 5))
+except Exception:
+    print(5)
+" 2>/dev/null || echo "5")
+
+MONTHLY_BEAD_ID=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('monthly_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+RECENT_DAILIES=$(printf '%s' "$NOTES_STR" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    items = n.get('recent_dailies', [])
+    for item in items:
+        print(item.get('id', '') + '\t' + item.get('date', ''))
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+
+# Gather content — only emit the section header if there's something to show
+MONTHLY_DESC=""
+if [[ -n "$MONTHLY_BEAD_ID" ]]; then
+  MONTHLY_DESC=$(bd show "$MONTHLY_BEAD_ID" --json 2>/dev/null | jq -r '.[0].description // ""' 2>/dev/null || echo "")
+fi
+
+if [[ -z "$MONTHLY_DESC" && -z "$RECENT_DAILIES" ]]; then
+  exit 0
+fi
+
+printf '\n## Huddle recent activity\n\n'
+
+if [[ -n "$MONTHLY_BEAD_ID" && -n "$MONTHLY_DESC" && "$MONTHLY_DESC" != "null" ]]; then
+  MONTHLY_TITLE=$(bd show "$MONTHLY_BEAD_ID" --json 2>/dev/null | jq -r '.[0].title // "Monthly summary"' 2>/dev/null || echo "Monthly summary")
+  printf '### %s\n\n%s\n\n' "$MONTHLY_TITLE" "$MONTHLY_DESC"
+fi
+
+if [[ -n "$RECENT_DAILIES" ]]; then
+  DAILY_COUNT=0
+  while IFS=$'\t' read -r daily_id daily_date; do
+    [[ -z "$daily_id" ]] && continue
+    [[ "$DAILY_COUNT" -ge "$N_DAILIES" ]] && break
+    DAILY_DESC=$(bd show "$daily_id" --json 2>/dev/null | jq -r '.[0].description // ""' 2>/dev/null || echo "")
+    if [[ -n "$DAILY_DESC" && "$DAILY_DESC" != "null" ]]; then
+      printf '### Daily %s (%s)\n\n%s\n\n' "$daily_date" "$daily_id" "$DAILY_DESC"
+    fi
+    DAILY_COUNT=$(( DAILY_COUNT + 1 ))
+  done <<< "$RECENT_DAILIES"
 fi
 
 exit 0

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -72,6 +72,18 @@ if [[ -z "$ROOT_ID" ]]; then
   printf '    bash scripts/hooks/huddle-bootstrap.sh\n'
   exit 0
 fi
+# Verify the root bead is still reachable. If it was deleted/closed/renamed
+# under us, hooks would silently stop injecting — surface a specific notice
+# so the user knows to re-bootstrap. `bd show` exits non-zero for missing IDs.
+if ! bd show "$ROOT_ID" --json >/dev/null 2>&1; then
+  printf '## ⚠️ Huddle root bead missing\n\n'
+  # shellcheck disable=SC2016  # backticks are literal Markdown, not command substitution
+  printf 'config.json points at %s but `bd show %s` failed.\n' "$ROOT_ID" "$ROOT_ID"
+  printf 'The bead may have been deleted, archived, or the bd workspace moved.\n\n'
+  printf 'To rebuild:\n'
+  printf '    bash scripts/hooks/huddle-bootstrap.sh\n'
+  exit 0
+fi
 
 # Read stdin JSON (best-effort; never fail SessionStart on parse errors)
 INPUT=""
@@ -209,6 +221,15 @@ try:
 except Exception:
     print(5)
 " 2>/dev/null || echo "5")
+# Sanitize: a non-numeric value ('null', '', 'abc') from the JSON would later
+# trip `[[ "$DAILY_COUNT" -ge "$N_DAILIES" ]]` with "integer expression expected"
+# on stderr. Default to 5; clamp to [1, 20] so a bad setting can't blow up the
+# session-start output budget.
+if ! [[ "$N_DAILIES" =~ ^[0-9]+$ ]]; then
+  N_DAILIES=5
+fi
+if (( N_DAILIES < 1 )); then N_DAILIES=1; fi
+if (( N_DAILIES > 20 )); then N_DAILIES=20; fi
 
 MONTHLY_BEAD_ID=$(printf '%s' "$NOTES_STR" | python3 -c "
 import sys, json


### PR DESCRIPTION
## Summary

- Implements `huddle-bootstrap.sh` — idempotent one-time init that creates the root epic, today's daily bead, this month's monthly bead, and writes `.agents/huddle/config.json` with the root bead ID
- Implements `huddle-rotate.sh` — phase A atomic shell rotation: acquires `rotation.lock` (lockf/flock 60s), re-checks date inside the lock, creates new daily/monthly beads, atomically updates root notes JSON, posts "→ continued in" comments on old beads, and prints OLD/NEW bead IDs for phase B (LLM summarization dispatched separately as a subagent per SKILL.md §Rotation)
- Replaces `huddle-rotation-check.sh` stub with real date-compare: reads `config.json` → root bead notes → `today_bead.date` vs `$(date +%F)`
- Wires `huddle-poll.sh` to read `today_bead.id` from config instead of hardcoded PP-cvh; adds bootstrap fast-exit path
- Wires `huddle-session-start.sh` with bootstrap-needed notice (§7.1), full rotation-needed template (§7.2), and summary injection (monthly desc + N recent daily descs, default N=5)
- Updates `SKILL.md` with full lifecycle: bootstrap, rotation subagent dispatch template, bead hierarchy diagram, updated state-file table
- Updates `docs/superpowers/specs/2026-05-17-huddle-system-design.md` — replaces all `.claude/huddle/` references with `.agents/huddle/` (PR #1390 migration correction)

PP-cvh stays open as historical archive (no write after bootstrap).

## Test Plan

- [ ] `pnpm run check` passes (includes shellcheck on all hook scripts)
- [ ] `shellcheck scripts/hooks/huddle-{bootstrap,rotate,rotation-check,poll,session-start}.sh` — all clean
- [ ] `bash -n scripts/hooks/huddle-bootstrap.sh` — no syntax errors
- [ ] `bash -n scripts/hooks/huddle-rotate.sh` — no syntax errors
- [ ] Verify spec file has zero `.claude/huddle/` references: `grep -c '.claude/huddle' docs/superpowers/specs/2026-05-17-huddle-system-design.md` = 0
- [ ] Manual smoke: `bash scripts/hooks/huddle-bootstrap.sh` on a checkout that doesn't have `config.json` yet — should create root + daily + monthly beads and write config
- [ ] Re-run bootstrap — should print "already bootstrapped" and exit 0

## Related Issues

Closes PP-m4ki (huddle rotation PR)
Follows from PR #1357 (foundation), PR #1385 (throttle), PR #1390 (path migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)