### PR TITLE
feat(ui): add :user-invalid styling + aria-invalid blur sync to Input/Textarea (PP-kqbk.2)

### DIFF
--- a/src/components/ui/input.test.tsx
+++ b/src/components/ui/input.test.tsx
@@ -64,4 +64,32 @@ describe("Input", () => {
       expect(onBlur).toHaveBeenCalledOnce();
     });
   });
+
+  describe("caller-controlled aria-invalid", () => {
+    it("preserves caller-provided aria-invalid=true on blur even when checkValidity() passes", async () => {
+      // Form libraries (react-hook-form, Radix FormControl) set aria-invalid
+      // from schema validation, not native constraints. The blur handler
+      // must not clobber that with checkValidity().
+      const user = userEvent.setup();
+      render(<Input data-testid="inp" aria-invalid="true" />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.type(input, "anything");
+      await user.tab();
+
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("preserves caller-provided aria-invalid=false on blur even when checkValidity() fails", async () => {
+      const user = userEvent.setup();
+      render(<Input data-testid="inp" aria-invalid="false" required />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.tab();
+
+      expect(input).toHaveAttribute("aria-invalid", "false");
+    });
+  });
 });

--- a/src/components/ui/input.test.tsx
+++ b/src/components/ui/input.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Input } from "./input";
+
+describe("Input", () => {
+  describe("aria-invalid blur sync", () => {
+    it("sets aria-invalid=true on blur when value violates required constraint", async () => {
+      const user = userEvent.setup();
+      render(<Input data-testid="inp" required />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.tab();
+
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("sets aria-invalid=false on blur when value satisfies required constraint", async () => {
+      const user = userEvent.setup();
+      render(<Input data-testid="inp" required />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.type(input, "hello");
+      await user.tab();
+
+      expect(input).toHaveAttribute("aria-invalid", "false");
+    });
+
+    it("sets aria-invalid=true on blur when email format is invalid", async () => {
+      const user = userEvent.setup();
+      render(<Input data-testid="inp" type="email" />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.type(input, "not-an-email");
+      await user.tab();
+
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("sets aria-invalid=false on blur when email format is valid", async () => {
+      const user = userEvent.setup();
+      render(<Input data-testid="inp" type="email" />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.type(input, "user@example.com");
+      await user.tab();
+
+      expect(input).toHaveAttribute("aria-invalid", "false");
+    });
+
+    it("calls caller-provided onBlur in addition to syncing aria-invalid", async () => {
+      const user = userEvent.setup();
+      const onBlur = vi.fn();
+      render(<Input data-testid="inp" onBlur={onBlur} />);
+      const input = screen.getByTestId("inp");
+
+      await user.click(input);
+      await user.tab();
+
+      expect(onBlur).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -5,8 +5,17 @@ import { cn } from "~/lib/utils";
 function Input({
   className,
   type,
+  onBlur,
   ...props
 }: React.ComponentProps<"input">): React.JSX.Element {
+  function handleBlur(e: React.FocusEvent<HTMLInputElement>): void {
+    e.currentTarget.setAttribute(
+      "aria-invalid",
+      e.currentTarget.checkValidity() ? "false" : "true"
+    );
+    onBlur?.(e);
+  }
+
   return (
     <input
       type={type}
@@ -15,8 +24,10 @@ function Input({
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground bg-input/30 border-input h-9 w-full min-w-0 rounded-md border px-3 py-2 text-base shadow-xs transition-[color,box-shadow] duration-150 outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "[&:user-invalid]:border-destructive [&:user-invalid]:ring-destructive/40",
         className
       )}
+      onBlur={handleBlur}
       {...props}
     />
   );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,10 +9,15 @@ function Input({
   ...props
 }: React.ComponentProps<"input">): React.JSX.Element {
   function handleBlur(e: React.FocusEvent<HTMLInputElement>): void {
-    e.currentTarget.setAttribute(
-      "aria-invalid",
-      e.currentTarget.checkValidity() ? "false" : "true"
-    );
+    // Skip native-validity sync when the caller controls aria-invalid
+    // (e.g. react-hook-form, Radix FormControl) — otherwise blur would
+    // clobber schema/library-driven invalid state with checkValidity().
+    if (!("aria-invalid" in props)) {
+      e.currentTarget.setAttribute(
+        "aria-invalid",
+        e.currentTarget.checkValidity() ? "false" : "true"
+      );
+    }
     onBlur?.(e);
   }
 

--- a/src/components/ui/textarea.test.tsx
+++ b/src/components/ui/textarea.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Textarea } from "./textarea";
+
+describe("Textarea", () => {
+  describe("aria-invalid blur sync", () => {
+    it("sets aria-invalid=true on blur when value violates required constraint", async () => {
+      const user = userEvent.setup();
+      render(<Textarea data-testid="ta" required />);
+      const textarea = screen.getByTestId("ta");
+
+      await user.click(textarea);
+      await user.tab();
+
+      expect(textarea).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("sets aria-invalid=false on blur when value satisfies required constraint", async () => {
+      const user = userEvent.setup();
+      render(<Textarea data-testid="ta" required />);
+      const textarea = screen.getByTestId("ta");
+
+      await user.click(textarea);
+      await user.type(textarea, "some content");
+      await user.tab();
+
+      expect(textarea).toHaveAttribute("aria-invalid", "false");
+    });
+
+    it("calls caller-provided onBlur in addition to syncing aria-invalid", async () => {
+      const user = userEvent.setup();
+      const onBlur = vi.fn();
+      render(<Textarea data-testid="ta" onBlur={onBlur} />);
+      const textarea = screen.getByTestId("ta");
+
+      await user.click(textarea);
+      await user.tab();
+
+      expect(onBlur).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/ui/textarea.test.tsx
+++ b/src/components/ui/textarea.test.tsx
@@ -40,4 +40,32 @@ describe("Textarea", () => {
       expect(onBlur).toHaveBeenCalledOnce();
     });
   });
+
+  describe("caller-controlled aria-invalid", () => {
+    it("preserves caller-provided aria-invalid=true on blur even when checkValidity() passes", async () => {
+      // Form libraries (react-hook-form, Radix FormControl) set aria-invalid
+      // from schema validation, not native constraints. The blur handler
+      // must not clobber that with checkValidity().
+      const user = userEvent.setup();
+      render(<Textarea data-testid="ta" aria-invalid="true" />);
+      const textarea = screen.getByTestId("ta");
+
+      await user.click(textarea);
+      await user.type(textarea, "anything");
+      await user.tab();
+
+      expect(textarea).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("preserves caller-provided aria-invalid=false on blur even when checkValidity() fails", async () => {
+      const user = userEvent.setup();
+      render(<Textarea data-testid="ta" aria-invalid="false" required />);
+      const textarea = screen.getByTestId("ta");
+
+      await user.click(textarea);
+      await user.tab();
+
+      expect(textarea).toHaveAttribute("aria-invalid", "false");
+    });
+  });
 });

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,10 +8,15 @@ function Textarea({
   ...props
 }: React.ComponentProps<"textarea">): React.JSX.Element {
   function handleBlur(e: React.FocusEvent<HTMLTextAreaElement>): void {
-    e.currentTarget.setAttribute(
-      "aria-invalid",
-      e.currentTarget.checkValidity() ? "false" : "true"
-    );
+    // Skip native-validity sync when the caller controls aria-invalid
+    // (e.g. react-hook-form, Radix FormControl) — otherwise blur would
+    // clobber schema/library-driven invalid state with checkValidity().
+    if (!("aria-invalid" in props)) {
+      e.currentTarget.setAttribute(
+        "aria-invalid",
+        e.currentTarget.checkValidity() ? "false" : "true"
+      );
+    }
     onBlur?.(e);
   }
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -4,15 +4,26 @@ import { cn } from "~/lib/utils";
 
 function Textarea({
   className,
+  onBlur,
   ...props
 }: React.ComponentProps<"textarea">): React.JSX.Element {
+  function handleBlur(e: React.FocusEvent<HTMLTextAreaElement>): void {
+    e.currentTarget.setAttribute(
+      "aria-invalid",
+      e.currentTarget.checkValidity() ? "false" : "true"
+    );
+    onBlur?.(e);
+  }
+
   return (
     <textarea
       data-slot="textarea"
       className={cn(
         "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border px-3 py-2 text-base shadow-xs transition-[color,box-shadow] duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "[&:user-invalid]:border-destructive [&:user-invalid]:ring-destructive/40",
         className
       )}
+      onBlur={handleBlur}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- Add `[&:user-invalid]:border-destructive [&:user-invalid]:ring-destructive/40` CSS variants to `Input` and `Textarea` so the browser-native invalid state (`:user-invalid`, Baseline Widely available since Nov 2023) shows the destructive ring/border styling without any JS — matches the existing `aria-invalid:` variants already present.
- Add an `onBlur` handler to both primitives that calls `e.currentTarget.checkValidity()` and sets `aria-invalid` to `"true"` or `"false"`, so screen readers announce per-field errors immediately after the user leaves the field. Caller-provided `onBlur` is still forwarded.
- Add RTL unit tests (8 total across `input.test.tsx` and `textarea.test.tsx`) asserting: invalid on blur when constraint violated, valid on blur when satisfied, and caller `onBlur` still fires.

Implements CORE-FORM-003 and CORE-FORM-004.

## Test Plan

- [ ] `pnpm exec vitest run src/components/ui/input.test.tsx src/components/ui/textarea.test.tsx` — all 8 tests pass
- [ ] `pnpm run typecheck` — no type errors
- [ ] Visual check at `/login`: email field shows red border after blur when left empty or malformed, but not on initial render
- [ ] Visual check at `/signup`: same behaviour on required fields
- [ ] Visual check at `/report`: same behaviour

## Related Issues

Closes PP-kqbk.2

—Claude-Meridian