### PR TITLE
fix(workflow): huddle resilience — bootstrap self-heal + poll warning + whoami SESSION_ID required (PP-cex3, PP-sjkz)

### DIFF
--- a/scripts/hooks/huddle-bootstrap.sh
+++ b/scripts/hooks/huddle-bootstrap.sh
@@ -45,31 +45,125 @@ if [[ -f "$CONFIG_FILE" ]]; then
   ROOT_ID=$(jq -r '.root_bead_id // ""' "$CONFIG_FILE" 2>/dev/null)
   if [[ -n "$ROOT_ID" ]]; then
     # Verify root bead still exists and is accessible
-    ROOT_STATUS=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].status // "missing"' 2>/dev/null || echo "missing")
+    ROOT_JSON_CHECK=$(bd show "$ROOT_ID" --json 2>/dev/null) || ROOT_JSON_CHECK="[]"
+    ROOT_STATUS=$(printf '%s' "$ROOT_JSON_CHECK" | jq -r '.[0].status // "missing"' 2>/dev/null || echo "missing")
     if [[ "$ROOT_STATUS" != "missing" ]]; then
       printf 'Huddle already bootstrapped.\n'
       printf '  Root bead: %s (status: %s)\n' "$ROOT_ID" "$ROOT_STATUS"
-      NOTES_STR=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+      NOTES_STR=$(printf '%s' "$ROOT_JSON_CHECK" | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+
+      # --- Notes validation ---
+      # Validate that notes JSON is present, parseable, and has required keys.
+      # If not, self-heal by reconstructing from existing children.
+      NOTES_VALID=false
       if [[ -n "$NOTES_STR" ]]; then
-        TODAY_BEAD=$(printf '%s' "$NOTES_STR" | python3 -c "
+        NOTES_CHECK=$(printf '%s' "$NOTES_STR" | python3 -c "
 import sys, json
 try:
     n = json.loads(sys.stdin.read())
-    print(n.get('today_bead', {}).get('id', 'unknown'))
+    required = ['schema_version', 'today_bead', 'monthly_bead']
+    missing = [k for k in required if k not in n]
+    today_id = (n.get('today_bead') or {}).get('id', '')
+    monthly_id = (n.get('monthly_bead') or {}).get('id', '')
+    if missing or not today_id or not monthly_id:
+        print('invalid')
+    else:
+        print('ok:' + today_id + ':' + monthly_id)
 except Exception:
-    print('unknown')
-" 2>/dev/null || echo "unknown")
-        MONTHLY_BEAD=$(printf '%s' "$NOTES_STR" | python3 -c "
-import sys, json
-try:
-    n = json.loads(sys.stdin.read())
-    print(n.get('monthly_bead', {}).get('id', 'unknown'))
-except Exception:
-    print('unknown')
-" 2>/dev/null || echo "unknown")
+    print('invalid')
+" 2>/dev/null || echo "invalid")
+        if [[ "$NOTES_CHECK" == ok:* ]]; then
+          NOTES_VALID=true
+          TODAY_BEAD="${NOTES_CHECK#ok:}"
+          TODAY_BEAD="${TODAY_BEAD%%:*}"
+          MONTHLY_BEAD="${NOTES_CHECK##*:}"
+        fi
+      fi
+
+      if [[ "$NOTES_VALID" == true ]]; then
         printf '  Today daily: %s\n' "$TODAY_BEAD"
         printf '  Monthly:     %s\n' "$MONTHLY_BEAD"
+        exit 0
       fi
+
+      # --- Self-heal: notes are missing or invalid ---
+      printf '\nWARNING: Root notes were missing or invalid — attempting recovery from existing children.\n'
+      printf '  (This is the self-heal path triggered by the 2026-05-20 incident on PP-lt12.)\n\n'
+
+      TODAY=$(date +%F)
+      MONTH=$(date +%Y-%m)
+      NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+      # Query children of root bead to find today's daily and this month's monthly.
+      CHILDREN_JSON=$(bd children "$ROOT_ID" --json 2>/dev/null) || CHILDREN_JSON="[]"
+
+      RECOVER_IDS=$(printf '%s' "$CHILDREN_JSON" | python3 -c "
+import sys, json
+children = json.loads(sys.stdin.read())
+today = sys.argv[1]
+month = sys.argv[2]
+today_id = ''
+monthly_id = ''
+today_date = ''
+monthly_month = ''
+for c in children:
+    title = c.get('title', '')
+    status = c.get('status', '')
+    if status == 'closed':
+        continue
+    if title == 'Huddle daily ' + today:
+        today_id = c.get('id', '')
+        today_date = today
+    if title == 'Huddle monthly ' + month:
+        monthly_id = c.get('id', '')
+        monthly_month = month
+print(today_id + ':' + today_date + ':' + monthly_id + ':' + monthly_month)
+" "$TODAY" "$MONTH" 2>/dev/null || echo "::::")
+
+      RECOVER_TODAY_ID="${RECOVER_IDS%%:*}"
+      REST="${RECOVER_IDS#*:}"
+      RECOVER_TODAY_DATE="${REST%%:*}"
+      REST="${REST#*:}"
+      RECOVER_MONTHLY_ID="${REST%%:*}"
+      RECOVER_MONTHLY_MONTH="${REST##*:}"
+
+      if [[ -z "$RECOVER_TODAY_ID" ]]; then
+        printf 'ERROR: Recovery failed — could not find an open "Huddle daily %s" child under %s.\n' "$TODAY" "$ROOT_ID" >&2
+        printf 'Manual action required: create the daily bead and write root notes manually.\n' >&2
+        printf 'See: bash scripts/hooks/huddle-bootstrap.sh (full bootstrap from scratch).\n' >&2
+        exit 1
+      fi
+      if [[ -z "$RECOVER_MONTHLY_ID" ]]; then
+        printf 'ERROR: Recovery failed — could not find an open "Huddle monthly %s" child under %s.\n' "$MONTH" "$ROOT_ID" >&2
+        printf 'Manual action required: create the monthly bead and write root notes manually.\n' >&2
+        exit 1
+      fi
+
+      # Rebuild and write root notes JSON from recovered children.
+      RECOVERED_NOTES=$(python3 -c "
+import json, sys
+notes = {
+    'schema_version': 1,
+    'today_bead': {'id': sys.argv[1], 'date': sys.argv[2]},
+    'monthly_bead': {'id': sys.argv[3], 'month': sys.argv[4]},
+    'recent_dailies': [{'id': sys.argv[1], 'date': sys.argv[2]}],
+    'settings': {
+        'n_dailies_to_inject': 5,
+        'day_boundary_tz': 'local',
+        'stale_name_cutoff_days': 14
+    },
+    'last_rotation': sys.argv[5]
+}
+print(json.dumps(notes))
+" "$RECOVER_TODAY_ID" "$RECOVER_TODAY_DATE" "$RECOVER_MONTHLY_ID" "$RECOVER_MONTHLY_MONTH" "$NOW")
+
+      bd update "$ROOT_ID" --notes "$RECOVERED_NOTES"
+
+      printf 'Recovery complete.\n'
+      printf '  Root notes were missing/invalid — recovered from existing children.\n'
+      printf '  Root bead:   %s\n' "$ROOT_ID"
+      printf '  Today daily: %s (%s)\n' "$RECOVER_TODAY_ID" "$RECOVER_TODAY_DATE"
+      printf '  Monthly:     %s (%s)\n' "$RECOVER_MONTHLY_ID" "$RECOVER_MONTHLY_MONTH"
       exit 0
     fi
     printf 'Warning: root bead %s is missing or inaccessible; re-bootstrapping.\n' "$ROOT_ID"

--- a/scripts/hooks/huddle-poll.sh
+++ b/scripts/hooks/huddle-poll.sh
@@ -180,17 +180,24 @@ if [[ -z "$ROOT_ID" ]]; then
   exit 0
 fi
 
+# --- Fetch root bead JSON (shared by integrity check, rotation check, and slow path) ---
+# Fetch once here and reuse below. If bd is unavailable or the bead is
+# inaccessible, fail open silently — we do NOT want to emit a false "notes
+# malformed" warning when the real issue is a bd outage.
+ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || exit 0
+[[ -n "$ROOT_JSON" ]] || exit 0
+
 # --- Root notes integrity check ---
 # config.json exists but root notes may be null/malformed (e.g. 2026-05-20
 # incident on PP-lt12 where notes were wiped between 00:41 and 01:08 UTC).
 # Emit a visible stderr diagnostic so the user knows polling is degraded;
 # still exit 0 so the user prompt is not blocked.
-ROOT_NOTES_CHECK=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+NOTES_STR=$(printf '%s' "$ROOT_JSON" | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
 NOTES_OK=true
-if [[ -z "$ROOT_NOTES_CHECK" ]]; then
+if [[ -z "$NOTES_STR" ]]; then
   NOTES_OK=false
 else
-  TODAY_CHECK=$(printf '%s' "$ROOT_NOTES_CHECK" | python3 -c "
+  TODAY_CHECK=$(printf '%s' "$NOTES_STR" | python3 -c "
 import sys, json
 try:
     n = json.loads(sys.stdin.read())
@@ -214,9 +221,9 @@ if [[ -f "$ROTATION_CHECK_SCRIPT" ]]; then
   source "$ROTATION_CHECK_SCRIPT"
   if huddle_rotation_needed; then
     STORED_DATE=""
-    NOTES_STR_ROT=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
-    if [[ -n "$NOTES_STR_ROT" ]]; then
-      STORED_DATE=$(printf '%s' "$NOTES_STR_ROT" | python3 -c "
+    # Reuse ROOT_JSON + NOTES_STR already fetched above (avoids a second bd call).
+    if [[ -n "$NOTES_STR" ]]; then
+      STORED_DATE=$(printf '%s' "$NOTES_STR" | python3 -c "
 import sys, json
 try:
     n = json.loads(sys.stdin.read())
@@ -252,10 +259,9 @@ else
   LAST_SEEN="0"
 fi
 
-# Resolve today_bead.id from root notes, then fetch its comments
-ROOT_JSON=$(bd show "$ROOT_ID" --json 2>/dev/null) || { exit 0; }
-NOTES_STR=$(printf '%s' "$ROOT_JSON" | jq -r '.[0].notes // ""' 2>/dev/null) || { exit 0; }
-[[ -n "$NOTES_STR" ]] || { exit 0; }
+# Resolve today_bead.id from root notes, then fetch its comments.
+# ROOT_JSON and NOTES_STR are already populated from the integrity check above;
+# the notes-integrity gate above guarantees NOTES_STR is non-empty here.
 TODAY_BEAD_ID=$(printf '%s' "$NOTES_STR" | python3 -c "
 import sys, json
 try:

--- a/scripts/hooks/huddle-poll.sh
+++ b/scripts/hooks/huddle-poll.sh
@@ -180,6 +180,33 @@ if [[ -z "$ROOT_ID" ]]; then
   exit 0
 fi
 
+# --- Root notes integrity check ---
+# config.json exists but root notes may be null/malformed (e.g. 2026-05-20
+# incident on PP-lt12 where notes were wiped between 00:41 and 01:08 UTC).
+# Emit a visible stderr diagnostic so the user knows polling is degraded;
+# still exit 0 so the user prompt is not blocked.
+ROOT_NOTES_CHECK=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
+NOTES_OK=true
+if [[ -z "$ROOT_NOTES_CHECK" ]]; then
+  NOTES_OK=false
+else
+  TODAY_CHECK=$(printf '%s' "$ROOT_NOTES_CHECK" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+  if [[ -z "$TODAY_CHECK" ]]; then
+    NOTES_OK=false
+  fi
+fi
+if [[ "$NOTES_OK" == false ]]; then
+  printf 'huddle-poll: root notes JSON is null or malformed on %s. Run bash scripts/hooks/huddle-bootstrap.sh to recover. Polling skipped this turn.\n' "$ROOT_ID" >&2
+  exit 0
+fi
+
 # --- Rotation check ---
 ROTATION_CHECK_SCRIPT="$(dirname "$0")/huddle-rotation-check.sh"
 if [[ -f "$ROTATION_CHECK_SCRIPT" ]]; then

--- a/scripts/hooks/huddle-whoami.sh
+++ b/scripts/hooks/huddle-whoami.sh
@@ -16,11 +16,11 @@
 # uses the full registered name when matching `—<name>` sign-offs.
 #
 # Subcommands:
-#   whoami [SESSION_ID]      Print the registered name for SESSION_ID (or the
-#                            discovered session, see below). Empty if unknown.
-#   register NAME [SESSION_ID]
+#   whoami SESSION_ID        Print the registered name for SESSION_ID. Exits 1
+#                            with usage if SESSION_ID is omitted.
+#   register NAME SESSION_ID
 #                            Add or update SESSION_ID → NAME in the JSON map.
-#                            If SESSION_ID is omitted, uses the discovered one.
+#                            Exits 1 with usage if SESSION_ID is omitted.
 #   list                     Dump all session_id → name pairs (sorted by name).
 #   discover                 Print the best-guess session_id of the calling
 #                            shell (Claude Code only; see WARNING below).
@@ -31,9 +31,11 @@
 # Codex, etc.) do not write transcripts there and MUST pass session_id
 # explicitly — their bootstrap shims already do (see
 # .agents/hooks/agy-beads-bootstrap.cjs). Even within Claude Code the
-# heuristic is racy when multiple sessions are active; agents should learn
-# their session_id from the SessionStart hook payload and pass it explicitly.
-# The discover heuristic is a convenience fallback only.
+# heuristic is racy when multiple sessions are active: it returns the newest
+# transcript, which is wrong for any non-newest session (2026-05-20 incident
+# on PP-lt12 — root cause of PP-sjkz). SESSION_ID is therefore REQUIRED for
+# whoami and register; the discover subcommand invokes the heuristic only
+# when the caller explicitly requests it.
 
 set -euo pipefail
 
@@ -98,7 +100,10 @@ case "$cmd" in
   whoami)
     sid="${2:-}"
     if [[ -z "$sid" ]]; then
-      sid=$(discover_session_id) || { echo ""; exit 0; }
+      printf 'Usage: huddle-whoami.sh whoami SESSION_ID\n' >&2
+      printf 'SESSION_ID is required — the heuristic is unreliable when multiple sessions are active.\n' >&2
+      printf 'Use the discover subcommand if you want the heuristic result explicitly.\n' >&2
+      exit 1
     fi
     jq -r --arg sid "$sid" '.[$sid] // ""' "$NAMES_JSON"
     ;;
@@ -118,10 +123,10 @@ case "$cmd" in
     fi
     sid="${3:-}"
     if [[ -z "$sid" ]]; then
-      sid=$(discover_session_id) || {
-        echo "huddle-whoami.sh: could not discover session_id; pass it explicitly" >&2
-        exit 1
-      }
+      printf 'Usage: huddle-whoami.sh register NAME SESSION_ID\n' >&2
+      printf 'SESSION_ID is required — the heuristic is unreliable when multiple sessions are active.\n' >&2
+      printf 'Use: bash scripts/hooks/huddle-whoami.sh discover  to get the discovered session_id.\n' >&2
+      exit 1
     fi
     # Reject duplicate names: if any OTHER session_id already owns this name,
     # registering it again would make the self-filter suppress both sessions'


### PR DESCRIPTION
## Summary

Two bugs surfaced from the 2026-05-20 huddle incident on PP-lt12. Both are fixed here.

### PP-cex3 — bootstrap self-heal + poll null-notes warning

Root notes on PP-lt12 were silently wiped between 00:41 and 01:08 UTC. Every poll session stopped seeing coordination comments with no signal.

- **`huddle-bootstrap.sh`**: After the existing idempotency check confirms the root bead is alive, now also validates that notes JSON is present, parseable, and contains `schema_version`, `today_bead.id`, and `monthly_bead.id`. If any check fails, queries open children under the root bead, rebuilds notes from the matching daily/monthly beads, writes via `bd update`, and prints a clear recovery message. Previously a clobbered system silently reported "Huddle already bootstrapped" and exited without healing.

- **`huddle-poll.sh`**: After resolving `ROOT_ID` from `config.json`, now checks that root notes are non-null and contain a parseable `today_bead.id`. If not, emits a stderr diagnostic and exits 0. Previously the script exited silently, leaving sessions with no injection and no signal.

### PP-sjkz — huddle-whoami: SESSION_ID required for whoami and register

A 21h-old session called `whoami` without a SESSION_ID, got "Slingshot" back (the newest transcript, belonging to a different session), signed comments as `—Claude-Slingshot`, and broke self-filter expectations for both sessions. Diagnosis took ~30 min.

- **`huddle-whoami.sh` `whoami`**: SESSION_ID is now required. Omitting it prints usage to stderr and exits 1 instead of silently running the racy heuristic.
- **`huddle-whoami.sh` `register`**: SESSION_ID is now required. Same change.
- **`huddle-whoami.sh` `discover`**: Unchanged — its explicit purpose is to invoke the heuristic when the caller wants it.
- Hook-payload callers (`huddle-session-start.sh`, `huddle-poll.sh`) already pass `session_id` explicitly from the hook JSON, so no call-site changes needed.

## Test plan

- [x] `pnpm run check` passes (shellcheck, typecheck, unit tests — all 125 test files)
- [x] Self-heal path tested with throwaway bead PP-1csf (now closed): null notes + open children → recovery message + valid notes written and verified via `bd show --json`
- [x] Re-run after recovery exits cleanly on the happy path without re-triggering self-heal
- [x] Null-notes warning tested: stderr diagnostic emitted, exit code 0
- [x] `huddle-whoami.sh whoami` (no args) → exit 1 with usage
- [x] `huddle-whoami.sh register Foo` (no session_id) → exit 1 with usage
- [x] `huddle-whoami.sh whoami <session_id>` → exit 0, empty output for unknown sid
- [x] `huddle-whoami.sh discover` → exit 0, returns session UUID
- [x] PP-lt12 (real root) not touched during testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)