### PR TITLE
test(ci): NEGATIVE — verify E2E skip on scripts/{hooks,workflow}/ only changes (PP-iq16)

### DIFF
--- a/scripts/hooks/huddle-lib.sh
+++ b/scripts/hooks/huddle-lib.sh
@@ -39,3 +39,5 @@ huddle_state_dir() {
   main_root=$(dirname "$abs_common")
   printf '%s/.agents/huddle' "$main_root"
 }
+
+# verify-skip-PP-iq16 — test PR for has_code exclusion (scripts/hooks/)

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -174,3 +174,5 @@ check_no_merge_conflict() {
       ;;
   esac
 }
+
+# verify-skip-PP-iq16 — test PR for has_code exclusion (scripts/workflow/)


### PR DESCRIPTION
**Verification PR for #1404 (PP-iq16). Will be closed without merging.**

Touches a single comment-line in two files:
- `scripts/hooks/huddle-lib.sh` (matches new `!scripts/hooks/**` exclusion)
- `scripts/workflow/_pr-gates.sh` (matches new `!scripts/workflow/**` exclusion)

**Expected CI behavior** (verifies #1404's `has_code` filter expansion works):
- [ ] `Detect Changes` job runs; sets `code: false`
- [ ] `E2E Smoke Tests (Chromium)` → Skipped
- [ ] `E2E Smoke Tests (Mobile Chrome)` → Skipped
- [ ] `E2E Full Tests (Chromium)` → Skipped
- [ ] `Supabase Integration Tests` → Skipped
- [ ] All `setup`-dependent jobs (typecheck/lint/format/test-unit/etc.) → Skipped
- [ ] `Fast Linters` and `Gitleaks` → Success (Tier 1, run unconditionally)
- [ ] `CI Gate` → Success (tier 2 accepts Skipped)