### PR TITLE
feat(ui): add :user-invalid styling and aria-invalid blur sync (PP-kqbk.2)

### DIFF
--- a/src/components/ui/input.test.tsx
+++ b/src/components/ui/input.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import * as React from "react";
+import { Input } from "./input";
+
+describe("Input", () => {
+  it("renders correctly", () => {
+    render(<Input data-testid="input" />);
+    expect(screen.getByTestId("input")).toBeInTheDocument();
+  });
+
+  it("updates aria-invalid to true on blur when native validation fails", async () => {
+    const user = userEvent.setup();
+    render(<Input required data-testid="input" />);
+    const input = screen.getByTestId("input");
+
+    expect(input).not.toHaveAttribute("aria-invalid");
+
+    await user.click(input);
+    await user.tab();
+
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("updates aria-invalid to false on blur when native validation passes", async () => {
+    const user = userEvent.setup();
+    render(<Input required data-testid="input" />);
+    const input = screen.getByTestId("input");
+
+    await user.type(input, "valid input");
+    await user.tab();
+
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("invokes caller-supplied onBlur callback", async () => {
+    const user = userEvent.setup();
+    const handleBlur = vi.fn();
+    render(<Input onBlur={handleBlur} data-testid="input" />);
+    const input = screen.getByTestId("input");
+
+    await user.click(input);
+    await user.tab();
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -5,6 +5,7 @@ import { cn } from "~/lib/utils";
 function Input({
   className,
   type,
+  onBlur,
   ...props
 }: React.ComponentProps<"input">): React.JSX.Element {
   return (
@@ -15,8 +16,16 @@ function Input({
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground bg-input/30 border-input h-9 w-full min-w-0 rounded-md border px-3 py-2 text-base shadow-xs transition-[color,box-shadow] duration-150 outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "[&:user-invalid]:ring-destructive/40 [&:user-invalid]:border-destructive",
         className
       )}
+      onBlur={(e) => {
+        e.currentTarget.setAttribute(
+          "aria-invalid",
+          e.currentTarget.checkValidity() ? "false" : "true"
+        );
+        onBlur?.(e);
+      }}
       {...props}
     />
   );

--- a/src/components/ui/textarea.test.tsx
+++ b/src/components/ui/textarea.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import * as React from "react";
+import { Textarea } from "./textarea";
+
+describe("Textarea", () => {
+  it("renders correctly", () => {
+    render(<Textarea data-testid="textarea" />);
+    expect(screen.getByTestId("textarea")).toBeInTheDocument();
+  });
+
+  it("updates aria-invalid to true on blur when native validation fails", async () => {
+    const user = userEvent.setup();
+    render(<Textarea required data-testid="textarea" />);
+    const textarea = screen.getByTestId("textarea");
+
+    expect(textarea).not.toHaveAttribute("aria-invalid");
+
+    await user.click(textarea);
+    await user.tab();
+
+    expect(textarea).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("updates aria-invalid to false on blur when native validation passes", async () => {
+    const user = userEvent.setup();
+    render(<Textarea required data-testid="textarea" />);
+    const textarea = screen.getByTestId("textarea");
+
+    await user.type(textarea, "valid content");
+    await user.tab();
+
+    expect(textarea).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("invokes caller-supplied onBlur callback", async () => {
+    const user = userEvent.setup();
+    const handleBlur = vi.fn();
+    render(<Textarea onBlur={handleBlur} data-testid="textarea" />);
+    const textarea = screen.getByTestId("textarea");
+
+    await user.click(textarea);
+    await user.tab();
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -4,15 +4,23 @@ import { cn } from "~/lib/utils";
 
 function Textarea({
   className,
+  onBlur,
   ...props
 }: React.ComponentProps<"textarea">): React.JSX.Element {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border px-3 py-2 text-base shadow-xs transition-[color,box-shadow] duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/40 aria-invalid:border-destructive [&:user-invalid]:ring-destructive/40 [&:user-invalid]:border-destructive bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border px-3 py-2 text-base shadow-xs transition-[color,box-shadow] duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
+      onBlur={(e) => {
+        e.currentTarget.setAttribute(
+          "aria-invalid",
+          e.currentTarget.checkValidity() ? "false" : "true"
+        );
+        onBlur?.(e);
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
### Summary
* Added `:user-invalid` border and ring styling to the shared `Input` and `Textarea` primitives to support native validation feedback after user interaction without mirroring invalid state in JS.
* Added an `onBlur` event handler to both primitives that dynamically sets `aria-invalid` to `"true"` or `"false"` based on `e.currentTarget.checkValidity()`, ensuring screen readers announce validity state changes.
* Suppressed visual feedback during initial render by utilizing the browser-native `:user-invalid` pseudo-class (Widely available since Nov 2023).

### Test Plan
- [x] Unit tests written in `src/components/ui/input.test.tsx` and `src/components/ui/textarea.test.tsx` asserting correct `aria-invalid` state syncs on blur under valid and invalid conditions.
- [x] Verified unit and integration test suite passing locally via `pnpm run check`.
- [x] Full preflight verification completed successfully via `pnpm run preflight`.

Closes PP-kqbk.2

—Antigravity-Validation
