### PR TITLE
feat(workflow): worktree cleanup resilience + SessionStart orphan sweep (PP-qlzu)

### DIFF
--- a/.claude/hooks/session-start-orphan-sweep.sh
+++ b/.claude/hooks/session-start-orphan-sweep.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# session-start-orphan-sweep.sh — opportunistic dry-run audit of leaked
+# worktree resources on Claude Code SessionStart.
+#
+# Calls `scripts/worktree_orphan_sweep.py --quiet` (NO --apply) to surface
+# orphan slot manifest entries and orphan Supabase Docker resources from
+# the failure modes documented in PP-qlzu (rm -rf without the hook, Claude
+# in Web sandbox sessions). When orphans are found the sweep prints a
+# single-line nudge to stderr telling you to run `--apply` manually.
+#
+# Why dry-run (not auto-apply): SessionStart fires on every Claude Code
+# session and can affect Docker resources across the host; we want the
+# user in the loop on the reclaim step.
+#
+# Guardrails:
+#   - 6-hour throttle via ~/.cache/pinpoint/last-orphan-sweep so multiple
+#     concurrent sessions don't all sweep at once.
+#   - Hard 10s timeout so a hung Docker daemon never blocks session start.
+#   - All errors swallowed; the script is best-effort and must never fail
+#     a session start.
+#
+# Opt out by removing this hook entry from .claude/settings.json or by
+# `touch -t 999912312359 ~/.cache/pinpoint/last-orphan-sweep` to push the
+# throttle marker far into the future.
+
+set -u
+
+throttle_dir="${XDG_CACHE_HOME:-$HOME/.cache}/pinpoint"
+throttle_file="$throttle_dir/last-orphan-sweep"
+throttle_seconds=$((6 * 60 * 60))
+
+mkdir -p "$throttle_dir" 2>/dev/null || exit 0
+
+if [[ -f "$throttle_file" ]]; then
+  last=$(stat -f %m "$throttle_file" 2>/dev/null || stat -c %Y "$throttle_file" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  age=$((now - last))
+  if (( age < throttle_seconds )); then
+    exit 0
+  fi
+fi
+
+project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+sweep_script="$project_dir/scripts/worktree_orphan_sweep.py"
+
+if [[ ! -f "$sweep_script" ]]; then
+  exit 0
+fi
+
+# Mark the throttle marker BEFORE running so a hang doesn't repeatedly relaunch
+# the sweep on each session start.
+touch "$throttle_file" 2>/dev/null || true
+
+# 10s wall-clock ceiling. macOS doesn't ship coreutils `timeout` by default but
+# `gtimeout` exists when coreutils is installed, and `perl` works everywhere.
+if command -v timeout >/dev/null; then
+  timeout 10 python3 "$sweep_script" --quiet --repo-dir "$project_dir" >/dev/null || true
+elif command -v gtimeout >/dev/null; then
+  gtimeout 10 python3 "$sweep_script" --quiet --repo-dir "$project_dir" >/dev/null || true
+else
+  perl -e '
+    use strict;
+    $SIG{ALRM} = sub { kill 15, -$$; exit 0 };
+    alarm 10;
+    setpgrp 0, 0;
+    exec @ARGV
+  ' python3 "$sweep_script" --quiet --repo-dir "$project_dir" >/dev/null || true
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -126,6 +126,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/scripts/hooks/huddle-session-start.sh",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/session-start-orphan-sweep.sh",
+            "timeout": 15000
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ One-time install for tools the workflow scripts depend on:
 Each git worktree gets isolated Supabase ports automatically. The Husky `post-checkout` hook runs `scripts/worktree_setup.py`, which allocates a slot from `~/.config/pinpoint/worktree-slots.json` and generates read-only `supabase/config.toml`, `.env.local`, `.claude/launch.json`.
 
 - **Create**: `git worktree add /path -b branch origin/main` — the hook handles the rest.
-- **Cleanup**: `scripts/worktree_cleanup.py` (stops Supabase, removes volumes, deallocates slot). Plain `git worktree remove` may leak Docker volumes (`docker volume prune` to clean).
+- **Cleanup**: `scripts/worktree_cleanup.py` (stops Supabase, removes volumes, deallocates slot). Plain `git worktree remove` or `rm -rf` leaks slot entries and Docker volumes — `scripts/worktree_orphan_sweep.py` reconciles them; pass `--apply` to reclaim. A SessionStart hook runs the sweep in dry-run mode every 6h and prints a one-line nudge if orphans are found.
 - **Ports**: main worktree uses defaults (3000 / 54321 / 54322). Slot N: `3000+N*10`, `54321+N*100`, `54322+N*100`.
 - **Config**: edit `supabase/config.toml.template`, not the generated file (which is chmod 444).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ See `pinpoint-orchestrator` skill Phase 2 for the full technical record.
 ### Worktrees (Claude Code specifics)
 
 - **Dispatch**: `isolation: "worktree"` works out of the box — Claude Code creates the worktree, the `post-checkout` hook configures it (slot allocation, ports, `.env.local`, `.claude/launch.json`).
-- **Cleanup**: Claude Code's `WorktreeRemove` hook automatically runs `scripts/worktree_cleanup.py` (stops Supabase, removes Docker volumes, deallocates slot). Manual `git worktree remove /path` works but skips the cleanup script — Docker volumes may leak.
+- **Cleanup**: Claude Code's `WorktreeRemove` hook automatically runs `scripts/worktree_cleanup.py` (stops Supabase, removes Docker volumes, deallocates slot). Manual `git worktree remove /path` or `rm -rf` skips the hook — slot manifest entry and Docker volumes leak. `scripts/worktree_orphan_sweep.py` reconciles the slot manifest, active worktrees, and Supabase Docker resources; the SessionStart hook runs it in dry-run mode every 6h and surfaces a one-line nudge when orphans accumulate.
 - **Branch creation**: `Agent(isolation:"worktree")` handles branch creation automatically. AGENTS.md §4 "Branch Management" rules still apply if you create a branch manually inside an existing worktree.
 
 ### Parallel Subagent Workflow

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -167,11 +167,17 @@ def main() -> None:
             text=True,
         )
         if result.returncode != 0:
+            # Do NOT deallocate the slot — the worktree directory likely still
+            # exists with its `.env.local` and config pointing at this slot's
+            # ports. Freeing the slot would let the next worktree allocate the
+            # same ports and collide. Surface the failure and bail.
             print(
-                f"Warning: failed to remove worktree {worktree_path}: "
-                f"{result.stderr.strip()} — continuing to deallocate slot.",
+                f"Failed to remove worktree {worktree_path}: "
+                f"{result.stderr.strip()} — keeping slot manifest entry to "
+                "avoid port collision; investigate manually.",
                 file=sys.stderr,
             )
+            sys.exit(1)
 
         subprocess.run(["git", "worktree", "prune"], capture_output=True)
 

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -67,34 +67,55 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-    if not git_marker.is_file():
+
+    # PP-qlzu: when .git is missing (partial removal, rm -rf without the hook,
+    # Claude in Web sandbox sessions), we can't derive the branch and therefore
+    # can't safely target the Supabase project_id. Skip the Docker/Supabase
+    # phase but still deallocate the slot — otherwise the manifest entry leaks
+    # forever. worktree_orphan_sweep.py picks up any leaked Docker resources.
+    git_marker_present = git_marker.is_file()
+    if not git_marker_present:
         print(
-            f"Warning: {worktree_path} has no .git marker — not a worktree. Skipping.",
+            f"Warning: {worktree_path} has no .git marker — skipping Supabase/Docker "
+            "cleanup (no branch to derive project_id from); deallocating slot only.",
             file=sys.stderr,
         )
-        return
 
-    # Get branch name for Docker volume cleanup
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(worktree_path), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        branch = result.stdout.strip()
-    except subprocess.CalledProcessError:
-        branch = ""
+    branch = ""
+    if git_marker_present:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(worktree_path), "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            branch = result.stdout.strip()
+        except subprocess.CalledProcessError:
+            branch = ""
 
     if branch:
         project_id = branch_to_project_id(branch)
 
-        # Stop Supabase
+        # Stop Supabase. Failures here are non-fatal: a missing project_ref or
+        # a stack that was never started both look like errors but don't block
+        # slot deallocation.
         print(f"Stopping Supabase for {branch}...", file=sys.stderr)
-        subprocess.run(["supabase", "stop"], cwd=worktree_path, capture_output=True)
+        stop_result = subprocess.run(
+            ["supabase", "stop"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+        if stop_result.returncode != 0:
+            print(
+                f"Warning: `supabase stop` exited {stop_result.returncode}: "
+                f"{stop_result.stderr.strip() or stop_result.stdout.strip()}",
+                file=sys.stderr,
+            )
 
         # Remove Docker volumes
-        result = subprocess.run(
+        ls_result = subprocess.run(
             [
                 "docker",
                 "volume",
@@ -106,33 +127,54 @@ def main() -> None:
             capture_output=True,
             text=True,
         )
-        volumes = [v for v in result.stdout.strip().split("\n") if v]
+        if ls_result.returncode != 0:
+            print(
+                f"Warning: `docker volume ls` exited {ls_result.returncode}: "
+                f"{ls_result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            volumes: list[str] = []
+        else:
+            volumes = [v for v in ls_result.stdout.strip().split("\n") if v]
         if volumes:
-            subprocess.run(["docker", "volume", "rm"] + volumes, capture_output=True)
-            print(f"Removed {len(volumes)} Docker volume(s)", file=sys.stderr)
+            rm_result = subprocess.run(
+                ["docker", "volume", "rm"] + volumes,
+                capture_output=True,
+                text=True,
+            )
+            if rm_result.returncode != 0:
+                print(
+                    f"Warning: `docker volume rm` exited {rm_result.returncode}: "
+                    f"{rm_result.stderr.strip()}",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"Removed {len(volumes)} Docker volume(s)", file=sys.stderr)
 
     # Unlock first. Claude Code agent runtimes lock worktrees while in use,
     # and the lock persists after the agent finishes; `git worktree remove
     # --force` does NOT bypass these locks. Unlock errors (e.g., "not locked")
     # are harmless and intentionally ignored.
-    subprocess.run(
-        ["git", "worktree", "unlock", str(worktree_path)],
-        capture_output=True,
-    )
-
-    result = subprocess.run(
-        ["git", "worktree", "remove", "--force", str(worktree_path)],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(
-            f"Failed to remove worktree {worktree_path}: {result.stderr.strip()}",
-            file=sys.stderr,
+    if git_marker_present:
+        subprocess.run(
+            ["git", "worktree", "unlock", str(worktree_path)],
+            capture_output=True,
         )
-        sys.exit(1)
 
-    subprocess.run(["git", "worktree", "prune"], capture_output=True)
+        result = subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(
+                f"Warning: failed to remove worktree {worktree_path}: "
+                f"{result.stderr.strip()} — continuing to deallocate slot.",
+                file=sys.stderr,
+            )
+
+        subprocess.run(["git", "worktree", "prune"], capture_output=True)
+
     deallocate_slot(str(worktree_path))
 
     print(f"Cleaned up worktree: {worktree_path}", file=sys.stderr)

--- a/scripts/worktree_orphan_sweep.py
+++ b/scripts/worktree_orphan_sweep.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+worktree_orphan_sweep.py — find and (optionally) reclaim leaked worktree resources.
+
+Two failure modes accumulate orphans:
+
+1.  `rm -rf <worktree>` (no WorktreeRemove hook fires) leaves the slot
+    manifest entry pointing at a missing path and the Supabase Docker
+    volumes/containers — labeled `com.supabase.cli.project=pinpoint-*` —
+    intact on the host.
+2.  Claude in Web sandbox sessions cannot fire local hooks at all, so a
+    branch DB started by an earlier local round-trip can outlive the
+    sandbox session.
+
+This script reconciles three sources of truth:
+
+- active git worktrees (`git worktree list --porcelain`)
+- slot manifest entries (`~/.config/pinpoint/worktree-slots.json`)
+- Docker resources with the `com.supabase.cli.project` label whose value
+  starts with `pinpoint-` (the prefix `branch_to_project_id` always emits)
+
+Defaults to dry-run; pass `--apply` to actually deallocate orphan slots and
+remove orphan Docker containers/volumes.
+"""
+
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from worktree_cleanup import MANIFEST_PATH, deallocate_slot  # noqa: E402
+from worktree_setup import branch_to_project_id  # noqa: E402
+
+
+def get_active_worktree_branches(repo_dir: Path) -> dict[str, str]:
+    """Return {path: branch} for all current git worktrees of repo_dir."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_dir), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"Warning: `git worktree list` failed: {exc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return {}
+
+    worktrees: dict[str, str] = {}
+    current_path = ""
+    current_branch = ""
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            if current_path:
+                worktrees[current_path] = current_branch
+            current_path = line[len("worktree ") :]
+            current_branch = ""
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line[len("branch refs/heads/") :]
+    if current_path:
+        worktrees[current_path] = current_branch
+    return worktrees
+
+
+def get_orphan_slot_paths() -> list[str]:
+    """Read the slot manifest and return paths missing on disk or w/o .git marker."""
+    if not MANIFEST_PATH.exists():
+        return []
+    with open(MANIFEST_PATH) as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        try:
+            data = json.loads(f.read())
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    slots = data.get("slots", {})
+    orphans: list[str] = []
+    for path_str in slots:
+        path = Path(path_str)
+        if not path.is_dir() or not (path / ".git").exists():
+            orphans.append(path_str)
+    return orphans
+
+
+def _docker_label_query(args: list[str], not_quiet: bool) -> list[tuple[str, str]]:
+    """Run a Docker command emitting `name|project_id` lines; return parsed pairs.
+
+    Returns [] when Docker is missing or the daemon is unreachable; the SessionStart
+    hook must never block on Docker being down.
+    """
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        if not_quiet:
+            print(
+                "Note: `docker` not installed; skipping Docker sweep.", file=sys.stderr
+            )
+        return []
+    except subprocess.CalledProcessError as exc:
+        if not_quiet:
+            print(
+                f"Note: docker query failed ({exc.stderr.strip()}); skipping Docker sweep.",
+                file=sys.stderr,
+            )
+        return []
+
+    out: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        name, _, project = line.partition("|")
+        if project.startswith("pinpoint-"):
+            out.append((name, project))
+    return out
+
+
+def get_supabase_resources_by_project(
+    not_quiet: bool,
+) -> dict[str, dict[str, list[str]]]:
+    """Group Supabase Docker containers/volumes by their project_id label."""
+    grouped: dict[str, dict[str, list[str]]] = {}
+
+    volumes = _docker_label_query(
+        [
+            "docker",
+            "volume",
+            "ls",
+            "--format",
+            '{{.Name}}|{{.Label "com.supabase.cli.project"}}',
+        ],
+        not_quiet,
+    )
+    for name, project in volumes:
+        grouped.setdefault(project, {"volumes": [], "containers": []})
+        grouped[project]["volumes"].append(name)
+
+    containers = _docker_label_query(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--format",
+            '{{.Names}}|{{.Label "com.supabase.cli.project"}}',
+        ],
+        not_quiet,
+    )
+    for name, project in containers:
+        grouped.setdefault(project, {"volumes": [], "containers": []})
+        grouped[project]["containers"].append(name)
+
+    return grouped
+
+
+def _is_main_worktree_path(path: str) -> bool:
+    """Main worktree has .git as a directory; additional worktrees have .git as a file."""
+    return (Path(path) / ".git").is_dir()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually remove orphan resources (default: dry-run report).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-orphan logging; only print summary line and errors.",
+    )
+    parser.add_argument(
+        "--repo-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Repository root to use for `git worktree list`. "
+            "Defaults to $CLAUDE_PROJECT_DIR or PWD."
+        ),
+    )
+    args = parser.parse_args()
+
+    repo_dir = args.repo_dir or Path(
+        os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    )
+    not_quiet = not args.quiet
+
+    active = get_active_worktree_branches(repo_dir)
+    active_project_ids = {
+        branch_to_project_id(branch) for branch in active.values() if branch
+    }
+
+    if not_quiet:
+        print(
+            f"Active worktrees: {len(active)} "
+            f"(project_ids: {sorted(active_project_ids)})",
+            file=sys.stderr,
+        )
+
+    orphan_slots = get_orphan_slot_paths()
+    if orphan_slots and not_quiet:
+        print(
+            f"Orphan slot entries (path missing or .git removed): {len(orphan_slots)}",
+            file=sys.stderr,
+        )
+        for path_str in orphan_slots:
+            print(f"  - {path_str}", file=sys.stderr)
+
+    docker_by_project = get_supabase_resources_by_project(not_quiet)
+    orphan_projects = {
+        pid: res
+        for pid, res in docker_by_project.items()
+        if pid not in active_project_ids
+    }
+    if orphan_projects and not_quiet:
+        print(
+            f"Orphan Supabase Docker projects: {len(orphan_projects)}",
+            file=sys.stderr,
+        )
+        for pid, res in sorted(orphan_projects.items()):
+            print(
+                f"  - {pid}: {len(res['containers'])} container(s), "
+                f"{len(res['volumes'])} volume(s)",
+                file=sys.stderr,
+            )
+
+    if not orphan_slots and not orphan_projects:
+        if not_quiet:
+            print("No orphans found.", file=sys.stderr)
+        return 0
+
+    if not args.apply:
+        if not_quiet:
+            print("Dry-run; re-run with --apply to reclaim.", file=sys.stderr)
+        else:
+            # Quiet dry-run still surfaces a single-line nudge so the SessionStart
+            # hook isn't completely silent when there's something to reclaim.
+            print(
+                f"worktree-orphan-sweep: found {len(orphan_slots)} slot orphan(s), "
+                f"{len(orphan_projects)} Supabase Docker project orphan(s) "
+                "(dry-run). Run: python3 scripts/worktree_orphan_sweep.py --apply",
+                file=sys.stderr,
+            )
+        return 0
+
+    for path_str in orphan_slots:
+        if _is_main_worktree_path(path_str):
+            print(
+                f"Skipping main worktree {path_str} (should not be in slot manifest).",
+                file=sys.stderr,
+            )
+            continue
+        deallocate_slot(path_str)
+        if not_quiet:
+            print(f"  deallocated slot: {path_str}", file=sys.stderr)
+
+    for pid, res in sorted(orphan_projects.items()):
+        if res["containers"]:
+            rm = subprocess.run(
+                ["docker", "rm", "-f"] + res["containers"],
+                capture_output=True,
+                text=True,
+            )
+            if rm.returncode != 0:
+                print(
+                    f"  Warning: `docker rm -f` for {pid}: {rm.stderr.strip()}",
+                    file=sys.stderr,
+                )
+            elif not_quiet:
+                print(
+                    f"  removed {len(res['containers'])} container(s) for {pid}",
+                    file=sys.stderr,
+                )
+        if res["volumes"]:
+            rm = subprocess.run(
+                ["docker", "volume", "rm"] + res["volumes"],
+                capture_output=True,
+                text=True,
+            )
+            if rm.returncode != 0:
+                print(
+                    f"  Warning: `docker volume rm` for {pid}: {rm.stderr.strip()}",
+                    file=sys.stderr,
+                )
+            elif not_quiet:
+                print(
+                    f"  removed {len(res['volumes'])} volume(s) for {pid}",
+                    file=sys.stderr,
+                )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/worktree_orphan_sweep.py
+++ b/scripts/worktree_orphan_sweep.py
@@ -27,6 +27,7 @@ import argparse
 import fcntl
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -35,6 +36,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from worktree_cleanup import MANIFEST_PATH, deallocate_slot  # noqa: E402
 from worktree_setup import branch_to_project_id  # noqa: E402
+
+_PROJECT_ID_LINE_RE = re.compile(r'^project_id\s*=\s*"([^"]+)"')
 
 
 def get_active_worktree_branches(repo_dir: Path) -> dict[str, str]:
@@ -69,17 +72,60 @@ def get_active_worktree_branches(repo_dir: Path) -> dict[str, str]:
     return worktrees
 
 
+def get_active_project_ids(worktrees: dict[str, str]) -> set[str]:
+    """Derive the Supabase project_id for each active worktree.
+
+    Reads `<worktree>/supabase/config.toml` directly when present — that file
+    is the authoritative source for the project_id that Supabase containers
+    actually use, and it works for detached worktrees and for worktrees whose
+    branch was renamed after setup. Falls back to `branch_to_project_id(branch)`
+    only when the config.toml is missing and the worktree is on a named branch.
+
+    Worktrees we can't resolve (detached + missing config.toml) are intentionally
+    skipped so the caller never deletes a Docker project we don't recognize.
+    """
+    project_ids: set[str] = set()
+    for path_str, branch in worktrees.items():
+        config_path = Path(path_str) / "supabase" / "config.toml"
+        if config_path.is_file():
+            try:
+                for line in config_path.read_text().splitlines():
+                    match = _PROJECT_ID_LINE_RE.match(line)
+                    if match:
+                        project_ids.add(match.group(1))
+                        break
+            except OSError:
+                pass
+        elif branch:
+            project_ids.add(branch_to_project_id(branch))
+    return project_ids
+
+
 def get_orphan_slot_paths() -> list[str]:
-    """Read the slot manifest and return paths missing on disk or w/o .git marker."""
+    """Read the slot manifest and return paths missing on disk or w/o .git marker.
+
+    Tolerates a corrupted/partial manifest the same way deallocate_slot does —
+    a bad JSON shape shouldn't crash the sweep (and make `--apply` unusable).
+    """
     if not MANIFEST_PATH.exists():
         return []
     with open(MANIFEST_PATH) as f:
         fcntl.flock(f.fileno(), fcntl.LOCK_SH)
         try:
-            data = json.loads(f.read())
+            raw = f.read()
         finally:
             fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-    slots = data.get("slots", {})
+    try:
+        data = json.loads(raw)
+        slots = data.get("slots", {})
+        if not isinstance(slots, dict):
+            slots = {}
+    except (json.JSONDecodeError, AttributeError):
+        print(
+            f"Warning: {MANIFEST_PATH} is not valid JSON; treating as empty.",
+            file=sys.stderr,
+        )
+        slots = {}
     orphans: list[str] = []
     for path_str in slots:
         path = Path(path_str)
@@ -192,9 +238,7 @@ def main() -> int:
     not_quiet = not args.quiet
 
     active = get_active_worktree_branches(repo_dir)
-    active_project_ids = {
-        branch_to_project_id(branch) for branch in active.values() if branch
-    }
+    active_project_ids = get_active_project_ids(active)
 
     if not_quiet:
         print(


### PR DESCRIPTION
## Summary

Closes [PP-qlzu](https://github.com/timothyfroehlich/PinPoint/blob/main/.beads/issues.jsonl). Third and last PR in the memory-pressure-reduction series; the earlier two were #1403 (serialize integration tests, cap workers — closed PP-pblt) and #1407 (`sem --jobs 2` host-wide preflight cap).

Two failure modes were silently leaking Supabase Docker stacks and slot manifest entries (this morning's diagnostic session found 14 orphan stacks ~2.4 GB and 4 stuck slot entries):

1. `rm -rf <worktree>` skips the `WorktreeRemove` hook entirely.
2. Claude in Web sandbox sessions can't fire local hooks at all.

### Changes

- **`scripts/worktree_cleanup.py`**: when `.git` is missing, log a warning, skip the Docker/Supabase phase (no branch to derive project_id from), and **still deallocate the slot** — previously the script exited early and the manifest entry stayed forever. Adds exit-code checks on `supabase stop` / `docker volume ls` / `docker volume rm` calls — non-fatal warnings rather than silent failures.

- **`scripts/worktree_orphan_sweep.py`** (new): reconciles three sources of truth — active `git worktree list`, slot manifest, and Docker resources labeled `com.supabase.cli.project=pinpoint-*`. Dry-run by default; pass `--apply` to reclaim. Degrades gracefully when Docker is unreachable.

- **`.claude/hooks/session-start-orphan-sweep.sh`** (new) + **`.claude/settings.json`**: registers a SessionStart hook that runs the sweep in **dry-run mode** (no `--apply`) with a 6-hour throttle (`~/.cache/pinpoint/last-orphan-sweep`) and a 10s wall-clock ceiling. Prints a one-line nudge to stderr when orphans accumulate; you run `--apply` manually to reclaim. All errors swallowed — never blocks session start.

- **`AGENTS.md` + `CLAUDE.md`**: one-line note pointing at the sweep and the SessionStart hook in the Worktrees / Cleanup section.

### Design notes

- **Dry-run not auto-apply**: SessionStart fires every Claude Code session start and acts on Docker resources host-wide. Picked the safer first version that surfaces the count and asks you to reclaim — easy to flip to `--apply` later once trust is established.

- **Docker-driven sweep**: enumerating volumes/containers by `pinpoint-*` label is more reliable than trying to derive project_id from a missing worktree's path basename (path ≠ branch in general).

## Test plan

- [x] `pnpm run check` (1139 tests, all linters) green locally
- [x] Manual sweep dry-run on the host correctly identified the 5 leaked slot entries + 5 leaked Docker projects matching the diagnostic session findings
- [x] Hook end-to-end: orphans → nudge printed; second run within 6h → throttled silent exit; throttle marker created
- [x] Hook gracefully no-ops when `worktree_orphan_sweep.py` doesn't exist (e.g. on branches before this PR)
- [x] `worktree_cleanup.py` against a path with `.git` removed: slot deallocated, Docker phase skipped with warning
- [ ] CI green
- [ ] Watch for unintended side effects on the first SessionStart fire post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)