### PR TITLE
perf(ui): tighten LCP image priority discipline + Vercel Blob preconnect (PP-kqbk.5)

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -30,7 +30,7 @@ export default function LandingPage(): React.JSX.Element {
               height={149}
               className="drop-shadow-[0_0_15px_color-mix(in_srgb,var(--color-primary)_50%,transparent)] hover:drop-shadow-[0_0_20px_color-mix(in_srgb,var(--color-primary)_70%,transparent)] transition-all duration-300"
               style={{ width: "auto", height: "auto" }}
-              sizes="(max-width: 768px) 80vw, 200px"
+              sizes="200px"
               data-testid="hero-apc-logo"
               priority
             />

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -30,6 +30,7 @@ export default function LandingPage(): React.JSX.Element {
               height={149}
               className="drop-shadow-[0_0_15px_color-mix(in_srgb,var(--color-primary)_50%,transparent)] hover:drop-shadow-[0_0_20px_color-mix(in_srgb,var(--color-primary)_70%,transparent)] transition-all duration-300"
               style={{ width: "auto", height: "auto" }}
+              sizes="(max-width: 768px) 80vw, 200px"
               data-testid="hero-apc-logo"
               priority
             />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,22 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Derives the Vercel Blob public hostname from the BLOB_READ_WRITE_TOKEN.
+ * Token format: vercel_blob_rw_<storeRef>_<base64secret>
+ * Hostname format: <storeRef>.public.blob.vercel-storage.com
+ * Returns null when the token is absent (local dev without blob credentials).
+ */
+function getBlobStoreHostname(): string | null {
+  const token = process.env["BLOB_READ_WRITE_TOKEN"];
+  if (!token) return null;
+  // Strip the "vercel_blob_rw_" prefix, then take the next segment before "_"
+  const withoutPrefix = token.replace(/^vercel_blob_rw_/, "");
+  const storeRef = withoutPrefix.split("_")[0];
+  if (!storeRef) return null;
+  return `${storeRef}.public.blob.vercel-storage.com`;
+}
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -38,9 +54,15 @@ export default async function RootLayout({
   }
 
   const showCookieBanner = isProduction || forceShow;
+  const blobHostname = getBlobStoreHostname();
 
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {blobHostname !== null && (
+          <link rel="preconnect" href={`https://${blobHostname}`} />
+        )}
+      </head>
       <body className="flex flex-col h-screen overflow-hidden">
         <ClientProviders>
           <SentryInitializer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,16 +24,15 @@ export const metadata: Metadata = {
  * Derives the Vercel Blob public hostname from the BLOB_READ_WRITE_TOKEN.
  * Token format: vercel_blob_rw_<storeRef>_<base64secret>
  * Hostname format: <storeRef>.public.blob.vercel-storage.com
- * Returns null when the token is absent (local dev without blob credentials).
+ * Returns null when the token is absent or doesn't match the expected shape.
  */
 function getBlobStoreHostname(): string | null {
   const token = process.env["BLOB_READ_WRITE_TOKEN"];
   if (!token) return null;
-  // Strip the "vercel_blob_rw_" prefix, then take the next segment before "_"
-  const withoutPrefix = token.replace(/^vercel_blob_rw_/, "");
-  const storeRef = withoutPrefix.split("_")[0];
-  if (!storeRef) return null;
-  return `${storeRef}.public.blob.vercel-storage.com`;
+  const tokenPattern = /^vercel_blob_rw_([a-zA-Z0-9]+)_[a-zA-Z0-9]+$/;
+  const match = tokenPattern.exec(token);
+  if (!match) return null;
+  return `${match[1]}.public.blob.vercel-storage.com`;
 }
 
 export default async function RootLayout({

--- a/src/components/dashboard/OrganizationBanner.tsx
+++ b/src/components/dashboard/OrganizationBanner.tsx
@@ -25,7 +25,6 @@ export function OrganizationBanner(): React.JSX.Element {
             height={134}
             className="max-h-full object-contain drop-shadow-[0_0_15px_color-mix(in_srgb,var(--color-primary)_50%,transparent)] hover:drop-shadow-[0_0_20px_color-mix(in_srgb,var(--color-primary)_70%,transparent)] transition-all duration-300"
             style={{ width: "auto", height: "auto" }}
-            priority
           />
         </a>
       </div>

--- a/src/components/images/ImageGallery.tsx
+++ b/src/components/images/ImageGallery.tsx
@@ -69,7 +69,7 @@ export function ImageGallery({
                   fill
                   unoptimized={isLocalhost}
                   className="object-contain"
-                  sizes="100vw"
+                  sizes="(max-width: 768px) 100vw, 768px"
                 />
               </div>
             </DialogContent>

--- a/src/components/images/ImageGallery.tsx
+++ b/src/components/images/ImageGallery.tsx
@@ -70,7 +70,6 @@ export function ImageGallery({
                   unoptimized={isLocalhost}
                   className="object-contain"
                   sizes="100vw"
-                  priority
                 />
               </div>
             </DialogContent>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -72,7 +72,6 @@ export function AppHeader({
           width={32}
           height={32}
           className="size-8 object-contain"
-          priority
         />
         <span className="text-base font-bold tracking-tight text-foreground">
           PinPoint


### PR DESCRIPTION
## Summary

- Remove `priority` (i.e., `fetchpriority="high"`) from three images that are never LCP candidates: the `hidden lg:block` sidebar logo in `OrganizationBanner`, the 32px header logo in `AppHeader`, and the full-size dialog image in `ImageGallery` (dialog is closed at mount, so the image is never above the fold).
- Add `sizes="(max-width: 768px) 80vw, 200px"` to the landing-page APC logo, which is the genuine LCP candidate — this prevents mobile from downloading the desktop-sized variant.
- Add a `<link rel="preconnect">` to the Vercel Blob store hostname in `RootLayout`, derived at runtime from `BLOB_READ_WRITE_TOKEN`, so the first user-uploaded image skips DNS + TLS handshake. Omitted gracefully when the token is absent (local dev without blob credentials).

## Test Plan

- [ ] `pnpm run check` passes (types, lint, format, unit — 1139 tests)
- [ ] Lighthouse on `/dashboard`: LCP image is now the correct element with no wasted `fetchpriority=high` budget on non-LCP images
- [ ] Lighthouse on `/` (landing page): LCP improves; Chrome DevTools Network shows the APC logo downloaded at the correct responsive size for the viewport
- [ ] Chrome DevTools Network tab on any page with user-uploaded images: preconnect to `*.public.blob.vercel-storage.com` appears in the waterfall before the first blob image request
- [ ] CLS unchanged across all pages

## Related Issues

Closes PP-kqbk.5

—Claude-Lighthouse