### PR TITLE
fix(hooks): support worktree_id and worktree_path payload in WorktreeCreate hook (PP-f4co)

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -61,17 +61,30 @@ print(payload.get('$1') or '')
 }
 
 BASE_PATH=$(parse_field cwd)
-NAME=$(parse_field name)
+WORKTREE_ID=$(parse_field worktree_id)
+NAME_FIELD=$(parse_field name)
+WORKTREE_PATH_FIELD=$(parse_field worktree_path)
 
-if [ -z "$BASE_PATH" ] || [ -z "$NAME" ]; then
-  echo "worktree-create.sh: missing cwd or name in hook input" >&2
+if [ -z "$BASE_PATH" ] || { [ -z "$WORKTREE_ID" ] && [ -z "$NAME_FIELD" ]; }; then
+  echo "worktree-create.sh: missing cwd, worktree_id, or name in hook input" >&2
   exit 1
+fi
+
+if [ -n "$WORKTREE_ID" ]; then
+  NAME="$WORKTREE_ID"
+else
+  NAME="$NAME_FIELD"
 fi
 
 # Match Claude Code's pre-hook native naming so existing tooling (cleanup hook,
 # worktree manifest, orchestrator skill) continues to recognize the worktree.
 BRANCH="worktree-${NAME}"
-WORKTREE_PATH="${BASE_PATH}/.claude/worktrees/${NAME}"
+
+if [ -n "$WORKTREE_PATH_FIELD" ]; then
+  WORKTREE_PATH="$WORKTREE_PATH_FIELD"
+else
+  WORKTREE_PATH="${BASE_PATH}/.claude/worktrees/${NAME}"
+fi
 
 # Ensure the parent directory exists before `git worktree add` tries to write.
 # (Claude Code's `name` is currently a flat `agent-<hex>` slug with no slashes,

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -22,16 +22,26 @@
 #     "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/worktree-create.sh"
 #   No positional args are passed; all input comes from the JSON payload on stdin.
 #
-# Stdin payload fields (verified empirically via diagnostic dump, PP-pno7, 2026-05-16):
+# Stdin payload fields (supports both empirical and documented shapes):
+#   Documented:
 #   {
 #     "session_id":        "<uuid>",
 #     "transcript_path":   "<path to .jsonl>",
 #     "cwd":               "<repo root absolute path>",   ← used as BASE_PATH
 #     "hook_event_name":   "WorktreeCreate",
-#     "name":              "agent-<hex>"                   ← used as worktree dir name + branch
+#     "worktree_id":       "<id>",                         ← used as NAME if present
+#     "worktree_path":     "<path>"                        ← used as WORKTREE_PATH if present
 #   }
-#   The hook derives `BRANCH = worktree-${name}` to match Claude Code's native
-#   pre-hook naming convention (e.g., `worktree-agent-a20a236fe97a6d41c`).
+#   Empirical (current Claude Code version fallback):
+#   {
+#     "session_id":        "<uuid>",
+#     "transcript_path":   "<path to .jsonl>",
+#     "cwd":               "<repo root absolute path>",
+#     "hook_event_name":   "WorktreeCreate",
+#     "name":              "agent-<hex>"                   ← fallback for NAME
+#   }
+#   The hook derives `BRANCH = worktree-${NAME}` to match Claude Code's native
+#   pre-hook naming convention.
 #
 # Platform: macOS uses /usr/bin/lockf (ships with macOS, backed by flock(2)).
 #   Linux uses flock(1) from util-linux. Detected at runtime.

--- a/scripts/tests/test_worktree_create_hook.py
+++ b/scripts/tests/test_worktree_create_hook.py
@@ -1,0 +1,117 @@
+"""Unit tests for the WorktreeCreate hook script."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).parent.parent.parent / ".claude/hooks/worktree-create.sh"
+
+
+@pytest.fixture
+def mock_git(tmp_path: Path):
+    # Create a dummy git executable that records calls to a file
+    git_bin_dir = tmp_path / "bin"
+    git_bin_dir.mkdir()
+    git_script = git_bin_dir / "git"
+    calls_log = tmp_path / "git_calls.txt"
+
+    # Write dummy git script
+    git_script.write_text(f"""#!/bin/bash
+# Simply log the arguments and exit 0
+echo "$@" >> {calls_log}
+""")
+    git_script.chmod(0o755)
+
+    return {
+        "bin_dir": git_bin_dir,
+        "log_path": calls_log,
+    }
+
+
+def run_hook(stdin_data: dict, env_modifications: dict = None) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    if env_modifications:
+        env.update(env_modifications)
+
+    process = subprocess.Popen(
+        ["bash", str(HOOK_PATH)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+    stdout, stderr = process.communicate(input=json.dumps(stdin_data))
+    return process.returncode, stdout, stderr
+
+
+def test_hook_empirical_shape(mock_git: dict, tmp_path: Path) -> None:
+    stdin_data = {
+        "session_id": "test-session",
+        "transcript_path": "test-path",
+        "cwd": str(tmp_path),
+        "hook_event_name": "WorktreeCreate",
+        "name": "agent-emp-test",
+    }
+
+    env_mods = {"PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}"}
+
+    return_code, stdout, stderr = run_hook(stdin_data, env_mods)
+
+    assert return_code == 0, f"Hook failed with stderr: {stderr}"
+
+    assert mock_git["log_path"].exists()
+    calls = mock_git["log_path"].read_text().splitlines()
+    assert len(calls) == 1
+
+    expected_branch = "worktree-agent-emp-test"
+    expected_path = str(tmp_path / ".claude/worktrees/agent-emp-test")
+    assert (
+        f"-C {tmp_path} worktree add {expected_path} -b {expected_branch}" in calls[0]
+    )
+
+
+def test_hook_documented_shape(mock_git: dict, tmp_path: Path) -> None:
+    stdin_data = {
+        "session_id": "test-session",
+        "transcript_path": "test-path",
+        "cwd": str(tmp_path),
+        "hook_event_name": "WorktreeCreate",
+        "worktree_id": "agent-doc-test",
+        "worktree_path": str(tmp_path / "custom-path"),
+    }
+
+    env_mods = {"PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}"}
+
+    return_code, stdout, stderr = run_hook(stdin_data, env_mods)
+
+    assert return_code == 0, f"Hook failed with stderr: {stderr}"
+
+    assert mock_git["log_path"].exists()
+    calls = mock_git["log_path"].read_text().splitlines()
+    assert len(calls) == 1
+
+    expected_branch = "worktree-agent-doc-test"
+    expected_path = str(tmp_path / "custom-path")
+    assert (
+        f"-C {tmp_path} worktree add {expected_path} -b {expected_branch}" in calls[0]
+    )
+
+
+def test_hook_missing_required_fields(mock_git: dict, tmp_path: Path) -> None:
+    stdin_data = {
+        "session_id": "test-session",
+        "transcript_path": "test-path",
+        "cwd": str(tmp_path),
+        "hook_event_name": "WorktreeCreate",
+    }
+
+    env_mods = {"PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}"}
+
+    return_code, stdout, stderr = run_hook(stdin_data, env_mods)
+
+    assert return_code != 0
+    assert "missing cwd, worktree_id, or name" in stderr

--- a/scripts/tests/test_worktree_create_hook.py
+++ b/scripts/tests/test_worktree_create_hook.py
@@ -31,8 +31,17 @@ echo "$@" >> {calls_log}
     }
 
 
-def run_hook(stdin_data: dict, env_modifications: dict = None) -> tuple[int, str, str]:
+def run_hook(
+    stdin_data: dict, tmp_path: Path, env_modifications: dict = None
+) -> tuple[int, str, str]:
     env = os.environ.copy()
+    # Isolate HOME and XDG_CONFIG_HOME to prevent test flakiness and interference
+    # with developer's config lock file in ~/.config/pinpoint
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    env["HOME"] = str(fake_home)
+    env["XDG_CONFIG_HOME"] = str(fake_home / ".config")
+
     if env_modifications:
         env.update(env_modifications)
 
@@ -59,7 +68,7 @@ def test_hook_empirical_shape(mock_git: dict, tmp_path: Path) -> None:
 
     env_mods = {"PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}"}
 
-    return_code, stdout, stderr = run_hook(stdin_data, env_mods)
+    return_code, stdout, stderr = run_hook(stdin_data, tmp_path, env_mods)
 
     assert return_code == 0, f"Hook failed with stderr: {stderr}"
 
@@ -86,7 +95,7 @@ def test_hook_documented_shape(mock_git: dict, tmp_path: Path) -> None:
 
     env_mods = {"PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}"}
 
-    return_code, stdout, stderr = run_hook(stdin_data, env_mods)
+    return_code, stdout, stderr = run_hook(stdin_data, tmp_path, env_mods)
 
     assert return_code == 0, f"Hook failed with stderr: {stderr}"
 
@@ -111,7 +120,7 @@ def test_hook_missing_required_fields(mock_git: dict, tmp_path: Path) -> None:
 
     env_mods = {"PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}"}
 
-    return_code, stdout, stderr = run_hook(stdin_data, env_mods)
+    return_code, stdout, stderr = run_hook(stdin_data, tmp_path, env_mods)
 
     assert return_code != 0
     assert "missing cwd, worktree_id, or name" in stderr


### PR DESCRIPTION
## Summary

- Parse both documented `worktree_id`/`worktree_path` and empirical `name` hook payload shapes.
- Keep hook fail-closed if neither shape works.
- Implement comprehensive pytest unit tests for the hook script covering all payload shapes.

## Bead

PP-f4co: (BUG) WorktreeCreate hook stdin payload uses 'name' but docs say 'worktree_id'/'worktree_path'

## Verification

Commands run:

- `shellcheck .claude/hooks/worktree-create.sh`
- `python3 -m pytest scripts/tests/test_worktree_create_hook.py -v`
- `pnpm run check:linters`
- `pnpm run check`

Result: all passing.

## Notes

None.