### PR TITLE
chore(ci): tighten Supabase branch cleanup cadence 6h → 3h

### DIFF
--- a/.github/workflows/supabase-branch-cleanup.yaml
+++ b/.github/workflows/supabase-branch-cleanup.yaml
@@ -1,7 +1,7 @@
 # Supabase Branch Cleanup
 #
 # Deletes Supabase preview branch DBs for PRs that no longer have the
-# 'preview' label (or whose PR is closed). Runs every 6 hours and can be
+# 'preview' label (or whose PR is closed). Runs every 3 hours and can be
 # triggered manually.
 #
 # Required GitHub Secrets (same as supabase-branch-setup.yaml):
@@ -12,7 +12,7 @@ name: Supabase Branch Cleanup
 
 on:
   schedule:
-    - cron: '0 */6 * * *'  # every 6 hours
+    - cron: '0 */3 * * *'  # every 3 hours
   workflow_dispatch:        # manual trigger
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ Use worktree-isolated subagents for independent tasks. Tool-specific dispatch, h
 
 - Default: PRs do **not** get a usable branch DB (saves ~$0.32/day/branch).
 - Enable: add the `preview` label. Within ~5 min, `Supabase Branch Setup` GHA runs Drizzle migrations + seed.
-- Cleanup: `Supabase Branch Cleanup` cron runs every 6h.
+- Cleanup: `Supabase Branch Cleanup` cron runs every 3h.
 - Env var fallbacks in `server.ts`/`middleware.ts` cover both PinPoint and integration naming.
 
 ## 7. Documentation


### PR DESCRIPTION
## Summary
- Drops the `Supabase Branch Cleanup` cron from every 6 hours to every 3 hours.
- Realistic recovery window — if a PR doesn't get the `preview` label within a few hours of opening, it's unlikely to be labeled later, and the extra 3h of unlabeled-branch compute is wasted.
- Updates the AGENTS.md §6 note to match.

## Test plan
- [ ] CI green