### PR TITLE
feat(workflow): agy-ui label + agy-dispatch/agy-triage skills (PP-lpvv)

### DIFF
--- a/.agents/rules/AGY.md
+++ b/.agents/rules/AGY.md
@@ -13,3 +13,5 @@ This file provides workspace rules and context exclusive to the Google Antigravi
 ## Executing agy-ready Beads
 
 If Tim asks you to work an `agy-ready` bead — or to "find an agy-ready bead and take it to review" — follow `.agents/skills/pinpoint-agy-execute/SKILL.md` end-to-end. Do not skip steps. The skill covers environment verification, bead claim, implementation, verification, commit, push, PR open, CI watch, Copilot review, ready-for-review labeling, and handoff.
+
+UI beads tagged `agy-ui` require `/browser` verification at Steps 5 and 11 of the execute skill. Start Supabase and the dev server first — `/browser` grants Chrome access only, it does not start the stack.

--- a/.agents/skills/pinpoint-agy-dispatch/SKILL.md
+++ b/.agents/skills/pinpoint-agy-dispatch/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: pinpoint-agy-dispatch
+description: Run in Claude Code to hand a specific bead to Antigravity. Emits a copy-paste prompt for the Antigravity 2.0 agent manager. Does NOT create branches or worktrees — the agent manager does that from the prompt text.
+---
+
+# pinpoint-agy-dispatch
+
+**When to invoke:** Tim says "dispatch this to Antigravity", "hand PP-xxx to agy", or "pick an agy-ready bead and send it to Antigravity."
+
+Run **in Claude Code** (not in Antigravity). The output is a copy-paste prompt for the Antigravity 2.0 agent manager.
+
+---
+
+## Why this skill exists
+
+The Antigravity 2.0 agent manager derives the worktree name and branch name from the **initial prompt text**. A generic opening like "find an agy-ready bead and take it to review" produces a generic branch (e.g., `agent-find-an-agy-ready`). A specific imperative naming the bead produces a well-named branch (e.g., `implement-pp-xxxx-fix-email-field`).
+
+This skill's primary job is to ensure the first line of the emitted prompt is always a specific imperative naming the bead.
+
+---
+
+## Step 1 — Resolve the bead
+
+**If Tim gives you a bead ID:** use it directly.
+
+**If no bead ID is given:** run:
+
+```sh
+bd query "label=agy-ready AND status=open" --priority-max=2
+```
+
+Pick the top result by priority, then by ID (lexicographic tiebreak).
+
+---
+
+## Step 2 — Read the bead
+
+```sh
+bd show <id>
+```
+
+Read: title, description, acceptance criteria, labels, all comments.
+
+**Verify `agy-ready` is present.** If it is absent, stop and tell Tim:
+
+> "PP-xxx does not have the `agy-ready` label. Run the `pinpoint-agy-triage` skill to evaluate it before dispatching."
+
+**Detect `agy-ui`.** Note whether the `agy-ui` label is present — this controls whether the UI-verification block is included in the emitted prompt.
+
+---
+
+## Step 3 — Emit the copy-paste prompt
+
+Output the following fenced block for Tim to paste into the Antigravity 2.0 agent manager.
+
+**Critical formatting rule:** the very first line must be a specific imperative naming the bead ID and a concise title. The agent manager uses this line to name the worktree and branch. Do not open with "find a bead", "work on an issue", or any generic sentence.
+
+---
+
+**Prompt template (non-UI bead):**
+
+````
+```
+Implement <id>: <concise title from bead>
+
+Bead: <id> — <full bead title>
+
+Goal: <1–3 sentences in plain language describing what needs to change and why, derived from the bead description. No jargon. Write as if explaining to someone who hasn't read the bead.>
+
+Follow the `pinpoint-agy-execute` skill end-to-end. The bead is already selected — start at Step 2 (claim).
+
+Verification command: <exact command from the bead, e.g. `pnpm run check` or `pnpm exec playwright test e2e/foo.spec.ts --project=chromium`>
+```
+````
+
+---
+
+**Prompt template (UI bead — `agy-ui` label present):**
+
+````
+```
+Implement <id>: <concise title from bead>
+
+Bead: <id> — <full bead title>
+
+Goal: <1–3 sentences in plain language describing what needs to change and why, derived from the bead description.>
+
+Follow the `pinpoint-agy-execute` skill end-to-end. The bead is already selected — start at Step 2 (claim).
+
+Verification command: <exact command from the bead>
+
+UI verification (this is an `agy-ui` bead):
+
+Before opening the PR (after Step 5, before Step 8): start Supabase (`supabase start`) and the dev server (`pnpm dev`) for this worktree. The assigned port is in `.env.local` and `.claude/launch.json`. Use `/browser` to open the app at that port and confirm: <paste acceptance criteria verbatim>.
+
+After addressing Copilot review (after Step 10, before Step 11): re-run `/browser` to confirm the review changes did not break the UI.
+
+Note: `/browser` grants Chrome access only. You must start the stack manually before using it.
+```
+````
+
+---
+
+After the fenced block, add exactly one line:
+
+> Paste this into the Antigravity 2.0 agent manager to spawn a new agent. The branch name is derived from the first line.
+
+---
+
+## What this skill does NOT do
+
+- Does not create a branch or worktree (the agent manager does that).
+- Does not claim the bead or update its status (Antigravity does that at Step 2 of agy-execute).
+- Does not modify any files.
+- Does not run any tests.
+
+If Tim asks you to also triage the bead first, load the `pinpoint-agy-triage` skill.

--- a/.agents/skills/pinpoint-agy-dispatch/SKILL.md
+++ b/.agents/skills/pinpoint-agy-dispatch/SKILL.md
@@ -67,7 +67,7 @@ Bead: <id> — <full bead title>
 
 Goal: <1–3 sentences in plain language describing what needs to change and why, derived from the bead description. No jargon. Write as if explaining to someone who hasn't read the bead.>
 
-Follow the `pinpoint-agy-execute` skill end-to-end. The bead is already selected — start at Step 2 (claim).
+Follow the `pinpoint-agy-execute` skill starting at Step 1 — the bead ID is already specified, so skip the discovery query, but still run the Step 1 label-verification (`agy-ready`) and `agy-ui` detection. Then continue end-to-end (Step 2 claim onward).
 
 Verification command: <exact command from the bead, e.g. `pnpm run check` or `pnpm exec playwright test e2e/foo.spec.ts --project=chromium`>
 ```
@@ -85,7 +85,7 @@ Bead: <id> — <full bead title>
 
 Goal: <1–3 sentences in plain language describing what needs to change and why, derived from the bead description.>
 
-Follow the `pinpoint-agy-execute` skill end-to-end. The bead is already selected — start at Step 2 (claim).
+Follow the `pinpoint-agy-execute` skill starting at Step 1 — the bead ID is already specified, so skip the discovery query, but still run the Step 1 label-verification (`agy-ready`) and `agy-ui` detection. Then continue end-to-end (Step 2 claim onward).
 
 Verification command: <exact command from the bead>
 

--- a/.agents/skills/pinpoint-agy-execute/SKILL.md
+++ b/.agents/skills/pinpoint-agy-execute/SKILL.md
@@ -24,9 +24,13 @@ The Antigravity GUI creates the worktree at session launch; the `post-checkout` 
 
 ## Step 1 — Pick the bead
 
+**Dispatched via `pinpoint-agy-dispatch`:** The initial prompt names the bead explicitly (first line is a specific imperative, e.g. "Implement PP-xxx: …"). Use that bead ID. Still verify the `agy-ready` label per the rule below before proceeding.
+
 **With no bead specified:** Run `bd query "label=agy-ready AND status=open" --priority-max=2`. Pick the top result by priority, then by ID (lexicographic tiebreak). If the list is empty, tell Tim there are no tagged candidates and stop.
 
 **With a bead ID specified:** Skip the query. Verify the bead has the `agy-ready` label by running `bd show <id>` and checking the LABELS line. If the label is absent, refuse to proceed and ask Tim to confirm the bead is groomed.
+
+**Detect `agy-ui`:** Also check whether the bead carries the `agy-ui` label. If it does, browser verification is required at Steps 5 and 11 — note this now so you don't miss it later.
 
 ---
 
@@ -85,6 +89,16 @@ pnpm run preflight
 The `preflight` command is capped at 2 host-wide concurrent runs via `sem --jobs 2`. Accept the wait — do **not** use `preflight:unlocked` unless Tim explicitly says to.
 
 Fix any failures. If a failure is unrelated to your change and was pre-existing, note it in the PR description but do not abandon — fix your change so the pre-existing failure is the only one remaining, and call it out explicitly.
+
+**`agy-ui` branch:** If the bead carries the `agy-ui` label, do the following after the automated verification passes and before opening the PR (Step 8):
+
+1. Start Supabase: `supabase start`
+2. Start the dev server: `pnpm dev`
+   - The assigned port is in `.env.local` (key `NEXT_PUBLIC_APP_URL`) and `.claude/launch.json`.
+3. Use `/browser` to open the app at the worktree's port.
+4. Confirm the acceptance criteria render/behave correctly as stated in the bead.
+
+`/browser` grants Chrome access only — it does not start the stack. You must run steps 1–2 yourself before using it. If you cannot start Supabase (port collision, stuck container), stop and ask Tim.
 
 ---
 
@@ -245,6 +259,10 @@ Sign all replies with `—Antigravity` (em-dash U+2014, not a hyphen). Declined 
 ## Step 11 — Label ready-for-review
 
 Once CI is green **and** zero unresolved Copilot threads remain:
+
+**`agy-ui` branch:** Before applying the label, re-verify the UI. Copilot fixes may introduce regressions. Use `/browser` to open the app at the worktree's port and confirm the acceptance criteria still hold. If the stack is no longer running, restart it (`supabase start` + `pnpm dev`) first — `/browser` grants Chrome access only.
+
+Once UI verification passes (or the bead has no `agy-ui` label):
 
 ```
 mcp__github__update_pull_request(

--- a/.agents/skills/pinpoint-agy-execute/SKILL.md
+++ b/.agents/skills/pinpoint-agy-execute/SKILL.md
@@ -94,7 +94,7 @@ Fix any failures. If a failure is unrelated to your change and was pre-existing,
 
 1. Start Supabase: `supabase start`
 2. Start the dev server: `pnpm dev`
-   - The assigned port is in `.env.local` (key `NEXT_PUBLIC_APP_URL`) and `.claude/launch.json`.
+   - The assigned port is in `.env.local` (key `PORT`; the full URL is `NEXT_PUBLIC_SITE_URL`) and `.claude/launch.json`.
 3. Use `/browser` to open the app at the worktree's port.
 4. Confirm the acceptance criteria render/behave correctly as stated in the bead.
 

--- a/.agents/skills/pinpoint-agy-triage/SKILL.md
+++ b/.agents/skills/pinpoint-agy-triage/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: pinpoint-agy-triage
+description: Grooming skill for deciding whether to tag a bead agy-ready (and optionally agy-ui). Use during grooming sessions when evaluating whether a bead is suitable for Antigravity to execute autonomously.
+---
+
+# pinpoint-agy-triage
+
+**When to invoke:** During grooming, when Tim asks "is this agy-ready?" or "which beads can Antigravity work on?", or when running a batch triage of open work.
+
+---
+
+## What is Antigravity?
+
+Antigravity is Google's CLI agent harness (currently Gemini-based) with full local environment access — Supabase, dev server, browser via Chrome. It is **less inquisitive** than Claude Sonnet: it will not stop mid-task to ask clarifying questions. Every bead it executes must be decision-closed before it starts.
+
+Use the `agy-ready` label to mark candidates. Use the `agy-ui` label additionally for beads where acceptance requires visual or interaction verification in a running browser.
+
+---
+
+## Triage Gates
+
+**ALL six gates must pass** before tagging `agy-ready`. Failing even one gate means the bead is not ready — do not tag.
+
+### Gate 1 — Decision-closed (load-bearing)
+
+No "discuss with user", no architectural forks, no TBDs. Every interpretive choice has a written answer in the bead description, acceptance criteria, or a linked decision bead.
+
+If the bead has "Option A / Option B / Option C" branches with no chosen winner, it is NOT ready. Antigravity will pick the first plausible option and ship it.
+
+### Gate 2 — Scope-pinned
+
+Specific files, or an unambiguous "do X wherever pattern Y appears" instruction. Acceptance criteria must be writable as concrete test assertions.
+
+### Gate 3 — Concrete acceptance
+
+End-state is testable with objective evidence:
+
+- "X test passes"
+- "Y string no longer in repo"
+- "form has `type=email autocomplete=email`"
+- "DB constraint rejects bad insert"
+- "component renders `<element>` at viewport ≥ md"
+
+NOT acceptable: "improve UX", "make it cleaner", "looks better."
+
+### Gate 4 — Concrete verification plan
+
+The bead names the exact command(s) to run:
+
+- `pnpm run check`
+- `pnpm run preflight`
+- `pnpm exec playwright test e2e/path/file.spec.ts --project=chromium`
+
+If verification requires CI (e.g., a Supabase branch DB), say so explicitly in the bead.
+
+### Gate 5 — UI eligibility
+
+UI beads **are** eligible for Antigravity. Antigravity can drive a Chrome browser to verify visual changes.
+
+**Tag `agy-ui` when:** the bead changes rendered output (component, page, layout, styling, or interaction) and the acceptance criteria are only confirmable by looking at or interacting with the running UI.
+
+**Do NOT tag `agy-ui` for:** pure logic, scripts, tests, docs, or changes whose acceptance is fully captured by a passing test or absent string.
+
+Gates 1–3 still apply to UI beads. "Does this look right?" beads fail Gate 3 (no concrete acceptance). Pre-approved mockups with exact dimensions or a linked design-bible section satisfy Gate 1 + Gate 3 together.
+
+### Gate 6 — Self-contained
+
+No dependency on an open PR, no cross-bead coordination, no waiting on a teammate.
+
+---
+
+## Workflow
+
+### Tagging
+
+When all gates pass:
+
+```sh
+bd label add agy-ready <id>
+```
+
+If the bead also satisfies the `agy-ui` condition (Gate 5):
+
+```sh
+bd label add agy-ui <id>
+```
+
+Append a one-line fit note explaining why it passes — this helps the next grooming pass confirm the tag is still valid:
+
+```sh
+bd comment <id> 'agy-ready: <one-line fit note>'
+# e.g.: 'agy-ready: scope-pinned to auth form fields; pnpm run check verification; no open decisions'
+# e.g.: 'agy-ready + agy-ui: icon swap in MachineCard; visual confirmation needed; exact target is the wrench icon → cog icon per design-bible §12'
+```
+
+### When a gate fails but is fixable
+
+If a gate fails due to a missing verification plan, an undecided UI detail, or an open Option A/B fork, leave a comment describing the gap instead of tagging:
+
+```sh
+bd comment <id> 'agy-candidate but not ready: missing verification command. Add the exact pnpm command to run after implementation.'
+```
+
+Do not tag `agy-ready` — surface for refinement.
+
+### Discovering candidates
+
+```sh
+bd query "label=agy-ready AND status=open" --priority-max=2
+```
+
+The `--priority-max=2` filter is a heuristic — P1/P2 beads first. Remove it to see all priorities.
+
+### Post-execution
+
+After Antigravity ships a PR, treat it like any other agent PR: Copilot review, CI, ready-for-review label, then Tim merges. No special handling needed.
+
+---
+
+## When in doubt, default to FAIL
+
+Under-tagging is safe — Antigravity just has fewer candidates to pick from.
+
+Over-tagging causes Antigravity to make judgment calls it was never meant to make, silently shipping wrong choices.
+
+If a gate is ambiguous, leave a `bd comment` describing the gap and skip the tag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,19 +42,22 @@
 
 Load relevant skills for every task. If your tool doesn't support skills, read the file directly. All skills live at `.agents/skills/<name>/SKILL.md`.
 
-| Category   | Skill                            | When to use                                         |
-| :--------- | :------------------------------- | :-------------------------------------------------- |
-| UI         | `pinpoint-ui`                    | Components, shadcn/ui, forms, responsive design     |
-| UI         | `pinpoint-design-bible`          | Design system, page archetypes, spacing, surfaces   |
-| TypeScript | `pinpoint-typescript`            | Type errors, generics, Drizzle types                |
-| Testing    | `pinpoint-testing`               | Writing tests, PGlite, test-layer decisions         |
-| Testing    | `pinpoint-e2e`                   | E2E tests, worker isolation, Playwright stability   |
-| Security   | `pinpoint-security`              | Auth, CSP, Zod, Supabase SSR                        |
-| Patterns   | `pinpoint-patterns`              | Server Actions, data fetching, architecture         |
-| Workflow   | `pinpoint-briefing`              | Session-start health review                         |
-| Workflow   | `pinpoint-pr-workflow`           | Full PR lifecycle: commit, push, CI, Copilot, merge |
-| Workflow   | `pinpoint-orchestrator`          | Parallel subagent work in worktrees                 |
-| Workflow   | `pinpoint-dispatch-e2e-teammate` | Dispatching a teammate end-to-end                   |
+| Category    | Skill                            | When to use                                                     |
+| :---------- | :------------------------------- | :-------------------------------------------------------------- |
+| UI          | `pinpoint-ui`                    | Components, shadcn/ui, forms, responsive design                 |
+| UI          | `pinpoint-design-bible`          | Design system, page archetypes, spacing, surfaces               |
+| TypeScript  | `pinpoint-typescript`            | Type errors, generics, Drizzle types                            |
+| Testing     | `pinpoint-testing`               | Writing tests, PGlite, test-layer decisions                     |
+| Testing     | `pinpoint-e2e`                   | E2E tests, worker isolation, Playwright stability               |
+| Security    | `pinpoint-security`              | Auth, CSP, Zod, Supabase SSR                                    |
+| Patterns    | `pinpoint-patterns`              | Server Actions, data fetching, architecture                     |
+| Workflow    | `pinpoint-briefing`              | Session-start health review                                     |
+| Workflow    | `pinpoint-pr-workflow`           | Full PR lifecycle: commit, push, CI, Copilot, merge             |
+| Workflow    | `pinpoint-orchestrator`          | Parallel subagent work in worktrees                             |
+| Workflow    | `pinpoint-dispatch-e2e-teammate` | Dispatching a teammate end-to-end                               |
+| Antigravity | `pinpoint-agy-triage`            | Grooming: evaluate whether a bead is agy-ready/agy-ui           |
+| Antigravity | `pinpoint-agy-dispatch`          | Emit an Antigravity copy-paste prompt for a chosen bead         |
+| Antigravity | `pinpoint-agy-execute`           | Runbook for Antigravity to execute an agy-ready bead end-to-end |
 
 ## 4. Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,28 +75,10 @@ See `pinpoint-orchestrator` skill for the full workflow and known-bug details.
 
 The `TeammateIdle` hook enforces push-before-idle automatically for teammates. The manual "Landing the Plane" checklist in AGENTS.md applies to the lead agent and solo sessions.
 
-### Antigravity Candidates
+### Antigravity
 
-Some work is well-suited for Antigravity — Google's CLI agent harness (currently Gemini), which has full local environment access (Supabase, dev server, browser via Playwright) but is **less inquisitive** than Claude Sonnet. Because Antigravity won't stop mid-task to ask clarifying questions, every bead it executes must be decision-closed before it starts.
+Antigravity is Google's CLI agent harness (currently Gemini) with full local environment access. Beads tagged `agy-ready` are cleared for autonomous execution; `agy-ui` additionally marks beads whose acceptance requires browser verification.
 
-Tag those issues with the `agy-ready` label so they're easy to discover and dispatch. Follow `.agents/skills/pinpoint-agy-execute/SKILL.md` to drive a tagged bead end-to-end to ready-for-review from an Antigravity session.
-
-> Commands below use `bd` (the [beads](https://github.com/timothyfroehlich/beads) issue tracker that PinPoint uses for task management — the full command reference is loaded at session start via the `bd prime` hook). `<id>` refers to a beads issue ID like `PP-3or`.
-
-**Triage gates — ALL must pass before tagging `agy-ready`:**
-
-1. **Decision-closed (iron).** No "discuss with user", no architectural forks, no TBDs. Every interpretive choice has a written answer in the bead description, acceptance criteria, or a linked decision bead. If the bead has "Option A / Option B / Option C" branches with no chosen winner, it is NOT ready. (This is the load-bearing gate — Antigravity will pick the first plausible option and ship it.)
-2. **Scope-pinned.** Specific files, or unambiguous "do X wherever pattern Y appears" instructions. Acceptance criteria must be writable as concrete test assertions.
-3. **Concrete acceptance.** End-state is testable: "X test passes", "Y string no longer in repo", "form has `type=email autocomplete=email`", "DB constraint rejects bad insert". Not "improve UX", not "make it cleaner".
-4. **Concrete verification plan.** Bead names the exact command(s) to run: `pnpm run check`, `pnpm run preflight`, `pnpm exec playwright test e2e/path/file.spec.ts --project=chromium`. If verification needs CI (e.g., Supabase branch DB), say so explicitly.
-5. **UI work is mechanical OR pre-approved.** Rename, prop rewire, copy change, icon swap, class addition (`motion-reduce:`), `aria-foo` add, delete dead element. Or: pre-approved mockup / exact dimensions / linked design bible section. NO "does this look right?" judgment.
-6. **Self-contained.** No dependency on an open PR, no cross-bead coordination, no waiting on a teammate.
-
-**Workflow:**
-
-- Tag during grooming: `bd label add agy-ready <id>` and append a one-line fit note.
-- If a fixable gate fails (missing verification plan, undecided UI, open Option A/B fork), leave a `bd comment` describing the gap instead of tagging — surface for refinement.
-- Discover candidates: `bd query "label=agy-ready AND status=open" --priority-max=2` (priority filter is a heuristic — pick P1/P2 first).
-- After Antigravity ships a PR, treat it like any other agent PR: Copilot review, CI, ready-for-review label, then Tim merges.
-
-**When in doubt, default to FAIL.** Under-tagging is safe — Antigravity just has fewer candidates to pick from. Over-tagging causes Antigravity to make judgment calls it was never meant to make, silently shipping wrong choices. If a gate is ambiguous, add a `bd comment` describing the gap and skip the tag.
+- **Triage gates and tagging workflow:** `pinpoint-agy-triage` skill.
+- **Handing a bead to Antigravity:** `pinpoint-agy-dispatch` skill (run in Claude Code; emits a copy-paste prompt for the Antigravity 2.0 agent manager).
+- **Executing a bead inside Antigravity:** `pinpoint-agy-execute` skill.


### PR DESCRIPTION
## Summary

- New `pinpoint-agy-triage` skill: extracts the Antigravity candidate-tagging criteria from `CLAUDE.md` into a grooming-focused skill; rewrites gate 5 to allow UI beads (tagged `agy-ui`) for browser-verified acceptance
- New `pinpoint-agy-dispatch` skill: run in Claude Code to emit a bead-specific copy-paste prompt for the Antigravity 2.0 agent manager; first line is always a specific imperative so the branch name is derived from the bead, not from "find an agy-ready bead"
- Updates `pinpoint-agy-execute`: adds `agy-ui` branch to Steps 1, 5, and 11; clarifies that `/browser` grants Chrome access only and the stack (Supabase + dev server) must be started manually before using it
- Slims `CLAUDE.md` Antigravity section from 25 lines to 4-line pointer; adds Antigravity skill rows to `AGENTS.md` §3 table; adds `agy-ui` one-liner to `AGY.md`

## Bead

PP-lpvv

## Verification

Commands run:

- `pnpm run check`

Result: all passing (127 test files, 1150 tests).

## Notes

This is a docs/skills-only change — no product code modified.