### PR TITLE
feat(huddle): auto-post coordination notices on PR merge + PR open (PP-uq5i)

### DIFF
--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -173,7 +173,17 @@ Edit `.claude/settings.json` and update `HUDDLE_THROTTLE_SECONDS=180` on the Pos
 
 ## How to post coordination updates
 
-Post to today's active bead. To find today's bead ID, check what the session-start hook reported, or look up via (huddle state lives at `<main-worktree>/.agents/huddle/`, resolved via `git rev-parse --git-common-dir` — `huddle-lib.sh` itself uses the same lookup):
+**Two events are auto-posted — you don't need to post these manually:**
+
+- **Merge** (`scripts/workflow/merge-pr.sh`): after a squash-merge succeeds, the script posts "Merged PR #N (PP-xxx): title. Sync main if you have active branches." to today's bead.
+- **PR opened** (`scripts/hooks/huddle-pr-announce.sh` PostToolUse hook): when you call `gh pr create` (Bash) or `mcp__github__create_pull_request`, the hook auto-posts "Opened PR #N (PP-xxx): title." Dedup-safe — re-fires are ignored.
+
+**What still requires a manual post** (the judgment calls automation can't make):
+
+- A bead you filed for a non-obvious finding: "Filed PP-xxx: <finding>."
+- A coordination need — file/area conflict risk: "Working on <file/area> in <branch>; flag if conflict."
+
+To post, find today's bead ID (the session-start hook reported it, or look it up):
 
     HUDDLE_DIR="$(dirname "$(git rev-parse --git-common-dir)")/.agents/huddle"
     bd show "$(jq -r '.root_bead_id' "$HUDDLE_DIR/config.json")" --json | jq -r '.[0].notes | fromjson | .today_bead.id'
@@ -182,32 +192,26 @@ Then post:
 
     bd comments add <TODAY_BEAD_ID> "Your update here. —<YourName>"
 
-Things worth posting:
-
-- A PR you merged ("Merged PR #N (PP-xxx). Sync main if you have active branches.")
-- A PR you opened ("Opened PR #N (PP-xxx): brief title.")
-- A bead you filed for a non-obvious finding ("Filed PP-xxx: <finding>.")
-- A coordination need ("Working on file Y in branch Z; flag if conflict.")
-
 Things NOT worth posting:
 
 - Every single commit
 - Internal debugging chatter
-- "I started working on X" (only post merge/discovery)
+- "I started working on X" (merges and PR-opens are already auto-posted)
 
 Sign with `—<YourFullRegisteredName>` (em-dash + your registered name). The self-filter matches this suffix to suppress your own echoes.
 
 ## Scripts
 
-| Script                                   | Trigger                                    | Purpose                                                             |
-| ---------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
-| `scripts/hooks/huddle-bootstrap.sh`      | manual (one-time)                          | Init root epic + daily + monthly + config.json                      |
-| `scripts/hooks/huddle-rotate.sh`         | rotation subagent                          | Phase A: atomic create-and-pointer-update; outputs OLD/NEW bead IDs |
-| `scripts/hooks/huddle-poll.sh`           | UserPromptSubmit + PostToolUse (throttled) | Inject new today_bead comments since last_seen                      |
-| `scripts/hooks/huddle-session-start.sh`  | SessionStart                               | Bootstrap notice, rotation notice, identity, summary injection      |
-| `scripts/hooks/huddle-whoami.sh`         | manual                                     | Register/lookup/list/discover session→name mappings                 |
-| `scripts/hooks/huddle-rotation-check.sh` | sourced by both hooks                      | Date-compare: returns 0 if today_bead.date < today                  |
-| `scripts/hooks/huddle-lib.sh`            | sourced by all hooks                       | Shared helpers (state-dir resolver)                                 |
+| Script                                   | Trigger                                              | Purpose                                                             |
+| ---------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
+| `scripts/hooks/huddle-bootstrap.sh`      | manual (one-time)                                    | Init root epic + daily + monthly + config.json                      |
+| `scripts/hooks/huddle-rotate.sh`         | rotation subagent                                    | Phase A: atomic create-and-pointer-update; outputs OLD/NEW bead IDs |
+| `scripts/hooks/huddle-poll.sh`           | UserPromptSubmit + PostToolUse (throttled)           | Inject new today_bead comments since last_seen                      |
+| `scripts/hooks/huddle-session-start.sh`  | SessionStart                                         | Bootstrap notice, rotation notice, identity, summary injection      |
+| `scripts/hooks/huddle-pr-announce.sh`    | PostToolUse (Bash\|mcp**github**create_pull_request) | Auto-post PR-open notice; dedup + fail-open                         |
+| `scripts/hooks/huddle-whoami.sh`         | manual                                               | Register/lookup/list/discover session→name mappings                 |
+| `scripts/hooks/huddle-rotation-check.sh` | sourced by both hooks                                | Date-compare: returns 0 if today_bead.date < today                  |
+| `scripts/hooks/huddle-lib.sh`            | sourced by all hooks                                 | Shared helpers (state-dir resolver, today-bead ID resolver)         |
 
 ## State files
 

--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -202,16 +202,16 @@ Sign with `—<YourFullRegisteredName>` (em-dash + your registered name). The se
 
 ## Scripts
 
-| Script                                   | Trigger                                              | Purpose                                                             |
-| ---------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
-| `scripts/hooks/huddle-bootstrap.sh`      | manual (one-time)                                    | Init root epic + daily + monthly + config.json                      |
-| `scripts/hooks/huddle-rotate.sh`         | rotation subagent                                    | Phase A: atomic create-and-pointer-update; outputs OLD/NEW bead IDs |
-| `scripts/hooks/huddle-poll.sh`           | UserPromptSubmit + PostToolUse (throttled)           | Inject new today_bead comments since last_seen                      |
-| `scripts/hooks/huddle-session-start.sh`  | SessionStart                                         | Bootstrap notice, rotation notice, identity, summary injection      |
-| `scripts/hooks/huddle-pr-announce.sh`    | PostToolUse (Bash\|mcp**github**create_pull_request) | Auto-post PR-open notice; dedup + fail-open                         |
-| `scripts/hooks/huddle-whoami.sh`         | manual                                               | Register/lookup/list/discover session→name mappings                 |
-| `scripts/hooks/huddle-rotation-check.sh` | sourced by both hooks                                | Date-compare: returns 0 if today_bead.date < today                  |
-| `scripts/hooks/huddle-lib.sh`            | sourced by all hooks                                 | Shared helpers (state-dir resolver, today-bead ID resolver)         |
+| Script                                   | Trigger                                                  | Purpose                                                             |
+| ---------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------- |
+| `scripts/hooks/huddle-bootstrap.sh`      | manual (one-time)                                        | Init root epic + daily + monthly + config.json                      |
+| `scripts/hooks/huddle-rotate.sh`         | rotation subagent                                        | Phase A: atomic create-and-pointer-update; outputs OLD/NEW bead IDs |
+| `scripts/hooks/huddle-poll.sh`           | UserPromptSubmit + PostToolUse (throttled)               | Inject new today_bead comments since last_seen                      |
+| `scripts/hooks/huddle-session-start.sh`  | SessionStart                                             | Bootstrap notice, rotation notice, identity, summary injection      |
+| `scripts/hooks/huddle-pr-announce.sh`    | PostToolUse (`Bash`\|`mcp__github__create_pull_request`) | Auto-post PR-open notice; dedup + fail-open                         |
+| `scripts/hooks/huddle-whoami.sh`         | manual                                                   | Register/lookup/list/discover session→name mappings                 |
+| `scripts/hooks/huddle-rotation-check.sh` | sourced by both hooks                                    | Date-compare: returns 0 if today_bead.date < today                  |
+| `scripts/hooks/huddle-lib.sh`            | sourced by all hooks                                     | Shared helpers (state-dir resolver, today-bead ID resolver)         |
 
 ## State files
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,16 @@
         ]
       },
       {
+        "matcher": "Bash|mcp__github__create_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/scripts/hooks/huddle-pr-announce.sh",
+            "timeout": 10000
+          }
+        ]
+      },
+      {
         "hooks": [
           {
             "type": "command",

--- a/scripts/hooks/huddle-lib.sh
+++ b/scripts/hooks/huddle-lib.sh
@@ -39,3 +39,33 @@ huddle_state_dir() {
   main_root=$(dirname "$abs_common")
   printf '%s/.agents/huddle' "$main_root"
 }
+
+# huddle_today_bead_id — print the ID of today's active coordination bead.
+# Returns 0 on success (and prints the ID), non-zero + empty on any failure.
+# Fail-open: callers MUST treat a non-zero return as "skip quietly".
+#
+# Resolution path:
+#   huddle_state_dir → config.json → root_bead_id → `bd show` root notes JSON
+#   → .today_bead.id
+#
+# shellcheck disable=SC2317  # function is sourced and called by callers
+huddle_today_bead_id() {
+  local state_dir config_file root_id notes_str today_id
+  state_dir=$(huddle_state_dir) || return 1
+  config_file="$state_dir/config.json"
+  [[ -f "$config_file" ]] || return 1
+  root_id=$(jq -r '.root_bead_id // ""' "$config_file" 2>/dev/null) || return 1
+  [[ -n "$root_id" ]] || return 1
+  notes_str=$(bd show "$root_id" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null) || return 1
+  [[ -n "$notes_str" ]] || return 1
+  today_id=$(printf '%s' "$notes_str" | python3 -c "
+import sys, json
+try:
+    n = json.loads(sys.stdin.read())
+    print(n.get('today_bead', {}).get('id', ''))
+except Exception:
+    print('')
+" 2>/dev/null) || return 1
+  [[ -n "$today_id" ]] || return 1
+  printf '%s' "$today_id"
+}

--- a/scripts/hooks/huddle-pr-announce.sh
+++ b/scripts/hooks/huddle-pr-announce.sh
@@ -11,15 +11,15 @@
 #   1. Bash: command matches `gh pr create` and stdout contains a /pull/N URL.
 #   2. MCP:  tool_name == mcp__github__create_pull_request, response has .number/.html_url/.title.
 #
-# Dedup: skips posting if today's bead comments already mention "PR #N".
+# Dedup: skips posting if today's bead comments already mention "PR #N" (word-bounded).
 #
 # HUDDLE_DRY_RUN=1: print the would-post text to stdout instead of calling bd.
 #   Used by test_huddle_pr_announce.py.
 
 set -euo pipefail
 
-# Fail-open on missing dependencies.
-for dep in jq python3; do
+# Fail-open on missing dependencies (including bd).
+for dep in jq python3 bd; do
   command -v "$dep" >/dev/null 2>&1 || exit 0
 done
 
@@ -31,96 +31,81 @@ fi
 
 [[ -n "$INPUT" ]] || exit 0
 
-# --- CHEAP EARLY-EXIT: bail unless this is a PR create ---
-# Parse tool_name from stdin. Use python3 for correctness (jq may not handle
-# escaped chars in tool_response reliably). Any parse failure → exit 0.
-TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "
+# --- Parse all fields in one python3 invocation (fast path) ---
+# Outputs five fields separated by ASCII STX (\x02), a non-whitespace, non-printable
+# byte that won't appear in JSON string values (tool names, PR numbers, PR titles are
+# all safe). STX avoids bash's IFS whitespace-collapsing on empty fields.
+# Fields: tool_name STX tool_cmd STX pr_number STX pr_title STX resp_output
+# Any parse failure → five STX → all variables empty → exit 0 at case statement.
+_PARSED=$(printf '%s' "$INPUT" | python3 -c "
 import sys, json
+SEP = chr(2)  # STX — non-whitespace, not in JSON values
 try:
-    print(json.load(sys.stdin).get('tool_name') or '')
+    d = json.load(sys.stdin)
+    tool_name = d.get('tool_name') or ''
+    tool_input = d.get('tool_input') or {}
+    tool_cmd = tool_input.get('command') or '' if isinstance(tool_input, dict) else ''
+    resp = d.get('tool_response') or {}
+
+    pr_number = ''
+    pr_title = ''
+    resp_output = ''
+
+    if tool_name == 'mcp__github__create_pull_request':
+        if isinstance(resp, str):
+            try:
+                resp = json.loads(resp)
+            except Exception:
+                resp = {}
+        if isinstance(resp, dict):
+            pr_number = str(resp.get('number') or resp.get('pullRequest', {}).get('number') or '')
+            pr_title = str(resp.get('title') or resp.get('pullRequest', {}).get('title') or '')
+    elif tool_name == 'Bash':
+        if isinstance(resp, dict):
+            resp_output = str(resp.get('output') or resp.get('stdout') or '')
+        elif resp is not None:
+            resp_output = str(resp)
+
+    print(SEP.join([tool_name, tool_cmd, pr_number, pr_title, resp_output]))
 except Exception:
-    print('')
+    print(SEP.join(['', '', '', '', '']))
 " 2>/dev/null) || exit 0
 
+# Use STX (\x02) as IFS — it is a non-whitespace byte, so bash `read` treats
+# consecutive STX chars as separate empty fields (no collapsing).
+# Compatible with bash 3.2 (macOS default) since it requires no `mapfile`.
+_STX=$(printf '\002')
+OLD_IFS="$IFS"
+IFS="$_STX"
+# shellcheck disable=SC2162  # -r is intentional; IFS is set above
+read -r TOOL_NAME TOOL_CMD PR_NUMBER PR_TITLE TOOL_RESPONSE <<< "$_PARSED"
+IFS="$OLD_IFS"
+
+# --- CHEAP EARLY-EXIT: bail unless this is a PR create ---
 case "$TOOL_NAME" in
   mcp__github__create_pull_request)
-    # MCP path — proceed to parse below
+    # MCP path — PR_NUMBER and PR_TITLE already populated above
     ;;
   Bash)
     # Only proceed if the command looks like `gh pr create`
-    TOOL_CMD=$(printf '%s' "$INPUT" | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    cmd = d.get('tool_input', {}).get('command') or ''
-    print(cmd)
-except Exception:
-    print('')
-" 2>/dev/null) || exit 0
     case "$TOOL_CMD" in
       *"gh pr create"*) ;;
       *) exit 0 ;;
     esac
+    # Only proceed on success: output must contain a GitHub pull URL
+    case "$TOOL_RESPONSE" in
+      *"github.com/"*"/pull/"*);;
+      *) exit 0 ;;
+    esac
+    # Parse PR number from the URL in the output
+    PR_NUMBER=$(printf '%s' "$TOOL_RESPONSE" | grep -oE '/pull/([0-9]+)' | head -1 | grep -oE '[0-9]+' || echo "")
+    # Title is not in the gh pr create stdout; bead ID won't be parsed for this shape.
+    PR_TITLE=""
     ;;
   *)
     exit 0
     ;;
 esac
-
-# --- Parse PR number and title from tool response ---
-PR_NUMBER=""
-PR_TITLE=""
-
-if [[ "$TOOL_NAME" == "mcp__github__create_pull_request" ]]; then
-  # MCP shape: tool_response is a JSON object with .number, .html_url, .title
-  PR_NUMBER=$(printf '%s' "$INPUT" | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    resp = d.get('tool_response') or {}
-    if isinstance(resp, str):
-        resp = json.loads(resp)
-    print(resp.get('number') or resp.get('pullRequest', {}).get('number') or '')
-except Exception:
-    print('')
-" 2>/dev/null) || PR_NUMBER=""
-  PR_TITLE=$(printf '%s' "$INPUT" | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    resp = d.get('tool_response') or {}
-    if isinstance(resp, str):
-        resp = json.loads(resp)
-    print(resp.get('title') or resp.get('pullRequest', {}).get('title') or '')
-except Exception:
-    print('')
-" 2>/dev/null) || PR_TITLE=""
-else
-  # Bash shape: parse /pull/N URL from tool_response (stdout of gh pr create)
-  TOOL_RESPONSE=$(printf '%s' "$INPUT" | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    resp = d.get('tool_response') or {}
-    # tool_response may be a dict with 'output' or 'stdout', or a string directly
-    if isinstance(resp, dict):
-        print(resp.get('output') or resp.get('stdout') or '')
-    else:
-        print(str(resp))
-except Exception:
-    print('')
-" 2>/dev/null) || TOOL_RESPONSE=""
-
-  # Only proceed on success: output must contain a GitHub pull URL
-  case "$TOOL_RESPONSE" in
-    *"github.com/"*"/pull/"*);;
-    *) exit 0 ;;
-  esac
-
-  PR_NUMBER=$(printf '%s' "$TOOL_RESPONSE" | grep -oE '/pull/([0-9]+)' | head -1 | grep -oE '[0-9]+' || echo "")
-  # Title is not in the gh pr create stdout; bead ID won't be parsed for this shape.
-  PR_TITLE=""
-fi
 
 # Bail if we couldn't parse a PR number
 [[ -n "$PR_NUMBER" ]] || exit 0
@@ -134,15 +119,18 @@ TODAY_BEAD=$(huddle_today_bead_id 2>/dev/null) || exit 0
 [[ -n "$TODAY_BEAD" ]] || exit 0
 
 # --- Dedup: skip if today's bead already mentions this PR ---
-EXISTING=$(bd comments "$TODAY_BEAD" --json 2>/dev/null | jq -r '.[].text' 2>/dev/null | grep -F "PR #${PR_NUMBER}" || echo "")
+# Use word-boundary grep to avoid PR #12 false-matching inside PR #123.
+# Fail-open: if bd or jq error, skip dedup and proceed to post.
+EXISTING=$(bd comments "$TODAY_BEAD" --json 2>/dev/null | jq -r '.[].text' 2>/dev/null | grep -E "PR #${PR_NUMBER}([^0-9]|$)" || echo "")
 if [[ -n "$EXISTING" ]]; then
   exit 0
 fi
 
 # --- Parse PinPoint bead ID from PR title (convention: trailing "(PP-xxx)") ---
+# Bead IDs may include dots (e.g. PP-yxw.9), so allow [a-z0-9.] in the capture.
 BEAD_ID=""
 if [[ -n "$PR_TITLE" ]]; then
-  BEAD_ID=$(printf '%s' "$PR_TITLE" | grep -oE '\(PP-[a-z0-9]+\)' | tail -1 | tr -d '()' || echo "")
+  BEAD_ID=$(printf '%s' "$PR_TITLE" | grep -oE '\(PP-[a-z0-9.]+\)' | tail -1 | tr -d '()' || echo "")
 fi
 
 BEAD_PART=""

--- a/scripts/hooks/huddle-pr-announce.sh
+++ b/scripts/hooks/huddle-pr-announce.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# huddle-pr-announce.sh — PostToolUse hook: announce newly-opened PRs to the
+# huddle coordination bead.
+#
+# Fires on EVERY PostToolUse call (matcher: Bash|mcp__github__create_pull_request).
+# Must be FAST and FAIL-OPEN: it must never block a tool call, never error visibly,
+# and must exit quickly when the tool is not a PR create.
+#
+# Supported tool shapes:
+#   1. Bash: command matches `gh pr create` and stdout contains a /pull/N URL.
+#   2. MCP:  tool_name == mcp__github__create_pull_request, response has .number/.html_url/.title.
+#
+# Dedup: skips posting if today's bead comments already mention "PR #N".
+#
+# HUDDLE_DRY_RUN=1: print the would-post text to stdout instead of calling bd.
+#   Used by test_huddle_pr_announce.py.
+
+set -euo pipefail
+
+# Fail-open on missing dependencies.
+for dep in jq python3; do
+  command -v "$dep" >/dev/null 2>&1 || exit 0
+done
+
+# --- Read stdin JSON (best-effort, fail-open) ---
+INPUT=""
+if [[ ! -t 0 ]]; then
+  IFS= read -r -d '' INPUT || true
+fi
+
+[[ -n "$INPUT" ]] || exit 0
+
+# --- CHEAP EARLY-EXIT: bail unless this is a PR create ---
+# Parse tool_name from stdin. Use python3 for correctness (jq may not handle
+# escaped chars in tool_response reliably). Any parse failure → exit 0.
+TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('tool_name') or '')
+except Exception:
+    print('')
+" 2>/dev/null) || exit 0
+
+case "$TOOL_NAME" in
+  mcp__github__create_pull_request)
+    # MCP path — proceed to parse below
+    ;;
+  Bash)
+    # Only proceed if the command looks like `gh pr create`
+    TOOL_CMD=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    cmd = d.get('tool_input', {}).get('command') or ''
+    print(cmd)
+except Exception:
+    print('')
+" 2>/dev/null) || exit 0
+    case "$TOOL_CMD" in
+      *"gh pr create"*) ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# --- Parse PR number and title from tool response ---
+PR_NUMBER=""
+PR_TITLE=""
+
+if [[ "$TOOL_NAME" == "mcp__github__create_pull_request" ]]; then
+  # MCP shape: tool_response is a JSON object with .number, .html_url, .title
+  PR_NUMBER=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    resp = d.get('tool_response') or {}
+    if isinstance(resp, str):
+        resp = json.loads(resp)
+    print(resp.get('number') or resp.get('pullRequest', {}).get('number') or '')
+except Exception:
+    print('')
+" 2>/dev/null) || PR_NUMBER=""
+  PR_TITLE=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    resp = d.get('tool_response') or {}
+    if isinstance(resp, str):
+        resp = json.loads(resp)
+    print(resp.get('title') or resp.get('pullRequest', {}).get('title') or '')
+except Exception:
+    print('')
+" 2>/dev/null) || PR_TITLE=""
+else
+  # Bash shape: parse /pull/N URL from tool_response (stdout of gh pr create)
+  TOOL_RESPONSE=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    resp = d.get('tool_response') or {}
+    # tool_response may be a dict with 'output' or 'stdout', or a string directly
+    if isinstance(resp, dict):
+        print(resp.get('output') or resp.get('stdout') or '')
+    else:
+        print(str(resp))
+except Exception:
+    print('')
+" 2>/dev/null) || TOOL_RESPONSE=""
+
+  # Only proceed on success: output must contain a GitHub pull URL
+  case "$TOOL_RESPONSE" in
+    *"github.com/"*"/pull/"*);;
+    *) exit 0 ;;
+  esac
+
+  PR_NUMBER=$(printf '%s' "$TOOL_RESPONSE" | grep -oE '/pull/([0-9]+)' | head -1 | grep -oE '[0-9]+' || echo "")
+  # Title is not in the gh pr create stdout; bead ID won't be parsed for this shape.
+  PR_TITLE=""
+fi
+
+# Bail if we couldn't parse a PR number
+[[ -n "$PR_NUMBER" ]] || exit 0
+
+# --- State directory and today's bead ---
+LIB_SCRIPT="$(dirname "$0")/huddle-lib.sh"
+[[ -f "$LIB_SCRIPT" ]] || exit 0
+# shellcheck source=huddle-lib.sh disable=SC1091
+source "$LIB_SCRIPT"
+TODAY_BEAD=$(huddle_today_bead_id 2>/dev/null) || exit 0
+[[ -n "$TODAY_BEAD" ]] || exit 0
+
+# --- Dedup: skip if today's bead already mentions this PR ---
+EXISTING=$(bd comments "$TODAY_BEAD" --json 2>/dev/null | jq -r '.[].text' 2>/dev/null | grep -F "PR #${PR_NUMBER}" || echo "")
+if [[ -n "$EXISTING" ]]; then
+  exit 0
+fi
+
+# --- Parse PinPoint bead ID from PR title (convention: trailing "(PP-xxx)") ---
+BEAD_ID=""
+if [[ -n "$PR_TITLE" ]]; then
+  BEAD_ID=$(printf '%s' "$PR_TITLE" | grep -oE '\(PP-[a-z0-9]+\)' | tail -1 | tr -d '()' || echo "")
+fi
+
+BEAD_PART=""
+[[ -n "$BEAD_ID" ]] && BEAD_PART=" ($BEAD_ID)"
+TITLE_PART=""
+[[ -n "$PR_TITLE" ]] && TITLE_PART=": $PR_TITLE"
+
+SIGN="${HUDDLE_NAME:-huddle-auto}"
+MSG="Opened PR #${PR_NUMBER}${BEAD_PART}${TITLE_PART}. —${SIGN}"
+
+# --- Post (or dry-run) ---
+if [[ "${HUDDLE_DRY_RUN:-}" == "1" ]]; then
+  printf '%s\n' "$MSG"
+  exit 0
+fi
+
+bd comments add "$TODAY_BEAD" "$MSG" >/dev/null 2>&1 || true
+
+exit 0

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -178,6 +178,14 @@ if [[ -n "$NAME" ]]; then
   printf 'Registered as: **%s** (self-filter active for your own posts)\n\n' "$NAME"
   printf 'If this scrolls out of context later, recall your name with:\n'
   printf '    bash scripts/hooks/huddle-whoami.sh whoami %s\n\n' "$SESSION_ID"
+  # Resolve today_bead_id for the copy-paste command (fail-open: fall back to placeholder)
+  _TODAY_ID_REG=$(huddle_today_bead_id 2>/dev/null) || _TODAY_ID_REG="<today-bead-id>"
+  [[ -n "$_TODAY_ID_REG" ]] || _TODAY_ID_REG="<today-bead-id>"
+  printf 'Post a coordination update when you:\n'
+  printf '  - File a bead for a non-obvious finding: "Filed PP-xxx: <finding>. —<YourName>"\n'
+  printf '  - Touch an area others may conflict on: "Working on <file/area> in <branch>; flag if conflict. —<YourName>"\n'
+  printf '  (Merges and PR opens are auto-posted — no manual action needed for those.)\n\n'
+  printf '    bd comments add %s "Your update. —%s"\n\n' "$_TODAY_ID_REG" "$NAME"
   # shellcheck disable=SC2016  # backticks are literal Markdown
   printf 'Full reference: `.agents/skills/pinpoint-huddle/SKILL.md`\n'
 else

--- a/scripts/tests/test_huddle_pr_announce.py
+++ b/scripts/tests/test_huddle_pr_announce.py
@@ -1,0 +1,208 @@
+"""Unit tests for scripts/hooks/huddle-pr-announce.sh."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).parent.parent / "hooks" / "huddle-pr-announce.sh"
+
+
+def run_hook(
+    stdin_data: dict,
+    env_modifications: dict | None = None,
+) -> tuple[int, str, str]:
+    """Run the hook with the given stdin payload and return (rc, stdout, stderr)."""
+    env = os.environ.copy()
+    # HUDDLE_DRY_RUN=1 makes the hook print the would-post text instead of calling bd.
+    env["HUDDLE_DRY_RUN"] = "1"
+    if env_modifications:
+        env.update(env_modifications)
+
+    process = subprocess.Popen(
+        ["bash", str(HOOK_PATH)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+    stdout, stderr = process.communicate(input=json.dumps(stdin_data))
+    return process.returncode, stdout, stderr
+
+
+# ---------------------------------------------------------------------------
+# Helpers: synthetic stdin payloads
+# ---------------------------------------------------------------------------
+
+
+def _bash_pr_create_payload(
+    command: str = "gh pr create --title 'feat: something (PP-abc1)' --body '...'",
+    pr_url: str = "https://github.com/timothyfroehlich/PinPoint/pull/42",
+    pr_title: str | None = None,
+) -> dict:
+    """PostToolUse payload for a successful `gh pr create` Bash invocation."""
+    return {
+        "session_id": "test-session-123",
+        "transcript_path": "/tmp/sessions/test-session-123.jsonl",
+        "cwd": "/tmp/project",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {
+            "output": f"https://github.com/timothyfroehlich/PinPoint/pull/42\n{pr_url}"
+        },
+    }
+
+
+def _mcp_create_pr_payload(
+    pr_number: int = 99,
+    pr_url: str = "https://github.com/timothyfroehlich/PinPoint/pull/99",
+    pr_title: str = "feat(huddle): auto-post notices (PP-uq5i)",
+) -> dict:
+    """PostToolUse payload for a successful mcp__github__create_pull_request call."""
+    return {
+        "session_id": "test-session-456",
+        "transcript_path": "/tmp/sessions/test-session-456.jsonl",
+        "cwd": "/tmp/project",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "mcp__github__create_pull_request",
+        "tool_input": {
+            "owner": "timothyfroehlich",
+            "repo": "PinPoint",
+            "title": pr_title,
+            "body": "Description here.",
+            "head": "feat/huddle-PP-uq5i",
+            "base": "main",
+        },
+        "tool_response": {
+            "number": pr_number,
+            "html_url": pr_url,
+            "title": pr_title,
+        },
+    }
+
+
+def _non_pr_bash_payload(command: str = "git status") -> dict:
+    """PostToolUse payload for a non-PR-create Bash call."""
+    return {
+        "session_id": "test-session-789",
+        "transcript_path": "/tmp/sessions/test-session-789.jsonl",
+        "cwd": "/tmp/project",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {"output": "On branch main\n"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBashPrCreatePayload:
+    def test_parses_pr_number(self) -> None:
+        payload = _bash_pr_create_payload()
+        rc, stdout, stderr = run_hook(payload)
+        assert rc == 0, f"Hook exited {rc}; stderr={stderr!r}"
+        assert "PR #42" in stdout, f"Expected 'PR #42' in stdout, got: {stdout!r}"
+
+    def test_parses_bead_id_from_command(self) -> None:
+        payload = _bash_pr_create_payload(
+            command="gh pr create --title 'feat: do a thing (PP-abc1)' --body '...'",
+        )
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        # Bead ID comes from the PR title in this hook; for Bash shape, title is
+        # not in the response — bead part may be absent. Just confirm no crash.
+        assert "PR #42" in stdout
+
+    def test_output_contains_sign_off(self) -> None:
+        payload = _bash_pr_create_payload()
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert "—huddle-auto" in stdout or "—" in stdout
+
+    def test_custom_huddle_name(self) -> None:
+        payload = _bash_pr_create_payload()
+        rc, stdout, _ = run_hook(
+            payload, env_modifications={"HUDDLE_NAME": "Claude-TestAgent"}
+        )
+        assert rc == 0
+        assert "—Claude-TestAgent" in stdout
+
+
+class TestMcpCreatePrPayload:
+    def test_parses_pr_number(self) -> None:
+        payload = _mcp_create_pr_payload(pr_number=99)
+        rc, stdout, stderr = run_hook(payload)
+        assert rc == 0, f"Hook exited {rc}; stderr={stderr!r}"
+        assert "PR #99" in stdout, f"Expected 'PR #99' in stdout, got: {stdout!r}"
+
+    def test_parses_pr_title(self) -> None:
+        payload = _mcp_create_pr_payload(
+            pr_number=99,
+            pr_title="feat(huddle): auto-post notices (PP-uq5i)",
+        )
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert "auto-post notices" in stdout
+
+    def test_parses_bead_id_from_title(self) -> None:
+        payload = _mcp_create_pr_payload(
+            pr_number=99,
+            pr_title="feat(huddle): auto-post (PP-uq5i)",
+        )
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert "PP-uq5i" in stdout
+
+    def test_output_contains_sign_off(self) -> None:
+        payload = _mcp_create_pr_payload()
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert "—" in stdout
+
+    def test_custom_huddle_name(self) -> None:
+        payload = _mcp_create_pr_payload()
+        rc, stdout, _ = run_hook(
+            payload, env_modifications={"HUDDLE_NAME": "Antigravity-HuddleFix"}
+        )
+        assert rc == 0
+        assert "—Antigravity-HuddleFix" in stdout
+
+
+class TestEarlyExit:
+    def test_non_pr_bash_produces_no_output(self) -> None:
+        payload = _non_pr_bash_payload("git status")
+        rc, stdout, stderr = run_hook(payload)
+        assert rc == 0, f"Hook failed: stderr={stderr!r}"
+        assert stdout == "", f"Expected empty stdout for non-PR-create, got: {stdout!r}"
+
+    def test_pnpm_bash_produces_no_output(self) -> None:
+        payload = _non_pr_bash_payload("pnpm run check")
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert stdout == ""
+
+    def test_gh_pr_view_bash_produces_no_output(self) -> None:
+        payload = _non_pr_bash_payload("gh pr view 42 --json title")
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert stdout == ""
+
+    def test_bash_pr_create_no_url_in_output_produces_no_output(self) -> None:
+        """If gh pr create Bash call's output has no pull URL, no post."""
+        payload = {
+            "session_id": "test-session",
+            "transcript_path": "/tmp/sessions/s.jsonl",
+            "cwd": "/tmp/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr create --title 'feat: x'"},
+            "tool_response": {"output": "error: something went wrong\n"},
+        }
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        assert stdout == ""

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -144,7 +144,9 @@ echo "MERGED: PR #$PR"
 # The merge is already done — a huddle failure must NEVER propagate an error.
 # shellcheck source=../hooks/huddle-lib.sh disable=SC1091
 (
-  set +euo pipefail
+  set +e
+  set +u
+  set +o pipefail
   _HUDDLE_LIB="$(dirname "$0")/../hooks/huddle-lib.sh"
   if [[ ! -f "$_HUDDLE_LIB" ]]; then
     exit 0
@@ -152,8 +154,9 @@ echo "MERGED: PR #$PR"
   source "$_HUDDLE_LIB"
   _TODAY=$(huddle_today_bead_id 2>/dev/null) || exit 0
   [[ -n "$_TODAY" ]] || exit 0
-  # Parse PinPoint bead ID from PR title (convention: trailing "(PP-xxx)")
-  _BEAD_ID=$(printf '%s' "$PR_TITLE" | grep -oE '\(PP-[a-z0-9]+\)' | tail -1 | tr -d '()' || echo "")
+  # Parse PinPoint bead ID from PR title (convention: trailing "(PP-xxx)").
+  # Bead IDs may include dots (e.g. PP-yxw.9), so allow [a-z0-9.] in the capture.
+  _BEAD_ID=$(printf '%s' "$PR_TITLE" | grep -oE '\(PP-[a-z0-9.]+\)' | tail -1 | tr -d '()' || echo "")
   # Compact changed-files hint for collision awareness (top-level dirs, first 5)
   _FILES=$(gh pr view "$PR" --json files --jq '[.files[].path | split("/")[0]] | unique | .[:5] | join(", ")' 2>/dev/null || echo "")
   _BEAD_PART=""

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -139,3 +139,28 @@ fi
 # no sentinel needed. (A leftover sentinel would silently bypass the next user-level merge.)
 gh pr merge "$PR" "${MERGE_ARGS[@]}"
 echo "MERGED: PR #$PR"
+
+# --- Post huddle coordination notice (fail-open) ---
+# The merge is already done — a huddle failure must NEVER propagate an error.
+# shellcheck source=../hooks/huddle-lib.sh disable=SC1091
+(
+  set +euo pipefail
+  _HUDDLE_LIB="$(dirname "$0")/../hooks/huddle-lib.sh"
+  if [[ ! -f "$_HUDDLE_LIB" ]]; then
+    exit 0
+  fi
+  source "$_HUDDLE_LIB"
+  _TODAY=$(huddle_today_bead_id 2>/dev/null) || exit 0
+  [[ -n "$_TODAY" ]] || exit 0
+  # Parse PinPoint bead ID from PR title (convention: trailing "(PP-xxx)")
+  _BEAD_ID=$(printf '%s' "$PR_TITLE" | grep -oE '\(PP-[a-z0-9]+\)' | tail -1 | tr -d '()' || echo "")
+  # Compact changed-files hint for collision awareness (top-level dirs, first 5)
+  _FILES=$(gh pr view "$PR" --json files --jq '[.files[].path | split("/")[0]] | unique | .[:5] | join(", ")' 2>/dev/null || echo "")
+  _BEAD_PART=""
+  [[ -n "$_BEAD_ID" ]] && _BEAD_PART=" ($_BEAD_ID)"
+  _FILES_PART=""
+  [[ -n "$_FILES" ]] && _FILES_PART=" [touched: $_FILES]"
+  _SIGN="${HUDDLE_NAME:-huddle-auto}"
+  _MSG="Merged PR #$PR$_BEAD_PART: $PR_TITLE$_FILES_PART. Sync main if you have active branches. —$_SIGN"
+  bd comments add "$_TODAY" "$_MSG" >/dev/null 2>&1 || true
+) || true


### PR DESCRIPTION
## Summary

- **merge-pr.sh**: after a successful squash-merge, posts `Merged PR #N (PP-xxx): title. [touched: dirs]. Sync main if you have active branches. —huddle-auto` to today's huddle bead. Wrapped in a fail-open subshell so a huddle failure can never propagate through an already-completed merge.
- **huddle-lib.sh**: new `huddle_today_bead_id` helper — resolves today's bead ID from `config.json → bd show root → .today_bead.id`; used by merge-pr.sh, the PR-announce hook, and session-start.
- **huddle-session-start.sh**: the registered-branch footer (`Full reference: SKILL.md`) is extended with inline judgment-post triggers (file-a-bead-for-finding, flag-conflict-risk) + a copy-paste `bd comments add <today> "..." —<YourName>` command with today's bead ID resolved live.
- **NEW `scripts/hooks/huddle-pr-announce.sh`**: PostToolUse hook for `Bash|mcp__github__create_pull_request`. Cheap early-exit on any non-PR-create Bash command. Handles both tool-response shapes (gh stdout URL + MCP JSON). Deduplication by PR#. Fail-open throughout. `HUDDLE_DRY_RUN=1` seam for testing.
- **`.claude/settings.json`**: registers `huddle-pr-announce.sh` as a PostToolUse hook (invoked via `bash`, mode 644, no `chmod` needed).
- **NEW `scripts/tests/test_huddle_pr_announce.py`**: 13 tests — Bash payload parses PR#, MCP payload parses PR# + title + bead ID, early-exit assertions for non-PR-create Bash calls. All pass.
- **pinpoint-huddle SKILL.md**: documents the two auto-posts (merge + PR-open), narrows "what to post manually" to judgment calls only (filing beads for findings, conflict flags).

Closes PP-uq5i.

## Verification

- `pnpm run check` passes (shellcheck clean on all modified/new scripts; ruff clean on new test)
- `python3 -m pytest scripts/tests/test_huddle_pr_announce.py -v` — 13/13 passed
- Manual `HUDDLE_DRY_RUN=1` smoke with Bash payload: `Opened PR #42. —huddle-auto`
- Manual `HUDDLE_DRY_RUN=1` smoke with MCP payload: `Opened PR #99 (PP-uq5i): feat(huddle): auto-post notices (PP-uq5i). —huddle-auto`
- Early-exit smoke (non-PR Bash): no output produced
- `merge-pr.sh --dry-run`: exits before merge (no huddle block reached) — confirmed unchanged behavior

**Note on PostToolUse + subagents**: Per the bead decision, `huddle-pr-announce.sh` does NOT skip subagent sessions (unlike huddle-poll.sh) — subagent-opened PRs are intended to be captured. Whether PostToolUse fires at all for subagent tool calls depends on the Claude Code harness version; the hook degrades gracefully if it doesn't.