### PR TITLE
feat(huddle): enrich gh-pr-create announcements with title + bead ID (PP-d62h)

### DIFF
--- a/scripts/hooks/huddle-pr-announce.sh
+++ b/scripts/hooks/huddle-pr-announce.sh
@@ -15,9 +15,17 @@
 #
 # HUDDLE_DRY_RUN=1: print the would-post text to stdout instead of calling bd.
 #   Used by test_huddle_pr_announce.py.
-# HUDDLE_PR_TITLE_OVERRIDE: when set, skip the `gh pr view` network call and use
-#   this string as PR_TITLE in the Bash branch. Intended for dry-run tests so no
+# HUDDLE_PR_TITLE_OVERRIDE: when set, skip the `gh pr view` fetch and use this
+#   string as PR_TITLE in the Bash branch. Intended for dry-run tests so no
 #   network call is made. Example: HUDDLE_PR_TITLE_OVERRIDE="fix thing (PP-abc1)"
+# HUDDLE_FORCE_TITLE_FETCH=1: test-only. Lets the `gh pr view` fetch branch run
+#   even under HUDDLE_DRY_RUN=1, so a test can exercise the real fetch path with a
+#   fake `gh` on PATH (no network). Production never sets this.
+#
+# The `gh pr view` title fetch (Bash path) is bounded by a 3s timeout(1)/gtimeout(1)
+# when available so a slow/stalled call can't hold this PostToolUse hook toward the
+# harness's ~10s timeout; if no timeout binary exists it falls back to a bare gh
+# call. Any gh failure is fail-open → empty title → bare message.
 
 set -euo pipefail
 
@@ -102,11 +110,22 @@ case "$TOOL_NAME" in
     esac
     # Parse PR number from the URL in the output
     PR_NUMBER=$(printf '%s' "$TOOL_RESPONSE" | grep -oE '/pull/([0-9]+)' | head -1 | grep -oE '[0-9]+' || echo "")
-    # Fetch PR title: use override if set (for dry-run tests), else call gh (fail-open).
+    # Fetch PR title (see header comment for the timeout/fail-open contract):
+    #   1. HUDDLE_PR_TITLE_OVERRIDE wins (test seam, no network).
+    #   2. Otherwise call `gh pr view`, bounded by timeout(1)/gtimeout(1) if present.
+    # Network gate: the gh call is skipped under dry-run UNLESS the test opts in via
+    # HUDDLE_FORCE_TITLE_FETCH=1 (paired with a fake `gh` on PATH). Production never
+    # sets that, so dry-run tests stay network-free.
     if [[ -n "${HUDDLE_PR_TITLE_OVERRIDE:-}" ]]; then
       PR_TITLE="$HUDDLE_PR_TITLE_OVERRIDE"
-    elif [[ "${HUDDLE_DRY_RUN:-}" != "1" ]] && [[ -n "$PR_NUMBER" ]]; then
-      PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq .title 2>/dev/null || echo "")
+    elif { [[ "${HUDDLE_DRY_RUN:-}" != "1" ]] || [[ "${HUDDLE_FORCE_TITLE_FETCH:-}" == "1" ]]; } && [[ -n "$PR_NUMBER" ]]; then
+      _TIMEOUT=""
+      if command -v timeout >/dev/null 2>&1; then
+        _TIMEOUT="timeout 3"
+      elif command -v gtimeout >/dev/null 2>&1; then
+        _TIMEOUT="gtimeout 3"
+      fi
+      PR_TITLE=$($_TIMEOUT gh pr view "$PR_NUMBER" --json title --jq .title 2>/dev/null || echo "")
     else
       PR_TITLE=""
     fi

--- a/scripts/hooks/huddle-pr-announce.sh
+++ b/scripts/hooks/huddle-pr-announce.sh
@@ -15,6 +15,9 @@
 #
 # HUDDLE_DRY_RUN=1: print the would-post text to stdout instead of calling bd.
 #   Used by test_huddle_pr_announce.py.
+# HUDDLE_PR_TITLE_OVERRIDE: when set, skip the `gh pr view` network call and use
+#   this string as PR_TITLE in the Bash branch. Intended for dry-run tests so no
+#   network call is made. Example: HUDDLE_PR_TITLE_OVERRIDE="fix thing (PP-abc1)"
 
 set -euo pipefail
 
@@ -99,8 +102,14 @@ case "$TOOL_NAME" in
     esac
     # Parse PR number from the URL in the output
     PR_NUMBER=$(printf '%s' "$TOOL_RESPONSE" | grep -oE '/pull/([0-9]+)' | head -1 | grep -oE '[0-9]+' || echo "")
-    # Title is not in the gh pr create stdout; bead ID won't be parsed for this shape.
-    PR_TITLE=""
+    # Fetch PR title: use override if set (for dry-run tests), else call gh (fail-open).
+    if [[ -n "${HUDDLE_PR_TITLE_OVERRIDE:-}" ]]; then
+      PR_TITLE="$HUDDLE_PR_TITLE_OVERRIDE"
+    elif [[ "${HUDDLE_DRY_RUN:-}" != "1" ]] && [[ -n "$PR_NUMBER" ]]; then
+      PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq .title 2>/dev/null || echo "")
+    else
+      PR_TITLE=""
+    fi
     ;;
   *)
     exit 0

--- a/scripts/tests/test_huddle_pr_announce.py
+++ b/scripts/tests/test_huddle_pr_announce.py
@@ -2,10 +2,31 @@
 
 import json
 import os
+import stat
 import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 HOOK_PATH = Path(__file__).parent.parent / "hooks" / "huddle-pr-announce.sh"
+
+
+@contextmanager
+def fake_gh_on_path(script_body: str) -> Iterator[str]:
+    """Yield a PATH string with a temp dir holding a fake `gh` executable prepended.
+
+    `script_body` is the bash body of the stub (after the shebang). Use it to
+    simulate `gh pr view ... --jq .title` returning a title or failing, without a
+    network call. The real `gh` is shadowed only for the duration of the context.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        gh_stub = Path(tmp) / "gh"
+        gh_stub.write_text(f"#!/usr/bin/env bash\n{script_body}\n")
+        gh_stub.chmod(
+            gh_stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        )
+        yield f"{tmp}{os.pathsep}{os.environ.get('PATH', '')}"
 
 
 def run_hook(
@@ -184,6 +205,66 @@ class TestBashPrCreateWithTitleOverride:
         assert rc == 0
         # Bare format: no title colon-separator, no bead ID
         assert stdout.strip() == "Opened PR #42. —huddle-auto"
+
+
+class TestBashPrCreateRealGhFetch:
+    """Exercise the production `gh pr view` title-fetch branch with a fake `gh`.
+
+    HUDDLE_FORCE_TITLE_FETCH=1 lets the fetch branch run even under dry-run, so a
+    stub `gh` on PATH stands in for the real CLI — verifying the actual invocation
+    and fail-open behavior without any network call.
+    """
+
+    def test_fetches_title_from_gh(self) -> None:
+        """A successful `gh pr view --jq .title` produces an enriched announcement."""
+        payload = _bash_pr_create_payload()
+        # Stub returns the title (as `gh ... --jq .title` would, i.e. unwrapped).
+        with fake_gh_on_path("echo 'some fix (PP-abc.1)'") as path:
+            rc, stdout, stderr = run_hook(
+                payload,
+                env_modifications={"HUDDLE_FORCE_TITLE_FETCH": "1", "PATH": path},
+            )
+        assert rc == 0, f"Hook exited {rc}; stderr={stderr!r}"
+        assert (
+            stdout.strip()
+            == "Opened PR #42 (PP-abc.1): some fix (PP-abc.1). —huddle-auto"
+        )
+
+    def test_gh_failure_falls_back_to_bare(self) -> None:
+        """If `gh` exits non-zero, the hook fails open to the bare message."""
+        payload = _bash_pr_create_payload()
+        with fake_gh_on_path("echo 'gh: not authenticated' >&2; exit 1") as path:
+            rc, stdout, stderr = run_hook(
+                payload,
+                env_modifications={"HUDDLE_FORCE_TITLE_FETCH": "1", "PATH": path},
+            )
+        assert rc == 0, f"Hook exited {rc}; stderr={stderr!r}"
+        assert stdout.strip() == "Opened PR #42. —huddle-auto"
+
+    def test_gh_invoked_with_expected_args(self) -> None:
+        """The fetch passes the parsed PR number and the title JSON/jq flags."""
+        payload = _bash_pr_create_payload()
+        # The hook discards gh's stderr (2>/dev/null), so the stub records its argv
+        # to a file named by GH_ARGV_FILE instead.
+        with tempfile.TemporaryDirectory() as argv_dir:
+            argv_file = Path(argv_dir) / "argv.txt"
+            stub = 'printf "%s\\n" "$*" > "$GH_ARGV_FILE"; echo "t (PP-xyz.2)"'
+            with fake_gh_on_path(stub) as path:
+                rc, stdout, _ = run_hook(
+                    payload,
+                    env_modifications={
+                        "HUDDLE_FORCE_TITLE_FETCH": "1",
+                        "PATH": path,
+                        "GH_ARGV_FILE": str(argv_file),
+                    },
+                )
+            assert rc == 0
+            recorded = argv_file.read_text().strip()
+        # gh was called as: pr view 42 --json title --jq .title
+        assert recorded == "pr view 42 --json title --jq .title", (
+            f"Unexpected gh argv: {recorded!r}"
+        )
+        assert "PP-xyz.2" in stdout
 
 
 class TestMcpCreatePrPayload:

--- a/scripts/tests/test_huddle_pr_announce.py
+++ b/scripts/tests/test_huddle_pr_announce.py
@@ -114,8 +114,8 @@ class TestBashPrCreatePayload:
         )
         rc, stdout, _ = run_hook(payload)
         assert rc == 0
-        # Bead ID comes from the PR title in this hook; for Bash shape, title is
-        # not in the response — bead part may be absent. Just confirm no crash.
+        # Without HUDDLE_PR_TITLE_OVERRIDE the Bash path has no title; PR number
+        # must appear but bead/title parts are absent. Just confirm no crash.
         assert "PR #42" in stdout
 
     def test_output_contains_sign_off(self) -> None:
@@ -131,6 +131,59 @@ class TestBashPrCreatePayload:
         )
         assert rc == 0
         assert "—Claude-TestAgent" in stdout
+
+
+class TestBashPrCreateWithTitleOverride:
+    """Tests for the enriched Bash path using HUDDLE_PR_TITLE_OVERRIDE.
+
+    HUDDLE_PR_TITLE_OVERRIDE injects a PR title without making a network call,
+    so these tests are dry-run-safe while verifying the enriched announcement.
+    """
+
+    def test_enriched_output_contains_title_and_bead(self) -> None:
+        """Bash path with title override produces title + bead in announcement."""
+        payload = _bash_pr_create_payload()
+        rc, stdout, stderr = run_hook(
+            payload,
+            env_modifications={"HUDDLE_PR_TITLE_OVERRIDE": "some fix (PP-abc.1)"},
+        )
+        assert rc == 0, f"Hook exited {rc}; stderr={stderr!r}"
+        assert "PR #42" in stdout, f"Expected 'PR #42' in stdout, got: {stdout!r}"
+        assert "PP-abc.1" in stdout, f"Expected 'PP-abc.1' in stdout, got: {stdout!r}"
+        assert "some fix" in stdout, f"Expected title in stdout, got: {stdout!r}"
+
+    def test_enriched_output_format(self) -> None:
+        """Full format: 'Opened PR #N (PP-xxx): <title>. —huddle-auto'."""
+        payload = _bash_pr_create_payload()
+        rc, stdout, _ = run_hook(
+            payload,
+            env_modifications={"HUDDLE_PR_TITLE_OVERRIDE": "some fix (PP-abc.1)"},
+        )
+        assert rc == 0
+        assert (
+            stdout.strip()
+            == "Opened PR #42 (PP-abc.1): some fix (PP-abc.1). —huddle-auto"
+        )
+
+    def test_title_without_bead_id(self) -> None:
+        """Title override with no bead ID still produces title part."""
+        payload = _bash_pr_create_payload()
+        rc, stdout, _ = run_hook(
+            payload,
+            env_modifications={"HUDDLE_PR_TITLE_OVERRIDE": "plain title no bead"},
+        )
+        assert rc == 0
+        assert "PR #42" in stdout
+        assert "plain title no bead" in stdout
+        assert "PP-" not in stdout
+
+    def test_no_override_falls_back_to_bare(self) -> None:
+        """Without override and in dry-run mode, output is the bare PR number message."""
+        payload = _bash_pr_create_payload()
+        rc, stdout, _ = run_hook(payload)
+        assert rc == 0
+        # Bare format: no title colon-separator, no bead ID
+        assert stdout.strip() == "Opened PR #42. —huddle-auto"
 
 
 class TestMcpCreatePrPayload:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `HUDDLE_PR_TITLE_OVERRIDE` env seam to the Bash branch of `huddle-pr-announce.sh` so dry-run tests can inject a title without making a network call
- When the override is not set and the hook is not in dry-run mode, fetches the PR title via `gh pr view "$PR_NUMBER" --json title --jq .title` (fail-open: gh errors fall back to empty title → bare message, preserving today's behavior)
- Bare-Bash announcements now produce `Opened PR #N (PP-xxx): <title>. —huddle-auto` matching the MCP path quality

## Verification

Manual dry-run smoke tests (no `bd`, no network):

```
# Enriched output with title override
$ printf '...' | HUDDLE_DRY_RUN=1 HUDDLE_PR_TITLE_OVERRIDE="some fix (PP-abc.1)" bash scripts/hooks/huddle-pr-announce.sh
Opened PR #99 (PP-abc.1): some fix (PP-abc.1). —huddle-auto

# Bare fallback without override (dry-run skips gh pr view)
$ printf '...' | HUDDLE_DRY_RUN=1 bash scripts/hooks/huddle-pr-announce.sh
Opened PR #99. —huddle-auto
```

Test suite: `python3 -m pytest scripts/tests/test_huddle_pr_announce.py -v` — 17 passed (13 existing + 4 new in `TestBashPrCreateWithTitleOverride`).

`pnpm run check` — all checks passed (shellcheck, ruff, typecheck, unit tests).

Closes PP-d62h.
EOF
)