### PR TITLE
docs: changelog week of May 25, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 116, "lastUpdated": "2026-05-17" }
+{ "totalEntries": 122, "lastUpdated": "2026-05-24" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,21 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## May 25, 2026
+
+### New Features
+
+- **Swipeable Mobile Drawer** — The "More" menu at the bottom of the screen on mobile now opens as a drawer with a drag handle; swipe or drag it down to dismiss it, with smooth physics that match the rest of the app
+- **Live Field Validation** — Text and textarea fields now show a red border the moment you leave a field with invalid input, so you get feedback right away without having to submit the form first
+
+### Bug Fixes
+
+- Machine owners who had previously clicked "Unwatch" on their own machine were silently missing new-issue notification emails and Discord DMs — they now always receive notifications when a new issue is filed on a machine they own
+- On phones and tablets, the reason why a machine's Edit button was greyed out was hidden inside a hover tooltip that touch screens can never trigger — the explanation now appears as plain visible text directly below the button
+- Login and sign-up forms now correctly tell your browser's password manager which field is a current password and which is a new password, so autofill works as expected; required fields are now marked with asterisks, and the mobile keyboard shows "Next" or "Done" at the right moments during sign-up
+- Keyboard-only users can now press Tab on any page to reveal a "Skip to main content" link that jumps past the navigation bar; the Issues table also now has properly labeled column headers for screen readers
+
+---
+
 ## May 18, 2026
 
 ### New Features


### PR DESCRIPTION
Weekly changelog entry for the week of May 18–24, 2026. Covers 6 user-facing bullets across 2 new features and 4 bug fixes.

## New Features

- **Swipeable Mobile Drawer** — The mobile "More" menu now opens as a drag-handle drawer with swipe-to-dismiss physics (PR #1410)
- **Live Field Validation** — Text fields now show a red border immediately on blur when input is invalid, before the form is submitted (PR #1400)

## Bug Fixes

- Machine owners who had unwatched their own machine were silently missing new-issue notifications — always notified now (PR #1414)
- On touch devices, the reason a machine's Edit button was greyed out was hidden in an untrappable hover tooltip — now shown as visible text (PR #1411)
- Login/sign-up forms now correctly label current vs. new password fields for browser password managers; required fields marked with asterisks; mobile keyboard flow improved (PR #1398)
- "Skip to main content" link added for keyboard users; Issues table column headers properly labeled for screen readers (PR #1416)

## Excluded (not user-facing)

Deps bumps (#1379, #1381, #1384, #1397, #1402, #1415), CI/workflow tooling (#1391, #1392, #1404, #1407, #1422), agent/huddle coordination (#1385, #1395, #1401, #1418, #1423, #1425, #1426), docs/skills (#1386, #1389, #1393, #1419, #1421), test-only fixes (#1367, #1378, #1382, #1383, #1394), internal refactors (#1375, #1403, #1409, #1412, #1413, #1424), and workflow infra (#1357, #1374, #1390).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKcrDHSNQPTKYEpgzJxH5n)_