### PR TITLE
feat(workflow): opt-in prototype mode for rapid iteration (PP-awt5)

### DIFF
--- a/.agents/skills/pinpoint-prototype-mode/SKILL.md
+++ b/.agents/skills/pinpoint-prototype-mode/SKILL.md
@@ -60,8 +60,9 @@ These are cheap and keep "fast" from becoming "unusable" or "dangerous":
   expected; the point of this mode is you're _not_ committing yet.)
 - **Never touch production** (no prod DB, no prod deploy, no prod secrets).
 - **Never delete or weaken existing tests** to make something pass.
-- **Auth / secrets / RLS safety** (AGENTS.md §2.1 #5, #10) still applies — a
-  prototype that leaks data isn't a prototype, it's a bug.
+- **Auth, permissions, and data-privacy rules still apply** (AGENTS.md §2.1 #5
+  Supabase SSR, #10 email privacy, #11 permissions matrix) — a prototype that
+  leaks data or bypasses a permission check isn't a prototype, it's a bug.
 - **`localhost` not `127.0.0.1`** (#14) — breaking this wastes iteration time
   on auth failures, so keep it.
 

--- a/.agents/skills/pinpoint-prototype-mode/SKILL.md
+++ b/.agents/skills/pinpoint-prototype-mode/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pinpoint-prototype-mode
+description: Opt-in rapid-iteration mode for design/idea exploration. Relaxes test/lint/type rigor in favor of speed while tracking the resulting debt. Use when the user says "prototype mode", "rapid iteration", "vibe", or asks to explore an idea quickly without worrying about tests passing. Also read this to EXIT the mode.
+---
+
+# PinPoint Prototype Mode
+
+A deliberately-entered, deliberately-exited mode for iterating on designs and
+ideas fast — without stopping to make tests, lint, and types green at every
+step. The work is **not** done when prototype mode ends; the mode tracks
+exactly what rigor was skipped so it can be repaid.
+
+## When to use
+
+Enter **only** when the user explicitly asks: "prototype mode", "rapid
+iteration", "let's just explore", "vibe on this", "don't worry about tests for
+now", or similar. **Never self-elect into this mode.** Full rigor (AGENTS.md
+§2) is always the default.
+
+## Entering the mode
+
+1. Announce: "⚡ Entering prototype mode — rigor relaxed, debt tracked."
+2. Create the marker file `.prototype-mode` at the worktree root (it is
+   gitignored). Seed it with the ledger template below.
+3. From here on, follow the relaxed rules and append to the ledger as you skip
+   things.
+
+Marker file template:
+
+```markdown
+# Prototype mode — entered <ISO date/time>
+
+Goal: <one line: what are we exploring?>
+
+## Debt ledger (repay before this work is "real")
+
+- [ ] (nothing skipped yet)
+```
+
+## What is RELAXED in prototype mode
+
+- **Don't run `preflight`/`check`/tests before showing work.** Show the change
+  and move on. Iterate on the idea, not the gates.
+- **Don't fix every lint / type-strictness error mid-flight.** A red squiggle
+  is fine while exploring. Log it in the ledger.
+- **Don't write test coverage yet.** Log "needs tests: <what>" in the ledger.
+- **Don't polish for DRY / architecture / Rule-of-Three.** Duplicate freely;
+  note it for later.
+- **Don't spawn review subagents or worry about Copilot/CI.**
+
+Every time you skip one of these, add a concrete line to the ledger. "Later"
+must be a real checklist, not an implied promise.
+
+## What is NEVER relaxed (even in prototype mode)
+
+These are cheap and keep "fast" from becoming "unusable" or "dangerous":
+
+- **No commit, no push, no PR.** Prototype work stays in the working tree. (If
+  you do commit, pre-commit/preflight hooks still run and will block — that's
+  expected; the point of this mode is you're _not_ committing yet.)
+- **Never touch production** (no prod DB, no prod deploy, no prod secrets).
+- **Never delete or weaken existing tests** to make something pass.
+- **Auth / secrets / RLS safety** (AGENTS.md §2.1 #5, #10) still applies — a
+  prototype that leaks data isn't a prototype, it's a bug.
+- **`localhost` not `127.0.0.1`** (#14) — breaking this wastes iteration time
+  on auth failures, so keep it.
+
+## Exiting the mode
+
+Triggered when the user says "exit prototype mode", "make this real", "let's
+land it", or starts asking for tests/PR/commit.
+
+1. Read `.prototype-mode` and present the debt ledger as a checklist of what
+   must now happen: tests to write, lint/type errors to fix, `preflight` to
+   green, DRY cleanup.
+2. Delete the marker file.
+3. Announce: "✅ Exited prototype mode. Repaying debt:" followed by the
+   checklist. Then resume full AGENTS.md §2 rigor.
+
+Do not silently drop the ledger. If the user wants to abandon the prototype
+entirely, confirm before deleting the marker without repaying.

--- a/.agents/skills/pinpoint-prototype-mode/SKILL.md
+++ b/.agents/skills/pinpoint-prototype-mode/SKILL.md
@@ -1,21 +1,40 @@
 ---
 name: pinpoint-prototype-mode
-description: Opt-in rapid-iteration mode for design/idea exploration. Relaxes test/lint/type rigor in favor of speed while tracking the resulting debt. Use when the user says "prototype mode", "rapid iteration", "vibe", or asks to explore an idea quickly without worrying about tests passing. Also read this to EXIT the mode.
+description: Opt-in rapid-iteration mode for UI/UX prototyping — layout, components, styling, page structure, interaction/flow. Relaxes test/lint/type rigor on presentational code in favor of speed while tracking the resulting debt. NOT for backend/internal work (data layer, server-action logic, auth, permissions, migrations). Use when the user says "prototype mode", "rapid iteration", "vibe", or asks to explore a UI/design idea quickly without worrying about tests passing. Also read this to EXIT the mode.
 ---
 
 # PinPoint Prototype Mode
 
-A deliberately-entered, deliberately-exited mode for iterating on designs and
-ideas fast — without stopping to make tests, lint, and types green at every
-step. The work is **not** done when prototype mode ends; the mode tracks
-exactly what rigor was skipped so it can be repaid.
+A deliberately-entered, deliberately-exited mode for iterating on **UI/UX**
+fast — layout, components, styling, page structure, interaction and flow —
+without stopping to make tests, lint, and types green at every step. The work
+is **not** done when prototype mode ends; the mode tracks exactly what rigor
+was skipped so it can be repaid.
+
+## Scope: UI/UX only
+
+This mode is for **visual and interaction design** — the stuff you want to see
+rendered, tweak, and see again. It is **not** a license to vibe-code internals.
+
+- **In scope:** components, layouts, Tailwind/styling, page composition,
+  responsive behavior, copy, empty/loading/error states, navigation and
+  interaction flow.
+- **Out of scope (keep full rigor):** the data layer, server-action business
+  logic, queries, migrations, auth, permissions, anything in `~/lib` that isn't
+  presentational. If a UI idea needs data, **stub or hard-code it** to see the
+  screen — don't build the real backend under relaxed rigor. When the design is
+  settled, exit the mode and build the backend properly.
+
+If the exploration starts requiring real backend/internal changes, that's the
+signal to exit prototype mode (or keep that slice rigorous) — say so rather
+than quietly relaxing rigor on logic that matters.
 
 ## When to use
 
 Enter **only** when the user explicitly asks: "prototype mode", "rapid
-iteration", "let's just explore", "vibe on this", "don't worry about tests for
-now", or similar. **Never self-elect into this mode.** Full rigor (AGENTS.md
-§2) is always the default.
+iteration", "let's just explore", "vibe on this UI", "don't worry about tests
+for now", or similar — and the work is **UI/UX**. **Never self-elect into this
+mode.** Full rigor (AGENTS.md §2) is always the default.
 
 ## Entering the mode
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -124,6 +124,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/scripts/hooks/huddle-poll.sh",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/scripts/hooks/prototype-mode-poll.sh",
+            "timeout": 5000
           }
         ]
       }
@@ -141,6 +146,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/session-start-orphan-sweep.sh",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/scripts/hooks/prototype-mode-poll.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Claude Code control files (ephemeral, worktree-local)
 .claude-hook-bypass
 .claude-merge-bypass
+.prototype-mode
 .claude-task-contract
 .claude/scheduled_tasks.lock
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Load relevant skills for every task. If your tool doesn't support skills, read t
 | Testing     | `pinpoint-e2e`                   | E2E tests, worker isolation, Playwright stability               |
 | Security    | `pinpoint-security`              | Auth, CSP, Zod, Supabase SSR                                    |
 | Patterns    | `pinpoint-patterns`              | Server Actions, data fetching, architecture                     |
+| Workflow    | `pinpoint-prototype-mode`        | Opt-in rapid iteration: relax test/lint/type rigor, track debt  |
 | Workflow    | `pinpoint-briefing`              | Session-start health review                                     |
 | Workflow    | `pinpoint-pr-workflow`           | Full PR lifecycle: commit, push, CI, Copilot, merge             |
 | Workflow    | `pinpoint-orchestrator`          | Parallel subagent work in worktrees                             |
@@ -108,6 +109,10 @@ Only stop services you started in this session, by specific PID or via worktree-
 | `pnpm run db:seed:from-prod`          | Reset local + seed from latest prod backup                                                                                                |
 | `ruff check && ruff format`           | Python lint/format (no venv needed)                                                                                                       |
 | `./scripts/workflow/pr-watch.py <PR>` | Watch CI for a PR (Monitor-compatible). Never hand-roll a polling loop.                                                                   |
+
+### Prototype mode (rapid iteration)
+
+When the user explicitly asks for "prototype mode" / "rapid iteration" / "just explore", load the `pinpoint-prototype-mode` skill and enter it. It relaxes the §2 rigor (skip preflight/tests before showing work, defer lint/type fixes, defer coverage and DRY) while logging every skipped item to a `.prototype-mode` debt ledger. It changes **agent behavior only** — pre-commit and `preflight` hooks still run on any real commit, which is fine because prototype work stays local and uncommitted. Never self-elect into it; full rigor is the default. A `UserPromptSubmit`/`SessionStart` hook reminds the agent while the marker exists, so the mode survives compaction. Exit on "exit prototype mode" / "make this real" — then repay the ledger.
 
 ### Which tests to run
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,23 +42,23 @@
 
 Load relevant skills for every task. If your tool doesn't support skills, read the file directly. All skills live at `.agents/skills/<name>/SKILL.md`.
 
-| Category    | Skill                            | When to use                                                     |
-| :---------- | :------------------------------- | :-------------------------------------------------------------- |
-| UI          | `pinpoint-ui`                    | Components, shadcn/ui, forms, responsive design                 |
-| UI          | `pinpoint-design-bible`          | Design system, page archetypes, spacing, surfaces               |
-| TypeScript  | `pinpoint-typescript`            | Type errors, generics, Drizzle types                            |
-| Testing     | `pinpoint-testing`               | Writing tests, PGlite, test-layer decisions                     |
-| Testing     | `pinpoint-e2e`                   | E2E tests, worker isolation, Playwright stability               |
-| Security    | `pinpoint-security`              | Auth, CSP, Zod, Supabase SSR                                    |
-| Patterns    | `pinpoint-patterns`              | Server Actions, data fetching, architecture                     |
-| Workflow    | `pinpoint-prototype-mode`        | Opt-in rapid iteration: relax test/lint/type rigor, track debt  |
-| Workflow    | `pinpoint-briefing`              | Session-start health review                                     |
-| Workflow    | `pinpoint-pr-workflow`           | Full PR lifecycle: commit, push, CI, Copilot, merge             |
-| Workflow    | `pinpoint-orchestrator`          | Parallel subagent work in worktrees                             |
-| Workflow    | `pinpoint-dispatch-e2e-teammate` | Dispatching a teammate end-to-end                               |
-| Antigravity | `pinpoint-agy-triage`            | Grooming: evaluate whether a bead is agy-ready/agy-ui           |
-| Antigravity | `pinpoint-agy-dispatch`          | Emit an Antigravity copy-paste prompt for a chosen bead         |
-| Antigravity | `pinpoint-agy-execute`           | Runbook for Antigravity to execute an agy-ready bead end-to-end |
+| Category    | Skill                            | When to use                                                             |
+| :---------- | :------------------------------- | :---------------------------------------------------------------------- |
+| UI          | `pinpoint-ui`                    | Components, shadcn/ui, forms, responsive design                         |
+| UI          | `pinpoint-design-bible`          | Design system, page archetypes, spacing, surfaces                       |
+| TypeScript  | `pinpoint-typescript`            | Type errors, generics, Drizzle types                                    |
+| Testing     | `pinpoint-testing`               | Writing tests, PGlite, test-layer decisions                             |
+| Testing     | `pinpoint-e2e`                   | E2E tests, worker isolation, Playwright stability                       |
+| Security    | `pinpoint-security`              | Auth, CSP, Zod, Supabase SSR                                            |
+| Patterns    | `pinpoint-patterns`              | Server Actions, data fetching, architecture                             |
+| Workflow    | `pinpoint-prototype-mode`        | Opt-in rapid UI/UX prototyping: relax rigor on presentation, track debt |
+| Workflow    | `pinpoint-briefing`              | Session-start health review                                             |
+| Workflow    | `pinpoint-pr-workflow`           | Full PR lifecycle: commit, push, CI, Copilot, merge                     |
+| Workflow    | `pinpoint-orchestrator`          | Parallel subagent work in worktrees                                     |
+| Workflow    | `pinpoint-dispatch-e2e-teammate` | Dispatching a teammate end-to-end                                       |
+| Antigravity | `pinpoint-agy-triage`            | Grooming: evaluate whether a bead is agy-ready/agy-ui                   |
+| Antigravity | `pinpoint-agy-dispatch`          | Emit an Antigravity copy-paste prompt for a chosen bead                 |
+| Antigravity | `pinpoint-agy-execute`           | Runbook for Antigravity to execute an agy-ready bead end-to-end         |
 
 ## 4. Environment
 
@@ -112,7 +112,7 @@ Only stop services you started in this session, by specific PID or via worktree-
 
 ### Prototype mode (rapid iteration)
 
-When the user explicitly asks for "prototype mode" / "rapid iteration" / "just explore", load the `pinpoint-prototype-mode` skill and enter it. It relaxes the §2 rigor (skip preflight/tests before showing work, defer lint/type fixes, defer coverage and DRY) while logging every skipped item to a `.prototype-mode` debt ledger. It changes **agent behavior only** — pre-commit and `preflight` hooks still run on any real commit, which is fine because prototype work stays local and uncommitted. Never self-elect into it; full rigor is the default. A `UserPromptSubmit`/`SessionStart` hook reminds the agent while the marker exists, so the mode survives compaction. Exit on "exit prototype mode" / "make this real" — then repay the ledger.
+When the user explicitly asks for "prototype mode" / "rapid iteration" / "just explore" **for UI/UX work**, load the `pinpoint-prototype-mode` skill and enter it. It's scoped to **presentation only** — layout, components, styling, page structure, interaction/flow — and explicitly **not** for backend/internal work (data layer, server-action logic, auth, permissions, migrations), which keep full rigor; stub data rather than building it. Within that scope it relaxes the §2 rigor (skip preflight/tests before showing work, defer lint/type fixes, defer coverage and DRY) while logging every skipped item to a `.prototype-mode` debt ledger. It changes **agent behavior only** — pre-commit and `preflight` hooks still run on any real commit, which is fine because prototype work stays local and uncommitted. Never self-elect into it; full rigor is the default. A `UserPromptSubmit`/`SessionStart` hook reminds the agent while the marker exists, so the mode survives compaction. Exit on "exit prototype mode" / "make this real" — then repay the ledger.
 
 ### Which tests to run
 

--- a/scripts/hooks/prototype-mode-poll.sh
+++ b/scripts/hooks/prototype-mode-poll.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2250  # unbraced $vars are consistent throughout this codebase
+# prototype-mode-poll.sh — remind the agent that prototype mode is active.
+#
+# Fires from UserPromptSubmit and SessionStart (registered in
+# .claude/settings.json). If a `.prototype-mode` marker file exists at the
+# worktree root, emit a system-reminder so the relaxed-rigor mode survives
+# context compaction and session restarts. Zero stdout = no injection (mode
+# inactive).
+#
+# The marker is created/deleted by the `pinpoint-prototype-mode` skill, not by
+# this hook. This hook only reads.
+set -euo pipefail
+
+marker="${CLAUDE_PROJECT_DIR:-.}/.prototype-mode"
+[ -f "$marker" ] || exit 0
+
+goal=$(grep -m1 '^Goal:' "$marker" 2>/dev/null || true)
+
+cat <<EOF
+<system-reminder>
+⚡ Prototype mode is ACTIVE (.prototype-mode present). Rigor is relaxed per the
+pinpoint-prototype-mode skill: don't run preflight/tests before showing work,
+don't fix every lint/type error, defer coverage and DRY — but log each skip to
+the debt ledger in .prototype-mode. Never commit/push, never touch prod, never
+delete tests. ${goal}
+The user exits with "exit prototype mode" / "make this real" — then repay the
+ledger. Read the pinpoint-prototype-mode skill if you need the full rules.
+</system-reminder>
+EOF

--- a/scripts/hooks/prototype-mode-poll.sh
+++ b/scripts/hooks/prototype-mode-poll.sh
@@ -21,6 +21,9 @@ goal=$(grep -m1 '^Goal:' "$marker" 2>/dev/null || true)
 # stdout as a reminder. Match the convention in huddle-poll.sh (no literal
 # wrapper tags).
 printf '## ⚡ Prototype mode is ACTIVE\n\n'
+printf 'Scope is UI/UX only (layout, components, styling, flow). Keep full '
+printf 'rigor on backend/internal logic (data, server actions, auth, '
+printf 'permissions, migrations) — stub data rather than building it.\n'
 printf 'Rigor is relaxed per the pinpoint-prototype-mode skill: do not run '
 printf 'preflight/tests before showing work, do not fix every lint/type '
 printf 'error, defer coverage and DRY — but log each skip to the debt ledger '

--- a/scripts/hooks/prototype-mode-poll.sh
+++ b/scripts/hooks/prototype-mode-poll.sh
@@ -17,14 +17,15 @@ marker="${CLAUDE_PROJECT_DIR:-.}/.prototype-mode"
 
 goal=$(grep -m1 '^Goal:' "$marker" 2>/dev/null || true)
 
-cat <<EOF
-<system-reminder>
-⚡ Prototype mode is ACTIVE (.prototype-mode present). Rigor is relaxed per the
-pinpoint-prototype-mode skill: don't run preflight/tests before showing work,
-don't fix every lint/type error, defer coverage and DRY — but log each skip to
-the debt ledger in .prototype-mode. Never commit/push, never touch prod, never
-delete tests. ${goal}
-The user exits with "exit prototype mode" / "make this real" — then repay the
-ledger. Read the pinpoint-prototype-mode skill if you need the full rules.
-</system-reminder>
-EOF
+# Emit plain markdown — the harness presents UserPromptSubmit/SessionStart
+# stdout as a reminder. Match the convention in huddle-poll.sh (no literal
+# wrapper tags).
+printf '## ⚡ Prototype mode is ACTIVE\n\n'
+printf 'Rigor is relaxed per the pinpoint-prototype-mode skill: do not run '
+printf 'preflight/tests before showing work, do not fix every lint/type '
+printf 'error, defer coverage and DRY — but log each skip to the debt ledger '
+printf 'in .prototype-mode. Never commit/push, never touch prod, never delete '
+printf 'tests.\n'
+[ -n "$goal" ] && printf '%s\n' "$goal"
+printf 'Exit with "exit prototype mode" / "make this real", then repay the '
+printf 'ledger. Read the pinpoint-prototype-mode skill for the full rules.\n'

--- a/scripts/hooks/prototype-mode-poll.sh
+++ b/scripts/hooks/prototype-mode-poll.sh
@@ -17,18 +17,14 @@ marker="${CLAUDE_PROJECT_DIR:-.}/.prototype-mode"
 
 goal=$(grep -m1 '^Goal:' "$marker" 2>/dev/null || true)
 
-# Emit plain markdown — the harness presents UserPromptSubmit/SessionStart
-# stdout as a reminder. Match the convention in huddle-poll.sh (no literal
-# wrapper tags).
-printf '## ⚡ Prototype mode is ACTIVE\n\n'
-printf 'Scope is UI/UX only (layout, components, styling, flow). Keep full '
-printf 'rigor on backend/internal logic (data, server actions, auth, '
-printf 'permissions, migrations) — stub data rather than building it.\n'
-printf 'Rigor is relaxed per the pinpoint-prototype-mode skill: do not run '
-printf 'preflight/tests before showing work, do not fix every lint/type '
-printf 'error, defer coverage and DRY — but log each skip to the debt ledger '
-printf 'in .prototype-mode. Never commit/push, never touch prod, never delete '
-printf 'tests.\n'
-[ -n "$goal" ] && printf '%s\n' "$goal"
-printf 'Exit with "exit prototype mode" / "make this real", then repay the '
-printf 'ledger. Read the pinpoint-prototype-mode skill for the full rules.\n'
+# Emit a compact plain-markdown reminder — the harness presents
+# UserPromptSubmit/SessionStart stdout as a reminder, and this fires every
+# turn while the marker exists, so keep it bounded. Match huddle-poll.sh's
+# convention (no literal wrapper tags). Full rules live in the skill.
+printf '⚡ **Prototype mode ACTIVE — UI/UX only.** Relax test/lint/type rigor '
+printf 'on presentation; keep full rigor on backend/data/auth (stub data, do '
+printf 'not build it). Log skips to the .prototype-mode ledger; never '
+printf 'commit/push, touch prod, or delete tests. '
+[ -n "$goal" ] && printf '%s ' "$goal"
+printf 'Exit: "exit prototype mode" / "make this real" → repay the ledger. '
+printf 'Full rules: pinpoint-prototype-mode skill.\n'


### PR DESCRIPTION
## What

Adds an **opt-in, deliberately-bounded rapid-iteration mode for UI/UX prototyping** — layout, components, styling, page structure, interaction/flow. It lets me iterate on the *visual* layer without stopping to make tests, lint, and types green at every step, while never silently dropping that rigor: what's deferred is logged to a debt ledger and repaid on exit.

**Scope is presentation only.** Backend/internal work (data layer, server-action logic, auth, permissions, migrations) keeps full rigor — stub or hard-code data to see a screen rather than building the backend under relaxed rigor. Relaxing rigor on presentational code is low-risk; relaxing it on data/auth is not. That scoping is what makes the mode safe.

Grounded in current "vibe coding vs production" guidance: the danger isn't iterating fast, it's *ambiguity about which mode you're in* and rigor that disappears instead of being deferred. So the mode is explicit to enter/exit, scoped to UI/UX, and tracks its own debt.

## How it works

- **`pinpoint-prototype-mode` skill** — the rules. "Scope: UI/UX only" (in/out of scope, stub-don't-build). Relaxed: skip preflight/tests before showing work, defer lint/type fixes, defer coverage and DRY. **Never relaxed:** no commit/push/PR (work stays local), no prod, no deleting existing tests, auth/permissions/data-privacy, `localhost` not `127.0.0.1`. Defines the debt-ledger format and the enter/exit protocol.
- **`scripts/hooks/prototype-mode-poll.sh`** — fires on `UserPromptSubmit` + `SessionStart`. If a `.prototype-mode` marker exists at the worktree root, it injects a single **concise plain-markdown reminder** (no literal wrapper tags — matches `huddle-poll.sh`) so the mode survives context compaction and session restarts. Zero stdout when the marker is absent.
- **`.claude/settings.json`** — registers the hook on both events (alongside the existing huddle hooks).
- **`.gitignore`** — the `.prototype-mode` marker is per-worktree and never committed.
- **`AGENTS.md`** — skill-table row + a §5 note clarifying the mode changes *agent behavior only*; pre-commit/preflight still run on any real commit (fine, since prototype work stays uncommitted).

## Usage

- Enter (UI/UX work): say "prototype mode" / "rapid iteration" / "just explore" → I load the skill and drop the marker.
- Exit: "exit prototype mode" / "make this real" → I surface the debt ledger as a checklist and resume full §2 rigor.
- Default is always full rigor; the agent never self-elects into the mode.

## Verification

- `pnpm run check` green (types, lint, format, shellcheck, yamllint, actionlint, ruff, unit tests). Pre-commit gate passed.
- Hook manually exercised: silent with no marker; emits the one-line reminder (including the ledger `Goal:` line) when the marker is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)