### PR TITLE
docs(agy-triage): recalibrate Gate 1 to blast-radius, not complexity (PP-qj2f)

### DIFF
--- a/.agents/skills/pinpoint-agy-triage/SKILL.md
+++ b/.agents/skills/pinpoint-agy-triage/SKILL.md
@@ -23,9 +23,17 @@ Use the `agy-ready` label to mark candidates. Use the `agy-ui` label additionall
 
 ### Gate 1 — Decision-closed (load-bearing)
 
-No "discuss with user", no architectural forks, no TBDs. Every interpretive choice has a written answer in the bead description, acceptance criteria, or a linked decision bead.
+No unresolved fork that (a) Tim holds a preference on AND (b) carries repo-wide blast radius or would be hard to catch in review. Every such choice must have a written answer in the bead description, acceptance criteria, or a linked decision bead.
 
-If the bead has "Option A / Option B / Option C" branches with no chosen winner, it is NOT ready. Antigravity will pick the first plausible option and ship it.
+If the bead has "Option A / Option B / Option C" branches with no chosen winner on a high-blast-radius question, it is NOT ready. Antigravity will pick the first plausible option and ship it.
+
+A capable executor applying a documented rule (e.g. CORE-TEST-005 to pick the cheapest test layer) is NOT an open fork. Micro-decisions that the executor can resolve by following existing project rules pass Gate 1 — especially when the bead's blast radius is low (tests, docs). The `pinpoint-agy-execute` runbook instructs the executor to stop and post a `bd comment` when genuinely torn, so it is not forced to guess silently.
+
+#### Blast radius calibration
+
+**Low blast radius** (tests, docs, isolated UI components): the executor may make reasonable micro-decisions and should post a `bd comment` when torn. Prefer tagging `agy-ready` with a delegated-decision note rather than blocking on every minor choice.
+
+**High blast radius** (new dependencies, lint/architecture rules, schema changes, permission logic, prod behavior): these forks require a pre-made decision in the bead. Antigravity must not invent answers here.
 
 ### Gate 2 — Scope-pinned
 
@@ -117,10 +125,8 @@ After Antigravity ships a PR, treat it like any other agent PR: Copilot review, 
 
 ---
 
-## When in doubt, default to FAIL
+## When in doubt
 
-Under-tagging is safe — Antigravity just has fewer candidates to pick from.
+**High blast radius (schema, permissions, prod behavior, new dependencies, lint architecture):** default to FAIL. Over-tagging causes Antigravity to make judgment calls it was never meant to make, silently shipping wrong choices. Leave a `bd comment` describing the gap and skip the tag.
 
-Over-tagging causes Antigravity to make judgment calls it was never meant to make, silently shipping wrong choices.
-
-If a gate is ambiguous, leave a `bd comment` describing the gap and skip the tag.
+**Low blast radius (tests, docs):** prefer tagging `agy-ready` with a delegated-decision note. Add a `bd comment` naming the micro-decisions the executor may resolve independently (e.g. "executor may choose cheapest test layer per CORE-TEST-005; post bd comment if torn"). Under-tagging safe work just starves Antigravity of good candidates.

--- a/.agents/skills/pinpoint-agy-triage/SKILL.md
+++ b/.agents/skills/pinpoint-agy-triage/SKILL.md
@@ -127,6 +127,6 @@ After Antigravity ships a PR, treat it like any other agent PR: Copilot review, 
 
 ## When in doubt
 
-**High blast radius (schema, permissions, prod behavior, new dependencies, lint architecture):** default to FAIL. Over-tagging causes Antigravity to make judgment calls it was never meant to make, silently shipping wrong choices. Leave a `bd comment` describing the gap and skip the tag.
+**High blast radius (schema, permissions, prod behavior, new dependencies, lint/architecture rules):** default to FAIL. Over-tagging causes Antigravity to make judgment calls it was never meant to make, silently shipping wrong choices. Leave a `bd comment` describing the gap and skip the tag.
 
 **Low blast radius (tests, docs):** prefer tagging `agy-ready` with a delegated-decision note. Add a `bd comment` naming the micro-decisions the executor may resolve independently (e.g. "executor may choose cheapest test layer per CORE-TEST-005; post bd comment if torn"). Under-tagging safe work just starves Antigravity of good candidates.


### PR DESCRIPTION
## Summary

- Gate 1 previously failed on any open interpretive decision, conflating task difficulty with the actual risk: silent divergence on forks Tim holds a preference on with high blast radius.
- A capable executor applying an existing project rule (e.g. CORE-TEST-005 choosing the cheapest test layer) is not an open fork — especially on low-blast-radius work like tests and docs, where mistakes are review-gated and have no prod impact.
- The `pinpoint-agy-execute` runbook already has a bd-comment escape valve for genuine uncertainty, so executors are not forced to guess.

**Three edits to `.agents/skills/pinpoint-agy-triage/SKILL.md`:**

1. **Gate 1 reworded** — now guards against unresolved forks that are (a) preference-laden AND (b) high blast radius or hard to catch in review. Micro-decisions resolved by existing rules pass Gate 1.
2. **Blast radius calibration subsection added** — distinguishes low blast radius (tests, docs: delegate with a bd-comment note) from high blast radius (schema, permissions, prod behavior, new deps: pre-made decision required).
3. **"When in doubt" reframed** — still default FAIL for high blast radius; prefer tagging agy-ready for low-blast-radius test/doc beads rather than starving Antigravity of good candidates.

References: PP-qj2f

## Test plan

- [x] `pnpm run check` passes (docs-only change; 1150 tests pass)
- [ ] Tim reviews Gate 1 wording and blast-radius calibration examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)