### PR TITLE
test(issues): add mobile E2E tests for StickyCommentComposer (PP-ab42)

### DIFF
--- a/e2e/full/issue-detail-sticky-composer.spec.ts
+++ b/e2e/full/issue-detail-sticky-composer.spec.ts
@@ -57,10 +57,16 @@ test.describe("StickyCommentComposer — mobile signed-out", () => {
     await page.goto(ISSUE_URL);
     await page.waitForLoadState("domcontentloaded");
 
+    // Assert that we are on the issue detail page and it loaded successfully (not redirected).
+    await expect(page).toHaveURL(ISSUE_URL);
+    await expect(
+      page.getByRole("heading", { level: 1, name: ISSUE.title })
+    ).toBeVisible();
+
     // The server-side check (accessLevel !== "unauthenticated") should prevent the
-    // StickyCommentComposer from rendering entirely, meaning it is not visible.
+    // StickyCommentComposer from rendering entirely, meaning it is not attached to the DOM.
     const stickyTrigger = page.getByRole("button", { name: "Add a comment" });
-    await expect(stickyTrigger).not.toBeVisible();
+    await expect(stickyTrigger).not.toBeAttached();
   });
 });
 

--- a/e2e/full/issue-detail-sticky-composer.spec.ts
+++ b/e2e/full/issue-detail-sticky-composer.spec.ts
@@ -1,13 +1,12 @@
 /**
- * E2E Tests: StickyCommentComposer — desktop CSS sticky-behavior (class-D)
+ * E2E Tests: StickyCommentComposer — visibility and authorization checks (class-D & class-E)
  *
- * Verifies that the mobile-only fixed-bottom comment composer is genuinely
- * hidden by `md:hidden` CSS at desktop viewport widths, and that the inline
- * composer in IssueTimeline is the only one visible.
- *
- * The three H-class scenarios (mobile signed-in render, mobile signed-out
- * server-side gate, sheet open/close) are covered by the RTL unit suite at
- * src/components/issues/StickyCommentComposer.test.tsx.
+ * Verifies that the mobile-only fixed-bottom comment composer:
+ * 1. Is hidden by `md:hidden` CSS at desktop viewport widths, and that the inline
+ *    composer in IssueTimeline is the only one visible.
+ * 2. Is hidden from unauthenticated (signed-out) visitors via the server-side gate,
+ *    even on mobile viewports.
+ * 3. Is visible for authenticated (signed-in) members on mobile viewports.
  */
 
 import { test, expect } from "@playwright/test";
@@ -20,7 +19,7 @@ const ISSUE = seededIssues.AFM[0];
 const ISSUE_URL = `/m/AFM/i/${ISSUE.num}`;
 
 // ----------------------------------------------------------------------------
-// Scenario 3: Desktop, signed-in (class-D CSS regression)
+// Scenario 1: Desktop, signed-in (class-D CSS regression)
 // ----------------------------------------------------------------------------
 
 test.describe("StickyCommentComposer — desktop signed-in", () => {
@@ -42,5 +41,45 @@ test.describe("StickyCommentComposer — desktop signed-in", () => {
     // The inline AddCommentForm in IssueTimeline is the only composer at desktop.
     // It is wrapped in data-testid="issue-comment-form".
     await expect(page.getByTestId("issue-comment-form")).toBeVisible();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 2: Mobile, signed-out (class-E server-side authorization gate)
+// ----------------------------------------------------------------------------
+
+test.describe("StickyCommentComposer — mobile signed-out", () => {
+  test.use({ viewport: { width: 375, height: 667 } });
+
+  test("sticky bar is NOT rendered on mobile for signed-out visitor", async ({
+    page,
+  }) => {
+    await page.goto(ISSUE_URL);
+    await page.waitForLoadState("domcontentloaded");
+
+    // The server-side check (accessLevel !== "unauthenticated") should prevent the
+    // StickyCommentComposer from rendering entirely, meaning it is not visible.
+    const stickyTrigger = page.getByRole("button", { name: "Add a comment" });
+    await expect(stickyTrigger).not.toBeVisible();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 3: Mobile, signed-in (class-E authorization verification)
+// ----------------------------------------------------------------------------
+
+test.describe("StickyCommentComposer — mobile signed-in", () => {
+  test.use({ viewport: { width: 375, height: 667 } });
+
+  test("sticky bar is rendered on mobile for signed-in member", async ({
+    page,
+  }, testInfo) => {
+    await loginAs(page, testInfo);
+    await page.goto(ISSUE_URL);
+    await page.waitForLoadState("domcontentloaded");
+
+    // Authenticated mobile users should see the StickyCommentComposer bar.
+    const stickyTrigger = page.getByRole("button", { name: "Add a comment" });
+    await expect(stickyTrigger).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Add mobile signed-in E2E tests for `StickyCommentComposer` to verify that the mobile-only bottom comment composer is rendered for authenticated members.
- Add mobile signed-out E2E tests for `StickyCommentComposer` to verify that the server-side gate (`accessLevel !== "unauthenticated"`) correctly prevents rendering the comment composer for signed-out visitors.

## Bead

PP-ab42: Add coverage for signed-out sticky-composer server-side gate (PP-4t3n backlog)

## Verification

Commands run:

- `pnpm exec playwright test e2e/full/issue-detail-sticky-composer.spec.ts --project=chromium`

Result: all passing.

## Notes

None.