### PR TITLE
test(machines): add machine page-level authorization coverage (PP-28hj)

### DIFF
--- a/e2e/smoke/machine-details-redesign.spec.ts
+++ b/e2e/smoke/machine-details-redesign.spec.ts
@@ -13,8 +13,8 @@
  *     - "should show Report Issue button in header" (class-H)
  *   Row 26 — Absorbed from e2e/smoke/machines-crud.spec.ts (now deleted):
  *     - machines list page overflow check (class-D)
- *   Row 26 — Downgraded to integration/unit (machine-actions.test.ts):
- *     - "non-admin cannot access /m/new page" (class-E)
+ *   Row 26 — Downgraded to integration/unit (machine-actions.test.ts) except /m/new page-level 403 (E2E):
+ *     - "non-admin cannot access /m/new page" (class-E page guard in E2E; mutation action in unit)
  *     - "should display seeded test machines with correct statuses" (class-B/D)
  *     - "should display machine issues on detail page via expando" (class-H — RTL)
  *     - "should display machine owner to all logged-in users" (class-D/H — RTL)

--- a/e2e/smoke/machine-details-redesign.spec.ts
+++ b/e2e/smoke/machine-details-redesign.spec.ts
@@ -124,4 +124,17 @@ test.describe("Machine Details Redesign", () => {
       /^pinpoint-TAF-issues-\d{4}-\d{2}-\d{2}\.csv$/
     );
   });
+
+  test("logged-in non-admin member is blocked from /m/new page", async ({
+    page,
+  }) => {
+    await page.goto("/m/new");
+
+    // Should show Forbidden page / Access Denied
+    await expect(page.getByText("Access Denied")).toBeVisible();
+    await expect(
+      page.locator("span").filter({ hasText: "Member" })
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+  });
 });

--- a/src/app/(app)/m/[initials]/(tabs)/page.test.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/page.test.tsx
@@ -1,0 +1,264 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import { machines, userProfiles } from "~/server/db/schema";
+import { createTestMachine, createTestUser } from "~/test/helpers/factories";
+import MachineInfoTab from "./page";
+
+// Mock Supabase Server Client
+const mockGetUser = vi.fn();
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+      },
+    }),
+}));
+
+// Mock next/headers
+vi.mock("next/headers", () => ({
+  headers: () => Promise.resolve(new Headers([["host", "localhost:3000"]])),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+}));
+
+// Mock the global db to point to our test db from PGlite
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  const db = await getTestDb();
+  return { db };
+});
+
+// Mock MachineTextFields to capture props passed down
+const mockMachineTextFields = vi.fn(() => (
+  <div data-testid="machine-text-fields" />
+));
+vi.mock("../machine-text-fields", () => ({
+  MachineTextFields: (props: {
+    machineId: string;
+    description: string | null;
+    tournamentNotes: string | null;
+    ownerRequirements: string | null;
+    ownerNotes: string | null;
+    canEditGeneral: boolean;
+    canEditOwnerNotes: boolean;
+    canViewOwnerRequirements: boolean;
+    canViewOwnerNotes: boolean;
+  }) => {
+    mockMachineTextFields(props);
+    return <div data-testid="machine-text-fields" />;
+  },
+}));
+
+describe("MachineInfoTab Page-Level Auth Integration", () => {
+  setupTestDb();
+
+  let testMachine: { id: string; initials: string; ownerId: string | null };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = await getTestDb();
+
+    // Create a test machine owned by a specific ID (or null)
+    const [machine] = await db
+      .insert(machines)
+      .values(
+        createTestMachine({
+          initials: "TAF",
+          name: "The Addams Family",
+          ownerId: null,
+        })
+      )
+      .returning();
+    testMachine = machine;
+  });
+
+  it("denies ownerRequirements view and ownerNotes view/edit to unauthenticated visitors", async () => {
+    // Mock no user logged in
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    // Call the server component
+    const result = await MachineInfoTab({
+      params: Promise.resolve({ initials: testMachine.initials }),
+    });
+
+    render(result);
+
+    expect(mockMachineTextFields).toHaveBeenCalled();
+    const props = mockMachineTextFields.mock.calls[0][0];
+
+    // Assert computed permissions passed to the child component
+    expect(props.canViewOwnerRequirements).toBe(false);
+    expect(props.canViewOwnerNotes).toBe(false);
+    expect(props.canEditGeneral).toBe(false);
+    expect(props.canEditOwnerNotes).toBe(false);
+  });
+
+  it("allows ownerRequirements view to guest, but denies ownerNotes view/edit", async () => {
+    const db = await getTestDb();
+
+    const guestId = randomUUID();
+    const guestEmail = "guest@test.com";
+
+    // Insert user profile
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: guestId,
+        email: guestEmail,
+        role: "guest",
+      })
+    );
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: guestId, email: guestEmail } },
+    });
+
+    const result = await MachineInfoTab({
+      params: Promise.resolve({ initials: testMachine.initials }),
+    });
+
+    render(result);
+
+    expect(mockMachineTextFields).toHaveBeenCalled();
+    const props = mockMachineTextFields.mock.calls[0][0];
+
+    // Guests can view requirements, but not view/edit owner notes
+    expect(props.canViewOwnerRequirements).toBe(true);
+    expect(props.canViewOwnerNotes).toBe(false);
+    expect(props.canEditGeneral).toBe(false);
+    expect(props.canEditOwnerNotes).toBe(false);
+  });
+
+  it("allows ownerRequirements view to non-owner member, but denies ownerNotes view/edit", async () => {
+    const db = await getTestDb();
+
+    const memberId = randomUUID();
+    const memberEmail = "member@test.com";
+
+    // Insert user profile
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: memberId,
+        email: memberEmail,
+        role: "member",
+      })
+    );
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: memberId, email: memberEmail } },
+    });
+
+    const result = await MachineInfoTab({
+      params: Promise.resolve({ initials: testMachine.initials }),
+    });
+
+    render(result);
+
+    expect(mockMachineTextFields).toHaveBeenCalled();
+    const props = mockMachineTextFields.mock.calls[0][0];
+
+    // Non-owner member can view requirements, but not view/edit owner notes
+    expect(props.canViewOwnerRequirements).toBe(true);
+    expect(props.canViewOwnerNotes).toBe(false);
+    expect(props.canEditGeneral).toBe(false);
+    expect(props.canEditOwnerNotes).toBe(false);
+  });
+
+  it("allows ownerRequirements view AND ownerNotes view/edit to machine owner member", async () => {
+    const db = await getTestDb();
+
+    const ownerId = randomUUID();
+    const ownerEmail = "owner@test.com";
+
+    // Insert owner profile
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: ownerId,
+        email: ownerEmail,
+        role: "member",
+      })
+    );
+
+    // Update machine owner
+    await db
+      .update(machines)
+      .set({ ownerId })
+      .where(eq(machines.id, testMachine.id));
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: ownerId, email: ownerEmail } },
+    });
+
+    const result = await MachineInfoTab({
+      params: Promise.resolve({ initials: testMachine.initials }),
+    });
+
+    render(result);
+
+    expect(mockMachineTextFields).toHaveBeenCalled();
+    const props = mockMachineTextFields.mock.calls[0][0];
+
+    // Owner member has full view & edit of owner requirements and notes
+    expect(props.canViewOwnerRequirements).toBe(true);
+    expect(props.canViewOwnerNotes).toBe(true);
+    expect(props.canEditGeneral).toBe(true);
+    expect(props.canEditOwnerNotes).toBe(true);
+  });
+
+  it("allows ownerRequirements view to admin, but denies ownerNotes view/edit if not the machine owner", async () => {
+    const db = await getTestDb();
+
+    const adminId = randomUUID();
+    const adminEmail = "admin@test.com";
+
+    // Insert admin profile
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: adminId,
+        email: adminEmail,
+        role: "admin",
+      })
+    );
+
+    // Set owner to someone else
+    const someoneElseId = randomUUID();
+    const someoneElseEmail = "someoneelse@test.com";
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: someoneElseId,
+        email: someoneElseEmail,
+        role: "member",
+      })
+    );
+
+    await db
+      .update(machines)
+      .set({ ownerId: someoneElseId })
+      .where(eq(machines.id, testMachine.id));
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: adminId, email: adminEmail } },
+    });
+
+    const result = await MachineInfoTab({
+      params: Promise.resolve({ initials: testMachine.initials }),
+    });
+
+    render(result);
+
+    expect(mockMachineTextFields).toHaveBeenCalled();
+    const props = mockMachineTextFields.mock.calls[0][0];
+
+    expect(props.canViewOwnerRequirements).toBe(true);
+    expect(props.canViewOwnerNotes).toBe(false);
+    expect(props.canEditGeneral).toBe(true);
+    expect(props.canEditOwnerNotes).toBe(false);
+  });
+});

--- a/src/app/(app)/m/[initials]/machine-text-fields.test.tsx
+++ b/src/app/(app)/m/[initials]/machine-text-fields.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MachineTextFields } from "./machine-text-fields";
+import type { ProseMirrorDoc } from "~/lib/tiptap/types";
+
+// Mock InlineEditableField to avoid rendering complex rich text editor
+vi.mock("~/components/inline-editable-field", () => ({
+  InlineEditableField: ({ label, testId }: any) => (
+    <div data-testid={testId}>
+      <span>{label}</span>
+    </div>
+  ),
+}));
+
+const mockDoc: ProseMirrorDoc = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Some content" }],
+    },
+  ],
+};
+
+const defaultProps = {
+  machineId: "mach-123",
+  description: mockDoc,
+  tournamentNotes: mockDoc,
+  ownerRequirements: mockDoc,
+  ownerNotes: mockDoc,
+  canEditGeneral: true,
+  canEditOwnerNotes: true,
+  canViewOwnerRequirements: true,
+  canViewOwnerNotes: true,
+};
+
+describe("MachineTextFields", () => {
+  it("renders description and tournament notes based on existence, but general fields are always present in layout", () => {
+    render(<MachineTextFields {...defaultProps} />);
+    expect(screen.getByTestId("machine-description")).toBeInTheDocument();
+    expect(screen.getByTestId("machine-tournament-notes")).toBeInTheDocument();
+  });
+
+  it("renders owner requirements if canViewOwnerRequirements is true", () => {
+    render(
+      <MachineTextFields {...defaultProps} canViewOwnerRequirements={true} />
+    );
+    expect(
+      screen.getByTestId("machine-owner-requirements")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render owner requirements if canViewOwnerRequirements is false", () => {
+    render(
+      <MachineTextFields {...defaultProps} canViewOwnerRequirements={false} />
+    );
+    expect(
+      screen.queryByTestId("machine-owner-requirements")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders owner notes if canViewOwnerNotes is true", () => {
+    render(<MachineTextFields {...defaultProps} canViewOwnerNotes={true} />);
+    expect(screen.getByTestId("machine-owner-notes")).toBeInTheDocument();
+  });
+
+  it("does not render owner notes if canViewOwnerNotes is false", () => {
+    render(<MachineTextFields {...defaultProps} canViewOwnerNotes={false} />);
+    expect(screen.queryByTestId("machine-owner-notes")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/m/[initials]/machine-text-fields.test.tsx
+++ b/src/app/(app)/m/[initials]/machine-text-fields.test.tsx
@@ -4,9 +4,14 @@ import { describe, it, expect, vi } from "vitest";
 import { MachineTextFields } from "./machine-text-fields";
 import type { ProseMirrorDoc } from "~/lib/tiptap/types";
 
+interface MockInlineEditableFieldProps {
+  label: string;
+  testId?: string;
+}
+
 // Mock InlineEditableField to avoid rendering complex rich text editor
 vi.mock("~/components/inline-editable-field", () => ({
-  InlineEditableField: ({ label, testId }: any) => (
+  InlineEditableField: ({ label, testId }: MockInlineEditableFieldProps) => (
     <div data-testid={testId}>
       <span>{label}</span>
     </div>


### PR DESCRIPTION
## Summary

- Add E2E test verifying that logged-in non-admin member is blocked from accessing the `/m/new` page (renders Forbidden).
- Add RTL unit/integration test for `MachineTextFields` Client Component verifying that `canViewOwnerRequirements` correctly gates the owner's requirements field display.

## Bead

PP-28hj: Add coverage for machine page-level authorization (/m/new 403 + canViewOwnerRequirements wiring)

## Verification

Commands run:

- `pnpm exec playwright test e2e/smoke/machine-details-redesign.spec.ts --project=chromium`
- `pnpm test src/app/\(app\)/m/\[initials\]/machine-text-fields.test.tsx --run`
- `pnpm run check`

Result: all passing.

## Notes

None.