### PR TITLE
test(privacy): broaden email-privacy regression test to mirror page findFirst (PP-kj0s)

### DIFF
--- a/src/test/integration/issue-services.test.ts
+++ b/src/test/integration/issue-services.test.ts
@@ -594,8 +594,8 @@ describe("Issue Service Functions (Integration)", () => {
         })
         .returning();
 
-      // Fetch the issue the same way page.tsx does: with reportedByUser and
-      // invitedReporter relations but without any root columns restriction.
+      // Fetch the issue matching the root columns selection behavior of the issue detail page
+      // (no columns restriction under issues, but with related tables restricted).
       const fetched = await db.query.issues.findFirst({
         where: eq(issues.id, emailOnlyIssue.id),
         with: {
@@ -605,6 +605,9 @@ describe("Issue Service Functions (Integration)", () => {
       });
 
       if (!fetched) throw new Error("Expected issue to exist");
+
+      // Verify that reporterEmail is actually retrieved by the query.
+      expect(fetched.reporterEmail).toBe("display@bug.com");
 
       // Pass the fetched issue directly to resolveIssueReporter to mirror how the page
       // invokes it. This ensures that any accidental access to reporterEmail (which is

--- a/src/test/integration/issue-services.test.ts
+++ b/src/test/integration/issue-services.test.ts
@@ -595,31 +595,21 @@ describe("Issue Service Functions (Integration)", () => {
         .returning();
 
       // Fetch the issue the same way page.tsx does: with reportedByUser and
-      // invitedReporter relations but WITHOUT selecting reporterEmail in the
-      // column set (the query omits it by design for privacy).
+      // invitedReporter relations but without any root columns restriction.
       const fetched = await db.query.issues.findFirst({
         where: eq(issues.id, emailOnlyIssue.id),
         with: {
           reportedByUser: { columns: { id: true, name: true } },
           invitedReporter: { columns: { id: true, name: true } },
         },
-        columns: {
-          id: true,
-          reportedBy: true,
-          reporterName: true,
-          // reporterEmail intentionally excluded — privacy contract
-        },
       });
 
       if (!fetched) throw new Error("Expected issue to exist");
 
-      // resolveIssueReporter only sees reportedByUser, invitedReporter, and
-      // reporterName.  All are null here.  The email must NOT appear.
-      const reporter = resolveIssueReporter({
-        reportedByUser: fetched.reportedByUser ?? null,
-        invitedReporter: fetched.invitedReporter ?? null,
-        reporterName: fetched.reporterName ?? null,
-      });
+      // Pass the fetched issue directly to resolveIssueReporter to mirror how the page
+      // invokes it. This ensures that any accidental access to reporterEmail (which is
+      // now retrieved by the query) will be caught.
+      const reporter = resolveIssueReporter(fetched);
 
       expect(reporter.name).toBe("Anonymous");
       expect(reporter.name).not.toContain("display@bug.com");


### PR DESCRIPTION
## Summary

- Updated the email-privacy regression integration test to query the issues table without column restrictions (no `columns` filter at the root), matching the `findFirst` query shape used by the issue detail page.
- Changed the invocation of `resolveIssueReporter` to pass the `fetched` issue object directly, mirroring how it's called on the page, ensuring any accidental access/fallback to `reporterEmail` at runtime fails the test.
- Deliberately regressed `resolveIssueReporter` to confirm the test fails as expected, then restored it.

## Bead

PP-kj0s: Broaden email-privacy regression test to mirror page findFirst query shape

## Verification

Commands run:

- `pnpm test:integration src/test/integration/issue-services.test.ts`
- `pnpm run preflight`

Result: all passing.

## Notes

- During the verification phase, started Supabase using `supabase start` in this worktree slot.
- Encountered a flaky E2E test failure (`[Mobile Chrome] › e2e/smoke/navigation.spec.ts:153:3 › Bottom Tab Bar (mobile only) › More sheet shows User Management only for admin users`) during preflight, which passed cleanly when run isolation-wise.