### PR TITLE
test(settings): add RTL coverage for ChangePasswordSection wrong-password error message (PP-p6pj)

### DIFF
--- a/src/app/(app)/settings/change-password-section.test.tsx
+++ b/src/app/(app)/settings/change-password-section.test.tsx
@@ -1,13 +1,29 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ChangePasswordSection } from "./change-password-section";
 import * as actions from "./actions";
+
+// Mock useActionState to control state across renders
+const mockUseActionState = vi.fn();
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof React>();
+  return {
+    ...actual,
+    useActionState: (fn: unknown, initialState: unknown) =>
+      mockUseActionState(fn, initialState),
+  };
+});
 
 // Spy on the server action to prevent module-level execution
 const changePasswordSpy = vi.spyOn(actions, "changePasswordAction");
 
 describe("ChangePasswordSection", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([undefined, vi.fn(), false]);
+  });
+
   it("renders all three password fields", () => {
     render(<ChangePasswordSection />);
     expect(screen.getByLabelText(/^Current Password\b/i)).toBeVisible();
@@ -32,5 +48,21 @@ describe("ChangePasswordSection", () => {
       "autocomplete",
       "new-password"
     );
+  });
+
+  it("renders the error message when the current password is wrong", () => {
+    mockUseActionState.mockReturnValue([
+      {
+        ok: false,
+        error: "WRONG_PASSWORD" as const,
+        message: "Current password is incorrect.",
+      },
+      vi.fn(),
+      false,
+    ]);
+
+    render(<ChangePasswordSection />);
+
+    expect(screen.getByText("Current password is incorrect.")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Added unit test coverage to verify that the `ChangePasswordSection` component correctly displays the `Current password is incorrect.` error message when the form action fails with `WRONG_PASSWORD`.
- Mocked React's `useActionState` hook to feed the component the action result.

## Bead

PP-p6pj: Add RTL coverage for ChangePasswordSection wrong-password error message

## Verification

Commands run:

- `pnpm run check`
- `pnpm vitest run src/app/\(app\)/settings/change-password-section.test.tsx`

Result: all passing.

## Notes

None.