### PR TITLE
fix(preflight): add tomli fallback to check-config-drift.py for Python 3.9 (PP-5x0f)

### DIFF
--- a/scripts/check-config-drift.py
+++ b/scripts/check-config-drift.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 import subprocess
 import sys
-import tomllib
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
 from pathlib import Path
 
 CONFIG_TEMPLATE_PATH = Path("supabase/config.toml.template")

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,3 @@
 pytest>=8.0.0
+tomli
+


### PR DESCRIPTION
## Summary

* Added a `tomli` fallback import to `check-config-drift.py` when `tomllib` (introduced in Python 3.11) is not present.
* Added `tomli` to `scripts/requirements.txt`.

## Bead

PP-5x0f: Preflight: check-config-drift.py needs Python 3.11+ tomllib (split from PP-pblt)

## Verification

Commands run:

* `/usr/bin/python3 scripts/check-config-drift.py` (simulates Python 3.9 system interpreter, fallback path checked and verified with `tomli` installed)
* `python3 scripts/check-config-drift.py` (simulates Python 3.14 native path using stdlib `tomllib`)
* `pnpm run check:config`
* `pnpm run check`

Result: all passing.

## Notes

None.