### PR TITLE
fix(e2e): poll Docker readiness in global-setup to fix CI flake (PP-149t)

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -58,29 +58,64 @@ function checkBrowserBinaries(config: FullConfig): void {
 }
 
 /**
+ * Block the current thread for `ms` milliseconds without a shell or child
+ * process. Used to pace Docker readiness retries. `Atomics.wait` on a throwaway
+ * SharedArrayBuffer is the standard synchronous-sleep primitive in Node.
+ */
+function sleepSync(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
  * Verify the Docker daemon is up. Supabase's local stack runs in Docker, so
  * a missing daemon would surface as confusing Postgres connection failures.
  * Uses spawnSync (not exec) — no shell, fixed argv, safe.
+ *
+ * On CI the runner's Docker daemon can still be coming up when global-setup
+ * runs, so a single-shot check races daemon startup and fails spuriously
+ * (PP-149t). Poll `docker info` with a bounded retry budget instead, tolerating
+ * a brief startup delay. A missing binary (ENOENT) is fatal immediately —
+ * retrying won't install Docker. Budget is tunable via env for CI.
  */
 function checkDocker(): void {
-  const result = spawnSync("docker", ["info"], {
-    stdio: "ignore",
-    timeout: 5000,
-  });
-  if (result.error?.code === "ENOENT") {
-    throw new Error(
-      "Docker is not installed.\n" +
-        "  Install OrbStack, Docker Desktop, or Docker Engine (whichever your platform supports).\n" +
-        "  Mac: brew install --cask orbstack"
-    );
+  const attempts = Number(process.env.E2E_DOCKER_READY_ATTEMPTS ?? "15");
+  const delayMs = Number(process.env.E2E_DOCKER_READY_DELAY_MS ?? "1000");
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const result = spawnSync("docker", ["info"], {
+      stdio: "ignore",
+      timeout: 5000,
+    });
+
+    if (result.error?.code === "ENOENT") {
+      throw new Error(
+        "Docker is not installed.\n" +
+          "  Install OrbStack, Docker Desktop, or Docker Engine (whichever your platform supports).\n" +
+          "  Mac: brew install --cask orbstack"
+      );
+    }
+
+    if (!result.error && result.status === 0) {
+      if (attempt > 1) {
+        console.log(`✅ Docker daemon ready (attempt ${attempt}/${attempts}).`);
+      }
+      return;
+    }
+
+    if (attempt < attempts) {
+      console.log(
+        `⏳ Docker daemon not ready (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms...`
+      );
+      sleepSync(delayMs);
+    }
   }
-  if (result.error || result.status !== 0) {
-    throw new Error(
-      "Docker daemon is not running. Supabase's local stack needs it.\n" +
-        "  Start your Docker daemon (e.g., OrbStack, Docker Desktop, Colima, or `systemctl start docker`).\n" +
-        "  Then wait a few seconds and re-run."
-    );
-  }
+
+  throw new Error(
+    `Docker daemon is not running after ${attempts} attempts. Supabase's local stack needs it.\n` +
+      "  Start your Docker daemon (e.g., OrbStack, Docker Desktop, Colima, or `systemctl start docker`).\n" +
+      "  Then wait a few seconds and re-run."
+  );
 }
 
 /**

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -63,8 +63,22 @@ function checkBrowserBinaries(config: FullConfig): void {
  * SharedArrayBuffer is the standard synchronous-sleep primitive in Node.
  */
 function sleepSync(ms: number): void {
-  if (ms <= 0) return;
+  // Guard non-finite values: Atomics.wait coerces NaN to +Infinity and would
+  // block forever, defeating the bounded readiness budget.
+  if (!Number.isFinite(ms) || ms <= 0) return;
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Read a numeric env override, falling back to `fallback` when unset or
+ * invalid (e.g. a typo'd `E2E_DOCKER_READY_DELAY_MS=abc` → NaN). Keeps the
+ * Docker readiness budget bounded regardless of bad input.
+ */
+function numEnv(name: string, fallback: number, min: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= min ? n : fallback;
 }
 
 /**
@@ -79,8 +93,8 @@ function sleepSync(ms: number): void {
  * retrying won't install Docker. Budget is tunable via env for CI.
  */
 function checkDocker(): void {
-  const attempts = Number(process.env.E2E_DOCKER_READY_ATTEMPTS ?? "15");
-  const delayMs = Number(process.env.E2E_DOCKER_READY_DELAY_MS ?? "1000");
+  const attempts = Math.floor(numEnv("E2E_DOCKER_READY_ATTEMPTS", 15, 1));
+  const delayMs = numEnv("E2E_DOCKER_READY_DELAY_MS", 1000, 0);
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
     const result = spawnSync("docker", ["info"], {

--- a/src/test/unit/global-setup.test.ts
+++ b/src/test/unit/global-setup.test.ts
@@ -67,6 +67,10 @@ describe("e2e/global-setup", () => {
       ...envBackup,
       NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
       POSTGRES_URL: "postgresql://postgres:postgres@localhost:54322/postgres",
+      // Keep the Docker readiness retry loop fast and deterministic in tests:
+      // a few attempts, no real sleep between them.
+      E2E_DOCKER_READY_ATTEMPTS: "3",
+      E2E_DOCKER_READY_DELAY_MS: "0",
     };
   });
 
@@ -170,16 +174,36 @@ describe("e2e/global-setup", () => {
     );
   });
 
-  it("throws daemon-down error when Docker exits with non-zero status", async () => {
+  it("throws daemon-down error after exhausting retries when Docker stays down", async () => {
     spawnSyncMock.mockReturnValue({ status: 1, error: null });
     const setup = await loadSetup();
 
     await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
       "Docker daemon is not running"
     );
+    // Retried up to the configured budget (E2E_DOCKER_READY_ATTEMPTS=3) before
+    // giving up, rather than failing on the first transient miss.
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
   });
 
-  it("throws not-installed error when Docker returns ENOENT", async () => {
+  it("recovers when Docker becomes ready within the retry budget", async () => {
+    // Daemon not ready on the first two polls, then comes up — global-setup
+    // should tolerate the transient startup delay and proceed (PP-149t).
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, error: null })
+      .mockReturnValueOnce({ status: 1, error: null })
+      .mockReturnValue({ status: 0, error: null });
+    execSyncMock.mockReturnValue(undefined);
+    const setup = await loadSetup();
+
+    await setup(EMPTY_CONFIG);
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    // Proceeded past the Docker check to the Supabase health probe.
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("fails fast without retrying when Docker is not installed (ENOENT)", async () => {
     const enoent = Object.assign(new Error("spawn docker ENOENT"), {
       code: "ENOENT",
     });
@@ -189,6 +213,8 @@ describe("e2e/global-setup", () => {
     await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
       "Docker is not installed"
     );
+    // ENOENT is fatal immediately — retrying won't install Docker.
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });
 
   it("throws install hint when a required browser binary is missing", async () => {

--- a/src/test/unit/global-setup.test.ts
+++ b/src/test/unit/global-setup.test.ts
@@ -203,6 +203,21 @@ describe("e2e/global-setup", () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
+  it("falls back to the default budget when retry env vars are invalid", async () => {
+    // A typo'd attempts value must not skip the probe (NaN loop → 0 probes)
+    // or, via an invalid delay, block forever — the budget stays bounded.
+    process.env.E2E_DOCKER_READY_ATTEMPTS = "abc";
+    process.env.E2E_DOCKER_READY_DELAY_MS = "0";
+    spawnSyncMock.mockReturnValue({ status: 1, error: null });
+    const setup = await loadSetup();
+
+    await expect(setup(EMPTY_CONFIG)).rejects.toThrow(
+      "Docker daemon is not running"
+    );
+    // Invalid attempts → falls back to the default of 15, still probing.
+    expect(spawnSyncMock).toHaveBeenCalledTimes(15);
+  });
+
   it("fails fast without retrying when Docker is not installed (ENOENT)", async () => {
     const enoent = Object.assign(new Error("spawn docker ENOENT"), {
       code: "ENOENT",


### PR DESCRIPTION
## Problem

E2E CI jobs (e.g. *E2E Full Tests (Chromium)*) intermittently fail at `e2e/global-setup.ts` `checkDocker()` with **"Docker daemon is not running"**. Re-running the job goes green — a transient infra race, tracked as **PP-149t**. Each hit costs a manual re-run + ~10–15 min and erodes trust in red CI.

## Root cause

These are GitHub-hosted `ubuntu-latest` runners where Docker is normally already up, but two things open a brief not-ready window that the **single-shot** `docker info` check raced:

- `step-security/harden-runner` runs `systemctl restart docker` to apply its egress policy (visible in the failing run's logs).
- Under load, `docker info` can exceed the 5s `spawnSync` timeout and return non-zero.

The old code threw on the *first* miss instead of tolerating a short startup delay.

## Fix

Replace the single shot with a **bounded poll** of `docker info` — the conventional "wait until Docker is available or timeout is reached" pattern (the same mechanism GitHub's runner uses internally):

- Default budget: 15 attempts × 1s, tunable via `E2E_DOCKER_READY_ATTEMPTS` / `E2E_DOCKER_READY_DELAY_MS`.
- `ENOENT` (Docker not installed) still fails fast — retrying can't install Docker.
- Synchronous `sleepSync` via `Atomics.wait` keeps `checkDocker()` signature unchanged.

Benefits local dev too (same single point of failure).

## Tests

`src/test/unit/global-setup.test.ts`:
- recovers when Docker becomes ready within the retry budget
- throws after exhausting retries when Docker stays down
- fails fast without retrying on ENOENT

Env-var knobs (`DELAY_MS=0`) keep the retry loop instant and deterministic.

## Verification

Not locally reproducible (CI infra). Validated by: targeted unit tests pass, typecheck/lint/format clean. True confirmation is absence of the flake across subsequent CI runs.

Closes PP-149t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)