### PR TITLE
chore(workflow): isolate @tiptap/* into a dedicated Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,23 @@ updates:
       semver-minor-days: 14
       semver-patch-days: 14
     groups:
-      # Group minor and patch updates together
+      # Group minor and patch updates together (Tiptap excluded — see the tiptap
+      # group; it must move in lockstep and skews transiently. PP-sg3m)
       minor-patch-updates:
         applies-to: version-updates
+        exclude-patterns:
+          - "@tiptap/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Tiptap adapter packages import internal helpers from @tiptap/core that
+      # only exist in the exactly-matching core version. Isolating them so a
+      # transient skew (unpinned transitive core vs. cooldown-held direct deps)
+      # never blocks the rest of the minor-patch group. PP-sg3m
+      tiptap:
+        applies-to: version-updates
+        patterns:
+          - "@tiptap/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

- Adds an `exclude-patterns: ["@tiptap/*"]` clause to the existing `minor-patch-updates` Dependabot group so tiptap packages no longer compete with the rest of the npm dependency batch.
- Adds a new `tiptap` group covering only `@tiptap/*` packages with the same `minor`/`patch` update types.
- No other changes (cooldown, labels, `security-updates` group, `github-actions` ecosystem are all untouched).

## Root cause (PP-sg3m)

Tiptap adapter packages (e.g. `@tiptap/extension-*`) import internal helpers from `@tiptap/core` that only exist in the **exactly-matching** core version. When Dependabot batches tiptap packages together with the rest of the minor-patch group, a transient version skew — unpinned transitive `@tiptap/core` bumped ahead of the cooldown-held direct dep — causes the combined PR to go red. This blocks **all** other minor/patch updates until the skew resolves.

Isolating tiptap into its own group lets the tiptap PR go transiently red in isolation without holding up the rest of the batch. The tiptap PR itself still gets created; it just no longer acts as a blast-radius multiplier.

Closes/tracks: PP-sg3m

🤖 Generated with [Claude Code](https://claude.com/claude-code)