### PR TITLE
fix(huddle): prefer $CLAUDE_SESSION_ID over racy transcript discovery (PP-bh7w)

### DIFF
--- a/scripts/hooks/huddle-whoami.sh
+++ b/scripts/hooks/huddle-whoami.sh
@@ -23,10 +23,12 @@
 #                            Exits 1 with usage if SESSION_ID is omitted.
 #   list                     Dump all session_id → name pairs (sorted by name).
 #   discover                 Print the best-guess session_id of the calling
-#                            shell (Claude Code only; see WARNING below).
+#                            shell. Prefers $CLAUDE_SESSION_ID when set;
+#                            falls back to the transcript heuristic with a
+#                            warning (Claude Code only; see WARNING below).
 #
-# WARNING — session_id discovery is a Claude-Code-specific best-effort
-# heuristic. It reads ~/.claude/projects/<mangled-root>/<session_id>.jsonl,
+# WARNING — the transcript-based session_id discovery is a Claude-Code-specific
+# best-effort heuristic. It reads ~/.claude/projects/<mangled-root>/<session_id>.jsonl,
 # the transcript location Claude Code uses. Other harnesses (Antigravity,
 # Codex, etc.) do not write transcripts there and MUST pass session_id
 # explicitly — their bootstrap shims already do (see
@@ -35,7 +37,7 @@
 # transcript, which is wrong for any non-newest session (2026-05-20 incident
 # on PP-lt12 — root cause of PP-sjkz). SESSION_ID is therefore REQUIRED for
 # whoami and register; the discover subcommand invokes the heuristic only
-# when the caller explicitly requests it.
+# when the caller explicitly requests it and $CLAUDE_SESSION_ID is absent.
 
 set -euo pipefail
 
@@ -151,7 +153,18 @@ case "$cmd" in
     ;;
 
   discover)
-    discover_session_id || { echo "(could not discover)" >&2; exit 1; }
+    # Prefer the env var set by Claude Code's hook context — it is guaranteed
+    # correct for the calling session. Fall back to the transcript heuristic
+    # only when the env var is absent, and warn that the result may be wrong
+    # when multiple sessions are active concurrently (PP-bh7w).
+    if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+      printf '%s\n' "$CLAUDE_SESSION_ID"
+    else
+      printf 'WARNING: CLAUDE_SESSION_ID is not set; falling back to transcript heuristic.\n' >&2
+      printf 'WARNING: This result may be incorrect when multiple Claude sessions are active.\n' >&2
+      printf 'WARNING: Pass the session_id explicitly, or run from a hook context where CLAUDE_SESSION_ID is set.\n' >&2
+      discover_session_id || { printf '(could not discover)\n' >&2; exit 1; }
+    fi
     ;;
 
   *)


### PR DESCRIPTION
## What

Fixes the session-id race in `scripts/hooks/huddle-whoami.sh`'s `discover` subcommand (PP-bh7w).

**Before:** `discover` always used the newest-transcript heuristic — whichever session most recently wrote to its `.jsonl` file. When multiple Claude sessions share a project, this returns the wrong session_id for any non-newest session.

**After:** `discover` now prefers the `$CLAUDE_SESSION_ID` environment variable when it is set (Claude Code injects this in hook contexts, so it is guaranteed correct). It falls back to the transcript heuristic only when the env var is absent, and prints three clear stderr warnings explaining the result may be wrong across concurrent sessions.

## Why the fallback is preserved

The huddle system is multi-harness: Antigravity (Gemini), Codex, and Gemini CLI are huddle participants too. Those harnesses do **not** set `$CLAUDE_SESSION_ID`. Removing or hard-erroring on the fallback would break `discover` for every non-Claude session. The net effect is: more-accurate identity when an env id exists, same behavior as today (plus an explicit warning) when it does not.

## CLI contract

Fully preserved:
- `whoami SESSION_ID` — requires explicit id (unchanged)
- `register NAME SESSION_ID` — requires explicit id (unchanged)
- `discover` — now prefers env var, falls back with warning (behavior change, non-breaking)
- `list` — unchanged

Explicit SESSION_ID arguments still win over everything, including the env var.

## Manual verifications

1. **With `CLAUDE_SESSION_ID` exported:** `CLAUDE_SESSION_ID=test-abc123 bash scripts/hooks/huddle-whoami.sh discover` prints `test-abc123` — the env var value, not the transcript heuristic.

2. **With `CLAUDE_SESSION_ID` unset:** `bash scripts/hooks/huddle-whoami.sh discover` still resolves via the transcript heuristic AND prints three WARNING lines to stderr confirming the fallback is active.

3. **Explicit session-id argument:** `bash scripts/hooks/huddle-whoami.sh whoami <some-id>` continues to require and use the explicit argument — the env var is not consulted.

Fixes: PP-bh7w