### PR TITLE
perf(issues): shared ticker for RelativeTime (PP-nut)

### DIFF
--- a/src/components/issues/RelativeTime.test.tsx
+++ b/src/components/issues/RelativeTime.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { RelativeTime } from "./RelativeTime";
+import { RelativeTimeProvider } from "./RelativeTimeProvider";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -10,9 +11,10 @@ afterEach(() => {
 
 describe("RelativeTime", () => {
   it("renders the fallback in SSR output (no client effects)", () => {
-    // Server render: useEffect doesn't run, so label stays null and fallback
-    // is what hits the wire. This is the whole reason this component exists —
-    // a hydration-safe initial paint before swapping to relative time.
+    // Server render: useSyncExternalStore uses the server snapshot (null),
+    // so the component renders the fallback. This is the whole reason this
+    // component exists — a hydration-safe initial paint before swapping to
+    // relative time.
     const html = renderToString(
       <RelativeTime
         value={new Date("2026-04-25T10:00:00Z")}
@@ -25,7 +27,11 @@ describe("RelativeTime", () => {
 
   it("swaps to a relative label after mount", async () => {
     const recent = new Date(Date.now() - 5 * 60_000); // 5 minutes ago
-    render(<RelativeTime value={recent} fallback="Apr 25, 2026" />);
+    render(
+      <RelativeTimeProvider>
+        <RelativeTime value={recent} fallback="Apr 25, 2026" />
+      </RelativeTimeProvider>
+    );
 
     await waitFor(() => {
       // date-fns formatDistanceToNow with addSuffix: true emits patterns like
@@ -36,15 +42,17 @@ describe("RelativeTime", () => {
 
   it("accepts a string value and parses it", async () => {
     render(
-      <RelativeTime
-        value="2026-04-25T10:00:00Z"
-        fallback="Apr 25, 2026, 10:00 AM"
-      />
+      <RelativeTimeProvider>
+        <RelativeTime
+          value="2026-04-25T10:00:00Z"
+          fallback="Apr 25, 2026, 10:00 AM"
+        />
+      </RelativeTimeProvider>
     );
 
-    // After mount, the effect runs and produces a relative label. Even with a
-    // date months in the future or past, formatDistanceToNow always emits
-    // something matching this pattern (e.g. "in X months", "X years ago").
+    // After mount, the provider fires its first tick and produces a relative
+    // label. Even with a date months in the future or past, formatDistanceToNow
+    // always emits something matching this pattern (e.g. "in X months", "X years ago").
     await waitFor(() => {
       expect(screen.getByText(/ago|just now|in /)).toBeInTheDocument();
     });
@@ -55,13 +63,15 @@ describe("RelativeTime", () => {
       // intentionally silent
     });
 
-    render(<RelativeTime value="not a date" fallback="N/A" />);
+    render(
+      <RelativeTimeProvider>
+        <RelativeTime value="not a date" fallback="N/A" />
+      </RelativeTimeProvider>
+    );
 
-    // Effect should early-return on NaN getTime() — no throw, no setLabel,
-    // and no console.warn (we only warn from the try/catch around formatRelative).
-    expect(screen.getByText("N/A")).toBeInTheDocument();
-
-    // Advance any pending microtasks; fallback must still be shown.
+    // Effect should detect NaN getTime() and keep the fallback even after
+    // the provider's first tick. No console.warn (we only warn from the
+    // try/catch around formatRelative, which is never reached for NaN dates).
     await act(async () => {
       await Promise.resolve();
     });
@@ -69,12 +79,22 @@ describe("RelativeTime", () => {
     expect(consoleWarn).not.toHaveBeenCalled();
   });
 
-  it("clears its interval on unmount", () => {
+  it("shared ticker stops when the provider unmounts", () => {
     const clearSpy = vi.spyOn(window, "clearInterval");
     const { unmount } = render(
-      <RelativeTime value={new Date()} fallback="now" />
+      <RelativeTimeProvider>
+        <RelativeTime value={new Date()} fallback="now" />
+      </RelativeTimeProvider>
     );
     unmount();
+    // The provider's cleanup stops the shared interval.
     expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it("renders fallback without a provider (no ticker running)", () => {
+    // Without a provider the store snapshot stays null — all instances render
+    // their fallback. This is a safe degraded mode (SSR, tests without wrapper).
+    render(<RelativeTime value={new Date()} fallback="static label" />);
+    expect(screen.getByText("static label")).toBeInTheDocument();
   });
 });

--- a/src/components/issues/RelativeTime.tsx
+++ b/src/components/issues/RelativeTime.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type React from "react";
-import { useEffect, useState } from "react";
 import { formatRelative } from "~/lib/dates";
+import { useRelativeNow } from "./RelativeTimeProvider";
 
 interface RelativeTimeProps {
   value: Date | string;
@@ -15,34 +15,9 @@ export function RelativeTime({
   value,
   fallback,
 }: RelativeTimeProps): React.JSX.Element {
-  const [label, setLabel] = useState<string | null>(null);
-
-  // Re-runs only when the instant changes, not the Date reference.
-  const depKey = value instanceof Date ? value.getTime() : value;
-
-  useEffect(() => {
-    const date = typeof value === "string" ? new Date(value) : value;
-    if (Number.isNaN(date.getTime())) {
-      // Reset label so a previous, now-stale value doesn't keep rendering when
-      // the prop changes to an invalid date — the resolved fallback should win.
-      setLabel(null);
-      return;
-    }
-
-    const update = (): void => {
-      try {
-        setLabel(formatRelative(date));
-      } catch (err) {
-        // formatDistanceToNow can throw RangeError on edge inputs; stay on fallback.
-        console.warn("[RelativeTime] formatRelative threw", err);
-      }
-    };
-    update();
-    const interval = window.setInterval(update, 60_000);
-    return () => {
-      window.clearInterval(interval);
-    };
-  }, [depKey]);
+  // `null` during SSR and before the provider's first tick — render fallback.
+  // After mount the shared ticker emits a number every 60s, causing a re-render.
+  const now = useRelativeNow();
 
   const resolvedFallback = (() => {
     if (fallback !== undefined) return fallback;
@@ -50,5 +25,24 @@ export function RelativeTime({
     return Number.isNaN(date.getTime()) ? "" : date.toISOString();
   })();
 
-  return <>{label ?? resolvedFallback}</>;
+  // Pre-mount / SSR path: render fallback (matches original useEffect behaviour).
+  if (now === null) {
+    return <>{resolvedFallback}</>;
+  }
+
+  const date = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) {
+    return <>{resolvedFallback}</>;
+  }
+
+  let label: string;
+  try {
+    label = formatRelative(date);
+  } catch (err) {
+    // formatDistanceToNow can throw RangeError on edge inputs; stay on fallback.
+    console.warn("[RelativeTime] formatRelative threw", err);
+    return <>{resolvedFallback}</>;
+  }
+
+  return <>{label}</>;
 }

--- a/src/components/issues/RelativeTimeProvider.tsx
+++ b/src/components/issues/RelativeTimeProvider.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * Shared 60-second ticker for RelativeTime components.
+ *
+ * Without this, every <RelativeTime> instance runs its own setInterval(60_000),
+ * meaning N mounted components → N timers. On a long issue timeline with many
+ * comments this is O(N) timers all firing every minute. The provider collapses
+ * that to a single interval regardless of how many instances are mounted.
+ *
+ * Architecture:
+ *  - A module-level external store (singleton) manages the ticker.
+ *  - RelativeTimeProvider mounts once in the app root and starts/stops it.
+ *  - useRelativeNow() subscribes via useSyncExternalStore — idiomatic React 18.
+ *  - RelativeTime reads from useRelativeNow() instead of its own interval.
+ *
+ * SSR / hydration contract:
+ *  - The server snapshot is `null` so that RelativeTime renders the fallback
+ *    during SSR and the first synchronous render on the client (before effects
+ *    fire). This preserves the original component's hydration-safe behaviour.
+ *  - After the provider mounts (useEffect → startTicker), the store emits the
+ *    current timestamp and all subscribers re-render with relative labels.
+ */
+
+import type React from "react";
+import { useEffect, useSyncExternalStore } from "react";
+
+// ---------------------------------------------------------------------------
+// External store (module-level singleton)
+// ---------------------------------------------------------------------------
+
+type Listener = () => void;
+
+/**
+ * `null` = server / pre-mount (render the fallback).
+ * `number` = client tick timestamp (render relative label).
+ */
+let _snapshot: number | null = null;
+let _interval: number | null = null;
+let _refCount = 0;
+const _listeners = new Set<Listener>();
+
+function notifyListeners(): void {
+  _snapshot = Date.now();
+  for (const listener of _listeners) {
+    listener();
+  }
+}
+
+/** Start the shared ticker. Safe to call multiple times; ref-counted. */
+function startTicker(): void {
+  _refCount++;
+  if (_interval === null) {
+    // Emit immediately so components update right after mount, then every 60s.
+    notifyListeners();
+    _interval = window.setInterval(notifyListeners, 60_000);
+  }
+}
+
+/** Stop the shared ticker. Only actually stops when all consumers have unmounted. */
+function stopTicker(): void {
+  _refCount = Math.max(0, _refCount - 1);
+  if (_refCount === 0 && _interval !== null) {
+    window.clearInterval(_interval);
+    _interval = null;
+    // Reset to null so a remount starts fresh with the fallback path.
+    _snapshot = null;
+  }
+}
+
+function subscribe(listener: Listener): () => void {
+  _listeners.add(listener);
+  return () => {
+    _listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): number | null {
+  return _snapshot;
+}
+
+function getServerSnapshot(): number | null {
+  // On the server there is no ticker — return null so RelativeTime renders
+  // its fallback, matching the original useEffect-based behaviour.
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount once in the app root (inside a Client boundary). Starts the shared
+ * 60-second ticker on mount and stops it on unmount.
+ */
+export function RelativeTimeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  useEffect(() => {
+    startTicker();
+    return stopTicker;
+  }, []);
+
+  return <>{children}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current timestamp as a number once the provider has mounted,
+ * or `null` during SSR / before the first tick (signals: render fallback).
+ * Updates every 60 seconds via the shared ticker.
+ */
+export function useRelativeNow(): number | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/components/issues/RelativeTimeProvider.tsx
+++ b/src/components/issues/RelativeTimeProvider.tsx
@@ -63,8 +63,13 @@ function stopTicker(): void {
   if (_refCount === 0 && _interval !== null) {
     window.clearInterval(_interval);
     _interval = null;
-    // Reset to null so a remount starts fresh with the fallback path.
+    // Reset to null so a remount starts fresh with the fallback path, and
+    // notify listeners so any still-subscribed components re-render to fallback
+    // rather than staying stuck on the last relative label.
     _snapshot = null;
+    for (const listener of _listeners) {
+      listener();
+    }
   }
 }
 

--- a/src/components/layout/ClientProviders.tsx
+++ b/src/components/layout/ClientProviders.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react";
 import { TooltipProvider } from "~/components/ui/tooltip";
+import { RelativeTimeProvider } from "~/components/issues/RelativeTimeProvider";
 
 /**
  * Global client-side providers wrapper.
@@ -12,11 +13,18 @@ import { TooltipProvider } from "~/components/ui/tooltip";
  *
  * Exception: CopyButton keeps its own local <TooltipProvider delayDuration={0}>
  * so that the "Copied!" tooltip appears instantly after a click.
+ *
+ * RelativeTimeProvider is mounted here so that all RelativeTime instances in the
+ * app share a single 60-second interval instead of each running their own timer.
  */
 export function ClientProviders({
   children,
 }: {
   children: React.ReactNode;
 }): React.JSX.Element {
-  return <TooltipProvider delayDuration={300}>{children}</TooltipProvider>;
+  return (
+    <TooltipProvider delayDuration={300}>
+      <RelativeTimeProvider>{children}</RelativeTimeProvider>
+    </TooltipProvider>
+  );
 }

--- a/src/components/notifications/NotificationList.test.tsx
+++ b/src/components/notifications/NotificationList.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NotificationList } from "./NotificationList";
+import { RelativeTimeProvider } from "~/components/issues/RelativeTimeProvider";
 import {
   markAsReadAction,
   markAllAsReadAction,
@@ -50,7 +51,13 @@ describe("NotificationList", () => {
 
   it("should display notifications in dropdown", async () => {
     const user = userEvent.setup();
-    render(<NotificationList notifications={mockNotifications} />);
+    // RelativeTimeProvider is required so RelativeTime renders relative labels
+    // (without it the shared ticker never starts and the fallback is shown).
+    render(
+      <RelativeTimeProvider>
+        <NotificationList notifications={mockNotifications} />
+      </RelativeTimeProvider>
+    );
 
     // Open dropdown
     const trigger = screen.getByRole("button", { name: /notifications/i });


### PR DESCRIPTION
## What

Replace the per-instance `window.setInterval(60_000)` in `RelativeTime` with a single shared ticker:

- **`RelativeTimeProvider`** (`src/components/issues/RelativeTimeProvider.tsx`): module-level external store with a ref-counted `window.setInterval`. Mounts once in `ClientProviders` at the app root.
- **`useRelativeNow()`**: `useSyncExternalStore` subscription to the shared store — idiomatic React 18 external-store pattern. Returns `null` during SSR / before first tick; returns a `number` timestamp on each subsequent tick.
- **`RelativeTime`**: now reads `useRelativeNow()` instead of running its own interval. `null` → render fallback (preserves SSR/hydration behavior); `number` → call `formatRelative`. Public props (`value`, `fallback`) are unchanged.
- **Tests**: `RelativeTime.test.tsx` updated to wrap with `RelativeTimeProvider` where needed; added a "renders fallback without a provider" test documenting the safe degraded mode. `NotificationList.test.tsx` wraps the relative-time assertion render in the provider.

## Why

PR #1270 Copilot review flagged this: N `RelativeTime` instances → N timers, each calling `formatRelative` and triggering a render every 60s. On a long issue timeline with many comments this is O(N) wasted work per minute. The fix collapses timer count to O(1) regardless of instance count.

## Timer count evidence

Before: each `RelativeTime` mount sets its own `window.setInterval`. DevTools Performance panel shows N timers for N visible timestamps.

After: `_refCount` in `RelativeTimeProvider.tsx` tracks mounts; exactly one `setInterval` runs while any component is mounted, zero when all are unmounted.

## Bead

PP-nut — spawned from PR #1270 Wave 3A scope-creep gate.