### PR TITLE
fix(flaky): invite-signup.spec.ts hardcoded sleep anti-pattern

### DIFF
--- a/e2e/full/invite-signup.spec.ts
+++ b/e2e/full/invite-signup.spec.ts
@@ -93,10 +93,7 @@ test.describe("User Invitation & Signup Flow", () => {
 
     console.log("[test] Admin logged out");
 
-    // 3. Get signup link from Mailpit
-    // Add small delay to allow backend processing time for email transmission.
-    // getSignupLink() performs internal polling, but this initial wait helps avoid early empty results.
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    // 3. Get signup link from Mailpit (getSignupLink polls for up to 30 s)
     const signupLink = await getSignupLink(userEmail);
     console.log(`[test] Got signup link: ${signupLink}`);
     expect(signupLink).toContain("/signup");
@@ -184,7 +181,6 @@ test.describe("User Invitation & Signup Flow", () => {
     // 3. Logout and complete signup
     await logout(page, testInfo);
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     const signupLink = await getSignupLink(userEmail);
     await page.goto(signupLink);
 


### PR DESCRIPTION
## Root-cause analysis

`invite-signup.spec.ts` contained two `await new Promise(r => setTimeout(r, 2000))` calls — one in each test — immediately before calling `getSignupLink()`. A comment said they "help avoid early empty results" during Mailpit email polling.

**Why the delay is not needed:**
`getSignupLink()` delegates to `MailpitClient.waitForEmail()`, which already implements a proper polling loop:

```ts
// e2e/support/mailpit.ts
while (Date.now() - startTime < timeout) {   // 30 s budget
  const allMessages = await this.getMessages(email);
  const match = allMessages.find(…);
  if (match) return match;
  await new Promise(r => setTimeout(r, interval));  // 750 ms between polls
}
return null;
```

The first poll fires immediately — no initial delay — and subsequent polls fire every 750 ms for up to 30 s. The hardcoded 2 s prefix delays:

1. **Burn 2 s of the 30 s polling budget** on every call — under very slow CI the effective window shrinks from 30 s to 28 s.
2. **Add 4 s of fixed overhead** per full `invite-signup.spec.ts` run (two tests × 2 s each).
3. **Are a Playwright anti-pattern** — equivalent to `page.waitForTimeout()`, which the Playwright docs explicitly recommend against because it makes tests brittle rather than waiting on a real condition.

## Fix

Remove both `await new Promise(r => setTimeout(r, 2000))` lines and the now-stale comment that justified them. `waitForEmail()`'s polling loop is the correct mechanism.

## Verification

- `pnpm run check` → 143 test files, 1281 tests, all green.
- E2E verification requires CI (invite flow touches live Supabase + Mailpit). Both invite-signup tests use `test.slow()` (3× default timeout), so the 4 s saving has no safety impact.

## Context

Identified during the 2026-05-31 weekly flaky-test audit. Two tests confirmed fixed during the same audit period:
- **PP-149t** (`checkDocker()` in `e2e/global-setup.ts`) — fixed by #1447
- **PP-bamx** (`issue-services.test.ts` misplaced in `integration-supabase` vitest project) — fixed by #1429

No open flaky-test issues remain in the tracker. This PR is a proactive cleanup of the strongest remaining anti-pattern.

https://claude.ai/code/session_01UVpGhqpKmV9JmGt8Pu1tR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVpGhqpKmV9JmGt8Pu1tR4)_