### PR TITLE
docs: changelog week of June 1, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 122, "lastUpdated": "2026-05-24" }
+{ "totalEntries": 124, "lastUpdated": "2026-05-31" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,17 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## June 1, 2026
+
+### New Features
+
+- **Machine Timeline** — Every machine page now has a Timeline tab showing the full history of that machine: issues reported and resolved, status changes, assignments, and notes from members. You can post your own tagged note (maintenance, parts, adjustment, upgrade, and more) directly on the timeline, and use the tag filter to zoom in on a specific type of activity.
+
+### Bug Fixes
+
+- The Unplayable, Low Priority, and Intermittent status badges now display in brighter colors that are easier to read, and small muted text throughout the app is slightly more legible. Filter dropdowns and notification preference toggles also now have proper labels for screen readers and assistive tools.
+
+---
+
 ## May 25, 2026
 
 ### New Features


### PR DESCRIPTION
Weekly changelog entry for the week of May 25–31, 2026. Two user-facing changes this week:

## New Features

- **Machine Timeline** (PR #1380) — Every machine page now has a Timeline tab showing the full history: issues reported/resolved, status changes, assignments, and member notes with tag filtering. Members can post their own tagged notes directly on the machine's timeline.

## Bug Fixes

- **Accessibility improvements** (PR #1449) — Unplayable, Low Priority, and Intermittent badge colors are now brighter and pass WCAG AA contrast; muted text throughout the app is slightly more legible. Filter dropdowns and notification preference toggles now have accessible labels for screen readers.

---

**Filtered out (non-user-facing):** PRs #1427–1429, #1430, #1433–1434, #1436–1438, #1440–1442, #1444–1448, #1450–1454 — test coverage additions, E2E/CI fixes, dependency bumps, developer tooling, refactors with no behavior change, and docs-only updates.

https://claude.ai/code/session_019HjS34sKxPy3w8zhhVipbp

---
_Generated by [Claude Code](https://claude.ai/code/session_019HjS34sKxPy3w8zhhVipbp)_