### PR TITLE
fix(db): run timeline backfill in db:seed:from-prod (PP-7kil)

### DIFF
--- a/scripts/seed-from-backup.sh
+++ b/scripts/seed-from-backup.sh
@@ -87,3 +87,10 @@ else
     echo -e "${RED}❌ Seeding failed!${NC}"
     exit 1
 fi
+
+# Backfill historical machine-timeline events from the freshly loaded prod data.
+# The prod dump carries machines/issues but no synthesized timeline_events for
+# pre-V1 history, so without this the Timeline tab is empty locally (PP-7kil).
+# Idempotent NOT-EXISTS backfill; matches what db:reset / db:fast-reset do.
+echo -e "${BLUE}🕓 Backfilling machine timeline events...${NC}"
+pnpm run db:_seed-timeline-backfill


### PR DESCRIPTION
`pnpm run db:seed:from-prod` dropped tables, ran `db:migrate`, loaded the prod dump via `psql`, and stopped — it never ran `db:_seed-timeline-backfill`. As a result, any local DB seeded from prod had empty machine timelines (no `machine_added`/`issue_opened`/`issue_closed` history), unlike `db:reset` / `db:fast-reset` which do run the backfill. This appends the idempotent NOT-EXISTS backfill after a successful dump load so local prod-seeded environments match the real history (the backfill script keeps its own localhost guard as a second safety layer). Refs PP-7kil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)