### PR TITLE
test(e2e): add .js extension to relative imports (PP-8x1c)

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -5,7 +5,7 @@
  * declare `dependencies: ["auth-setup"]` so this runs before any test.
  *
  * Usage in tests (opt-in):
- *   import { STORAGE_STATE } from "./support/auth-state";
+ *   import { STORAGE_STATE } from "./support/auth-state.js";
  *   test.use({ storageState: STORAGE_STATE.member });
  *
  * Exclude criteria (do NOT use storageState):
@@ -19,8 +19,8 @@ import { mkdirSync } from "fs";
 import { dirname } from "path";
 import { expect, type Page, test as setup } from "@playwright/test";
 
-import { TEST_USERS } from "./support/constants";
-import { STORAGE_STATE } from "./support/auth-state";
+import { TEST_USERS } from "./support/constants.js";
+import { STORAGE_STATE } from "./support/auth-state.js";
 
 /**
  * Logs in via UI and saves storageState to disk.

--- a/e2e/full/admin-help.spec.ts
+++ b/e2e/full/admin-help.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { loginAs } from "../support/actions";
-import { TEST_USERS } from "../support/constants";
+import { loginAs } from "../support/actions.js";
+import { TEST_USERS } from "../support/constants.js";
 
 test.describe("Admin Help Page", () => {
   test("admin can navigate to admin help page from help page", async ({

--- a/e2e/full/change-password.spec.ts
+++ b/e2e/full/change-password.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { loginAs, logout } from "../support/actions";
+import { loginAs, logout } from "../support/actions.js";
 import { createTestUser, deleteTestUser } from "../support/supabase-admin.js";
 
 const originalPassword = "TestPassword123";

--- a/e2e/full/form-resets.spec.ts
+++ b/e2e/full/form-resets.spec.ts
@@ -19,17 +19,17 @@ import {
   logout,
   selectOption,
   assertSelectValue,
-} from "../support/actions";
-import { cleanupTestEntities } from "../support/cleanup";
-import { seededMachines, TEST_USERS } from "../support/constants";
+} from "../support/actions.js";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import { seededMachines, TEST_USERS } from "../support/constants.js";
 import {
   fillReportForm,
   submitFormAndWaitForRedirect,
-} from "../support/page-helpers";
+} from "../support/page-helpers.js";
 import {
   getTestMachineInitials,
   getTestPrefix,
-} from "../support/test-isolation";
+} from "../support/test-isolation.js";
 
 // Worker-unique prefix so one worker's afterEach cannot delete another worker's
 // freshly-created issues. getTestPrefix() returns e.g. "w0_kg5x" — stable for

--- a/e2e/full/issue-list-extended.spec.ts
+++ b/e2e/full/issue-list-extended.spec.ts
@@ -1,9 +1,13 @@
 import { test, expect } from "@playwright/test";
-import { cleanupTestEntities } from "../support/cleanup";
-import { TEST_USERS, seededIssues, seededMachines } from "../support/constants";
-import { fillReportForm } from "../support/page-helpers";
-import { getTestIssueTitle } from "../support/test-isolation";
-import { STORAGE_STATE } from "../support/auth-state";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import {
+  TEST_USERS,
+  seededIssues,
+  seededMachines,
+} from "../support/constants.js";
+import { fillReportForm } from "../support/page-helpers.js";
+import { getTestIssueTitle } from "../support/test-isolation.js";
+import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("Issue List Features - Extended", () => {
   // Use Admin to ensure permissions for all inline edits

--- a/e2e/full/machine-details-extended.spec.ts
+++ b/e2e/full/machine-details-extended.spec.ts
@@ -17,9 +17,9 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { ensureLoggedIn, logout, loginAs } from "../support/actions";
-import { seededMachines, TEST_USERS } from "../support/constants";
-import { clearMachineField } from "../support/supabase-admin";
+import { ensureLoggedIn, logout, loginAs } from "../support/actions.js";
+import { seededMachines, TEST_USERS } from "../support/constants.js";
+import { clearMachineField } from "../support/supabase-admin.js";
 
 test.describe("Machine Details - Extended", () => {
   test.beforeEach(async ({ page }, testInfo) => {

--- a/e2e/full/machines-public-access.spec.ts
+++ b/e2e/full/machines-public-access.spec.ts
@@ -9,7 +9,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { seededMachines } from "../support/constants";
+import { seededMachines } from "../support/constants.js";
 
 test.describe("Machines Public Access", () => {
   test("unauthenticated user can view machines list", async ({ page }) => {

--- a/e2e/full/profile-settings.spec.ts
+++ b/e2e/full/profile-settings.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { TEST_USERS } from "../support/constants";
-import { STORAGE_STATE } from "../support/auth-state";
+import { TEST_USERS } from "../support/constants.js";
+import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("Profile Settings", () => {
   test.use({ storageState: STORAGE_STATE.member });

--- a/e2e/full/public-reporting-extended.spec.ts
+++ b/e2e/full/public-reporting-extended.spec.ts
@@ -6,10 +6,10 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { loginAs } from "../support/actions";
-import { cleanupTestEntities } from "../support/cleanup";
-import { TEST_USERS } from "../support/constants";
-import { fillReportForm } from "../support/page-helpers";
+import { loginAs } from "../support/actions.js";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import { TEST_USERS } from "../support/constants.js";
+import { fillReportForm } from "../support/page-helpers.js";
 
 const PUBLIC_PREFIX = "E2E Public Report";
 

--- a/e2e/full/report-stale-machine.spec.ts
+++ b/e2e/full/report-stale-machine.spec.ts
@@ -25,8 +25,8 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { ensureLoggedIn } from "../support/actions";
-import { TEST_USERS } from "../support/constants";
+import { ensureLoggedIn } from "../support/actions.js";
+import { TEST_USERS } from "../support/constants.js";
 
 const STALE_UUID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
 

--- a/e2e/full/rich-text.spec.ts
+++ b/e2e/full/rich-text.spec.ts
@@ -1,8 +1,11 @@
 // e2e/full/rich-text.spec.ts
 import { test, expect } from "@playwright/test";
-import { loginAs } from "../support/actions";
-import { createTestUser, createTestMachine } from "../support/supabase-admin";
-import { getTestPrefix } from "../support/test-isolation";
+import { loginAs } from "../support/actions.js";
+import {
+  createTestUser,
+  createTestMachine,
+} from "../support/supabase-admin.js";
+import { getTestPrefix } from "../support/test-isolation.js";
 
 /**
  * E2E tests for Rich Text Editor and @Mentions

--- a/e2e/full/status-overhaul.spec.ts
+++ b/e2e/full/status-overhaul.spec.ts
@@ -1,9 +1,12 @@
 import { test, expect } from "@playwright/test";
-import { updateIssueField, visibleIssueFieldControl } from "../support/actions";
-import { cleanupTestEntities } from "../support/cleanup";
-import { seededMachines, TEST_USERS } from "../support/constants";
-import { fillReportForm } from "../support/page-helpers";
-import { STORAGE_STATE } from "../support/auth-state";
+import {
+  updateIssueField,
+  visibleIssueFieldControl,
+} from "../support/actions.js";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import { seededMachines, TEST_USERS } from "../support/constants.js";
+import { fillReportForm } from "../support/page-helpers.js";
+import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("Status Overhaul E2E", () => {
   test.use({ storageState: STORAGE_STATE.member });

--- a/e2e/full/technician-role.spec.ts
+++ b/e2e/full/technician-role.spec.ts
@@ -8,8 +8,8 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { STORAGE_STATE } from "../support/auth-state";
-import { seededMachines } from "../support/constants";
+import { STORAGE_STATE } from "../support/auth-state.js";
+import { seededMachines } from "../support/constants.js";
 
 test.describe("Technician Role Permissions", () => {
   test.use({ storageState: STORAGE_STATE.technician });

--- a/e2e/full/username-account-settings.spec.ts
+++ b/e2e/full/username-account-settings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { loginAs } from "../support/actions";
+import { loginAs } from "../support/actions.js";
 
 test.describe("Username Account Settings", () => {
   test("settings page shows 'no email on file' for username accounts", async ({

--- a/e2e/smoke/admin-discord-integration.spec.ts
+++ b/e2e/smoke/admin-discord-integration.spec.ts
@@ -12,7 +12,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { STORAGE_STATE } from "../support/auth-state";
+import { STORAGE_STATE } from "../support/auth-state.js";
 import { assertNoA11yViolations } from "../support/actions.js";
 
 test.describe("Admin Discord integration page", () => {

--- a/e2e/smoke/auth-flows.spec.ts
+++ b/e2e/smoke/auth-flows.spec.ts
@@ -8,7 +8,7 @@
 
 import { test, expect } from "@playwright/test";
 import { loginAs, logout, assertNoA11yViolations } from "../support/actions.js";
-import { TEST_USERS } from "../support/constants";
+import { TEST_USERS } from "../support/constants.js";
 
 test.describe("Username Account Login", () => {
   test("login with username (no @) redirects to dashboard", async ({

--- a/e2e/smoke/issue-list.spec.ts
+++ b/e2e/smoke/issue-list.spec.ts
@@ -2,9 +2,9 @@ import { test, expect } from "@playwright/test";
 import {
   assertNoHorizontalOverflow,
   assertNoA11yViolations,
-} from "../support/actions";
-import { seededIssues } from "../support/constants";
-import { STORAGE_STATE } from "../support/auth-state";
+} from "../support/actions.js";
+import { seededIssues } from "../support/constants.js";
+import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("Issue List Features", () => {
   // Use Admin to ensure permissions for all operations

--- a/e2e/smoke/machine-details-redesign.spec.ts
+++ b/e2e/smoke/machine-details-redesign.spec.ts
@@ -35,9 +35,9 @@ import {
   loginAs,
   logout,
   assertNoA11yViolations,
-} from "../support/actions";
-import { seededMachines, TEST_USERS } from "../support/constants";
-import { clearMachineField } from "../support/supabase-admin";
+} from "../support/actions.js";
+import { seededMachines, TEST_USERS } from "../support/constants.js";
+import { clearMachineField } from "../support/supabase-admin.js";
 
 test.describe("Machine Details Redesign", () => {
   test.beforeEach(async ({ page }, testInfo) => {

--- a/e2e/smoke/public-reporting.spec.ts
+++ b/e2e/smoke/public-reporting.spec.ts
@@ -8,10 +8,10 @@ import { test, expect } from "@playwright/test";
 import {
   assertNoHorizontalOverflow,
   assertNoA11yViolations,
-} from "../support/actions";
-import { cleanupTestEntities } from "../support/cleanup";
-import { TEST_USERS } from "../support/constants";
-import { fillReportForm } from "../support/page-helpers";
+} from "../support/actions.js";
+import { cleanupTestEntities } from "../support/cleanup.js";
+import { TEST_USERS } from "../support/constants.js";
+import { fillReportForm } from "../support/page-helpers.js";
 
 const PUBLIC_PREFIX = "E2E Public Report";
 

--- a/e2e/smoke/report-form-clear.spec.ts
+++ b/e2e/smoke/report-form-clear.spec.ts
@@ -7,8 +7,8 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { STORAGE_STATE } from "../support/auth-state";
-import { cleanupTestEntities } from "../support/cleanup";
+import { STORAGE_STATE } from "../support/auth-state.js";
+import { cleanupTestEntities } from "../support/cleanup.js";
 import {
   fillReportForm,
   submitFormAndWaitForRedirect,

--- a/e2e/smoke/settings-loads.spec.ts
+++ b/e2e/smoke/settings-loads.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { STORAGE_STATE } from "../support/auth-state";
+import { STORAGE_STATE } from "../support/auth-state.js";
 import { assertNoA11yViolations } from "../support/actions.js";
 
 test.describe("Settings page (smoke)", () => {

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Page, Locator } from "@playwright/test";
-import { selectOption } from "./actions";
+import { selectOption } from "./actions.js";
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary

- Add explicit `.js` extension to all relative import specifiers in files under the `e2e/` directory.

## Bead

PP-8x1c: Standardize relative import specifiers in e2e specs (.js extensions / NodeNext)

## Verification

Commands run:

- `pnpm run check` (typecheck + lint + format passes)
- `pnpm exec playwright test --config=playwright.config.smoke.ts --project=chromium` (all chromium smoke tests pass)
- `pnpm exec playwright test e2e/full/change-password.spec.ts --project=chromium` (targeted full test passes)

Result: all passing.

## Notes

None.