### PR TITLE
docs(briefing): add Supabase advisor checks to session briefing

### DIFF
--- a/.agents/skills/pinpoint-briefing/SKILL.md
+++ b/.agents/skills/pinpoint-briefing/SKILL.md
@@ -117,6 +117,23 @@ Use the Sentry MCP tools:
 
 Flag issues with high event counts or new regressions.
 
+### Group F: Supabase Advisors
+
+Run the Supabase advisor checks against **prod** (project_id `udhesuizjsgxfeotqybn`, name: PinPoint-Prod). Call `mcp__plugin_supabase_supabase__get_advisors` twice:
+
+1. `type: "security"` — RLS gaps, exposed tables/functions, auth misconfig
+2. `type: "performance"` — unindexed FKs, RLS initplan re-evaluation, unused indexes
+
+**This is a deferred MCP tool**: load its schema first via `ToolSearch` query `select:mcp__plugin_supabase_supabase__get_advisors` before calling it.
+
+- If the tool schema comes back → run both checks.
+- If `No matching deferred tools found` → the Supabase MCP isn't connected. This is a **soft skip**: surface a one-line `Supabase MCP not connected, advisor check skipped` note in the briefing output and move on. Unlike Group E (Sentry), this is NOT a stop-and-ask gate — just don't drop it silently.
+
+**Triage guidance**: each lint carries a `level` — ERROR / WARN / INFO.
+
+- **ERROR-level security lints are immediate-attention items** (e.g. a public table with RLS disabled). Flag ERROR and WARN security lints prominently; INFO is informational.
+- Some findings are intentional by design. Tables with RLS **enabled but zero policies** are the deliberate "Drizzle-superuser-only access" pattern from migration 0034, not a regression. Cross-check every finding against known-intentional patterns before reporting it as a new problem.
+
 ---
 
 ## Step 2 — Structured Briefing Output
@@ -131,7 +148,7 @@ Synthesize all gathered data into this format:
 📅 Date: [today]
 
 ## 🚨 Needs Immediate Attention
-[Anything failing on main, critical security alerts, P0 bugs]
+[Anything failing on main, critical security alerts, P0 bugs, ERROR-level Supabase advisor findings]
 
 ## 🔐 Security
 pnpm audit:    [X vulns (critical/high/moderate)] or ✅ clean
@@ -151,6 +168,11 @@ Highlight: any with unresolved Copilot comments, failing CI, or stale > 7 days
 ## ⚠️ Sentry — New Errors
 [List: Error message | First seen | Event count | URL]
 Or: ✅ No new errors in last 5 days
+
+## 🛡️ Supabase Advisors
+Security:    [X errors, Y warnings] — list any ERROR-level findings with table/function name
+Performance: [X warnings, Z info] — summarize (unindexed FKs, RLS initplan, unused indexes)
+Or: ✅ No actionable advisor findings
 
 ## 📦 Beads State
 Ready to pick up: [top 5 from `bd ready`]

--- a/.agents/skills/pinpoint-briefing/SKILL.md
+++ b/.agents/skills/pinpoint-briefing/SKILL.md
@@ -134,6 +134,19 @@ Run the Supabase advisor checks against **prod** (project_id `udhesuizjsgxfeotqy
 - **ERROR-level security lints are immediate-attention items** (e.g. a public table with RLS disabled). Flag ERROR and WARN security lints prominently; INFO is informational.
 - Some findings are intentional by design. Tables with RLS **enabled but zero policies** are the deliberate "Drizzle-superuser-only access" pattern from migration 0034, not a regression. Cross-check every finding against known-intentional patterns before reporting it as a new problem.
 
+### Group G: Weekly Security Review
+
+A "Weekly Security Review" GitHub issue (label `security`, title `Weekly Security Review: <date range>`) is filed each week — an AI/human security pass over the week's PRs. It carries a **Verdict** line ("N findings need attention"), a Non-Negotiable checklist table, and detailed **Findings** (severity + recommendation). High-signal, often not yet tracked as beads. Find and read the most recent open one:
+
+```bash
+gh issue list --state open --label security --search "Weekly Security Review in:title" \
+  --limit 1 --json number,title,createdAt
+# then read the body of that issue number:
+gh issue view <number> --json title,body
+```
+
+Parse the **Verdict** line and each **Finding** (severity + one-line summary). Cross-reference every finding against beads and flag any NOT yet tracked. These issues stay **OPEN until findings are addressed**, so an open issue is normal — surface the freshest one; don't treat its open state as an alarm by itself.
+
 ---
 
 ## Step 2 — Structured Briefing Output
@@ -148,11 +161,12 @@ Synthesize all gathered data into this format:
 📅 Date: [today]
 
 ## 🚨 Needs Immediate Attention
-[Anything failing on main, critical security alerts, P0 bugs, ERROR-level Supabase advisor findings]
+[Anything failing on main, critical security alerts, P0 bugs, ERROR-level Supabase advisor findings, UNTRACKED non-trivial Weekly Security Review findings — call out for bead-filing]
 
 ## 🔐 Security
 pnpm audit:    [X vulns (critical/high/moderate)] or ✅ clean
 Dependabot:    [X open alerts] — link to any mergeable PRs
+Weekly Review: #NNNN (week of <dates>) — <verdict>; <X> findings [Y tracked, Z UNTRACKED]
 
 ## 📋 Open PRs
 [Table from pr-dashboard.sh: PR# | Title | CI | Copilot | Merge Ready]


### PR DESCRIPTION
## Summary

Adds a Supabase Advisors data-gathering step to the `pinpoint-briefing` skill so the prod advisor checks run as part of every session-start health review. Purely additive, doc-only change to one markdown file.

- **Step 1 — Group F: Supabase Advisors**: calls `mcp__plugin_supabase_supabase__get_advisors` twice (security + performance) against prod (PinPoint-Prod, `udhesuizjsgxfeotqybn`). Loads the deferred MCP tool via `ToolSearch` first; if the tool isn't available, soft-skips with a visible "Supabase MCP not connected, advisor check skipped" note (not a stop-and-ask gate). Triage guidance flags ERROR/WARN security lints and cross-checks against the known-intentional RLS-enabled-no-policy pattern from migration 0034.
- **Step 2 — Output**: new `## 🛡️ Supabase Advisors` section after Sentry; advisor ERRORs added to the "Needs Immediate Attention" guidance.

## Testing

- `pnpm run check` — clean (doc-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)