### PR TITLE
chore(huddle): make rotation-needed notice an explicit dispatch-now instruction

### DIFF
--- a/scripts/hooks/huddle-poll.sh
+++ b/scripts/hooks/huddle-poll.sh
@@ -233,10 +233,13 @@ except Exception:
 " 2>/dev/null || echo "")
     fi
     NOW_DATE=$(date +%F)
-    printf '## ⚠️ Huddle rotation needed\n\n'
+    printf '## ⚠️ Huddle rotation needed — DISPATCH NOW, do not defer\n\n'
     printf 'The active coordination bead points to date %s, but today is %s.\n' "$STORED_DATE" "$NOW_DATE"
-    printf 'Before continuing, dispatch the rotation subagent.\n\n'
-    printf 'See .agents/skills/pinpoint-huddle/SKILL.md for the dispatch template.\n'
+    printf 'Dispatch the rotation subagent IMMEDIATELY — before other work or your\n'
+    printf 'reply. This is a standing instruction, not optional: do NOT skip it,\n'
+    printf 'defer it, or ask the user whether to run it. It is safe even if a peer\n'
+    printf 'already rotated (the subagent no-ops under a file lock).\n\n'
+    printf 'Dispatch template: .agents/skills/pinpoint-huddle/SKILL.md.\n'
     exit 0
   fi
 fi

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -128,12 +128,15 @@ except Exception:
 " 2>/dev/null || echo "")
     fi
     NOW_DATE=$(date +%F)
-    printf '## ⚠️ Huddle rotation needed\n\n'
+    printf '## ⚠️ Huddle rotation needed — DISPATCH NOW, do not defer\n\n'
     printf 'The active coordination bead points to date %s, but today is %s.\n' "$STORED_DATE" "$NOW_DATE"
-    printf 'Before continuing, dispatch the rotation subagent — it will summarize\n'
-    printf 'the previous day, create today'\''s bead, update pointers, and post\n'
-    printf '"continued in" markers on closed beads.\n\n'
-    printf 'Dispatch template in .agents/skills/pinpoint-huddle/SKILL.md.\n'
+    printf 'Dispatch the rotation subagent IMMEDIATELY — before other work or your\n'
+    printf 'reply. This is a standing instruction, not optional: do NOT skip it,\n'
+    printf 'defer it, or ask the user whether to run it. It will summarize the\n'
+    printf 'previous day, create today'\''s bead, update pointers, and post\n'
+    printf '"continued in" markers on closed beads. Safe even if a peer already\n'
+    printf 'rotated (the subagent no-ops under a file lock).\n\n'
+    printf 'Dispatch template: .agents/skills/pinpoint-huddle/SKILL.md.\n'
     exit 0
   fi
 fi


### PR DESCRIPTION
## What

Strengthens the wording of the "Huddle rotation needed" notice emitted by the two huddle hook scripts (`huddle-poll.sh` and `huddle-session-start.sh`) from a soft suggestion to an unmistakable do-it-now instruction.

## Why

The previous phrasing ("Before continuing, dispatch the rotation subagent") was too soft — agents were treating it as optional and deferring the rotation. The new wording makes it an explicit standing instruction: dispatch immediately, before other work or the reply, and do not skip, defer, or ask the user whether to run it. It also notes the dispatch is safe even if a peer already rotated (the subagent no-ops under a file lock), removing the "is it still needed?" hesitation.

## Scope

Text-only. No logic, control flow, or other files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)