### PR TITLE
fix(security): exclude reporterEmail from RSC payload on issue detail page (PP-4grd)

### DIFF
--- a/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
@@ -79,6 +79,7 @@ export default async function IssueDetailPage({
         eq(issues.machineInitials, initials),
         eq(issues.issueNumber, issueNum)
       ),
+      columns: { reporterEmail: false },
       with: {
         machine: {
           columns: {


### PR DESCRIPTION
## Summary

- `reporterEmail` was included in the RSC serialized payload sent to the browser because the issue detail page query had no column restriction on the root `issues` table
- The field is never rendered (CORE-SEC-007 display rule intact) but its presence in the client bundle violates CORE-SEC-006 (minimal data at server→client boundary)
- Fix: add `columns: { reporterEmail: false }` to the `findFirst` call in `src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx` — one line, no behavior change

## Test Plan

- [ ] `pnpm run check` passes (all 1281 unit tests green)
- [ ] CI E2E — issue detail page renders correctly (no visible change expected)
- [ ] Verify `reporterEmail` is absent from the RSC payload in browser devtools Network tab (optional manual check)

## Related Issues

Closes PP-4grd

Surfaced by weekly security review #1458.