### PR TITLE
chore: concurrency hygiene + mem-budget harness/report (PP-3vdr.6, PP-3vdr.7)

### DIFF
--- a/docs/memory-budget-investigation-2026-06.md
+++ b/docs/memory-budget-investigation-2026-06.md
@@ -1,0 +1,86 @@
+# Memory-Pressure Investigation & Reduction Plan — 16 GB M5 Air
+
+**Date:** 2026-06-01 · **Author:** investigation session (Claude) · **Status:** data + recommendations (no levers implemented yet)
+
+## The thesis: a 5-developer workload on one developer's RAM
+
+PinPoint is developed **solo**, but with 4–5 parallel Claude Code sessions across git worktrees — i.e. a **5-person team's workload collapsed onto one 16 GB MacBook Air**. A real 5-person team has ~80 GB of combined RAM and never shares a Postgres or an editor process. You're sharing one machine. So the macOS _"system has run out of application memory"_ lockups aren't a mystery — they're the arithmetic of **per-developer overhead × 5, with no per-developer machines to absorb it.**
+
+The whole reduction strategy follows from this: **deduplicate the things a team would never share** (one DB instead of 5, one MCP server instead of 5, serialized heavy work instead of 5 concurrent), and **bound the per-run peaks** (worker caps, pressure gate).
+
+## Method (so the numbers are trustworthy)
+
+- Metric is **`phys_footprint`** (via `footprint -p <pid>`), _not_ RSS. RSS double-counts shared frameworks across processes — that's literally why the Force-Quit panel showed cmux and Chrome at an identical, inflated 14.24 GB (its per-app numbers sum to ~34 GB on a 16 GB machine; they're unreliable).
+- Harness: `scripts/diagnostics/mem-budget.sh` (`snap` / `watch` / `reduce`), attributing per-app subtrees and per-run process trees by pgid.
+- **Lesson paid for in this investigation:** the first two "max-workers" measurements were invalid — `pnpm run test:integration -- --max-workers=1` appends _after_ the script's hardcoded `--max-workers=4` and vitest ignored the override, so "1 vs 4" was really "4 vs 4." Always verify a cap took effect (wall-clock is the tell) before trusting a comparison.
+
+## Measured memory budget (phys_footprint)
+
+| Component                               | Cost                 | Notes                                                                                                                    |
+| --------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 1 Claude session **core**               | ~330 MB              | the `claude` binary                                                                                                      |
+| **chrome-devtools-mcp** per session     | **~567 MB**          | 3 Node procs (npm-exec + server + telemetry watchdog); **bigger than the session core**; launches a Chrome too when used |
+| 1 idle session total                    | **~900 MB**          | core + chrome-devtools-mcp; **×5 ≈ 4.5 GB before any work**                                                              |
+| 1 Supabase stack (containers)           | **~175 MB**          | 5 containers (db/kong/auth/rest/inbucket), inside the VM                                                                 |
+| **OrbStack VM** host overhead           | **~1.4 GB**          | nearly fixed once running; **does not shrink promptly when containers stop**                                             |
+| Integration suite, `--max-workers=4`    | **~6.6 GB**          | ~1.5 GB per concurrent PGlite fork                                                                                       |
+| Integration suite, `--max-workers=2`    | **~3.3 GB**          | wall-clock ~12 s                                                                                                         |
+| Integration suite, `--max-workers=1`    | **~1.8 GB**          | wall-clock 17 s (vs 9 s at 4)                                                                                            |
+| Unit suite (uncapped, ~9 jsdom workers) | ~3.2 GB              | no worker cap today                                                                                                      |
+| Your own Google Chrome                  | ~0.9–1 GB            | 13 procs                                                                                                                 |
+| Swap                                    | dynamic, seen 2–8 GB | reclaimed after you _quit_ (not pause) sessions                                                                          |
+
+**The cliff:** a single 4-worker integration run drove free RAM to **74–89 MB**. Two of those concurrently (two sessions) ≈ 13 GB transient — that's the lockup.
+
+## Key findings
+
+1. **PGlite is not leaking — it's concurrent-fork multiplication.** `pool: forks` + `isolate: true` ⇒ a new forked process per test file, each re-importing the module graph + a ~128 MB PGlite WASM heap ≈ ~1.5 GB/fork. `--max-workers` caps _concurrent_ forks, so **peak ≈ max-workers × 1.5 GB, independent of test count.** Forks are reaped between files (verified). → **Capping workers is a real, large lever; adding tests (PR-1469 RECLASS) raises runtime, not peak.**
+2. **One PGlite fork (~1.5 GB) costs ~8× a whole Supabase Postgres stack (~175 MB).** The "lightweight in-memory" framing is backwards at scale. A _single shared_ Postgres serving integration tests is far lighter than N in-process WASM instances — but switching is medium/high effort (needs per-worker isolation: schema-per-worker or template-clone à la IntegreSQL) and is only worth it if worker-capping proves insufficient.
+3. **chrome-devtools-mcp is the recent regression.** It's enabled **globally** (plugin loaded in every session), ~567 MB × N. Adding it ~tripled per-session footprint — which matches "things got much worse recently." (It's _probably_ not the literal "Google Chrome" row in your OOM screenshot — that was most likely your own browser + the panel's inflated accounting — but it's a real ~567 MB × 5 = ~2.8 GB standing cost.)
+4. **The lockup vector is the `sem` bypass.** The host-wide `sem --jobs 2` lock only wraps `preflight`. Bare `test:integration` / `build` / `smoke` run **unguarded**, so N sessions × ~4–6 GB stack up with nothing serializing them. (Slot allocation and the worktree-add `flock` are otherwise **sound** — verified.)
+5. **Your preflight "startup failures" — root-caused.** In the parallel phase, `lint:fix` (eslint --fix) and `format:fix` (prettier --write) **write the same ~521 source files simultaneously**; prettier reads a file mid-write → parse error → `npm-run-all` cascade-kills the run. Secondary: `test:ensure-schema` regenerating `schema.sql` while parallel consumers read it.
+6. **Stopping stacks ≠ freeing host RAM (immediately).** OrbStack's VM holds the freed memory (~1.4 GB) until it deflates or restarts. And **restarting OrbStack resurrects all previously-running stacks** (`restart: unless-stopped`) — so "quit OrbStack to free memory" only lasts until next launch.
+
+## Recommendations — ranked (GB saved across 5 sessions × low effort/risk)
+
+### Tier 1 — biggest win per effort
+
+1. **Disable `chrome-devtools-mcp` globally; enable on demand.** ~**2.8 GB** across 5 sessions, one settings edit. Re-enable only when actively browser-debugging. _(trivial / low)_
+2. **Extend the host-wide `sem` lock to the bare heavy scripts** (`test`, `test:integration`, `test:integration:supabase`, `build`, `smoke`), not just `preflight`. Caps concurrent heavy runs across all sessions → kills the lockup vector. Reuses the existing `preflight-locked.sh` pattern. _(small / low)_
+3. **Add a memory-pressure gate** — `scripts/guard/mem-precheck.sh` reading `kern.memorystatus_level` + swap, prepended to heavy scripts **and** a `PreToolUse` hook blocking heavy commands under pressure, with a `FORCE_MEM_PRECHECK=skip` override. Prevents starting a 6 GB run at 100 MB free. _(small / low)_
+4. **Cap `--max-workers=2` on the integration projects** (from 4) in `package.json`: peak ~6.6 GB→~3.3 GB for ~3 s more wall-clock. Also add `--max-workers=4` to the uncapped **unit** script. _(trivial / low)_ ✅ _verified lever_
+
+### Tier 2 — structural "share what a team wouldn't"
+
+5. **`--changed` inner loop.** A `test:changed` workflow (`vitest --changed <merge-base>`) so local iteration runs only affected tests — fewer forks, shorter peak window. Full suite stays in CI. _(small / low)_
+6. **On-demand / shared Supabase.** Enforce "only the active worktree's stack runs"; consider a **single shared Postgres** for the local integration path (with the **schema-change fence**: a guard in `db:migrate`/`db:generate`/`db:reset` that refuses when `.env.local` points at the shared stack). Saves ~(N−1)×175 MB container + avoids N×1.4 GB VM pressure. _(medium / medium)_
+7. **Cap the OrbStack VM memory** to measured need so Docker can't balloon to ~half RAM. _(trivial / low, GUI)_
+
+### Tier 3 — hygiene & correctness (from the audit)
+
+8. **Fix the preflight race:** serialize `lint:fix` → `format:fix`; write `schema.sql` atomically (tmp+rename); run `test:ensure-schema` once as a serial pre-step. Ends the intermittent startup failures. _(trivial / low)_
+9. **Prune the unit layer (PR #1469).** Merge Wave 1 deletes now; the asset is your integration/permissions tests, the liability is mock-heavy/implementation-coupled unit tests. Run **Stryker once, scoped to `src/lib/permissions/**`\*_ as a one-time value audit — not a standing gate. _(medium / low)\*
+10. **Audit bugs:** `db:fast-reset` truncates `user_profiles` but not `auth.users`; 8 leaked nested-worktree slots (`worktree_orphan_sweep.py --apply`); one unit-project file misusing PGlite; dead `save_manifest()`. _(trivial / low)_
+
+### Deliberately NOT recommended
+
+- **Switching integration to shared Postgres right now** (do worker-cap first; only escalate if still OOM).
+- **`vmThreads`/`vmForks` pool** (docs warn they leak; you have no leak).
+- Worker caps as the _only_ fix — they bound a single run, but 5 × capped runs still need the `sem` + pressure gate.
+
+## "5-devs-on-one-Mac" budget check (post-recommendations)
+
+5×330 MB cores + 1 shared MCP (567) + 1 shared stack (175) + OrbStack (1.4 GB) + macOS/apps (~4 GB) + **one** serialized capped test run (~3.3 GB) ≈ **~11 GB** — fits in 16 GB with headroom. Today's path (5×900 MB + 5 stacks + N concurrent 6.6 GB runs) does not.
+
+## Sequencing
+
+1. Tier 1 (#1–4) — immediate, reversible, ~5 GB of breathing room.
+2. #8 (preflight fix) — unblocks your daily friction.
+3. #5 (`--changed`) + #9 (prune) — lighten the inner loop.
+4. Re-measure with the harness; only then decide on #6 (shared Postgres) if still tight.
+
+## Open items / to verify before implementing
+
+- Confirm Vitest version vs the v4.0.18 sequential-OOM regression (#9560).
+- Test `pool: threads` for integration (shares module graph across workers → could cut the per-fork duplication further; PGlite-in-threads stability unverified).
+- Decide shared-stack vs per-worktree once worker-capping is measured in practice.

--- a/docs/memory-budget-investigation-2026-06.md
+++ b/docs/memory-budget-investigation-2026-06.md
@@ -11,7 +11,7 @@ The whole reduction strategy follows from this: **deduplicate the things a team 
 ## Method (so the numbers are trustworthy)
 
 - Metric is **`phys_footprint`** (via `footprint -p <pid>`), _not_ RSS. RSS double-counts shared frameworks across processes — that's literally why the Force-Quit panel showed cmux and Chrome at an identical, inflated 14.24 GB (its per-app numbers sum to ~34 GB on a 16 GB machine; they're unreliable).
-- Harness: `scripts/diagnostics/mem-budget.sh` (`snap` / `watch` / `reduce`), attributing per-app subtrees and per-run process trees by pgid.
+- Harness: `scripts/diagnostics/mem-budget.sh` (`snap` / `watch` / `reduce`), attributing per-app footprint by process-name pattern (`pgrep -f`) and tracking system free/swap/compressor for per-run deltas. (Per-run vitest-tree isolation by pgid was done with auxiliary throwaway scripts during the investigation, not this harness.)
 - **Lesson paid for in this investigation:** the first two "max-workers" measurements were invalid — `pnpm run test:integration -- --max-workers=1` appends _after_ the script's hardcoded `--max-workers=4` and vitest ignored the override, so "1 vs 4" was really "4 vs 4." Always verify a cap took effect (wall-clock is the tell) before trusting a comparison.
 
 ## Measured memory budget (phys_footprint)
@@ -59,7 +59,7 @@ The whole reduction strategy follows from this: **deduplicate the things a team 
 ### Tier 3 — hygiene & correctness (from the audit)
 
 8. **Fix the preflight race:** serialize `lint:fix` → `format:fix`; write `schema.sql` atomically (tmp+rename); run `test:ensure-schema` once as a serial pre-step. Ends the intermittent startup failures. _(trivial / low)_
-9. **Prune the unit layer (PR #1469).** Merge Wave 1 deletes now; the asset is your integration/permissions tests, the liability is mock-heavy/implementation-coupled unit tests. Run **Stryker once, scoped to `src/lib/permissions/**`\*_ as a one-time value audit — not a standing gate. _(medium / low)\*
+9. **Prune the unit layer (PR #1469).** Merge Wave 1 deletes now; the asset is your integration/permissions tests, the liability is mock-heavy/implementation-coupled unit tests. Run a one-time **Stryker** value audit scoped to `src/lib/permissions/**` — not a standing gate. _(medium / low)_
 10. **Audit bugs:** `db:fast-reset` truncates `user_profiles` but not `auth.users`; 8 leaked nested-worktree slots (`worktree_orphan_sweep.py --apply`); one unit-project file misusing PGlite; dead `save_manifest()`. _(trivial / low)_
 
 ### Deliberately NOT recommended

--- a/scripts/db-fast-reset.mjs
+++ b/scripts/db-fast-reset.mjs
@@ -21,8 +21,16 @@ async function fastReset() {
 
   try {
     console.log("🧹 Truncating tables...");
-    // Truncate all tables except migrations/schema-related if any
-    // We cascade to handle foreign keys
+    // Truncate all application tables except migrations/schema-related if any.
+    // We cascade to handle foreign keys.
+    //
+    // NOTE: auth.users is intentionally NOT truncated here. supabase/seed-users.mjs
+    // uses supabase.auth.admin.createUser with an "already exists" fallback that
+    // fetches the existing ID and upserts the public.user_profiles row, so the seed
+    // is idempotent even when auth.users retains rows from a prior run. Truncating
+    // auth.users would require Supabase Admin API access (the Postgres user cannot
+    // directly DELETE from auth.users in production configurations) and would break
+    // any active sessions. (PP-3vdr.6)
     await client`
       TRUNCATE TABLE
         "issue_images",

--- a/scripts/diagnostics/mem-budget.sh
+++ b/scripts/diagnostics/mem-budget.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# mem-budget.sh — macOS memory budget profiler for the PinPoint memory investigation.
+#
+# Measures phys_footprint (the metric the kernel + "out of application memory"
+# dialog use), NOT RSS. RSS double-counts shared frameworks across processes and
+# is what made cmux/Chrome show identical inflated numbers in the Force-Quit panel.
+#
+# Modes:
+#   snap  <label> [outfile]                 one detailed snapshot (system totals +
+#                                           per-app footprint attribution + docker)
+#   watch <label> <dur_s> <interval_s> [of] lightweight system-total sampling, for
+#                                           capturing peaks during test/build runs
+#   reduce <file>                           summarize a watch/snap file by label
+#
+# Default outfiles: /tmp/mem-budget-snaps.tsv  and  /tmp/mem-budget-watch.tsv
+set -u
+
+SNAP_COLS='epoch\tlabel\tphys_used_mb\tphys_free_mb\twired_mb\tcompressor_mb\tswap_used_mb\torbstack_mb\tclaude_mb\tnode_mb\tchrome_mb\tdocker_n\tdocker_mb\tfree_pct'
+WATCH_COLS='epoch\tlabel\tphys_used_mb\tphys_free_mb\tcompressor_mb\tswap_used_mb\tnode_mb\tdocker_n'
+
+# --- system totals (fast) ---
+sys_line() { top -l 1 -n 0 | grep PhysMem; }
+mb_from() { # "<num><M|G>" -> MB
+  awk -v s="$1" 'BEGIN{ if(match(s,/G/)){gsub(/[^0-9.]/,"",s); print s*1024} else {gsub(/[^0-9.]/,"",s); print s} }'
+}
+phys_used()  { local p; p=$(sys_line); mb_from "$(echo "$p" | grep -oE '[0-9]+[MG] used'   | grep -oE '[0-9]+[MG]')"; }
+phys_free()  { local p; p=$(sys_line); mb_from "$(echo "$p" | grep -oE '[0-9]+[MG] unused' | grep -oE '[0-9]+[MG]')"; }
+wired_mb()   { sys_line | grep -oE '[0-9]+M wired'      | grep -oE '[0-9]+'; }
+compr_mb()   { sys_line | grep -oE '[0-9]+M compressor' | grep -oE '[0-9]+'; }
+swap_used()  { sysctl -n vm.swapusage | sed -E 's/.*used = ([0-9.]+)M.*/\1/'; }
+free_pct()   { memory_pressure 2>/dev/null | awk -F': ' '/free percentage/{gsub(/%/,"",$2); print $2; exit}'; }
+
+# --- per-app phys_footprint attribution (accurate; excludes shared) ---
+_sum_fp_kb() { # sum phys_footprint (KB) over a list of pids on stdin
+  local pid total_kb=0 nu
+  while read -r pid; do
+    [ -z "$pid" ] && continue
+    nu=$(footprint -p "$pid" 2>/dev/null | awk '/^[[:space:]]*phys_footprint:/{print $2" "$3; exit}')
+    [ -z "$nu" ] && continue
+    total_kb=$(awk -v t="$total_kb" -v n="${nu% *}" -v u="${nu#* }" \
+      'BEGIN{m=(u=="GB")?n*1048576:(u=="MB")?n*1024:n; print t+m}')
+  done
+  awk -v t="$total_kb" 'BEGIN{printf "%.0f", t/1024}'
+}
+group_fp_mb()  { pgrep -f "$1" 2>/dev/null | _sum_fp_kb; }   # match full argv
+claude_fp_mb() { # session cores: processes whose comm basename is exactly "claude"
+  ps -axo pid=,comm= | awk '{n=split($2,a,"/"); if(a[n]=="claude") print $1}' | _sum_fp_kb
+}
+
+# --- docker / orbstack containers ---
+docker_n()  { docker ps -q 2>/dev/null | wc -l | tr -d ' '; }
+docker_mb() {
+  docker stats --no-stream --format '{{.MemUsage}}' 2>/dev/null | awk \
+    '{u=$1; if(u ~ /GiB/){gsub(/GiB/,"",u); s+=u*1024} else if(u ~ /MiB/){gsub(/MiB/,"",u); s+=u} else if(u ~ /kB/){gsub(/kB/,"",u); s+=u/1024}} END{printf "%.0f", s}'
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  snap)
+    label="${1:?label required}"; out="${2:-/tmp/mem-budget-snaps.tsv}"
+    [ -f "$out" ] || printf '%s\n' "$SNAP_COLS" > "$out"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$(date +%s)" "$label" "$(phys_used)" "$(phys_free)" "$(wired_mb)" "$(compr_mb)" "$(swap_used)" \
+      "$(group_fp_mb OrbStack)" "$(claude_fp_mb)" "$(group_fp_mb 'node|vitest|tsx|next-server')" \
+      "$(group_fp_mb 'Google Chrome')" "$(docker_n)" "$(docker_mb)" "$(free_pct)" | tee -a "$out"
+    ;;
+  watch)
+    label="${1:?label}"; dur="${2:?dur}"; iv="${3:?interval}"; out="${4:-/tmp/mem-budget-watch.tsv}"
+    [ -f "$out" ] || printf '%s\n' "$WATCH_COLS" > "$out"
+    end=$(( $(date +%s) + dur ))
+    while [ "$(date +%s)" -lt "$end" ]; do
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$(date +%s)" "$label" "$(phys_used)" "$(phys_free)" "$(compr_mb)" "$(swap_used)" \
+        "$(group_fp_mb 'node|vitest|tsx')" "$(docker_n)" >> "$out"
+      sleep "$iv"
+    done
+    ;;
+  reduce)
+    awk -F'\t' 'NR==1{next} {
+      lab=$2;
+      # column indices differ by file; detect by NF
+      if (NF>=14){ used=$3; free=$4; comp=$6; node=$10 } else { used=$3; free=$4; comp=$5; node=$7 }
+      if (free!=""){ if(minf[lab]==""||free+0<minf[lab]) minf[lab]=free+0 }
+      if (node+0>maxnode[lab]) maxnode[lab]=node+0
+      if (used+0>maxused[lab]) maxused[lab]=used+0
+      if (comp+0>maxcomp[lab]) maxcomp[lab]=comp+0
+      n[lab]++
+    } END{
+      printf "%-26s %-11s %-11s %-12s %-12s %s\n","label","max_used","min_free","max_node","max_compr","n";
+      for(l in n) printf "%-26s %-11s %-11s %-12s %-12s %s\n", l, maxused[l], minf[l], maxnode[l], maxcomp[l], n[l]
+    }' "${1:?file}"
+    ;;
+  *) echo "usage: $0 {snap <label>|watch <label> <dur> <iv>|reduce <file>}"; exit 2 ;;
+esac

--- a/scripts/tests/test_worktree_setup.py
+++ b/scripts/tests/test_worktree_setup.py
@@ -23,7 +23,6 @@ from worktree_setup import (
     parse_env_file,
     prune_manifest,
     resolve_brainstorm_server_path,
-    save_manifest,
 )
 
 # Testing philosophy for worktree setup
@@ -461,11 +460,6 @@ class TestManifest:
         slots = load_manifest()
         assert slots == {}
         assert self.manifest_path.exists()
-
-    def test_save_and_load_roundtrip(self) -> None:
-        save_manifest({"/tmp/wt-a": 3, "/tmp/wt-b": 7})
-        slots = load_manifest()
-        assert slots == {"/tmp/wt-a": 3, "/tmp/wt-b": 7}
 
     def test_prune_removes_nonexistent_paths(self, tmp_path: Path) -> None:
         existing_dir = tmp_path / "exists"

--- a/scripts/worktree_setup.py
+++ b/scripts/worktree_setup.py
@@ -154,14 +154,6 @@ def load_manifest() -> dict[str, int]:
         return {}
 
 
-def save_manifest(slots: dict[str, int]) -> None:
-    """Write the slot manifest (not atomic — callers use flock for safety)."""
-    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
-    MANIFEST_PATH.write_text(
-        json.dumps({"version": 1, "slots": slots}, indent=2) + "\n"
-    )
-
-
 def prune_manifest(slots: dict[str, int]) -> dict[str, int]:
     """Remove entries whose worktree directories no longer exist."""
     return {path: slot for path, slot in slots.items() if Path(path).is_dir()}

--- a/src/test/integration/machine-info-tab-auth.test.tsx
+++ b/src/test/integration/machine-info-tab-auth.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import React from "react";
 import { render } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -6,7 +7,7 @@ import { eq } from "drizzle-orm";
 import { getTestDb, setupTestDb } from "~/test/setup/pglite";
 import { machines, userProfiles } from "~/server/db/schema";
 import { createTestMachine, createTestUser } from "~/test/helpers/factories";
-import MachineInfoTab from "./page";
+import MachineInfoTab from "~/app/(app)/m/[initials]/(tabs)/page";
 
 // Mock Supabase Server Client
 const mockGetUser = vi.fn();
@@ -40,7 +41,7 @@ vi.mock("~/server/db", async () => {
 const mockMachineTextFields = vi.fn(() => (
   <div data-testid="machine-text-fields" />
 ));
-vi.mock("../machine-text-fields", () => ({
+vi.mock("~/app/(app)/m/[initials]/machine-text-fields", () => ({
   MachineTextFields: (props: {
     machineId: string;
     description: string | null;


### PR DESCRIPTION
## What

Clean rebuild of #1473 + #1474, which were polluted by the worktree-nesting bug (anthropics/claude-code#47548). origin/main was never affected; this re-lands the two clean change-sets via cherry-pick.

### PP-3vdr.6 — concurrency hygiene
- Remove dead `save_manifest()` (+ its test) from `scripts/worktree_setup.py` — all writes go through the flock-safe `_write_manifest_locked()`.
- Move the only unit-project PGlite test: `src/app/(app)/m/[initials]/(tabs)/page.test.tsx` → `src/test/integration/machine-info-tab-auth.test.tsx` (adds `@vitest-environment jsdom`).
- Document why `db-fast-reset.mjs` intentionally does NOT truncate `auth.users` (seed is idempotent; Admin API not reachable via the Postgres conn).

### PP-3vdr.7 — investigation deliverables
- Add `scripts/diagnostics/mem-budget.sh` (macOS phys_footprint profiler).
- Add `docs/memory-budget-investigation-2026-06.md`.

Follow-up `PP-3vdr.11` filed for the schema-lock stale-holder edge case Copilot flagged on the merged #1471 code.