### PR TITLE
chore(workflow): allow merge-pr.sh to merge Dependabot PRs

### DIFF
--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -11,7 +11,8 @@
 #                                 Combine with --force to bypass currency + threads + ci together.
 #
 # no_conflict gate is NEVER bypassable — GitHub rejects conflicting merges regardless of --admin.
-# Authorship gate has no bypass; this script operates only on PRs you authored.
+# Authorship gate has no bypass; this script operates only on PRs you authored OR PRs authored
+# by trusted Dependabot bot identities (app/dependabot, dependabot[bot], dependabot).
 # Both --force and --bypass-merge-requirements require manual permission approval
 # (settings.json permissions.ask).
 
@@ -49,8 +50,17 @@ PR_LABELS=$(jq -r '.labels | map(.name) | join(",")' <<< "$PR_INFO")
 PR_HEAD_SHA=$(jq -r .headRefOid <<< "$PR_INFO")
 CURRENT_USER=$(gh api user --jq .login)
 
-if [ "$PR_AUTHOR" != "$CURRENT_USER" ]; then
-  echo "REFUSE: merge-pr.sh only operates on your own PRs (PR author: $PR_AUTHOR, you: $CURRENT_USER)" >&2
+is_trusted_author() {
+  local author="$1"
+  [ "$author" = "$CURRENT_USER" ] && return 0
+  case "$author" in
+    "app/dependabot"|"dependabot[bot]"|"dependabot") return 0 ;;
+  esac
+  return 1
+}
+
+if ! is_trusted_author "$PR_AUTHOR"; then
+  echo "REFUSE: merge-pr.sh only operates on your own PRs or Dependabot PRs (PR author: $PR_AUTHOR, you: $CURRENT_USER)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Relaxes the authorship gate in `scripts/workflow/merge-pr.sh` to also allow trusted Dependabot bot identities (`app/dependabot`, `dependabot[bot]`, `dependabot`) in addition to the current authenticated user.
- All 4 gates (ci, currency, threads, no_conflict) still run for Dependabot PRs with no changes — the currency gate naturally SKIPs since Dependabot PRs have no Copilot reviews.
- Updates the header comment (line ~14) to document that Dependabot PRs are also permitted.

## Dry-run proof on PR #1472 (Dependabot PR — before/after)

**Before** (old behavior):
```
REFUSE: merge-pr.sh only operates on your own PRs (PR author: app/dependabot, you: timothyfroehlich)
```

**After** (new behavior):
```
Target: PR #1472 — chore(deps)(deps): bump the minor-patch-updates group across 1 directory with 7 updates
URL: https://github.com/timothyfroehlich/PinPoint/pull/1472
Head SHA: 90b1ffc742093d78736177e671bfb01e5c7197a7
PASS: ci: CI Gate conclusion=SUCCESS
SKIP: currency: no Copilot reviews exist for this PR
PASS: threads: 0 unresolved Copilot threads
PASS: no_conflict: MERGEABLE
RESULT: all gates passed
DRY RUN: would run: gh pr merge 1472 --squash --match-head-commit=90b1ffc742093d78736177e671bfb01e5c7197a7
```

## Test plan

- [x] `pnpm run check` passes (includes shellcheck on merge-pr.sh)
- [x] Dry-run on PR #1472 (Dependabot) produces `Target:` lines + all gates, not `REFUSE:`
- [ ] CI Gate passes on this PR
- [ ] Merge this PR using `bash scripts/workflow/merge-pr.sh <this-PR-number>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)