### PR TITLE
feat(memory): banded memory-pressure gate for heavy commands (PP-3vdr.8)

### DIFF
--- a/.claude/hooks/block-heavy-under-pressure.cjs
+++ b/.claude/hooks/block-heavy-under-pressure.cjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook: block heavy commands when the host is under critical memory pressure.
+ *
+ * Intercepts agent-issued commands that match the heavy-run pattern and runs
+ * scripts/guard/mem-precheck.sh. If the precheck exits non-zero (HARD-BLOCK
+ * zone), the tool call is denied with a clear message and the override hint.
+ *
+ * FAIL-OPEN: any error during the precheck (exec failure, parse error,
+ * unexpected exception) allows the command through. This hook must never
+ * wedge a session due to its own malfunction.
+ *
+ * Honors FORCE_MEM_PRECHECK=skip (passed through to the shell script).
+ * Passes through immediately in CI ($CI is set).
+ *
+ * Matched commands (substring search against the full command string):
+ *   pnpm run test:integration
+ *   pnpm run test:integration:supabase
+ *   pnpm run build
+ *   pnpm run smoke
+ *   pnpm run e2e
+ *   vitest run
+ *   playwright test
+ */
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const HEAVY_PATTERNS = [
+  /pnpm\s+run\s+(test:integration|test:integration:supabase|build|smoke|e2e)\b/,
+  /\bvitest\s+run\b/,
+  /\bplaywright\s+test\b/,
+];
+
+async function main() {
+  let inputData = "";
+  for await (const chunk of process.stdin) {
+    inputData += chunk;
+  }
+
+  if (!inputData.trim()) {
+    process.exit(0);
+  }
+
+  let input;
+  try {
+    input = JSON.parse(inputData);
+  } catch {
+    // Fail-open on parse error
+    process.exit(0);
+  }
+
+  const command = input.tool_input?.command;
+  if (!command) {
+    process.exit(0);
+  }
+
+  // Only intercept Bash tool calls
+  if (input.tool_name !== "Bash") {
+    process.exit(0);
+  }
+
+  // Fail-open if $CI is set — runners have their own isolation
+  if (process.env.CI) {
+    process.exit(0);
+  }
+
+  // Check if the command matches any heavy pattern
+  const isHeavy = HEAVY_PATTERNS.some((re) => re.test(command));
+  if (!isHeavy) {
+    process.exit(0);
+  }
+
+  // Locate the precheck script relative to the hook's own location.
+  // Hook lives at .claude/hooks/; script is at scripts/guard/mem-precheck.sh.
+  // We resolve from CLAUDE_PROJECT_DIR if available (set by Claude Code), then
+  // try __dirname-relative (two levels up), then cwd.
+  const candidates = [
+    process.env.CLAUDE_PROJECT_DIR &&
+      path.join(
+        process.env.CLAUDE_PROJECT_DIR,
+        "scripts",
+        "guard",
+        "mem-precheck.sh",
+      ),
+    path.join(__dirname, "..", "..", "scripts", "guard", "mem-precheck.sh"),
+    path.join(process.cwd(), "scripts", "guard", "mem-precheck.sh"),
+  ].filter(Boolean);
+
+  const precheckPath = candidates.find((p) => fs.existsSync(p));
+  if (!precheckPath) {
+    // Fail-open: script not found (e.g., not yet deployed)
+    process.exit(0);
+  }
+
+  try {
+    const env = { ...process.env };
+    // Propagate FORCE_MEM_PRECHECK if set in the agent's environment
+    execFileSync("bash", [precheckPath], {
+      env,
+      stdio: ["ignore", "ignore", "pipe"], // capture stderr
+      timeout: 330_000, // 5 min poll + 30 s buffer
+    });
+    // Precheck passed — allow
+    process.exit(0);
+  } catch (err) {
+    // exit code 1 from precheck → HARD-BLOCK
+    if (err.status === 1) {
+      const stderr = err.stderr?.toString("utf8") ?? "";
+      // Extract a compact reason from the precheck's stderr output
+      const lines = stderr.split("\n").filter((l) => l.trim().length > 0);
+      const summary = lines.slice(-6).join("\n");
+
+      const decision = {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason:
+            `Memory pressure gate blocked this command.\n\n${summary}\n\n` +
+            `Override (one run): set FORCE_MEM_PRECHECK=skip in your command, e.g.:\n` +
+            `  FORCE_MEM_PRECHECK=skip ${command.trim().split("\n")[0]}`,
+        },
+      };
+      process.stdout.write(JSON.stringify(decision));
+      process.exit(0);
+    }
+
+    // Any other failure (SIGTERM, timeout, exec error) → fail-open
+    process.exit(0);
+  }
+}
+
+main().catch(() => process.exit(0));

--- a/.claude/hooks/block-heavy-under-pressure.cjs
+++ b/.claude/hooks/block-heavy-under-pressure.cjs
@@ -74,6 +74,15 @@ async function main() {
     process.exit(0);
   }
 
+  // Honor an INLINE override: `FORCE_MEM_PRECHECK=skip pnpm run build`.
+  // The shell only exports that var into the child process when the command
+  // runs — it is NOT in this hook's own process.env. Without this check the
+  // hook would run the precheck and could deny a command the user explicitly
+  // told us to skip. Allow immediately when the inline override is present.
+  if (/(^|\s)FORCE_MEM_PRECHECK=skip(\s|$)/.test(command)) {
+    process.exit(0);
+  }
+
   // Locate the precheck script relative to the hook's own location.
   // Hook lives at .claude/hooks/; script is at scripts/guard/mem-precheck.sh.
   // We resolve from CLAUDE_PROJECT_DIR if available (set by Claude Code), then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,11 @@
             "type": "command",
             "command": "node .claude/hooks/block-bad-shell-patterns.cjs",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/block-heavy-under-pressure.cjs",
+            "timeout": 335000
           }
         ]
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Only stop services you started in this session, by specific PID or via worktree-
 | `pnpm run db:seed:from-prod`          | Reset local + seed from latest prod backup                                                                                                |
 | `ruff check && ruff format`           | Python lint/format (no venv needed)                                                                                                       |
 | `./scripts/workflow/pr-watch.py <PR>` | Watch CI for a PR (Monitor-compatible). Never hand-roll a polling loop.                                                                   |
+| `FORCE_MEM_PRECHECK=skip <command>`   | Bypass the memory-pressure gate for one run (e.g. when you know pressure is transient or acceptable).                                     |
 
 ### Prototype mode (rapid iteration)
 

--- a/scripts/guard/mem-precheck.sh
+++ b/scripts/guard/mem-precheck.sh
@@ -7,7 +7,7 @@
 #                                   if pressure clears → GO;
 #                                   if still tight at timeout → HARD-BLOCK.
 #   HARD-BLOCK  (free < 800 MB
-#                OR swap > 6500 MB): exit non-zero immediately with a message.
+#                OR swap >= 6500 MB): exit non-zero immediately with a message.
 #
 # "Free RAM" = (pages free + pages inactive) × page size, which matches what
 # macOS considers "available" (inactive pages are immediately reclaimable).
@@ -37,6 +37,15 @@ fi
 
 if [ "${FORCE_MEM_PRECHECK:-}" = "skip" ]; then
   echo "[mem-precheck] override: FORCE_MEM_PRECHECK=skip — skipping check." >&2
+  exit 0
+fi
+
+# Non-Darwin fail-open. The gate's metrics (vm_stat, sysctl vm.swapusage) are
+# macOS-only. On Linux/remote dev hosts vm_stat fails, _free_mb() reads 0, and
+# the script would HARD-BLOCK — wedging build/integration. The gate only
+# applies where its metrics are valid, so elsewhere we allow unconditionally.
+if [ "$(uname)" != "Darwin" ]; then
+  echo "[mem-precheck] non-Darwin host — skipping check (gate is macOS-only)." >&2
   exit 0
 fi
 
@@ -77,23 +86,32 @@ _swap_used_mb() {
   local raw
   raw=$(sysctl -n vm.swapusage 2>/dev/null) || { echo "0"; return; }
   # Format: "total = NNN.NNM  used = NNN.NNM  free = NNN.NNM  (encrypted)"
-  # Extract the "used = NNN.NNM" part and convert to integer MB.
-  local used_val used_unit
-  used_val=$(echo "$raw"  | awk '{ for(i=1;i<=NF;i++) if ($i=="used") print $(i+2) }')
-  used_unit=$(echo "$raw" | awk '{ for(i=1;i<=NF;i++) if ($i=="used") print $(i+3) }')
+  # The figure after "used =" is a single token with the unit suffixed, e.g.
+  # "280.88M" or "6.50G". Grab that one token (two fields after "used").
+  local used_token
+  used_token=$(echo "$raw" \
+    | awk '{ for (i=1;i<=NF;i++) if ($i=="used") { print $(i+2); break } }')
 
-  if [ -z "$used_val" ]; then
+  if [ -z "$used_token" ]; then
     echo "0"
     return
   fi
 
-  # Remove any trailing 'M' from the value (e.g., "280.88M" → "280.88")
-  used_val="${used_val%M}"
+  # Pull the trailing unit letter off the SAME token, then strip it from the
+  # numeric value. Default to M if no recognizable unit suffix is present.
+  local unit numeric
+  unit=$(printf '%s' "$used_token" | sed -E 's/^[0-9.]+//; s/[^A-Za-z].*$//')
+  numeric=$(printf '%s' "$used_token" | sed -E 's/[A-Za-z].*$//')
 
-  # Convert to integer MB (truncate decimals with printf)
-  case "${used_unit:-M}" in
-    G*) printf "%.0f\n" "$(echo "$used_val * 1024" | awk '{printf "%.0f", $1 * $3}')" ;;
-    *)  printf "%.0f\n" "$used_val" ;;
+  if [ -z "$numeric" ]; then
+    echo "0"
+    return
+  fi
+
+  # Convert to integer MB. G → ×1024, anything else (M/empty) → as-is.
+  case "${unit:-M}" in
+    G | g) awk -v v="$numeric" 'BEGIN { printf "%.0f\n", v * 1024 }' ;;
+    *)     awk -v v="$numeric" 'BEGIN { printf "%.0f\n", v }' ;;
   esac
 }
 
@@ -107,7 +125,7 @@ _hard_block() {
   echo "╚══════════════════════════════════════════════╝" >&2
   echo ""                                                >&2
   echo "  Free RAM : ${free_mb} MB  (need >= ${THRESHOLD_QUEUE} MB to queue, >= ${THRESHOLD_GO} MB to run)" >&2
-  echo "  Swap used: ${swap_mb} MB  (hard-block if > ${THRESHOLD_SWAP} MB)" >&2
+  echo "  Swap used: ${swap_mb} MB  (hard-block if >= ${THRESHOLD_SWAP} MB)" >&2
   echo ""                                                >&2
   echo "  Heavy command blocked. Options:" >&2
   echo "    • Wait for other sessions to finish, then retry." >&2

--- a/scripts/guard/mem-precheck.sh
+++ b/scripts/guard/mem-precheck.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# mem-precheck.sh — banded memory-pressure gate for heavy commands.
+#
+# Three zones based on current macOS host memory pressure:
+#   GO          (free >= 2 GB):    proceed immediately, exit 0.
+#   QUEUE/WARN  (800 MB–2 GB):     poll every 10 s for up to 5 min;
+#                                   if pressure clears → GO;
+#                                   if still tight at timeout → HARD-BLOCK.
+#   HARD-BLOCK  (free < 800 MB
+#                OR swap > 6500 MB): exit non-zero immediately with a message.
+#
+# "Free RAM" = (pages free + pages inactive) × page size, which matches what
+# macOS considers "available" (inactive pages are immediately reclaimable).
+#
+# Rationale for thresholds (see docs/memory-budget-investigation-2026-06.md):
+#   - A 2-worker integration run peaks at ~3.3 GB.
+#   - A measured single 4-worker run drove free RAM to 74–89 MB (the cliff).
+#   - Baseline idle 5-session load ≈ 4.5 GB before any work starts.
+#   - 2 GB free is a comfortable runway for one more heavy run.
+#   - 800 MB is the minimum defensible floor (some run in flight already).
+#   - Swap > 6500 MB indicates the machine is already swapping heavily; adding
+#     a 3–6 GB peak will extend run times dramatically and risk OOM.
+#
+# CI passthrough: if $CI is set, exit 0 (runner provides isolation).
+# Override:       if FORCE_MEM_PRECHECK=skip, exit 0 with a one-line notice.
+#
+# Usage (invoked via bash — no chmod needed):
+#   bash scripts/guard/mem-precheck.sh
+
+set -euo pipefail
+
+# ── overrides ────────────────────────────────────────────────────────────────
+
+if [ -n "${CI:-}" ]; then
+  exit 0
+fi
+
+if [ "${FORCE_MEM_PRECHECK:-}" = "skip" ]; then
+  echo "[mem-precheck] override: FORCE_MEM_PRECHECK=skip — skipping check." >&2
+  exit 0
+fi
+
+# ── thresholds (MB) ──────────────────────────────────────────────────────────
+
+THRESHOLD_GO=2048         # >= this: proceed immediately
+THRESHOLD_QUEUE=800       # >= this (but < GO): enter polling band
+THRESHOLD_SWAP=6500       # swap used above this: HARD-BLOCK regardless of free
+POLL_INTERVAL_SECONDS=10  # how often to re-sample in the QUEUE band
+POLL_TIMEOUT_SECONDS=300  # 5 minutes: give up and HARD-BLOCK if still tight
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+# Returns: free RAM in MB = (pages_free + pages_inactive) × page_size / 1 MB
+# vm_stat is authoritative for macOS free+reclaimable pages.
+_free_mb() {
+  local page_size
+  page_size=$(pagesize 2>/dev/null || sysctl -n hw.pagesize 2>/dev/null || echo 16384)
+
+  local raw_stats
+  raw_stats=$(vm_stat 2>/dev/null) || { echo "0"; return; }
+
+  local pages_free pages_inactive
+  pages_free=$(echo "$raw_stats" \
+    | awk '/^Pages free:/ { gsub(/\./, "", $3); print $3 + 0 }')
+  pages_inactive=$(echo "$raw_stats" \
+    | awk '/^Pages inactive:/ { gsub(/\./, "", $3); print $3 + 0 }')
+
+  # Guard against empty/failed parses — treat as 0 so we fail-safe
+  pages_free="${pages_free:-0}"
+  pages_inactive="${pages_inactive:-0}"
+
+  echo $(( (pages_free + pages_inactive) * page_size / 1024 / 1024 ))
+}
+
+# Returns: swap used in MB via sysctl vm.swapusage
+_swap_used_mb() {
+  local raw
+  raw=$(sysctl -n vm.swapusage 2>/dev/null) || { echo "0"; return; }
+  # Format: "total = NNN.NNM  used = NNN.NNM  free = NNN.NNM  (encrypted)"
+  # Extract the "used = NNN.NNM" part and convert to integer MB.
+  local used_val used_unit
+  used_val=$(echo "$raw"  | awk '{ for(i=1;i<=NF;i++) if ($i=="used") print $(i+2) }')
+  used_unit=$(echo "$raw" | awk '{ for(i=1;i<=NF;i++) if ($i=="used") print $(i+3) }')
+
+  if [ -z "$used_val" ]; then
+    echo "0"
+    return
+  fi
+
+  # Remove any trailing 'M' from the value (e.g., "280.88M" → "280.88")
+  used_val="${used_val%M}"
+
+  # Convert to integer MB (truncate decimals with printf)
+  case "${used_unit:-M}" in
+    G*) printf "%.0f\n" "$(echo "$used_val * 1024" | awk '{printf "%.0f", $1 * $3}')" ;;
+    *)  printf "%.0f\n" "$used_val" ;;
+  esac
+}
+
+# Print the HARD-BLOCK message and exit non-zero.
+_hard_block() {
+  local free_mb="$1"
+  local swap_mb="$2"
+  echo ""                                                >&2
+  echo "╔══════════════════════════════════════════════╗" >&2
+  echo "║  mem-precheck: HARD-BLOCK (memory pressure)  ║" >&2
+  echo "╚══════════════════════════════════════════════╝" >&2
+  echo ""                                                >&2
+  echo "  Free RAM : ${free_mb} MB  (need >= ${THRESHOLD_QUEUE} MB to queue, >= ${THRESHOLD_GO} MB to run)" >&2
+  echo "  Swap used: ${swap_mb} MB  (hard-block if > ${THRESHOLD_SWAP} MB)" >&2
+  echo ""                                                >&2
+  echo "  Heavy command blocked. Options:" >&2
+  echo "    • Wait for other sessions to finish, then retry." >&2
+  echo "    • Skip this check:  FORCE_MEM_PRECHECK=skip <command>" >&2
+  echo ""                                                >&2
+  exit 1
+}
+
+# ── classify and act ─────────────────────────────────────────────────────────
+
+_classify_and_act() {
+  local free_mb swap_mb
+  free_mb=$(_free_mb)
+  swap_mb=$(_swap_used_mb)
+
+  # Swap hard-block takes precedence regardless of free RAM reading.
+  if [ "$swap_mb" -ge "$THRESHOLD_SWAP" ]; then
+    echo "[mem-precheck] swap pressure: ${swap_mb} MB used (>= ${THRESHOLD_SWAP} MB limit)." >&2
+    _hard_block "$free_mb" "$swap_mb"
+  fi
+
+  if [ "$free_mb" -ge "$THRESHOLD_GO" ]; then
+    # GO: plenty of room
+    return 0
+  fi
+
+  if [ "$free_mb" -lt "$THRESHOLD_QUEUE" ]; then
+    # HARD-BLOCK immediately — not even worth queuing
+    echo "[mem-precheck] insufficient RAM: ${free_mb} MB free (need >= ${THRESHOLD_QUEUE} MB)." >&2
+    _hard_block "$free_mb" "$swap_mb"
+  fi
+
+  # QUEUE band: poll until free >= GO or timeout
+  local elapsed=0
+  echo "[mem-precheck] memory pressure: ${free_mb} MB free (queue band ${THRESHOLD_QUEUE}–${THRESHOLD_GO} MB)." >&2
+  echo "[mem-precheck] waiting up to ${POLL_TIMEOUT_SECONDS}s for pressure to clear ..." >&2
+
+  while [ "$elapsed" -lt "$POLL_TIMEOUT_SECONDS" ]; do
+    sleep "$POLL_INTERVAL_SECONDS"
+    elapsed=$(( elapsed + POLL_INTERVAL_SECONDS ))
+
+    free_mb=$(_free_mb)
+    swap_mb=$(_swap_used_mb)
+
+    echo "[mem-precheck] ${elapsed}s elapsed — free: ${free_mb} MB, swap: ${swap_mb} MB" >&2
+
+    # Swap may have crossed the line while waiting.
+    if [ "$swap_mb" -ge "$THRESHOLD_SWAP" ]; then
+      echo "[mem-precheck] swap pressure worsened during wait." >&2
+      _hard_block "$free_mb" "$swap_mb"
+    fi
+
+    if [ "$free_mb" -ge "$THRESHOLD_GO" ]; then
+      echo "[mem-precheck] pressure cleared — proceeding." >&2
+      return 0
+    fi
+  done
+
+  # Still in band after timeout → hard-block
+  echo "[mem-precheck] timeout after ${POLL_TIMEOUT_SECONDS}s — memory pressure did not clear." >&2
+  _hard_block "$free_mb" "$swap_mb"
+}
+
+_classify_and_act

--- a/scripts/workflow/heavy-run.sh
+++ b/scripts/workflow/heavy-run.sh
@@ -31,10 +31,18 @@ if [ "$#" -eq 0 ]; then
 fi
 
 # CI passthrough — runners already provide isolation; semaphore would deadlock
-# on single-slot environments.
+# on single-slot environments. mem-precheck also exits 0 in CI (redundant but
+# harmless), so skip the whole block.
 if [ -n "${CI:-}" ]; then
   exec "$@"
 fi
+
+# Memory-pressure gate — run BEFORE acquiring the sem slot so a heavy command
+# can never queue onto the semaphore while the host is already critically low.
+# The gate is banded: GO / QUEUE (polls up to 5 min) / HARD-BLOCK (exit 1).
+# Override: FORCE_MEM_PRECHECK=skip <command> bypasses the gate for one run.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "${SCRIPT_DIR}/../guard/mem-precheck.sh"
 
 # Detect GNU parallel's sem. moreutils also ships a `sem` binary that doesn't
 # speak --jobs/--id/--fg, so probe the version banner too.


### PR DESCRIPTION
## Summary

- Adds `scripts/guard/mem-precheck.sh` — a three-zone banded gate (GO / QUEUE / HARD-BLOCK) reading macOS `vm_stat` free+inactive pages and `sysctl vm.swapusage` before any heavy command runs.
- Integrates the gate into `scripts/workflow/heavy-run.sh` before the `sem` slot acquisition, so heavy commands are pressure-gated AND concurrency-capped.
- Adds `.claude/hooks/block-heavy-under-pressure.cjs` (PreToolUse hook) that intercepts agent-issued heavy commands (`pnpm run test:integration`, `build`, `smoke`, `e2e`; `vitest run`; `playwright test`) and denies them with an override hint when the host is in HARD-BLOCK territory. Fails-open on any unexpected error.
- Documents `FORCE_MEM_PRECHECK=skip` in `AGENTS.md` §5 Key commands.

## Thresholds (grounded in investigation)

| Zone | Condition | Action |
|------|-----------|--------|
| GO | free ≥ 2 GB | Proceed immediately |
| QUEUE | 800 MB ≤ free < 2 GB | Poll every 10 s for up to 5 min; proceed if cleared, hard-block on timeout |
| HARD-BLOCK | free < 800 MB OR swap > 6500 MB | Exit non-zero, print message + override hint |

Rationale: The investigation measured a 2-worker integration run peaking at ~3.3 GB; 2 GB free gives a comfortable runway. The measured cliff was 74–89 MB free during a 4-worker run; 800 MB is a defensive floor that still allows an in-flight run to be present. The 6500 MB swap threshold reflects the 2–8 GB swap range seen during OOM events, at the high end before active thrashing.

## Override

`FORCE_MEM_PRECHECK=skip <command>` bypasses the gate for one run. CI (`$CI` set) passes through automatically.

## Test plan

- [x] `bash scripts/guard/mem-precheck.sh` exits 0 on current machine (verified: GO zone)
- [x] `FORCE_MEM_PRECHECK=skip bash scripts/guard/mem-precheck.sh` exits 0 with override notice
- [x] `CI=true bash scripts/guard/mem-precheck.sh` exits 0 silently
- [x] `shellcheck scripts/guard/mem-precheck.sh` clean
- [x] `shellcheck scripts/workflow/heavy-run.sh` clean
- [x] `pnpm run check` green (138 test files, 1264 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)