### PR TITLE
test(audit): Wave 2 free-win inert deletes (PP-x4li.1.2)

### DIFF
--- a/src/test/integration/database-queries.test.ts
+++ b/src/test/integration/database-queries.test.ts
@@ -20,36 +20,6 @@ import {
 describe("Database Queries (PGlite)", () => {
   setupTestDb();
 
-  describe("Machines", () => {
-    it("should insert and query a machine", async () => {
-      const db = await getTestDb();
-      const testMachine = createTestMachine({ name: "Twilight Zone" });
-
-      await db.insert(machines).values(testMachine);
-
-      const result = await db.query.machines.findFirst({
-        where: eq(machines.name, "Twilight Zone"),
-      });
-
-      expect(result).toBeDefined();
-      expect(result?.name).toBe("Twilight Zone");
-    });
-
-    it("should find machine by id", async () => {
-      const db = await getTestDb();
-      const testMachine = createTestMachine();
-
-      await db.insert(machines).values(testMachine);
-
-      const result = await db.query.machines.findFirst({
-        where: eq(machines.id, testMachine.id),
-      });
-
-      expect(result).toBeDefined();
-      expect(result?.id).toBe(testMachine.id);
-    });
-  });
-
   describe("Issues", () => {
     it("should insert issue with machine reference", async () => {
       const db = await getTestDb();


### PR DESCRIPTION
## Summary

Implements bead PP-x4li.1.2: delete inert raw-Drizzle round-trip blocks from `database-queries.test.ts`. No changes to `export-action.test.ts` (re-verification found no blocks meeting the DELETE-inert definition).

## Deleted blocks

| File | Test name | Verdict | Reason |
|------|-----------|---------|--------|
| `src/test/integration/database-queries.test.ts` | `should insert and query a machine` | DELETE-inert | Inserts a machine via Drizzle and selects it back by name. Asserts only that the ORM round-trip works (`result` is defined, `result.name` matches input). Tests Drizzle + PGlite, not PinPoint code. |
| `src/test/integration/database-queries.test.ts` | `should find machine by id` | DELETE-inert | Inserts a machine via Drizzle and selects it back by id. Same pattern as above — pure ORM round-trip with no PinPoint logic exercised. |

Deleting both blocks emptied the `describe("Machines")` wrapper, which was also removed.

## Kept-but-considered blocks

### `src/test/integration/database-queries.test.ts`

| Test name | Verdict | Reason |
|-----------|---------|--------|
| `should insert issue with machine reference` | KEEP | Tests Drizzle relational query with the `with: { machine: true }` eager-load — exercises the schema relation definition, not just a bare insert+select. |
| `should enforce machine_initials NOT NULL constraint` | KEEP | Asserts a DB constraint violation (`rejects.toThrow()`). Tests PinPoint schema enforcement. |
| `should cascade delete issues when machine is deleted` | KEEP | Asserts cascade-delete behavior defined in the schema. Tests PinPoint schema enforcement. |
| `should insert and query user profile` | KEEP | Asserts `result?.name === "Test User"` — the `name` generated column that concatenates `firstName + lastName`. Tests PinPoint schema's computed field, not a plain round-trip. |
| `should link user to reported issues` | KEEP | Tests the `reportedByUser` foreign-key relation via Drizzle `with:` — exercises the schema relation definition. |
| `should create notification when issue is assigned` | KEEP | Tests manual notification creation workflow; verifies `type` and `resourceId` on the retrieved record. Reasonable integration smoke for the notifications schema. |
| `should create notification using library function (integration)` | KEEP | Calls `createNotification()` (PinPoint library function) and verifies it produces the expected notification row. Tests PinPoint code, not Drizzle itself. |
| `should delete notification (mark as read behavior)` | KEEP | Tests `db.delete` + verifies record is gone. Slightly redundant with pure ORM, but the "mark as read = delete" pattern is explicitly documented in the test comment and serves as behavioral documentation. |

### `src/app/(app)/issues/export-action.test.ts`

Re-verification found **zero blocks** meeting the DELETE-inert definition. The audit's count of "3 inert filter-arg assertions" refers to `toHaveBeenCalledOnce()` calls that are incidental sub-assertions within blocks that also assert real behavioral output. Per the task definition ("delete only blocks whose sole assertion is 'the mock was called'"), all four filter-parsing blocks are KEEP:

| Test name | Verdict | Reason |
|-----------|---------|--------|
| `passes parsed filters to buildWhereConditions` | KEEP | Also asserts `passedFilters.status` and `passedFilters.machine` values — real behavioral output. |
| `coerces ISO date strings in filtersJson into Date objects` | KEEP | Also asserts `passedFilters.createdFrom` is a `Date` instance with correct ISO string — tests date coercion logic. |
| `uses empty filters when filtersJson contains an invalid enum value` | KEEP | Also asserts `passedFilters.status` and `passedFilters.q` are `undefined` — tests the Zod safeParse fallback behavior. |
| `injects currentUserId from the authenticated user` | KEEP | Asserts `passedFilters.currentUserId === MOCK_USER.id` — tests userId injection, a real behavioral property. |

> **Verdict count divergence flagged:** The audit cited 3 inert blocks in `export-action.test.ts` but re-verification found 0 qualifying whole blocks. The `toHaveBeenCalledOnce()` assertion in each block is incidental to a richer assertion set; strict application of the definition ("sole meaningful assertion") preserves all four.

## Quality gates

- `pnpm run check`: green (1289 unit tests passing)
- `pnpm exec vitest run --project=unit export-action`: 16/16 passing
- `pnpm exec vitest run --project=integration src/test/integration/database-queries.test.ts`: 8/8 passing (was 10/10 before deletions)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)