### PR TITLE
test(audit): Wave 3 RECLASS images action tests to PGlite integration (PP-x4li.1.3)

### DIFF
--- a/src/server/actions/images.test.ts
+++ b/src/server/actions/images.test.ts
@@ -169,32 +169,6 @@ describe("uploadIssueImage", () => {
     }
   });
 
-  it("should insert record and revalidate for existing issue", async () => {
-    vi.mocked(rateLimit.checkImageUploadLimit).mockResolvedValue({
-      success: true,
-      limit: 5,
-      remaining: 4,
-      reset: 0,
-    });
-
-    vi.mocked(blobClient.uploadToBlob).mockResolvedValue({
-      url: "https://blob.com/test.jpg",
-      pathname: "issue-images/test-issue/test.jpg",
-      size: 1024,
-      uploadedAt: new Date(),
-    });
-
-    const formData = new FormData();
-    formData.append("issueId", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
-    const file = createMockFile("test.jpg", "image/jpeg", 2048);
-    formData.append("image", file);
-
-    const result = await uploadIssueImage(formData);
-
-    expect(result.ok).toBe(true);
-    expect(db.insert).toHaveBeenCalled();
-  });
-
   it("should cleanup blob if DB insert fails", async () => {
     vi.mocked(rateLimit.checkImageUploadLimit).mockResolvedValue({
       success: true,

--- a/src/test/integration/supabase/images.test.ts
+++ b/src/test/integration/supabase/images.test.ts
@@ -2,10 +2,13 @@
  * Integration Tests for Issue Images
  *
  * Tests image database operations, limits, and cascade behavior with PGlite.
+ * Also contains action-level integration tests for uploadIssueImage that verify
+ * real DB persistence and permission-enforcement via real DB ownership rows.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { eq, count } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
 import { getTestDb, setupTestDb } from "~/test/setup/pglite";
 import { createTestUser } from "~/test/helpers/factories";
 import {
@@ -16,6 +19,35 @@ import {
   issueImages,
 } from "~/server/db/schema";
 import { BLOB_CONFIG } from "~/lib/blob/config";
+import { createClient } from "~/lib/supabase/server";
+import { checkImageUploadLimit } from "~/lib/rate-limit";
+import { uploadToBlob } from "~/lib/blob/client";
+
+// Route the production `db` import to the PGlite worker instance so that
+// uploadIssueImage reads/writes real rows instead of a hand-rolled mock.
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("~/lib/blob/client", () => ({
+  uploadToBlob: vi.fn(),
+  deleteFromBlob: vi.fn(),
+}));
+
+vi.mock("~/lib/rate-limit", () => ({
+  checkImageUploadLimit: vi.fn(),
+  getClientIp: vi.fn(() => Promise.resolve("127.0.0.1")),
+  formatResetTime: vi.fn(() => "15 minutes"),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
 
 describe("Issue Images Database Operations (PGlite)", () => {
   setupTestDb();
@@ -287,5 +319,200 @@ describe("Issue Images Database Operations (PGlite)", () => {
 
       expect(activeCount[0].val).toBe(1);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action-level integration tests for uploadIssueImage
+// ---------------------------------------------------------------------------
+// These tests call the real server action against PGlite and only mock the
+// three external boundaries: blob storage, rate limiting, and Supabase auth.
+// ---------------------------------------------------------------------------
+
+describe("uploadIssueImage — action integration (PGlite)", () => {
+  setupTestDb();
+
+  // Helpers ----------------------------------------------------------------
+
+  function createMockFile(
+    name: string,
+    type: string,
+    sizeInBytes: number
+  ): File {
+    const content = new Array(sizeInBytes).fill("x").join("");
+    return new File([content], name, { type });
+  }
+
+  function mockAuth(userId: string | null) {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: userId ? { id: userId } : null },
+        }),
+      },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+  }
+
+  function mockRateLimitPass() {
+    vi.mocked(checkImageUploadLimit).mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: 0,
+    });
+  }
+
+  function mockBlobUpload(pathname = "issue-images/test-issue/test.jpg") {
+    vi.mocked(uploadToBlob).mockResolvedValue({
+      url: `https://blob.com/${pathname}`,
+      pathname,
+      size: 1024,
+      uploadedAt: new Date(),
+    });
+    return pathname;
+  }
+
+  async function seedIssueWithOwner(
+    reporterRole: "member" | "guest" | "technician" | "admin" = "member"
+  ) {
+    const db = await getTestDb();
+    const reporterId = randomUUID();
+    const ownerId = randomUUID();
+
+    await db
+      .insert(userProfiles)
+      .values(createTestUser({ id: reporterId, role: reporterRole }));
+    await db
+      .insert(userProfiles)
+      .values(createTestUser({ id: ownerId, role: "member" }));
+
+    const [machine] = await db
+      .insert(machines)
+      .values({ name: "Action Test Machine", initials: "ATM", ownerId })
+      .returning();
+
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        title: "Action Test Issue",
+        machineInitials: machine.initials,
+        issueNumber: 1,
+        severity: "playable",
+        reportedBy: reporterId,
+      })
+      .returning();
+
+    return { reporterId, ownerId, issueId: issue.id };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Block: "should insert record and revalidate for existing issue"
+  // RECLASS-integration: the real assertion is that an issueImages row persists
+  // in the DB. The unit test only checked that db.insert was called on a mock.
+  it("inserts an issueImages row for an existing issue", async () => {
+    const { reporterId, issueId } = await seedIssueWithOwner("member");
+    mockAuth(reporterId);
+    mockRateLimitPass();
+    const pathname = mockBlobUpload();
+
+    const { uploadIssueImage } = await import("~/server/actions/images");
+
+    const formData = new FormData();
+    formData.append("issueId", issueId);
+    formData.append("image", createMockFile("test.jpg", "image/jpeg", 2048));
+
+    const result = await uploadIssueImage(formData);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.imageId).toBeDefined();
+      expect(result.value.blobPathname).toBe(pathname);
+    }
+
+    // Assert the row actually persists in the real PGlite DB
+    const db = await getTestDb();
+    const rows = await db
+      .select()
+      .from(issueImages)
+      .where(eq(issueImages.issueId, issueId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.uploadedBy).toBe(reporterId);
+    expect(rows[0]?.fullBlobPathname).toBe(pathname);
+  });
+
+  // NEW coverage: permission-denied path for a non-reporter/non-owner member
+  // The unit test could not test this honestly — it required mocking DB ownership
+  // rows and the permission helpers simultaneously. Here we use real DB rows.
+  //
+  // Scenario: a `guest` user who is NOT the reporter of the issue and NOT the
+  // machine owner attempts to upload. `issues.update.reporting` grants guest
+  // access only on own issues (access: "own"), so this should be AUTH-denied.
+  it("denies upload to a guest who is not the issue reporter or machine owner", async () => {
+    const db = await getTestDb();
+
+    // Seed reporter (member) and a separate guest outsider
+    const reporterId = randomUUID();
+    const outsiderId = randomUUID();
+    const ownerId = randomUUID();
+
+    await db
+      .insert(userProfiles)
+      .values([
+        createTestUser({ id: reporterId, role: "member" }),
+        createTestUser({ id: outsiderId, role: "guest" }),
+        createTestUser({ id: ownerId, role: "member" }),
+      ]);
+
+    const [machine] = await db
+      .insert(machines)
+      .values({ name: "Perm Test Machine", initials: "PTM", ownerId })
+      .returning();
+
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        title: "Perm Test Issue",
+        machineInitials: machine.initials,
+        issueNumber: 2,
+        severity: "playable",
+        reportedBy: reporterId,
+      })
+      .returning();
+
+    // Auth: the outsider guest makes the request
+    mockAuth(outsiderId);
+    mockRateLimitPass();
+
+    vi.mocked(uploadToBlob).mockResolvedValue({
+      url: "https://blob.com/should-not-upload.jpg",
+      pathname: "issue-images/should-not-upload.jpg",
+      size: 1024,
+      uploadedAt: new Date(),
+    });
+
+    const { uploadIssueImage } = await import("~/server/actions/images");
+
+    const formData = new FormData();
+    formData.append("issueId", issue.id);
+    formData.append("image", createMockFile("test.jpg", "image/jpeg", 2048));
+
+    const result = await uploadIssueImage(formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("AUTH");
+      expect(result.message).toContain("permission");
+    }
+
+    // No blob should have been uploaded or DB row inserted
+    expect(uploadToBlob).not.toHaveBeenCalled();
+    const rows = await db
+      .select()
+      .from(issueImages)
+      .where(eq(issueImages.issueId, issue.id));
+    expect(rows).toHaveLength(0);
   });
 });

--- a/src/test/integration/supabase/images.test.ts
+++ b/src/test/integration/supabase/images.test.ts
@@ -22,6 +22,7 @@ import { BLOB_CONFIG } from "~/lib/blob/config";
 import { createClient } from "~/lib/supabase/server";
 import { checkImageUploadLimit } from "~/lib/rate-limit";
 import { uploadToBlob } from "~/lib/blob/client";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
 
 // Route the production `db` import to the PGlite worker instance so that
 // uploadIssueImage reads/writes real rows instead of a hand-rolled mock.
@@ -343,14 +344,32 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
     return new File([content], name, { type });
   }
 
+  // The action only calls `supabase.auth.getUser()`, so we provide a faithful
+  // full `getUser` response (`{ data, error: null }`) typed against the SDK's
+  // own return type. A single narrow cast to `SupabaseClient` is used at the SDK
+  // boundary because the mock implements only the `auth` slice the action
+  // consumes — no `unknown as` double-cast (CORE-TS-007).
+  type GetUserResult = Awaited<ReturnType<SupabaseClient["auth"]["getUser"]>>;
+
   function mockAuth(userId: string | null) {
+    const user = userId ? ({ id: userId } as User) : null;
+    const getUserResult: GetUserResult = user
+      ? { data: { user }, error: null }
+      : {
+          data: { user: null },
+          error: {
+            name: "AuthSessionMissingError",
+            message: "Auth session missing!",
+          } as GetUserResult["error"],
+        };
+
+    const auth: Pick<SupabaseClient["auth"], "getUser"> = {
+      getUser: vi.fn().mockResolvedValue(getUserResult),
+    };
+
     vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi.fn().mockResolvedValue({
-          data: { user: userId ? { id: userId } : null },
-        }),
-      },
-    } as unknown as Awaited<ReturnType<typeof createClient>>);
+      auth,
+    } as SupabaseClient);
   }
 
   function mockRateLimitPass() {
@@ -362,14 +381,18 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
     });
   }
 
-  function mockBlobUpload(pathname = "issue-images/test-issue/test.jpg") {
-    vi.mocked(uploadToBlob).mockResolvedValue({
-      url: `https://blob.com/${pathname}`,
-      pathname,
-      size: 1024,
-      uploadedAt: new Date(),
-    });
-    return pathname;
+  // Echo the pathname the action actually constructs back through the blob
+  // result, so the action's `blobPathname` output reflects the real key it built
+  // (per-issue prefix + timestamp) rather than a hardcoded test string.
+  function mockBlobUpload() {
+    vi.mocked(uploadToBlob).mockImplementation((_file, pathname) =>
+      Promise.resolve({
+        url: `https://blob.com/${pathname}`,
+        pathname,
+        size: 1024,
+        uploadedAt: new Date(),
+      })
+    );
   }
 
   async function seedIssueWithOwner(
@@ -416,7 +439,7 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
     const { reporterId, issueId } = await seedIssueWithOwner("member");
     mockAuth(reporterId);
     mockRateLimitPass();
-    const pathname = mockBlobUpload();
+    mockBlobUpload();
 
     const { uploadIssueImage } = await import("~/server/actions/images");
 
@@ -426,10 +449,26 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
 
     const result = await uploadIssueImage(formData);
 
+    // The action must construct the blob key with a per-issue prefix derived
+    // from the real issueId — assert the actual argument it passed to the blob
+    // client, not just the echoed mock value. This catches pathname-construction
+    // regressions (e.g. wrong prefix, leaked "pending"/"new" path).
+    const expectedPrefix = `issue-images/${issueId}/`;
+    expect(uploadToBlob).toHaveBeenCalledTimes(1);
+    // mock.calls[0] is the [file, pathname] tuple; assert on the pathname arg
+    // the action constructed.
+    const constructedPathname = vi.mocked(uploadToBlob).mock.calls[0][1];
+    expect(constructedPathname.startsWith(expectedPrefix)).toBe(true);
+    // The key suffix is `<timestamp>-<sanitized-filename>`; assert the filename
+    // survives and a numeric timestamp prefixes it.
+    expect(constructedPathname).toMatch(/\/\d+-test\.jpg$/);
+
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.imageId).toBeDefined();
-      expect(result.value.blobPathname).toBe(pathname);
+      // The action returns the key it built; it must carry the per-issue prefix.
+      expect(result.value.blobPathname).toBe(constructedPathname);
+      expect(result.value.blobPathname.startsWith(expectedPrefix)).toBe(true);
     }
 
     // Assert the row actually persists in the real PGlite DB
@@ -440,7 +479,8 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
       .where(eq(issueImages.issueId, issueId));
     expect(rows).toHaveLength(1);
     expect(rows[0]?.uploadedBy).toBe(reporterId);
-    expect(rows[0]?.fullBlobPathname).toBe(pathname);
+    expect(rows[0]?.fullBlobPathname).toBe(constructedPathname);
+    expect(rows[0]?.fullBlobPathname.startsWith(expectedPrefix)).toBe(true);
   });
 
   // NEW coverage: permission-denied path for a non-reporter/non-owner member


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements Wave 3 RECLASS for `src/server/actions/images.test.ts` per the unit-test audit (`docs/testing/unit-test-audit-2026-06.md`, row 7).

## Per-block disposition

| Block | Verdict | Reason |
|---|---|---|
| "should fail if rate limit exceeded" | **KEEP-unit** | Assertion fires before any DB call; pure rate-limit boundary check |
| "should fail if no image provided" | **KEEP-unit** | Assertion is a validation error; the DB path is incidental to the real point |
| "should upload image and return metadata for new issue" | **KEEP-unit** | `issueId="new"` — no DB interaction; blob is the only external boundary |
| "should handle blob upload failure for new issue" | **KEEP-unit** | Blob is an external boundary correctly mocked; no DB state involved |
| "should insert record and revalidate for existing issue" | **RECLASS → integration** | Real assertion is DB persistence; unit only checked `db.insert` was called on a mock |
| "should cleanup blob if DB insert fails" | **KEEP-unit** | Requires forcing a DB-insert throw mid-action; the action fetches the issue *before* uploading the blob, so a missing-issue FK violation fires VALIDATION before any blob upload — the cleanup path cannot be triggered via a real FK violation in a single-process test without mocking `~/server/db` |

## Divergence from audit's "3 RECLASS" count

The audit counted 3 RECLASS blocks for this file. On re-derivation, only 1 is a genuine RECLASS (the "insert record" block). The "cleanup blob" block was counted as RECLASS but cannot be triggered with a real PGlite DB without mocking `~/server/db` (prohibited in integration tests): the action reads the issue for ownership *before* uploading the blob, so there is no post-upload window to inject a FK violation. It remains KEEP-unit where a mock throw correctly exercises the cleanup guarantee.

## New integration coverage added

**Permission-denied path (NEW):** A `guest` user who is neither the issue reporter nor the machine owner attempts to upload to an existing issue. `issues.update.reporting` grants `guest` access only on own issues (`access: "own"`). The test asserts:
- Result is `AUTH` error with "permission" in the message
- `uploadToBlob` was never called (no blob wasted)
- No `issueImages` row was inserted in PGlite

This coverage was impossible to add honestly to the unit file — it required real DB ownership rows (issue.reportedBy, machine.ownerId, user.role) that the permission matrix reads to compute the access decision.

## No coverage lost

The unit file retains 5 blocks. The integration target gains 2 blocks (1 RECLASS + 1 new permission test). The "insert record" assertion is now stronger: instead of checking `db.insert` was called, it queries the real PGlite table and asserts the row exists with correct `uploadedBy` and `fullBlobPathname`.

## Quality gate

- `pnpm run check` — green (139 files, 1288 tests)
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/supabase/images.test.ts --project=integration-supabase` — 10 passed (8 existing + 2 new)
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/server/actions/images.test.ts --project=unit` — 5 passed

Root checkout stayed on `main`; all work done in worktree `agent-ada402144762e7419` on branch `test/wave3-images-reclass-PP-x4li`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)