### PR TITLE
test(audit): Wave 3 RECLASS delete-account-action to PGlite integration (PP-x4li.1.3)

### DIFF
--- a/src/app/(app)/settings/delete-account-action.test.ts
+++ b/src/app/(app)/settings/delete-account-action.test.ts
@@ -184,8 +184,11 @@ describe("deleteAccountAction", () => {
 
   // NOTE: "deletes account and redirects on success" — RECLASS'd to
   // src/test/integration/account-deletion.test.ts (Wave 3, PP-x4li.1.3).
-  // The integration test wires real PGlite and verifies DB state changes;
-  // external-boundary ordering (signOut → deleteUser) tests remain below.
+  // The integration test wires real PGlite and verifies DB state changes
+  // (issues/comments/machine references SET NULL). The external-boundary
+  // ordering invariant (admin signOut MUST revoke sessions before
+  // admin deleteUser removes the auth row) is a Supabase-admin-SDK boundary
+  // concern and is asserted at the unit layer in the best-effort test below.
 
   it("still redirects when auth deletion fails (best-effort)", async () => {
     const { redirect } = await import("next/navigation");
@@ -219,6 +222,17 @@ describe("deleteAccountAction", () => {
     );
     // Deletion must still run even when token revocation reports an error,
     // because anonymized data has been committed and the row needs to go.
+    expect(mockAdminSignOut).toHaveBeenCalledWith("user-1", "global");
     expect(mockDeleteUser).toHaveBeenCalledWith("user-1");
+
+    // SECURITY INVARIANT: admin signOut must revoke all sessions BEFORE the
+    // auth row is deleted — deleteUser() does not invalidate issued JWTs, so
+    // revoking sessions first prevents the deleted account remaining accessible
+    // until JWT expiry. Assert the call ordering explicitly.
+    const signOutOrder = mockAdminSignOut.mock.invocationCallOrder[0];
+    const deleteOrder = mockDeleteUser.mock.invocationCallOrder[0];
+    expect(signOutOrder).toBeDefined();
+    expect(deleteOrder).toBeDefined();
+    expect(signOutOrder).toBeLessThan(deleteOrder);
   });
 });

--- a/src/app/(app)/settings/delete-account-action.test.ts
+++ b/src/app/(app)/settings/delete-account-action.test.ts
@@ -182,26 +182,10 @@ describe("deleteAccountAction", () => {
     }
   });
 
-  it("deletes account and redirects on success", async () => {
-    const { redirect } = await import("next/navigation");
-
-    await expect(
-      deleteAccountAction(undefined, makeFormData("DELETE"))
-    ).rejects.toThrow("NEXT_REDIRECT");
-
-    // Admin signOut must revoke all sessions BEFORE the auth row is deleted —
-    // otherwise issued JWTs remain valid until they expire per the configured
-    // Supabase access token TTL.
-    expect(mockAdminSignOut).toHaveBeenCalledWith("user-1", "global");
-    expect(mockDeleteUser).toHaveBeenCalledWith("user-1");
-    const signOutOrder = mockAdminSignOut.mock.invocationCallOrder[0];
-    const deleteOrder = mockDeleteUser.mock.invocationCallOrder[0];
-    expect(signOutOrder).toBeDefined();
-    expect(deleteOrder).toBeDefined();
-    expect(signOutOrder).toBeLessThan(deleteOrder);
-    expect(mockSignOut).toHaveBeenCalled();
-    expect(redirect).toHaveBeenCalledWith("/");
-  });
+  // NOTE: "deletes account and redirects on success" — RECLASS'd to
+  // src/test/integration/account-deletion.test.ts (Wave 3, PP-x4li.1.3).
+  // The integration test wires real PGlite and verifies DB state changes;
+  // external-boundary ordering (signOut → deleteUser) tests remain below.
 
   it("still redirects when auth deletion fails (best-effort)", async () => {
     const { redirect } = await import("next/navigation");

--- a/src/test/integration/account-deletion.test.ts
+++ b/src/test/integration/account-deletion.test.ts
@@ -5,7 +5,7 @@
  * uses PGlite to verify database state changes and constraint adherence.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import { getTestDb, setupTestDb } from "~/test/setup/pglite";
 import {
@@ -25,6 +25,78 @@ import {
   getReassignmentTargets,
 } from "~/app/(app)/settings/account-deletion";
 import { randomUUID } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Module mocks required by deleteAccountAction integration describe block.
+// vi.mock() calls are hoisted to module scope by Vitest — they apply to the
+// entire file, but only the deleteAccountAction block actually invokes them.
+// ---------------------------------------------------------------------------
+
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+const mockGetUser = vi.fn();
+const mockSignOut = vi.fn();
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+        signOut: mockSignOut,
+      },
+    })
+  ),
+}));
+
+const mockDeleteUser = vi.fn();
+const mockAdminSignOut = vi.fn();
+vi.mock("~/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    auth: {
+      admin: {
+        deleteUser: mockDeleteUser,
+        signOut: mockAdminSignOut,
+      },
+    },
+  })),
+}));
+
+vi.mock("~/lib/blob/client", () => ({
+  deleteFromBlob: vi.fn(),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn(
+    (_error: unknown, code: string, message: string) => ({
+      ok: false as const,
+      code,
+      message,
+    })
+  ),
+}));
+
+class RedirectError extends Error {
+  constructor() {
+    super("NEXT_REDIRECT");
+    this.name = "RedirectError";
+  }
+}
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(() => {
+    throw new RedirectError();
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
 
 describe("Account Deletion Anonymization (PGlite)", () => {
   setupTestDb();
@@ -246,5 +318,124 @@ describe("Account Deletion Reassign Picker — guest filter (PP-hci / PP-aby)", 
 
     // The deleting user themselves must not appear (ne filter)
     expect(resultIds).not.toContain(deletingUserId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave-3 RECLASS: deleteAccountAction — action-level DB integration
+//
+// Block 4 of delete-account-action.test.ts ("deletes account and redirects
+// on success") was RECLASS'd here because its interesting assertion is about
+// DB state: after calling deleteAccountAction with real PGlite wired in via
+// vi.mock("~/server/db"), we can assert that anonymizeUserReferences actually
+// committed its anonymization transaction (issues/comments SET NULL'd,
+// machine unassigned).  The unit layer cannot make that assertion — it only
+// verified that the mock transaction callback was invoked.
+//
+// External-boundary checks (signOut/deleteUser call order) remain in the
+// unit file where they belong.
+// ---------------------------------------------------------------------------
+
+describe("deleteAccountAction — DB integration (PGlite)", () => {
+  setupTestDb();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignOut.mockResolvedValue({ error: null });
+    mockDeleteUser.mockResolvedValue({ error: null });
+    mockAdminSignOut.mockResolvedValue({ error: null });
+  });
+
+  it("anonymizes DB references and redirects on successful account deletion", async () => {
+    const { deleteAccountAction } =
+      await import("~/app/(app)/settings/actions");
+    const { redirect } = await import("next/navigation");
+    const db = await getTestDb();
+
+    // Use proper UUIDs — PGlite enforces uuid column types
+    const userId = randomUUID();
+    const otherUserId = randomUUID();
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: userId } } });
+
+    await db.insert(userProfiles).values([
+      createTestUser({
+        id: userId,
+        email: "deleter@example.com",
+        role: "member",
+      }),
+      createTestUser({ id: otherUserId, email: "other@example.com" }),
+    ]);
+
+    const machine = createTestMachine({ ownerId: userId, initials: "DM" });
+    await db.insert(machines).values(machine);
+
+    const issue = createTestIssue("DM", {
+      reportedBy: userId,
+      assignedTo: userId,
+      issueNumber: 1,
+    });
+    await db.insert(issues).values(issue);
+
+    const [comment] = await db
+      .insert(issueComments)
+      .values({ issueId: issue.id, authorId: userId, content: "goodbye" })
+      .returning();
+
+    // Call the real action — DB hits PGlite, external SDKs are mocked
+    const fd = new FormData();
+    fd.set("confirmation", "DELETE");
+    fd.set("reassignTo", "");
+
+    await expect(deleteAccountAction(undefined, fd)).rejects.toThrow(
+      "NEXT_REDIRECT"
+    );
+    expect(redirect).toHaveBeenCalledWith("/");
+
+    // New integration assertion — the unit layer could NOT verify these:
+    // anonymizeUserReferences committed its transaction, nulling out all references.
+    const updatedIssue = await db.query.issues.findFirst({
+      where: eq(issues.id, issue.id),
+    });
+    expect(updatedIssue?.reportedBy).toBeNull();
+    expect(updatedIssue?.assignedTo).toBeNull();
+
+    const updatedComment = await db.query.issueComments.findFirst({
+      where: eq(issueComments.id, comment.id),
+    });
+    expect(updatedComment?.authorId).toBeNull();
+    expect(updatedComment?.content).toBe("goodbye"); // content preserved
+
+    const updatedMachine = await db.query.machines.findFirst({
+      where: eq(machines.id, machine.id),
+    });
+    expect(updatedMachine?.ownerId).toBeNull(); // machine unassigned
+  });
+
+  it("returns SOLE_ADMIN from action when user is last admin in real DB", async () => {
+    const { deleteAccountAction } =
+      await import("~/app/(app)/settings/actions");
+    const db = await getTestDb();
+
+    // Use proper UUID — PGlite enforces uuid column types
+    const userId = randomUUID();
+    mockGetUser.mockResolvedValue({ data: { user: { id: userId } } });
+
+    await db
+      .insert(userProfiles)
+      .values(
+        createTestUser({ id: userId, email: "sole@example.com", role: "admin" })
+      );
+
+    const fd = new FormData();
+    fd.set("confirmation", "DELETE");
+    fd.set("reassignTo", "");
+
+    const result = await deleteAccountAction(undefined, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("SOLE_ADMIN");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Wave 3 of the unit-test audit (PP-x4li) for `delete-account-action.test.ts`. Migrates one block to real PGlite integration, adds a second new integration block, and keeps four blocks as unit.

## Per-block disposition

| Block | Verdict | Reasoning |
|-------|---------|-----------|
| "returns UNAUTHORIZED when not logged in" | **KEEP-unit** | Auth gate fires before any DB access; no DB state to assert. |
| "returns VALIDATION when confirmation is wrong" | **KEEP-unit** | Validation fires before any DB access. Pre-DB boundary. |
| "returns SOLE_ADMIN when user is last admin" | **KEEP-unit** | The action just catches `SoleAdminError` from `anonymizeUserReferences`. The DB-side SOLE_ADMIN logic is already covered in the existing integration tests. The unit block tests the action's error-code translation only. |
| "deletes account and redirects on success" | **RECLASS → integration** | The unit test's mock-transaction only verified the callback was invoked, never that DB rows were actually changed. Moved to PGlite integration to assert real DB state. |
| "still redirects when auth deletion fails (best-effort)" | **KEEP-unit** | Tests Supabase admin SDK boundary behavior. Not a DB-state assertion. |
| "reports admin signOut errors but still proceeds" | **KEEP-unit** | Tests Supabase admin SDK boundary behavior + error reporting. Not a DB-state assertion. |

**Divergence from the audit's "5 RECLASS" count:** Only 1 block is RECLASS'd (not 5). Blocks 3/5/6 test external-boundary behavior and error-code routing — not DB state. The audit over-counts here as expected (it's a guide, not a mandate).

## New integration coverage (in `account-deletion.test.ts`)

**Block 4 migration** (`deleteAccountAction — DB integration`):
- Wires real PGlite via `vi.mock("~/server/db", async () => { db: await getTestDb() })` (canonical pattern from PR #1479)
- Calls `deleteAccountAction` end-to-end with real DB
- **New assertions the unit layer could NOT make:**
  - `issues.reportedBy` and `issues.assignedTo` are genuinely `NULL` after deletion
  - `issueComments.authorId` is `NULL` but `content` is preserved
  - `machines.ownerId` is `NULL` (machine unassigned)

**New block** (`returns SOLE_ADMIN from action when user is last admin in real DB`):
- Exercises the full `deleteAccountAction → anonymizeUserReferences → SoleAdminError → SOLE_ADMIN` path with a real admin row in PGlite
- The existing integration tests cover `anonymizeUserReferences` directly; this covers the action-level catch/translate logic end-to-end

## No coverage lost

- Unit file retains 5 of 6 original blocks (all except the RECLASS'd block 4)
- RECLASS'd coverage is replaced by stronger integration assertions
- All 7 integration tests pass, all 5 unit tests pass, full `pnpm run check` green (1288 tests)

## Quality gate results

- `pnpm run check`: 1288 tests, all passed
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/account-deletion.test.ts --project=integration`: 7/7 passed
- `pnpm exec vitest run "src/app/(app)/settings/delete-account-action.test.ts" --project=unit`: 5/5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)