### PR TITLE
test(audit): Wave 3 RECLASS issue-action permission tests to PGlite integration (PP-x4li.1.3)

### DIFF
--- a/src/test/integration/issue-detail-permissions.test.ts
+++ b/src/test/integration/issue-detail-permissions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { getTestDb, setupTestDb } from "~/test/setup/pglite";
 import { createTestMachine, createTestUser } from "~/test/helpers/factories";
@@ -6,6 +6,44 @@ import { issues, machines, userProfiles } from "~/server/db/schema";
 import { getPermissionState } from "~/lib/permissions/helpers";
 import { type OwnershipContext } from "~/lib/permissions/helpers";
 import { type AccessLevel } from "~/lib/permissions/matrix";
+
+// ---------------------------------------------------------------------------
+// Module mocks for action-level integration tests (Wave 3 RECLASS, PP-x4li.1.3)
+//
+// These mocks route the production `db` through the PGlite worker instance
+// so real DB state drives the permission checks. Supabase auth, next/cache,
+// notifications, and logger are boundary mocks — they must not reach the
+// network in tests.
+//
+// The existing permission-state tests (below) call getTestDb() directly and
+// do NOT import from ~/server/db, so adding these mocks does not affect them.
+// ---------------------------------------------------------------------------
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("~/lib/notifications", () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  getChannels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe("Issue detail permission states (integration)", () => {
   setupTestDb();
@@ -209,5 +247,178 @@ describe("Issue detail permission states (integration)", () => {
       await buildContext("member", ownerId)
     );
     expect(state).toEqual({ allowed: true });
+  });
+});
+
+// =============================================================================
+// Wave 3 RECLASS: issue-actions permission wiring (PP-x4li.1.3)
+//
+// Migrated from src/test/unit/issue-actions.test.ts:
+//   - "should allow update if authorized" (updateIssueStatusAction describe)
+//   - "should deny update if unauthorized" (updateIssueStatusAction describe)
+//   - "should successfully update frequency" (updateIssueFrequencyAction describe)
+//
+// These three blocks were using a mocked checkPermission, which only verified
+// the mock was called — they did NOT exercise real permission logic. Here we
+// drive the real actions against PGlite and the real checkPermission so that
+// DB-derived ownership context (reportedBy, machine.ownerId) genuinely controls
+// the allow/deny outcome.
+//
+// External boundary mocks (Supabase auth, next/cache, notifications, logger)
+// are declared at the top of this file and shared across both describe blocks.
+// =============================================================================
+describe("issue action permission wiring — action-level integration (PP-x4li.1.3)", () => {
+  setupTestDb();
+
+  // Stable UUIDs for this describe block — distinct from the sibling describe
+  // above to avoid PGlite uniqueness conflicts when tests run in the same worker.
+  const MEMBER_USER_ID = "a0000000-0000-0000-0000-000000000001";
+  const GUEST_REPORTER_ID = "a0000000-0000-0000-0000-000000000002";
+  const GUEST_OTHER_ID = "a0000000-0000-0000-0000-000000000003";
+  const MACHINE_OWNER_ID = "a0000000-0000-0000-0000-000000000004";
+
+  let memberIssueId: string;
+  let guestOwnedIssueId: string;
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+
+    // Seed users — tables are cleaned by setupTestDb()'s afterEach, so no
+    // conflict handling is needed.
+    await db.insert(userProfiles).values([
+      createTestUser({
+        id: MACHINE_OWNER_ID,
+        role: "member",
+        email: "owner-action@test.com",
+      }),
+      createTestUser({
+        id: MEMBER_USER_ID,
+        role: "member",
+        email: "member-action@test.com",
+      }),
+      createTestUser({
+        id: GUEST_REPORTER_ID,
+        role: "guest",
+        email: "guest-reporter-action@test.com",
+      }),
+      createTestUser({
+        id: GUEST_OTHER_ID,
+        role: "guest",
+        email: "guest-other-action@test.com",
+      }),
+    ]);
+
+    // Seed machine
+    await db.insert(machines).values(
+      createTestMachine({
+        id: "b0000000-0000-0000-0000-000000000001",
+        initials: "PAT",
+        name: "Permission Action Test",
+        ownerId: MACHINE_OWNER_ID,
+      })
+    );
+
+    // Issue reported by a member (any member can update its reporting fields)
+    const [memberIssue] = await db
+      .insert(issues)
+      .values({
+        machineInitials: "PAT",
+        issueNumber: 10,
+        title: "Member-reported action test issue",
+        severity: "minor",
+        priority: "low",
+        frequency: "intermittent",
+        status: "new",
+        reportedBy: MEMBER_USER_ID,
+      })
+      .returning();
+    memberIssueId = memberIssue.id;
+
+    // Issue reported by a guest (only that guest can update its reporting fields)
+    const [guestIssue] = await db
+      .insert(issues)
+      .values({
+        machineInitials: "PAT",
+        issueNumber: 11,
+        title: "Guest-reported action test issue",
+        severity: "minor",
+        priority: "low",
+        frequency: "intermittent",
+        status: "new",
+        reportedBy: GUEST_REPORTER_ID,
+      })
+      .returning();
+    guestOwnedIssueId = guestIssue.id;
+  });
+
+  async function mockAuth(userId: string) {
+    const { createClient } = await import("~/lib/supabase/server");
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: userId } } }),
+      },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+  }
+
+  // -------------------------------------------------------------------------
+  // updateIssueStatusAction — permission wiring
+  //
+  // Migrated from the "should allow update if authorized" and
+  // "should deny update if unauthorized" blocks. The old unit tests mocked
+  // checkPermission; these drive the real permission matrix via PGlite state.
+  // -------------------------------------------------------------------------
+  it("allows updateIssueStatusAction for a member (issues.update.reporting = true for member)", async () => {
+    await mockAuth(MEMBER_USER_ID);
+    const { updateIssueStatusAction } =
+      await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("issueId", memberIssueId);
+    formData.append("status", "in_progress");
+
+    const result = await updateIssueStatusAction(undefined, formData);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("denies updateIssueStatusAction for a guest acting on another user's issue (issues.update.reporting = 'own')", async () => {
+    // GUEST_OTHER_ID is a guest who did NOT report guestOwnedIssueId
+    // (guestOwnedIssueId.reportedBy === GUEST_REPORTER_ID)
+    await mockAuth(GUEST_OTHER_ID);
+    const { updateIssueStatusAction } =
+      await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("issueId", guestOwnedIssueId);
+    formData.append("status", "in_progress");
+
+    const result = await updateIssueStatusAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // updateIssueFrequencyAction — permission wiring
+  //
+  // Migrated from "should successfully update frequency". The original block
+  // mocked checkPermission to return true; here we verify the real permission
+  // path allows a member (issues.update.reporting = true) and the action
+  // returns ok.
+  // -------------------------------------------------------------------------
+  it("allows updateIssueFrequencyAction for a member (issues.update.reporting = true for member)", async () => {
+    await mockAuth(MEMBER_USER_ID);
+    const { updateIssueFrequencyAction } =
+      await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("issueId", memberIssueId);
+    formData.append("frequency", "constant");
+
+    const result = await updateIssueFrequencyAction(undefined, formData);
+
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/test/unit/issue-actions.test.ts
+++ b/src/test/unit/issue-actions.test.ts
@@ -1,10 +1,27 @@
+/**
+ * Unit Tests — issue Server Actions (PP-x4li.1.3 post-RECLASS)
+ *
+ * KEEP-unit blocks only. The permission/authorization blocks and the service-
+ * delegation block were migrated or superseded in Wave 3 (PP-x4li.1.3):
+ *
+ * Migrated to src/test/integration/issue-detail-permissions.test.ts:
+ *   - updateIssueStatusAction: "should allow update if authorized"
+ *   - updateIssueStatusAction: "should deny update if unauthorized"
+ *   - updateIssueFrequencyAction: "should successfully update frequency"
+ *   (All three now exercise the real checkPermission against PGlite state.)
+ *
+ * Superseded by existing coverage in src/test/integration/issue-services.test.ts:
+ *   - addCommentAction: "should successfully add a comment"
+ *   (addIssueComment DB state + notification dispatch is block 7 in that file.)
+ *
+ * Remaining tests cover the boundaries that belong at the unit layer:
+ *   - Auth gate (unauthenticated → UNAUTHORIZED before any DB/service call)
+ *   - Zod validation (empty/malformed input → VALIDATION without side effects)
+ *   - Service-boundary error handling (service throws → SERVER result)
+ */
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  addCommentAction,
-  updateIssueStatusAction,
-  updateIssueFrequencyAction,
-} from "~/app/(app)/issues/actions";
-import { checkPermission } from "~/lib/permissions/helpers";
+import { addCommentAction } from "~/app/(app)/issues/actions";
 
 // Mock Next.js modules
 vi.mock("next/navigation", () => ({
@@ -24,7 +41,8 @@ vi.mock("~/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
-// Mock DB
+// Mock DB (only needed for revalidation path after addIssueComment; never
+// reached by the three KEEP-unit blocks below, but kept to satisfy the import)
 vi.mock("~/server/db", () => ({
   db: {
     insert: vi.fn(),
@@ -63,20 +81,8 @@ vi.mock("~/services/issues", () => ({
   addIssueComment: vi.fn(),
 }));
 
-// Mock permissions
-vi.mock("~/lib/permissions/helpers", () => ({
-  checkPermission: vi.fn(),
-  getAccessLevel: vi.fn().mockReturnValue("member"),
-}));
-
-import { revalidatePath } from "next/cache";
 import { createClient } from "~/lib/supabase/server";
-import {
-  addIssueComment,
-  updateIssueStatus,
-  updateIssueFrequency,
-} from "~/services/issues";
-import { db } from "~/server/db";
+import { addIssueComment } from "~/services/issues";
 
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
@@ -97,38 +103,6 @@ describe("addCommentAction", () => {
 
     // Setup service mock
     vi.mocked(addIssueComment).mockResolvedValue(undefined as any);
-
-    // Setup DB mock for fetching issue details
-    vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-      machineInitials: "MM",
-      issueNumber: 1,
-    } as any);
-  });
-
-  it("should successfully add a comment", async () => {
-    const commentObj = {
-      type: "doc",
-      content: [
-        {
-          type: "paragraph",
-          content: [{ type: "text", text: "Test comment" }],
-        },
-      ],
-    };
-    const formData = new FormData();
-    formData.append("issueId", validUuid);
-    formData.append("comment", JSON.stringify(commentObj));
-
-    const result = await addCommentAction(initialState, formData);
-
-    expect(result.ok).toBe(true);
-    expect(addIssueComment).toHaveBeenCalledWith({
-      issueId: validUuid,
-      content: commentObj,
-      userId: mockUser.id,
-      imagesMetadata: [],
-    });
-    expect(revalidatePath).toHaveBeenCalledWith("/m/MM/i/1");
   });
 
   it("should return an error if not authenticated", async () => {
@@ -187,138 +161,5 @@ describe("addCommentAction", () => {
     if (!result.ok) {
       expect(result.code).toBe("SERVER");
     }
-  });
-});
-
-describe("updateIssueStatusAction", () => {
-  const validUuid = "123e4567-e89b-12d3-a456-426614174000";
-  const mockUser = { id: "user-123" };
-  const initialState = undefined;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    // Setup default successful auth
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi.fn().mockResolvedValue({ data: { user: mockUser } }),
-      },
-    } as unknown as SupabaseClient);
-  });
-
-  it("should allow update if authorized", async () => {
-    // Mock issue found
-    vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-      status: "new",
-      machineInitials: "MM",
-      issueNumber: 1,
-      reportedBy: "user-123",
-      assignedTo: null,
-      machine: { ownerId: "owner-123", name: "Test Machine" },
-    } as any);
-
-    // Mock user profile
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    });
-
-    // Mock permission check true
-    vi.mocked(checkPermission).mockReturnValue(true);
-
-    // Mock update success
-    vi.mocked(updateIssueStatus).mockResolvedValue({
-      issueId: validUuid,
-      oldStatus: "new",
-      newStatus: "in_progress",
-    });
-
-    const formData = new FormData();
-    formData.append("issueId", validUuid);
-    formData.append("status", "in_progress");
-
-    const result = await updateIssueStatusAction(initialState, formData);
-
-    expect(result.ok).toBe(true);
-    expect(checkPermission).toHaveBeenCalled();
-    expect(updateIssueStatus).toHaveBeenCalled();
-    expect(revalidatePath).toHaveBeenCalledWith("/m/MM/i/1");
-    expect(revalidatePath).toHaveBeenCalledWith("/m/MM");
-  });
-
-  it("should deny update if unauthorized", async () => {
-    // Mock issue found
-    vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-      status: "new",
-      machineInitials: "MM",
-      issueNumber: 1,
-      reportedBy: "other-user",
-      assignedTo: null,
-      machine: { ownerId: "owner-123" },
-    } as any);
-
-    // Mock user profile
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    });
-
-    // Mock permission check false
-    vi.mocked(checkPermission).mockReturnValue(false);
-
-    const formData = new FormData();
-    formData.append("issueId", validUuid);
-    formData.append("status", "in_progress");
-
-    const result = await updateIssueStatusAction(initialState, formData);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("UNAUTHORIZED");
-    }
-    expect(checkPermission).toHaveBeenCalled();
-    expect(updateIssueStatus).not.toHaveBeenCalled();
-  });
-});
-
-describe("updateIssueFrequencyAction", () => {
-  const validUuid = "123e4567-e89b-12d3-a456-426614174000";
-  const mockUser = { id: "user-123" };
-  const initialState = undefined;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi.fn().mockResolvedValue({ data: { user: mockUser } }),
-      },
-    } as any);
-  });
-
-  it("should successfully update frequency", async () => {
-    vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-      machineInitials: "MM",
-      issueNumber: 1,
-      reportedBy: mockUser.id,
-      assignedTo: null,
-      machine: { ownerId: "owner-123" },
-    } as any);
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    } as any);
-    vi.mocked(checkPermission).mockReturnValue(true);
-    vi.mocked(updateIssueFrequency).mockResolvedValue({
-      issueId: validUuid,
-      oldFrequency: "intermittent",
-      newFrequency: "constant",
-    });
-
-    const formData = new FormData();
-    formData.append("issueId", validUuid);
-    formData.append("frequency", "constant");
-
-    const result = await updateIssueFrequencyAction(initialState, formData);
-
-    expect(result.ok).toBe(true);
-    expect(checkPermission).toHaveBeenCalled();
-    expect(updateIssueFrequency).toHaveBeenCalled();
   });
 });

--- a/src/test/unit/issue-actions.test.ts
+++ b/src/test/unit/issue-actions.test.ts
@@ -41,8 +41,10 @@ vi.mock("~/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
-// Mock DB (only needed for revalidation path after addIssueComment; never
-// reached by the three KEEP-unit blocks below, but kept to satisfy the import)
+// Mock DB to satisfy the import: the actions module imports ~/server/db,
+// which throws on a missing POSTGRES_URL in unit tests, so the mock is required
+// just to load the module. The three KEEP-unit blocks below never exercise a
+// real query — the revalidation path after addIssueComment is the only consumer.
 vi.mock("~/server/db", () => ({
   db: {
     insert: vi.fn(),


### PR DESCRIPTION
## Summary

Migrates permission/authorization blocks from `src/test/unit/issue-actions.test.ts` into the existing PGlite integration target `src/test/integration/issue-detail-permissions.test.ts`.

## Per-block disposition

| Source block | Disposition | Reason |
|---|---|---|
| `addCommentAction` — "should successfully add a comment" | SUPERSEDED by existing coverage | `addIssueComment` DB state (comment row + auto-watch + notification dispatch) is fully covered by block 7 in `issue-services.test.ts`; the unit block only asserted delegation + revalidatePath format |
| `addCommentAction` — "should return an error if not authenticated" | KEEP-unit | Auth gate — Supabase boundary, no DB involvement |
| `addCommentAction` — "should validate input" | KEEP-unit | Zod validation path, returns before any service call |
| `addCommentAction` — "should handle database errors gracefully" | KEEP-unit | Service-boundary error path with `addIssueComment` mocked |
| `updateIssueStatusAction` — "should allow update if authorized" | RECLASS → `issue-detail-permissions.test.ts` | Mocked `checkPermission` only asserted mock consultation; now drives real permission matrix against PGlite state |
| `updateIssueStatusAction` — "should deny update if unauthorized" | RECLASS → `issue-detail-permissions.test.ts` | Same — original mocked a member denial that is unreachable with real permissions; replaced with a meaningful guest-on-other's-issue scenario |
| `updateIssueFrequencyAction` — "should successfully update frequency" | RECLASS → `issue-detail-permissions.test.ts` | Mocked `checkPermission`; now uses real member user with real DB ownership context |

**Note on "deny" block**: the original unit test used a `member` user and mocked `checkPermission` to return `false`. With real permissions, `member` always gets `issues.update.reporting = true` (unconditionally). The replacement uses a `guest` user acting on a different user's issue, which is the actual permission boundary the matrix enforces (`"own"` → denied when userId ≠ reporterId).

## Confirmed

- Real `checkPermission` (NOT mocked) in all three integration tests — ownership context is derived from real PGlite rows (userProfiles, machines, issues)
- Matched `machine-timeline-permissions.test.ts` pattern: `vi.mock("~/server/db", async () => ({ db: await getTestDb() }))`, mocked Supabase auth, mocked next/cache, mocked notifications/logger as external boundaries
- No duplicate module mocks — boundary mocks declared once at file top, shared across both describe blocks
- Source file retained (3 KEEP-unit blocks remain)
- `pnpm run check` green (1256 tests passing)
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/issue-detail-permissions.test.ts --project=integration` → 10 passed
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/issue-services.test.ts --project=integration` → 31 passed
- `pnpm exec vitest run src/test/unit/issue-actions.test.ts --project=unit` → 3 passed
- Root worktree stayed on `main`; all work in worktree `agent-a732a41e439bd945b` on branch `test/wave3-issue-actions-reclass-PP-x4li`

🤖 Generated with [Claude Code](https://claude.com/claude-code)