### PR TITLE
test(audit): Wave 3 RECLASS public-issue assignedTo-permission tests to PGlite integration (PP-x4li.1.3)

### DIFF
--- a/src/test/integration/public-issue-submit.test.ts
+++ b/src/test/integration/public-issue-submit.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Integration Tests: submitPublicIssueAction — assignedTo permission handling
+ *
+ * Wave 3 RECLASS (PP-x4li.1.3): migrated 5 blocks from
+ * src/test/unit/public-issue-security.test.ts that used mocked db.query
+ * returning hand-fed roles. Here the DB is real PGlite: we insert actual
+ * userProfiles (with real roles) and machines, call the action, then assert
+ * the persisted issue's assignedTo against the REAL permission matrix.
+ *
+ * createIssue is used for REAL (not mocked) — the persisted row's assignedTo
+ * is the ground truth for each assertion.
+ *
+ * External boundaries kept mocked:
+ *   - ~/lib/security/turnstile  (no Cloudflare round-trip)
+ *   - ~/lib/rate-limit          (no Redis)
+ *   - ~/lib/supabase/server     (auth.getUser — identity only)
+ *   - next/headers, next/navigation, next/cache
+ *   - ~/lib/logger              (suppress output)
+ *   - ~/lib/notifications       (no email/discord delivery)
+ *   - ~/lib/observability/report-error (no Sentry)
+ *
+ * ~/lib/permissions/* is NOT mocked — the real matrix drives enforcement.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { issues, machines, userProfiles } from "~/server/db/schema";
+import { createTestUser, createTestMachine } from "~/test/helpers/factories";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+
+// ---------------------------------------------------------------------------
+// External-boundary mocks — declared once, never repeated per describe block
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+  cookies: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/security/turnstile", () => ({
+  verifyTurnstileToken: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("~/lib/rate-limit", () => ({
+  checkPublicIssueLimit: vi.fn().mockResolvedValue({ success: true, reset: 0 }),
+  getClientIp: vi.fn().mockResolvedValue("127.0.0.1"),
+  formatResetTime: vi.fn().mockReturnValue("0s"),
+}));
+
+// auth.getUser is overridden per-test via mockGetUser
+const mockGetUser = vi.fn();
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+// Notifications — avoid real email/discord delivery; DB writes still flow through PGlite
+vi.mock("~/lib/notifications", () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  getChannels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn(),
+}));
+
+// Real PGlite — all db.query.*, db.insert, db.update, db.transaction flow through
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  const db = await getTestDb();
+  return { db };
+});
+
+// Import AFTER the db mock so the action and createIssue pick up PGlite
+const { submitPublicIssueAction } = await import("~/app/(app)/report/actions");
+
+// ---------------------------------------------------------------------------
+// Fixtures — IDs generated per-test so they are valid Zod UUIDs
+// ---------------------------------------------------------------------------
+
+function makeFormData(opts: {
+  machineId: string;
+  assignedTo?: string;
+}): FormData {
+  const fd = new FormData();
+  fd.set("machineId", opts.machineId);
+  fd.set("title", "Integration test issue");
+  fd.set("severity", "minor");
+  fd.set("frequency", "intermittent");
+  if (opts.assignedTo !== undefined) {
+    fd.set("assignedTo", opts.assignedTo);
+  }
+  return fd;
+}
+
+async function seedUser(
+  role: "guest" | "member" | "technician" | "admin"
+): Promise<{ id: string; email: string }> {
+  const id = randomUUID();
+  const email = `${role}-${id}@test.com`;
+  const db = await getTestDb();
+  await db.insert(userProfiles).values(createTestUser({ id, role, email }));
+  return { id, email };
+}
+
+async function seedMachine(ownerId: string): Promise<{
+  id: string;
+  initials: string;
+}> {
+  // Use a short unique suffix so initials stay ≤ 10 chars (schema constraint)
+  const suffix = randomUUID().slice(0, 4).toUpperCase();
+  const initials = `PI${suffix}`;
+  const id = randomUUID();
+  const db = await getTestDb();
+  await db
+    .insert(machines)
+    .values(
+      createTestMachine({ id, initials, name: `Machine ${suffix}`, ownerId })
+    );
+  return { id, initials };
+}
+
+async function getPersistedAssignedTo(
+  machineInitials: string
+): Promise<string | null | undefined> {
+  const db = await getTestDb();
+  const row = await db.query.issues.findFirst({
+    where: eq(issues.machineInitials, machineInitials),
+    columns: { assignedTo: true },
+  });
+  return row?.assignedTo;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("submitPublicIssueAction — assignedTo permission handling (integration)", () => {
+  setupTestDb();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: unauthenticated
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("member can assign issue to another user", async () => {
+    const reporter = await seedUser("member");
+    const assignee = await seedUser("member");
+    const machine = await seedMachine(reporter.id);
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: reporter.id } } });
+
+    const result = await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({ machineId: machine.id, assignedTo: assignee.id })
+    );
+
+    // Authenticated users get { success, redirectTo }, not a redirect() throw
+    expect(result).toMatchObject({ success: true });
+
+    const assignedTo = await getPersistedAssignedTo(machine.initials);
+    expect(assignedTo).toBe(assignee.id);
+  });
+
+  it("admin can assign issue to another user", async () => {
+    const reporter = await seedUser("admin");
+    const assignee = await seedUser("member");
+    const machine = await seedMachine(reporter.id);
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: reporter.id } } });
+
+    const result = await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({ machineId: machine.id, assignedTo: assignee.id })
+    );
+
+    expect(result).toMatchObject({ success: true });
+
+    const assignedTo = await getPersistedAssignedTo(machine.initials);
+    expect(assignedTo).toBe(assignee.id);
+  });
+
+  it("member with empty assignedTo normalizes to null", async () => {
+    const reporter = await seedUser("member");
+    const machine = await seedMachine(reporter.id);
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: reporter.id } } });
+
+    const result = await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({ machineId: machine.id, assignedTo: "" }) // empty string = Unassigned
+    );
+
+    expect(result).toMatchObject({ success: true });
+
+    const assignedTo = await getPersistedAssignedTo(machine.initials);
+    expect(assignedTo).toBeNull();
+  });
+
+  it("guest assignedTo is stripped (unauthenticated)", async () => {
+    // Anonymous caller — no user profile in the DB for the reporter.
+    // The action skips the profile lookup entirely for unauthenticated requests
+    // and forces assignedTo → null via the anonymous branch.
+    const owner = await seedUser("member"); // needed for FK on machines.ownerId
+    const assignee = await seedUser("member");
+    const machine = await seedMachine(owner.id);
+
+    // Default mock: user = null (set in beforeEach)
+
+    // Anonymous path calls redirect() from next/navigation (mocked as vi.fn()).
+    // The mock does NOT throw, so the action returns normally after the call.
+    // We verify the persisted row directly.
+    await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({ machineId: machine.id, assignedTo: assignee.id })
+    );
+
+    const assignedTo = await getPersistedAssignedTo(machine.initials);
+    expect(assignedTo).toBeNull();
+  });
+
+  it("non-member (guest role) authenticated user assignedTo is stripped", async () => {
+    const reporter = await seedUser("guest");
+    const assignee = await seedUser("member");
+    const machine = await seedMachine(reporter.id);
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: reporter.id } } });
+
+    const result = await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({ machineId: machine.id, assignedTo: assignee.id })
+    );
+
+    expect(result).toMatchObject({ success: true });
+
+    const assignedTo = await getPersistedAssignedTo(machine.initials);
+    expect(assignedTo).toBeNull();
+  });
+});

--- a/src/test/unit/public-issue-security.test.ts
+++ b/src/test/unit/public-issue-security.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { submitPublicIssueAction } from "~/app/(app)/report/actions";
 
 // Mock server-only (no-op in test environment)
@@ -12,6 +12,10 @@ vi.mock("next/headers", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
 }));
 
 // Mock logger
@@ -35,7 +39,8 @@ vi.mock("~/lib/rate-limit", () => ({
   formatResetTime: vi.fn().mockReturnValue("0s"),
 }));
 
-// Mock Supabase
+// Mock Supabase — unauthenticated by default (error-sanitization test is for
+// the anonymous path; createIssue throws before any user-specific logic).
 vi.mock("~/lib/supabase/server", () => ({
   createClient: vi.fn().mockResolvedValue({
     auth: {
@@ -44,7 +49,8 @@ vi.mock("~/lib/supabase/server", () => ({
   }),
 }));
 
-// Mock DB
+// Mock DB — error-sanitization test mocks createIssue to throw before the DB
+// is queried for permission resolution, so the machine lookup still needs a stub.
 vi.mock("~/server/db", () => ({
   db: {
     query: {
@@ -58,18 +64,30 @@ vi.mock("~/server/db", () => ({
   },
 }));
 
-// Mock Service
+// Mock observability
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn(),
+}));
+
+// Mock Service — createIssue is mocked to throw a sensitive error
 vi.mock("~/services/issues", () => ({
   createIssue: vi.fn(),
 }));
 
 import { createIssue } from "~/services/issues";
 
+/**
+ * KEEP-unit: error-message sanitization at the action boundary.
+ *
+ * createIssue is mocked to throw a sensitive DB error; we assert that the
+ * action returns a generic client-facing message and never leaks internals.
+ * No real DB state is needed — this is purely a boundary sanitization check.
+ *
+ * The 5 assignedTo permission tests have been RECLASS'd to:
+ *   src/test/integration/public-issue-submit.test.ts  (PP-x4li.1.3)
+ */
 describe("Public Issue Reporting Security", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -95,177 +113,5 @@ describe("Public Issue Reporting Security", () => {
     expect(result.error).not.toBe(sensitiveError);
     expect(result.error).not.toContain("duplicate key");
     expect(result.error).toBe("Unable to submit the issue. Please try again.");
-  });
-
-  describe("assignedTo permission handling", () => {
-    const validUuid = "00000000-0000-0000-0000-000000000000";
-    const assigneeUuid = "11111111-1111-1111-8111-111111111111";
-
-    const createValidFormData = (assignedTo?: string) => {
-      const formData = new FormData();
-      formData.set("machineId", validUuid);
-      formData.set("title", "Test Issue");
-      formData.set("severity", "minor");
-      formData.set("frequency", "intermittent");
-      if (assignedTo !== undefined) {
-        formData.set("assignedTo", assignedTo);
-      }
-      return formData;
-    };
-
-    it("member can assign issue to another user", async () => {
-      // Setup: authenticated member
-      const { createClient } = await import("~/lib/supabase/server");
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: validUuid } },
-          }),
-        },
-      } as never);
-
-      const { db } = await import("~/server/db");
-      // Must mock both machines and userProfiles since clearAllMocks resets them
-      vi.mocked(db.query.machines.findFirst).mockResolvedValue({
-        initials: "MCH",
-      } as never);
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "member",
-      } as never);
-
-      vi.mocked(createIssue).mockResolvedValue({
-        id: "issue-1",
-        issueNumber: 1,
-      } as never);
-
-      const formData = createValidFormData(assigneeUuid);
-      await submitPublicIssueAction({ error: "" }, formData);
-
-      expect(createIssue).toHaveBeenCalledWith(
-        expect.objectContaining({ assignedTo: assigneeUuid })
-      );
-    });
-
-    it("admin can assign issue to another user", async () => {
-      const { createClient } = await import("~/lib/supabase/server");
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: validUuid } },
-          }),
-        },
-      } as never);
-
-      const { db } = await import("~/server/db");
-      vi.mocked(db.query.machines.findFirst).mockResolvedValue({
-        initials: "MCH",
-      } as never);
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "admin",
-      } as never);
-
-      vi.mocked(createIssue).mockResolvedValue({
-        id: "issue-1",
-        issueNumber: 1,
-      } as never);
-
-      const formData = createValidFormData(assigneeUuid);
-      await submitPublicIssueAction({ error: "" }, formData);
-
-      expect(createIssue).toHaveBeenCalledWith(
-        expect.objectContaining({ assignedTo: assigneeUuid })
-      );
-    });
-
-    it("member with empty assignedTo normalizes to null", async () => {
-      const { createClient } = await import("~/lib/supabase/server");
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: validUuid } },
-          }),
-        },
-      } as never);
-
-      const { db } = await import("~/server/db");
-      vi.mocked(db.query.machines.findFirst).mockResolvedValue({
-        initials: "MCH",
-      } as never);
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "member",
-      } as never);
-
-      vi.mocked(createIssue).mockResolvedValue({
-        id: "issue-1",
-        issueNumber: 1,
-      } as never);
-
-      const formData = createValidFormData(""); // Empty string = Unassigned
-      await submitPublicIssueAction({ error: "" }, formData);
-
-      expect(createIssue).toHaveBeenCalledWith(
-        expect.objectContaining({ assignedTo: null })
-      );
-    });
-
-    it("guest assignedTo is stripped (unauthenticated)", async () => {
-      // Default mock: user = null (unauthenticated)
-      const { createClient } = await import("~/lib/supabase/server");
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: null },
-          }),
-        },
-      } as never);
-
-      const { db } = await import("~/server/db");
-      vi.mocked(db.query.machines.findFirst).mockResolvedValue({
-        initials: "MCH",
-      } as never);
-
-      vi.mocked(createIssue).mockResolvedValue({
-        id: "issue-1",
-        issueNumber: 1,
-      } as never);
-
-      const formData = createValidFormData(assigneeUuid);
-      await submitPublicIssueAction({ error: "" }, formData);
-
-      expect(createIssue).toHaveBeenCalledWith(
-        expect.objectContaining({ assignedTo: null })
-      );
-    });
-
-    it("non-member authenticated user assignedTo is stripped", async () => {
-      const { createClient } = await import("~/lib/supabase/server");
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: validUuid } },
-          }),
-        },
-      } as never);
-
-      const { db } = await import("~/server/db");
-      vi.mocked(db.query.machines.findFirst).mockResolvedValue({
-        initials: "MCH",
-      } as never);
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "guest", // Not member or admin
-      } as never);
-
-      vi.mocked(createIssue).mockResolvedValue({
-        id: "issue-1",
-        issueNumber: 1,
-      } as never);
-
-      const formData = createValidFormData(assigneeUuid);
-      await submitPublicIssueAction({ error: "" }, formData);
-
-      expect(createIssue).toHaveBeenCalledWith(
-        expect.objectContaining({ assignedTo: null })
-      );
-    });
   });
 });


### PR DESCRIPTION
## Summary

Wave 3 of the RECLASS audit (PP-x4li.1.3): migrates the 5 `assignedTo` permission blocks from `src/test/unit/public-issue-security.test.ts` into a new PGlite integration test. The 1 error-sanitization block is kept in the unit file.

## Per-block disposition

| Block | Disposition | Rationale |
|---|---|---|
| "member can assign issue to another user" | RECLASS → integration | Role determined by real DB row; permission from real matrix |
| "admin can assign issue to another user" | RECLASS → integration | Same — real admin profile, real matrix check |
| "member with empty assignedTo normalizes to null" | RECLASS → integration | Empty-string normalization flows through real permission/assignment path |
| "guest assignedTo is stripped (unauthenticated)" | RECLASS → integration | Anonymous path; persisted row (null assignedTo) is ground truth |
| "non-member (guest role) authenticated user assignedTo is stripped" | RECLASS → integration | Guest role → real matrix → assignedTo stripped |
| "should not expose sensitive database error messages to client" | KEEP-unit | Error-message sanitization at boundary; no DB state needed |

## Real permission matrix + createIssue handling

- `~/lib/permissions/*` is NOT mocked — `getAccessLevel()` and `checkPermission("issues.report.assignee", ...)` use the real matrix. The matrix grants `member`, `technician`, `admin` access and denies `guest`/`unauthenticated`.
- `createIssue` is used for REAL (not mocked). The persisted issue row's `assignedTo` column is the ground-truth assertion — not a spy on arguments.

## Target

Created `src/test/integration/public-issue-submit.test.ts` (no existing file for this action). Placed in `src/test/integration/` → project `integration`.

## Duplicate mocks

No duplicate mocks. All boundary mocks are declared once at the top of the integration file.

## Source file status

`src/test/unit/public-issue-security.test.ts` is retained with the 1 KEEP-unit block (error sanitization) and the mocks it needs. The 5 RECLASS'd blocks have been removed.

## Quality gates

- `pnpm run check` — green (137 test files, 1255 tests)
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/public-issue-submit.test.ts --project=integration` — 5/5 pass
- `pnpm exec vitest run src/test/unit/public-issue-security.test.ts --project=unit` — 1/1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)