### PR TITLE
test(audit): Wave 3 RECLASS getRecentIssuesAction serialization to PGlite integration (PP-x4li.1.3)

### DIFF
--- a/src/app/(app)/report/actions.test.ts
+++ b/src/app/(app)/report/actions.test.ts
@@ -171,92 +171,10 @@ describe("getRecentIssuesAction", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Success path
+  // Success path (input-acceptance — DB mock is incidental; real DB checks
+  // are in src/test/integration/recent-issues.test.ts)
   // ---------------------------------------------------------------------------
   describe("success path", () => {
-    it("returns ok with properly serialized rows", async () => {
-      const fakeDate = new Date("2025-06-15T12:00:00.000Z");
-      vi.mocked(db.query.issues.findMany).mockResolvedValue([
-        {
-          id: "issue-1",
-          issueNumber: 42,
-          title: "Stuck flipper",
-          status: "new" as const,
-          severity: "major" as const,
-          priority: "high" as const,
-          frequency: "intermittent" as const,
-          createdAt: fakeDate,
-        },
-      ]);
-
-      const result = await getRecentIssuesAction("MM", 5);
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value).toHaveLength(1);
-        expect(result.value[0]).toEqual({
-          id: "issue-1",
-          issueNumber: 42,
-          title: "Stuck flipper",
-          status: "new",
-          severity: "major",
-          priority: "high",
-          frequency: "intermittent",
-          createdAt: "2025-06-15T12:00:00.000Z",
-        });
-      }
-      expect(db.query.issues.findMany).toHaveBeenCalledOnce();
-    });
-
-    it("returns ok with empty array when no issues exist", async () => {
-      vi.mocked(db.query.issues.findMany).mockResolvedValue([]);
-
-      const result = await getRecentIssuesAction("ABC", 10);
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value).toEqual([]);
-      }
-    });
-
-    it("returns multiple rows preserving order", async () => {
-      const dates = [
-        new Date("2025-06-15T12:00:00.000Z"),
-        new Date("2025-06-14T12:00:00.000Z"),
-      ];
-      vi.mocked(db.query.issues.findMany).mockResolvedValue([
-        {
-          id: "issue-1",
-          issueNumber: 10,
-          title: "First",
-          status: "new" as const,
-          severity: "minor" as const,
-          priority: "low" as const,
-          frequency: "constant" as const,
-          createdAt: dates[0],
-        },
-        {
-          id: "issue-2",
-          issueNumber: 9,
-          title: "Second",
-          status: "confirmed" as const,
-          severity: "cosmetic" as const,
-          priority: "medium" as const,
-          frequency: "frequent" as const,
-          createdAt: dates[1],
-        },
-      ]);
-
-      const result = await getRecentIssuesAction("XY", 5);
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value).toHaveLength(2);
-        expect(result.value[0]?.createdAt).toBe("2025-06-15T12:00:00.000Z");
-        expect(result.value[1]?.createdAt).toBe("2025-06-14T12:00:00.000Z");
-      }
-    });
-
     it("accepts machineInitials with hyphens", async () => {
       vi.mocked(db.query.issues.findMany).mockResolvedValue([]);
 

--- a/src/test/integration/recent-issues.test.ts
+++ b/src/test/integration/recent-issues.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Integration Tests: getRecentIssuesAction — serialization and ordering
+ *
+ * Wave 3 RECLASS (PP-x4li.1.3): migrated 3 blocks from
+ * src/app/(app)/report/actions.test.ts "success path" describe that used a
+ * mocked db.query.issues.findMany returning hand-crafted rows. Here the DB is
+ * real PGlite: we insert actual issues, call the action, and assert on the
+ * actual returned shape — ISO-string createdAt, correct ordering (newest
+ * first), and CORE-SEC-007 (no reporterEmail exposed).
+ *
+ * Why only these 3 blocks?
+ *   - "accepts machineInitials with hyphens" / "accepts boundary limit values"
+ *     are input-acceptance/validation paths whose mocked DB is incidental.
+ *     They stay in the unit file as unit tests.
+ *   - "returns err when db.query throws" is a forced-error path — can't
+ *     reproduce with a real DB. Stays in unit.
+ *   - All input-validation (Zod) blocks stay in unit.
+ *   - All submitPublicIssueAction blocks stay in unit (turnstile is an
+ *     external boundary, correctly mocked there).
+ *
+ * External boundaries kept mocked:
+ *   - next/navigation, next/cache, next/headers
+ *   - ~/lib/supabase/server
+ *   - ~/lib/rate-limit
+ *   - ~/lib/security/turnstile
+ *   - ~/lib/logger
+ *   - ~/lib/observability/report-error
+ *   - ~/lib/blob/client, ~/lib/blob/config
+ *   - ~/services/issues
+ *
+ * ~/server/db is redirected to PGlite via the canonical pattern.
+ * drizzle-orm and ~/server/db/schema are NOT mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import { issues, machines, userProfiles } from "~/server/db/schema";
+import {
+  createTestMachine,
+  createTestIssue,
+  createTestUser,
+} from "~/test/helpers/factories";
+
+// ---------------------------------------------------------------------------
+// External-boundary mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+  cookies: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("~/lib/rate-limit", () => ({
+  checkPublicIssueLimit: vi.fn().mockResolvedValue({ success: true, reset: 0 }),
+  formatResetTime: vi.fn().mockReturnValue("0s"),
+  getClientIp: vi.fn().mockResolvedValue("127.0.0.1"),
+}));
+
+vi.mock("~/lib/security/turnstile", () => ({
+  verifyTurnstileToken: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("~/lib/blob/config", () => ({
+  BLOB_CONFIG: {
+    maxFiles: 5,
+    maxFileSizeMB: 10,
+    LIMITS: { AUTHENTICATED_USER_MAX: 5, PUBLIC_USER_MAX: 3 },
+  },
+}));
+
+vi.mock("~/lib/blob/client", () => ({
+  deleteFromBlob: vi.fn(),
+}));
+
+vi.mock("~/services/issues", () => ({
+  createIssue: vi.fn(),
+}));
+
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn((_err: unknown, code: string, message: string) =>
+    Promise.resolve({ ok: false as const, code, message })
+  ),
+}));
+
+vi.mock("~/lib/notifications", () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  getChannels: vi.fn().mockResolvedValue([]),
+}));
+
+// Real PGlite — db.query.issues.findMany flows through the actual instance
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+// Import AFTER the db mock so the action picks up PGlite
+const { getRecentIssuesAction } = await import("~/app/(app)/report/actions");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getRecentIssuesAction — serialization and ordering (integration)", () => {
+  setupTestDb();
+
+  const OWNER_ID = "00000000-0000-0000-0000-000000000001";
+  const MACHINE_INITIALS = "MM";
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = await getTestDb();
+
+    // Seed a user (needed for FK on issues.reportedBy / machines.ownerId is optional)
+    await db
+      .insert(userProfiles)
+      .values(
+        createTestUser({ id: OWNER_ID, email: "owner@test.example.com" })
+      );
+
+    // Seed a machine
+    await db.insert(machines).values(
+      createTestMachine({
+        initials: MACHINE_INITIALS,
+        name: "Medieval Madness",
+      })
+    );
+  });
+
+  // Migrated from: "returns ok with properly serialized rows"
+  it("returns ok with properly serialized rows (createdAt as ISO string)", async () => {
+    const db = await getTestDb();
+    const fakeDate = new Date("2025-06-15T12:00:00.000Z");
+
+    await db.insert(issues).values(
+      createTestIssue(MACHINE_INITIALS, {
+        issueNumber: 42,
+        title: "Stuck flipper",
+        status: "new",
+        severity: "major",
+        priority: "high",
+        frequency: "intermittent",
+        reportedBy: OWNER_ID,
+        reporterEmail: null,
+        createdAt: fakeDate,
+        updatedAt: fakeDate,
+      })
+    );
+
+    const result = await getRecentIssuesAction(MACHINE_INITIALS, 5);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      const row = result.value[0];
+      expect(row.title).toBe("Stuck flipper");
+      expect(row.status).toBe("new");
+      expect(row.severity).toBe("major");
+      expect(row.priority).toBe("high");
+      expect(row.frequency).toBe("intermittent");
+      // createdAt must be serialized to ISO 8601 string, not a Date object
+      expect(typeof row.createdAt).toBe("string");
+      expect(row.createdAt).toBe("2025-06-15T12:00:00.000Z");
+    }
+  });
+
+  // Migrated from: "returns ok with empty array when no issues exist"
+  it("returns ok with empty array when no issues exist for the machine", async () => {
+    // No issues inserted — machine exists but has zero issues
+    const result = await getRecentIssuesAction(MACHINE_INITIALS, 10);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  // Migrated from: "returns multiple rows preserving order"
+  it("returns multiple rows ordered newest first (desc createdAt)", async () => {
+    const db = await getTestDb();
+
+    const olderDate = new Date("2025-06-14T12:00:00.000Z");
+    const newerDate = new Date("2025-06-15T12:00:00.000Z");
+
+    // Insert older first to verify ordering is by createdAt, not insert order
+    await db.insert(issues).values([
+      createTestIssue(MACHINE_INITIALS, {
+        issueNumber: 9,
+        title: "Older Issue",
+        status: "confirmed",
+        severity: "cosmetic",
+        priority: "medium",
+        frequency: "frequent",
+        reportedBy: OWNER_ID,
+        reporterEmail: null,
+        createdAt: olderDate,
+        updatedAt: olderDate,
+      }),
+      createTestIssue(MACHINE_INITIALS, {
+        issueNumber: 10,
+        title: "Newer Issue",
+        status: "new",
+        severity: "minor",
+        priority: "low",
+        frequency: "constant",
+        reportedBy: OWNER_ID,
+        reporterEmail: null,
+        createdAt: newerDate,
+        updatedAt: newerDate,
+      }),
+    ]);
+
+    const result = await getRecentIssuesAction(MACHINE_INITIALS, 5);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(2);
+      // Newest first
+      expect(result.value[0]?.createdAt).toBe("2025-06-15T12:00:00.000Z");
+      expect(result.value[0]?.title).toBe("Newer Issue");
+      expect(result.value[1]?.createdAt).toBe("2025-06-14T12:00:00.000Z");
+      expect(result.value[1]?.title).toBe("Older Issue");
+    }
+  });
+
+  // CORE-SEC-007: the action selects a minimal column set that must not include
+  // reporterEmail, even when the row has one stored in the DB.
+  it("does not expose reporterEmail on returned rows (CORE-SEC-007)", async () => {
+    const db = await getTestDb();
+
+    // Seed an issue where a reporter email was captured (anonymous reporter path)
+    // The action's SELECT columns list excludes this field — we verify it's absent.
+    await db.insert(issues).values(
+      createTestIssue(MACHINE_INITIALS, {
+        issueNumber: 1,
+        title: "Anonymous Reporter Issue",
+        status: "new",
+        severity: "minor",
+        priority: "medium",
+        frequency: "intermittent",
+        reportedBy: null,
+        reporterName: "Anonymous User",
+        reporterEmail: "anon@example.com",
+        createdAt: new Date("2025-06-15T12:00:00.000Z"),
+        updatedAt: new Date("2025-06-15T12:00:00.000Z"),
+      })
+    );
+
+    const result = await getRecentIssuesAction(MACHINE_INITIALS, 5);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      const row = result.value[0];
+      // reporterEmail must not be present on any returned row
+      expect(row).not.toHaveProperty("reporterEmail");
+      // reporterName must also be absent (not in the RecentIssueData interface)
+      expect(row).not.toHaveProperty("reporterName");
+    }
+  });
+});


### PR DESCRIPTION
## What

Migrates the 3 `getRecentIssuesAction` success-path blocks from mocked-DB unit tests to real PGlite integration (`src/test/integration/recent-issues.test.ts`):

| Migrated block | New integration assertion |
|---|---|
| returns ok with properly serialized rows | real row → ISO-string `createdAt`, minimal column shape |
| returns ok with empty array | real machine, zero issues |
| returns multiple rows preserving order | real rows, newest-first ordering |

Plus a **CORE-SEC-007** test: returned rows never expose `reporterEmail` even when one is stored in the DB.

## Kept as unit (16 blocks)
Zod input validation, boundary-limit acceptance, `submitPublicIssueAction` CAPTCHA branching (turnstile boundary), and the forced `db.query throws` error path — none assert real DB state.

## Notes
- `getRecentIssuesAction` runs its own `db.query.issues.findMany` (not the already-migrated `getIssues`), so this is genuinely new integration coverage.
- Canonical `vi.mock("~/server/db", … getTestDb())` pattern; no `drizzle-orm`/schema mocks; no duplicate module mocks.

Part of bead PP-x4li.1.3 (Wave 3 RECLASS-integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)