### PR TITLE
test(audit): Wave 3 RECLASS updateMachineTextField permission tests to PGlite integration (PP-x4li.1.3)

### DIFF
--- a/src/test/integration/machine-owner-promotion.test.ts
+++ b/src/test/integration/machine-owner-promotion.test.ts
@@ -1278,6 +1278,335 @@ describe("Machine Owner Promotion — Server Action Integration (PP-rb8)", () =>
     });
   });
 
+  describe("updateMachineTextField — field edit permission", () => {
+    // Wave 3 RECLASS (PP-x4li.1.3): blocks 4–11, 13–14 from
+    // src/test/unit/machine-actions.test.ts updateMachineTextField describe.
+    // Tests real permission matrix (checkPermission) against a real PGlite DB.
+    //
+    // Permission matrix reference:
+    //   machines.edit: unauthenticated=false, guest=false, member="owner",
+    //                  technician=true, admin=true
+    //   machines.edit.ownerNotes: all roles = "owner" (owner-only, even for admins)
+    //   machines.edit.ownerRequirements: owner-scoped
+
+    // A minimal valid ProseMirror doc for test payloads
+    const validDoc = {
+      type: "doc" as const,
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+
+    it("guest (non-owner) edits description → UNAUTHORIZED, field unchanged in DB", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineDescription } =
+        await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const guestUser = await createUser("guest");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: guestUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineDescription(machine.id, validDoc);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("UNAUTHORIZED");
+      }
+
+      // Read-only invariant: description must NOT have changed
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.description).toBeNull();
+    });
+
+    it("member-owner edits description → ok, description persisted in DB", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineDescription } =
+        await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: ownerUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineDescription(machine.id, validDoc);
+
+      expect(result.ok).toBe(true);
+
+      // Persistence invariant: description must be stored in DB
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.description).toBeDefined();
+      expect(machineAfter?.description).not.toBeNull();
+    });
+
+    it("member-owner edits ownerNotes → ok, ownerNotes persisted in DB", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineOwnerNotes } = await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: ownerUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineOwnerNotes(machine.id, validDoc);
+
+      expect(result.ok).toBe(true);
+
+      // Persistence invariant: ownerNotes must be stored in DB
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.ownerNotes).toBeDefined();
+      expect(machineAfter?.ownerNotes).not.toBeNull();
+    });
+
+    it("member NON-owner attempts ownerNotes → UNAUTHORIZED (owner-scoped), ownerNotes unchanged", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineOwnerNotes } = await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const nonOwnerMember = await createUser("member");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: nonOwnerMember.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineOwnerNotes(machine.id, validDoc);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("UNAUTHORIZED");
+      }
+
+      // Read-only invariant: ownerNotes must NOT have changed
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.ownerNotes).toBeNull();
+    });
+
+    it("technician NON-owner edits description → ok (machines.edit: technician=true), description persisted", async () => {
+      // Key behavioral test: machines.edit grants technician=true unconditionally,
+      // so a technician can edit description regardless of machine ownership.
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineDescription } =
+        await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const techUser = await createUser("technician");
+      // Machine owned by member, technician is NOT the owner
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: techUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineDescription(machine.id, validDoc);
+
+      expect(result.ok).toBe(true);
+
+      // Persistence invariant: description must be stored in DB
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.description).toBeDefined();
+      expect(machineAfter?.description).not.toBeNull();
+    });
+
+    it("technician NON-owner attempts ownerNotes → UNAUTHORIZED (machines.edit.ownerNotes: technician='owner'), ownerNotes unchanged", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineOwnerNotes } = await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const techUser = await createUser("technician");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: techUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineOwnerNotes(machine.id, validDoc);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("UNAUTHORIZED");
+      }
+
+      // Read-only invariant: ownerNotes must NOT have changed
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.ownerNotes).toBeNull();
+    });
+
+    it("admin NON-owner edits description → ok (machines.edit: admin=true), description persisted", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineDescription } =
+        await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const adminUser = await createUser("admin");
+      // Machine owned by member, admin is NOT the owner
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: adminUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineDescription(machine.id, validDoc);
+
+      expect(result.ok).toBe(true);
+
+      // Persistence invariant: description must be stored in DB
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.description).toBeDefined();
+      expect(machineAfter?.description).not.toBeNull();
+    });
+
+    it("admin NON-owner attempts ownerNotes → UNAUTHORIZED (machines.edit.ownerNotes: admin='owner'), ownerNotes unchanged", async () => {
+      // Matrix: machines.edit.ownerNotes is "owner" for ALL roles, including admin.
+      // Even an admin cannot edit ownerNotes unless they are the machine owner.
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineOwnerNotes } = await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const adminUser = await createUser("admin");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: adminUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineOwnerNotes(machine.id, validDoc);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("UNAUTHORIZED");
+      }
+
+      // Read-only invariant: ownerNotes must NOT have changed
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.ownerNotes).toBeNull();
+    });
+
+    it("owner edits ownerRequirements → ok, ownerRequirements persisted in DB", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineOwnerRequirements } =
+        await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: ownerUser.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineOwnerRequirements(machine.id, validDoc);
+
+      expect(result.ok).toBe(true);
+
+      // Persistence invariant: ownerRequirements must be stored in DB
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.ownerRequirements).toBeDefined();
+      expect(machineAfter?.ownerRequirements).not.toBeNull();
+    });
+
+    it("non-owner member → ownerRequirements UNAUTHORIZED (owner-scoped), ownerRequirements unchanged", async () => {
+      const { createClient } = await import("~/lib/supabase/server");
+      const { updateMachineOwnerRequirements } =
+        await import("~/app/(app)/m/actions");
+      const db = await getTestDb();
+
+      const ownerUser = await createUser("member");
+      const nonOwnerMember = await createUser("member");
+      const machine = await createMachine(ownerUser.id);
+
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          getUser: vi
+            .fn()
+            .mockResolvedValue({ data: { user: { id: nonOwnerMember.id } } }),
+        },
+      } as any);
+
+      const result = await updateMachineOwnerRequirements(machine.id, validDoc);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("UNAUTHORIZED");
+      }
+
+      // Read-only invariant: ownerRequirements must NOT have changed
+      const machineAfter = await db.query.machines.findFirst({
+        where: eq(machines.id, machine.id),
+      });
+      expect(machineAfter?.ownerRequirements).toBeNull();
+    });
+  });
+
   describe("DB trigger semantics — raw SQL (requires migration 0027 to be applied)", () => {
     it("should detect whether the trigger function exists in the PGlite schema", async () => {
       const db = await getTestDb();

--- a/src/test/unit/machine-actions.test.ts
+++ b/src/test/unit/machine-actions.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   updateMachineAction,
   updateMachineDescription,
-  updateMachineOwnerNotes,
   updateMachineOwnerRequirements,
 } from "~/app/(app)/m/actions";
 import { createClient } from "~/lib/supabase/server";
@@ -212,21 +211,23 @@ describe("updateMachineAction", () => {
 });
 
 // ---------------------------------------------------------------------------
-// updateMachineTextField unit tests (via exported wrapper functions)
+// updateMachineTextField unit tests (KEEP-unit blocks only)
 //
 // Permission matrix for reference:
 //   machines.edit: unauthenticated=false, guest=false, member="owner",
 //                  technician=true, admin=true
 //   machines.edit.ownerNotes: all roles = "owner" (owner-only, even for admins)
 //
-// Behavioral-change test: technician NON-owner can now edit description
-// (machines.edit: technician=true). Before the drift fix, the hardcoded
-// `role === "admin"` check denied technicians. The matrix now governs this.
+// Blocks 4–11 and 13–14 have been RECLASS'd to machine-owner-promotion.test.ts
+// (Wave 3 RECLASS, PP-x4li.1.3). Only pre-permission gate tests remain here:
+//   Block 1: unauthenticated auth gate (KEEP-unit)
+//   Block 2: machine not found existence gate (KEEP-unit)
+//   Block 3: invalid machineId Zod validation (KEEP-unit)
+//   Block 12: unauthenticated ownerRequirements auth gate (KEEP-unit)
 // ---------------------------------------------------------------------------
 
 describe("updateMachineTextField", () => {
   const ownerUserId = "550e8400-e29b-41d4-a716-446655440000";
-  const nonOwnerUserId = "550e8400-e29b-41d4-a716-446655440001";
   const machineId = "550e8400-e29b-41d4-a716-446655440002";
 
   // A minimal valid ProseMirror doc for test payloads
@@ -235,20 +236,6 @@ describe("updateMachineTextField", () => {
     content: [
       { type: "paragraph", content: [{ type: "text", text: "hello" }] },
     ],
-  };
-
-  // machine owned by ownerUserId
-  const ownedMachine = {
-    id: machineId,
-    ownerId: ownerUserId,
-    initials: "TM",
-  };
-
-  // machine owned by someone else (not the authenticated user)
-  const unownedMachine = {
-    id: machineId,
-    ownerId: "550e8400-e29b-41d4-a716-446655440099",
-    initials: "TM",
   };
 
   beforeEach(() => {
@@ -313,210 +300,8 @@ describe("updateMachineTextField", () => {
     expect(db.update).not.toHaveBeenCalled();
   });
 
-  it("guest (non-owner) attempts to edit description → err('UNAUTHORIZED'), no DB write", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "guest",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
-
-    const result = await updateMachineDescription(machineId, validDoc);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("UNAUTHORIZED");
-    }
-    expect(db.update).not.toHaveBeenCalled();
-  });
-
-  it("member-owner edits description → ok, DB write called", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: ownerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      ownedMachine as any
-    );
-    // db.update chain returns undefined (no .returning() needed for setText)
-    chain.where.mockResolvedValue(undefined);
-
-    const result = await updateMachineDescription(machineId, validDoc);
-
-    expect(result.ok).toBe(true);
-    expect(db.update).toHaveBeenCalled();
-  });
-
-  it("member-owner edits ownerNotes → ok, DB write called", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: ownerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      ownedMachine as any
-    );
-    chain.where.mockResolvedValue(undefined);
-
-    const result = await updateMachineOwnerNotes(machineId, validDoc);
-
-    expect(result.ok).toBe(true);
-    expect(db.update).toHaveBeenCalled();
-  });
-
-  it("member NON-owner attempts ownerNotes → err('UNAUTHORIZED') (owner-scoped permission)", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
-
-    const result = await updateMachineOwnerNotes(machineId, validDoc);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("UNAUTHORIZED");
-    }
-    expect(db.update).not.toHaveBeenCalled();
-  });
-
-  it("technician NON-owner edits description → ok (drift-fix behavioral test: machines.edit: technician=true)", async () => {
-    // This is the key regression test. Before the drift fix, the production code had a
-    // hardcoded `role === "admin"` check which denied technicians. After the fix,
-    // the matrix governs: machines.edit grants technician=true unconditionally,
-    // so a technician can edit description regardless of machine ownership.
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "technician",
-    } as any);
-    // Machine owned by someone else — technician is NOT the owner
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
-    chain.where.mockResolvedValue(undefined);
-
-    const result = await updateMachineDescription(machineId, validDoc);
-
-    expect(result.ok).toBe(true);
-    expect(db.update).toHaveBeenCalled();
-  });
-
-  it("technician NON-owner attempts ownerNotes → err('UNAUTHORIZED') (machines.edit.ownerNotes: technician='owner')", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "technician",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
-
-    const result = await updateMachineOwnerNotes(machineId, validDoc);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("UNAUTHORIZED");
-    }
-    expect(db.update).not.toHaveBeenCalled();
-  });
-
-  it("admin NON-owner edits description → ok (machines.edit: admin=true)", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "admin",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
-    chain.where.mockResolvedValue(undefined);
-
-    const result = await updateMachineDescription(machineId, validDoc);
-
-    expect(result.ok).toBe(true);
-    expect(db.update).toHaveBeenCalled();
-  });
-
-  it("admin NON-owner attempts ownerNotes → err('UNAUTHORIZED') (machines.edit.ownerNotes: admin='owner')", async () => {
-    // Matrix: machines.edit.ownerNotes is "owner" for ALL roles, including admin.
-    // Even an admin cannot edit ownerNotes unless they are the machine owner.
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "admin",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
-
-    const result = await updateMachineOwnerNotes(machineId, validDoc);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("UNAUTHORIZED");
-    }
-    expect(db.update).not.toHaveBeenCalled();
-  });
-
   // ---------------------------------------------------------------------------
-  // ownerRequirements permission tests
-  // (downgrades from e2e/full/machine-details-extended.spec.ts —
-  //  "should hide owner requirements from unauthenticated users" class-E)
+  // ownerRequirements auth gate (KEEP-unit — pre-permission, block 12)
   // ---------------------------------------------------------------------------
 
   it("unauthenticated caller → ownerRequirements err('UNAUTHORIZED'), no DB write", async () => {
@@ -525,54 +310,6 @@ describe("updateMachineTextField", () => {
         getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
       },
     } as unknown as SupabaseClient);
-
-    const result = await updateMachineOwnerRequirements(machineId, validDoc);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("UNAUTHORIZED");
-    }
-    expect(db.update).not.toHaveBeenCalled();
-  });
-
-  it("owner edits ownerRequirements → ok, DB write called", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: ownerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      ownedMachine as any
-    );
-    chain.where.mockResolvedValue(undefined);
-
-    const result = await updateMachineOwnerRequirements(machineId, validDoc);
-
-    expect(result.ok).toBe(true);
-    expect(db.update).toHaveBeenCalled();
-  });
-
-  it("non-owner member → ownerRequirements err('UNAUTHORIZED') (owner-scoped)", async () => {
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi
-          .fn()
-          .mockResolvedValue({ data: { user: { id: nonOwnerUserId } } }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-      role: "member",
-    } as any);
-    vi.mocked(db.query.machines.findFirst).mockResolvedValue(
-      unownedMachine as any
-    );
 
     const result = await updateMachineOwnerRequirements(machineId, validDoc);
 


### PR DESCRIPTION
## Summary

Migrates the `updateMachineTextField` permission blocks from `src/test/unit/machine-actions.test.ts` to the PGlite integration home at `src/test/integration/machine-owner-promotion.test.ts`, completing the Wave 3 RECLASS (PP-x4li.1.3). This is the **last machine-actions group** — after this PR merges, the entire `machine-actions.test.ts` RECLASS (Wave 3) is complete.

## Per-block disposition (all 14)

| # | Block | Disposition | Notes |
|---|-------|-------------|-------|
| 1 | unauthenticated → UNAUTHORIZED, no DB write | **KEEP-unit** | Auth gate, pre-permission |
| 2 | machine not found → NOT_FOUND, no DB write | **KEEP-unit** | Existence gate, pre-permission |
| 3 | invalid machineId (not a UUID) → VALIDATION | **KEEP-unit** | Zod validation gate |
| 4 | guest (non-owner) edits description → UNAUTHORIZED | **RECLASS** | Real guest + real matrix; field unchanged asserted |
| 5 | member-owner edits description → ok, DB write | **RECLASS** | Real owner; description persistence asserted |
| 6 | member-owner edits ownerNotes → ok, DB write | **RECLASS** | Real owner; ownerNotes persistence asserted |
| 7 | member NON-owner attempts ownerNotes → UNAUTHORIZED | **RECLASS** | Real member non-owner; ownerNotes unchanged asserted |
| 8 | technician NON-owner edits description → ok | **RECLASS** | Real technician (machines.edit: technician=true); persistence asserted |
| 9 | technician NON-owner attempts ownerNotes → UNAUTHORIZED | **RECLASS** | Real tech → owner-scoped denied; ownerNotes unchanged asserted |
| 10 | admin NON-owner edits description → ok | **RECLASS** | Real admin; persistence asserted |
| 11 | admin NON-owner attempts ownerNotes → UNAUTHORIZED | **RECLASS** | Real admin → owner-scoped denied; ownerNotes unchanged asserted |
| 12 | unauthenticated → ownerRequirements UNAUTHORIZED | **KEEP-unit** | Auth gate, pre-permission |
| 13 | owner edits ownerRequirements → ok, DB write | **RECLASS** | Real owner; ownerRequirements persistence asserted |
| 14 | non-owner member → ownerRequirements UNAUTHORIZED | **RECLASS** | Real member non-owner → denied; ownerRequirements unchanged asserted |

**Counts**: 10 RECLASS → integration, 4 KEEP-unit (remain in source)

## Confirmations

- **Read-only invariants asserted**: Every denied/UNAUTHORIZED RECLASS block re-queries the real DB to confirm the field (`description`/`ownerNotes`/`ownerRequirements`) was NOT changed.
- **Persistence asserted**: Every "ok" RECLASS block queries the real DB and asserts the field's new value is stored (not null).
- **Real permissions**: All RECLASS'd blocks use a real PGlite DB and mock auth only at the Supabase boundary — `checkPermission()` runs against the actual permission matrix.
- **No duplicate module mocks**: Added no new `vi.mock()` calls; the file already had all required mocks (`~/server/db`, `~/lib/supabase/server`, `next/navigation`, `next/cache`, `~/lib/notifications`, `~/lib/logger`).
- **updateMachineAction KEEP-unit remainder untouched**: The 3-block `updateMachineAction` describe in `machine-actions.test.ts` was not modified.
- **Removed unused import**: `updateMachineOwnerNotes` removed from unit test imports since no KEEP-unit block uses it.

## Quality gates

- `pnpm run check`: green (1211 unit tests pass, 137 test files)
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/machine-owner-promotion.test.ts --project=integration`: green (42 tests pass, including 10 new)
- `pnpm exec vitest run src/test/unit/machine-actions.test.ts --project=unit`: green (7 KEEP-unit tests pass)

## Wave 3 RECLASS completion note

This is the last `machine-actions.test.ts` group. After merge, Wave 3 RECLASS for machine actions is complete:
- #1486 — createMachineAction RECLASS
- #1487 — updateMachineAction RECLASS
- This PR — updateMachineTextField RECLASS (final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)