### PR TITLE
test(audit): Wave 4 RECLASS comment-action audit tests to PGlite integration (PP-x4li.1.4)

### DIFF
--- a/src/test/integration/issue-comment-actions.test.ts
+++ b/src/test/integration/issue-comment-actions.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Integration Tests: Comment Actions (addCommentAction, editCommentAction, deleteCommentAction)
+ *
+ * Wave 4 RECLASS (PP-x4li.1.4): migrated from
+ * src/test/unit/delete-comment-audit.test.ts. The source file mocked
+ * ~/server/db entirely, meaning DB-state assertions (soft-delete, eventData,
+ * content=null) were verified against mock call args — not real rows.
+ *
+ * Here we drive the real actions against PGlite via the canonical
+ * `vi.mock("~/server/db", async () => ({ db: await getTestDb() }))` pattern
+ * so that every DB write is actually persisted and read back.
+ *
+ * Per-block disposition (source file had 11 blocks):
+ *
+ *   RECLASS → this file (9 blocks):
+ *     deleteCommentAction:
+ *       1. author soft-delete → isSystem=true, content=null, eventData.deletedBy="author"
+ *       2. admin soft-delete → eventData.deletedBy="admin"
+ *       3. unauthenticated → UNAUTHORIZED + read-only invariant (no row mutated)
+ *       4. non-existent comment → NOT_FOUND + read-only invariant
+ *       5. system comment → UNAUTHORIZED + read-only invariant
+ *       6. non-admin trying to delete another user's comment → UNAUTHORIZED + read-only
+ *     addCommentAction:
+ *       7. happy path → comment row persisted in real DB
+ *     editCommentAction:
+ *       8. author edits own comment → content updated in real DB
+ *       9. non-author (including admin) → UNAUTHORIZED + read-only invariant
+ *
+ *   KEEP-unit (2 blocks, stayed in source):
+ *     deleteCommentAction:
+ *       - "should return VALIDATION error for invalid commentId"   (pure Zod)
+ *       - "should return VALIDATION error for missing commentId"   (pure Zod)
+ *
+ * Permissions: deleteCommentAction uses checkPermission("comments.delete") and
+ * checkPermission("comments.delete.any"). We drive those with REAL permission
+ * matrix (~/lib/permissions/* is NOT mocked). editCommentAction does a direct
+ * authorId === userId check — no matrix call, but we still verify real row state.
+ *
+ * Read-only invariants on denied paths (lesson from Wave 3 Copilot review):
+ * after every UNAUTHORIZED/NOT_FOUND error, we assert the issueComments table
+ * row is unchanged — confirming the action bailed out before any DB write.
+ *
+ * External boundaries mocked (never reach network):
+ *   - ~/lib/supabase/server   (Supabase auth)
+ *   - next/cache              (revalidatePath)
+ *   - next/navigation         (redirect)
+ *   - ~/lib/logger            (log.*)
+ *   - ~/lib/observability/report-error (serverActionError, reportError)
+ *   - ~/lib/notifications     (createNotification, getChannels)
+ *
+ * NOT mocked:
+ *   - ~/server/db             (routed to PGlite)
+ *   - ~/lib/permissions/*     (real matrix — CORE-ARCH-008)
+ *   - drizzle-orm, ~/server/db/schema
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import { createTestMachine, createTestUser } from "~/test/helpers/factories";
+import {
+  authUsers,
+  issueComments,
+  issues,
+  machines,
+  userProfiles,
+} from "~/server/db/schema";
+
+// ---------------------------------------------------------------------------
+// External-boundary mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn((_err: unknown, code: string, message: string) =>
+    Promise.resolve({ ok: false as const, code, message })
+  ),
+}));
+
+vi.mock("~/lib/notifications", () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  getChannels: vi.fn().mockResolvedValue([]),
+}));
+
+// Real PGlite — all DB writes flow through the actual PGlite worker instance.
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+// ---------------------------------------------------------------------------
+// Shared auth helper
+// ---------------------------------------------------------------------------
+
+async function mockAuth(userId: string | null) {
+  const { createClient } = await import("~/lib/supabase/server");
+  vi.mocked(createClient).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+      }),
+    },
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ProseMirror doc with non-empty content (docToPlainText returns "Hello world")
+// ---------------------------------------------------------------------------
+const validCommentDoc = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Hello world" }],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// deleteCommentAction — integration
+// ---------------------------------------------------------------------------
+
+describe("deleteCommentAction — integration (PP-x4li.1.4)", () => {
+  setupTestDb();
+
+  // Stable IDs for this describe block
+  const MEMBER_ID = "c0000000-0000-0000-0000-000000000001";
+  const ADMIN_ID = "c0000000-0000-0000-0000-000000000002";
+  const OTHER_MEMBER_ID = "c0000000-0000-0000-0000-000000000003";
+
+  let issueId: string;
+  let commentId: string;
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+
+    // Seed auth.users entries (required by the FK from userProfiles)
+    await db.insert(authUsers).values([
+      { id: MEMBER_ID, email: "member-del@test.com" },
+      { id: ADMIN_ID, email: "admin-del@test.com" },
+      { id: OTHER_MEMBER_ID, email: "other-del@test.com" },
+    ]);
+
+    // Seed user profiles
+    await db.insert(userProfiles).values([
+      createTestUser({
+        id: MEMBER_ID,
+        role: "member",
+        email: "member-del@test.com",
+      }),
+      createTestUser({
+        id: ADMIN_ID,
+        role: "admin",
+        email: "admin-del@test.com",
+      }),
+      createTestUser({
+        id: OTHER_MEMBER_ID,
+        role: "member",
+        email: "other-del@test.com",
+      }),
+    ]);
+
+    // Seed machine
+    await db.insert(machines).values(
+      createTestMachine({
+        id: "d0000000-0000-0000-0000-000000000001",
+        initials: "DEL",
+        name: "Delete Comment Test Machine",
+        ownerId: MEMBER_ID,
+      })
+    );
+
+    // Seed issue
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        machineInitials: "DEL",
+        issueNumber: 1,
+        title: "Test issue for comment deletion",
+        severity: "minor",
+        priority: "low",
+        frequency: "intermittent",
+        status: "new",
+        reportedBy: MEMBER_ID,
+      })
+      .returning();
+    issueId = issue.id;
+
+    // Seed a regular comment authored by MEMBER_ID
+    const [comment] = await db
+      .insert(issueComments)
+      .values({
+        issueId,
+        authorId: MEMBER_ID,
+        content: validCommentDoc,
+        isSystem: false,
+      })
+      .returning();
+    commentId = comment.id;
+  });
+
+  // Block 1: author soft-delete → isSystem=true, content=null, eventData.deletedBy="author"
+  it("converts comment to audit trail when author deletes their own comment", async () => {
+    await mockAuth(MEMBER_ID);
+    const { deleteCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", commentId);
+
+    const result = await deleteCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(true);
+
+    // Verify real DB state — the row is still present but converted
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+
+    expect(row).toBeDefined();
+    expect(row.isSystem).toBe(true);
+    expect(row.authorId).toBeNull();
+    expect(row.content).toBeNull();
+    expect(row.eventData).toMatchObject({
+      type: "comment_deleted",
+      deletedBy: "author",
+    });
+  });
+
+  // Block 2: admin soft-delete → eventData.deletedBy="admin"
+  it("converts comment to audit trail with deletedBy='admin' when admin deletes another user's comment", async () => {
+    await mockAuth(ADMIN_ID);
+    const { deleteCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", commentId);
+
+    const result = await deleteCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(true);
+
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+
+    expect(row.isSystem).toBe(true);
+    expect(row.authorId).toBeNull();
+    expect(row.content).toBeNull();
+    expect(row.eventData).toMatchObject({
+      type: "comment_deleted",
+      deletedBy: "admin",
+    });
+  });
+
+  // Block 3: unauthenticated → UNAUTHORIZED + read-only invariant
+  it("returns UNAUTHORIZED for unauthenticated user and does not mutate the comment row", async () => {
+    await mockAuth(null);
+    const { deleteCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", commentId);
+
+    const result = await deleteCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNAUTHORIZED");
+    }
+
+    // Read-only invariant: comment row unchanged
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+    expect(row.isSystem).toBe(false);
+    expect(row.authorId).toBe(MEMBER_ID);
+    expect(row.content).not.toBeNull();
+  });
+
+  // Block 4: non-existent comment → NOT_FOUND + read-only invariant
+  it("returns NOT_FOUND when comment does not exist", async () => {
+    await mockAuth(MEMBER_ID);
+    const { deleteCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const nonExistentId = "00000000-dead-beef-0000-000000000000";
+    const formData = new FormData();
+    formData.append("commentId", nonExistentId);
+
+    const result = await deleteCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("NOT_FOUND");
+    }
+
+    // Read-only invariant: existing comment row still pristine
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+    expect(row.isSystem).toBe(false);
+  });
+
+  // Block 5: system comment → UNAUTHORIZED + read-only invariant
+  it("returns UNAUTHORIZED for system comments and does not mutate them", async () => {
+    // Create a system comment (audit event row)
+    const db = await getTestDb();
+    const [systemComment] = await db
+      .insert(issueComments)
+      .values({
+        issueId,
+        authorId: null,
+        content: null,
+        isSystem: true,
+        eventData: { type: "status_changed", from: "new", to: "in_progress" },
+      })
+      .returning();
+
+    await mockAuth(MEMBER_ID);
+    const { deleteCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", systemComment.id);
+
+    const result = await deleteCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNAUTHORIZED");
+      expect(result.message).toBe("System comments cannot be deleted");
+    }
+
+    // Read-only invariant: system comment row still has isSystem=true and original eventData
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, systemComment.id));
+    expect(row.isSystem).toBe(true);
+    expect(row.eventData).toMatchObject({ type: "status_changed" });
+  });
+
+  // Block 6: non-admin member tries to delete another user's comment → UNAUTHORIZED + read-only
+  it("returns UNAUTHORIZED when non-admin tries to delete another user's comment", async () => {
+    // OTHER_MEMBER_ID is a member who did NOT author the comment (MEMBER_ID did)
+    await mockAuth(OTHER_MEMBER_ID);
+    const { deleteCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", commentId);
+
+    const result = await deleteCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNAUTHORIZED");
+    }
+
+    // Read-only invariant: comment row unchanged
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+    expect(row.isSystem).toBe(false);
+    expect(row.authorId).toBe(MEMBER_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addCommentAction — integration
+// ---------------------------------------------------------------------------
+
+describe("addCommentAction — integration (PP-x4li.1.4)", () => {
+  setupTestDb();
+
+  const MEMBER_ID = "e0000000-0000-0000-0000-000000000001";
+  let issueId: string;
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+
+    await db
+      .insert(authUsers)
+      .values({ id: MEMBER_ID, email: "member-add@test.com" });
+
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: MEMBER_ID,
+        role: "member",
+        email: "member-add@test.com",
+      })
+    );
+
+    await db.insert(machines).values(
+      createTestMachine({
+        id: "f0000000-0000-0000-0000-000000000001",
+        initials: "ADD",
+        name: "Add Comment Test Machine",
+        ownerId: MEMBER_ID,
+      })
+    );
+
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        machineInitials: "ADD",
+        issueNumber: 1,
+        title: "Test issue for add comment",
+        severity: "minor",
+        priority: "low",
+        frequency: "intermittent",
+        status: "new",
+        reportedBy: MEMBER_ID,
+      })
+      .returning();
+    issueId = issue.id;
+  });
+
+  // Block 7: happy path → comment row persisted in real DB
+  it("persists the comment row in the database on happy path", async () => {
+    await mockAuth(MEMBER_ID);
+    const { addCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("issueId", issueId);
+    formData.append("comment", JSON.stringify(validCommentDoc));
+
+    const result = await addCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(true);
+
+    // Verify real DB state — a comment row exists with the correct content and author
+    const db = await getTestDb();
+    const rows = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].authorId).toBe(MEMBER_ID);
+    expect(rows[0].isSystem).toBe(false);
+    expect(rows[0].content).toMatchObject(validCommentDoc);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// editCommentAction — integration
+// ---------------------------------------------------------------------------
+
+describe("editCommentAction — integration (PP-x4li.1.4)", () => {
+  setupTestDb();
+
+  const AUTHOR_ID = "a1000000-0000-0000-0000-000000000001";
+  const NON_AUTHOR_ID = "a1000000-0000-0000-0000-000000000002";
+
+  let issueId: string;
+  let commentId: string;
+
+  const originalDoc = {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Original content" }],
+      },
+    ],
+  };
+
+  const updatedDoc = {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Updated content" }],
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    const db = await getTestDb();
+
+    await db.insert(authUsers).values([
+      { id: AUTHOR_ID, email: "author-edit@test.com" },
+      { id: NON_AUTHOR_ID, email: "non-author-edit@test.com" },
+    ]);
+
+    await db.insert(userProfiles).values([
+      createTestUser({
+        id: AUTHOR_ID,
+        role: "member",
+        email: "author-edit@test.com",
+      }),
+      createTestUser({
+        id: NON_AUTHOR_ID,
+        role: "admin",
+        email: "non-author-edit@test.com",
+      }),
+    ]);
+
+    await db.insert(machines).values(
+      createTestMachine({
+        id: "b1000000-0000-0000-0000-000000000001",
+        initials: "EDT",
+        name: "Edit Comment Test Machine",
+        ownerId: AUTHOR_ID,
+      })
+    );
+
+    const [issue] = await db
+      .insert(issues)
+      .values({
+        machineInitials: "EDT",
+        issueNumber: 1,
+        title: "Test issue for edit comment",
+        severity: "minor",
+        priority: "low",
+        frequency: "intermittent",
+        status: "new",
+        reportedBy: AUTHOR_ID,
+      })
+      .returning();
+    issueId = issue.id;
+
+    const [comment] = await db
+      .insert(issueComments)
+      .values({
+        issueId,
+        authorId: AUTHOR_ID,
+        content: originalDoc,
+        isSystem: false,
+      })
+      .returning();
+    commentId = comment.id;
+  });
+
+  // Block 8: author edits own comment → content updated in real DB
+  it("updates the comment content in the database when the author edits their own comment", async () => {
+    await mockAuth(AUTHOR_ID);
+    const { editCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", commentId);
+    formData.append("comment", JSON.stringify(updatedDoc));
+
+    const result = await editCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(true);
+
+    // Verify real DB state — content is updated
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+
+    expect(row.content).toMatchObject(updatedDoc);
+    expect(row.authorId).toBe(AUTHOR_ID);
+  });
+
+  // Block 9: non-author (including admin) → UNAUTHORIZED + read-only invariant
+  it("returns UNAUTHORIZED and does not mutate the comment when a non-author tries to edit", async () => {
+    // NON_AUTHOR_ID is an admin, but editCommentAction enforces author-only at
+    // the action boundary (admins can delete but cannot edit others' comments).
+    await mockAuth(NON_AUTHOR_ID);
+    const { editCommentAction } = await import("~/app/(app)/issues/actions");
+
+    const formData = new FormData();
+    formData.append("commentId", commentId);
+    formData.append("comment", JSON.stringify(updatedDoc));
+
+    const result = await editCommentAction(undefined, formData);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNAUTHORIZED");
+    }
+
+    // Read-only invariant: comment row content unchanged
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId));
+
+    expect(row.content).toMatchObject(originalDoc);
+  });
+});

--- a/src/test/unit/delete-comment-audit.test.ts
+++ b/src/test/unit/delete-comment-audit.test.ts
@@ -13,8 +13,9 @@
  * These stay as unit tests because they test input-parsing boundaries that
  * require no real DB or auth infrastructure.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { deleteCommentAction } from "~/app/(app)/issues/actions";
+import { db } from "~/server/db";
 
 // Mock Next.js modules
 vi.mock("next/cache", () => ({
@@ -77,6 +78,20 @@ vi.mock("~/lib/observability/report-error", () => ({
 }));
 
 describe("deleteCommentAction — input validation (KEEP-unit)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Asserts the action short-circuits on a Zod validation failure BEFORE any
+  // DB access. Catches regressions where a DB read/write accidentally moves
+  // ahead of input validation.
+  function expectNoDbAccess() {
+    expect(db.query.issueComments.findFirst).not.toHaveBeenCalled();
+    expect(db.query.issues.findFirst).not.toHaveBeenCalled();
+    expect(db.query.userProfiles.findFirst).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  }
+
   it("should return VALIDATION error for invalid commentId", async () => {
     const formData = new FormData();
     formData.append("commentId", "not-a-uuid");
@@ -87,6 +102,7 @@ describe("deleteCommentAction — input validation (KEEP-unit)", () => {
     if (!result.ok) {
       expect(result.code).toBe("VALIDATION");
     }
+    expectNoDbAccess();
   });
 
   it("should return VALIDATION error for missing commentId", async () => {
@@ -99,5 +115,6 @@ describe("deleteCommentAction — input validation (KEEP-unit)", () => {
     if (!result.ok) {
       expect(result.code).toBe("VALIDATION");
     }
+    expectNoDbAccess();
   });
 });

--- a/src/test/unit/delete-comment-audit.test.ts
+++ b/src/test/unit/delete-comment-audit.test.ts
@@ -1,20 +1,20 @@
 /**
- * Unit Tests: Comment Actions (add, edit, delete)
+ * Unit Tests: Comment Actions — Input Validation (Zod)
  *
- * Tests that:
- * - addCommentAction persists a comment on happy path
- * - editCommentAction updates a comment when the author makes the call, and
- *   returns UNAUTHORIZED for non-authors (including admins trying to edit
- *   another user's comment — i.e. admins can delete but cannot edit others)
- * - deleteCommentAction converts a comment to an audit trail message
- *   rather than actually deleting the row
+ * Wave 4 RECLASS (PP-x4li.1.4): The DB-state blocks (soft-delete, permission
+ * wiring, auth checks) have been migrated to
+ * src/test/integration/issue-comment-actions.test.ts.
+ *
+ * Remaining blocks here are pure Zod input-validation paths for
+ * deleteCommentAction that do not depend on DB state:
+ *   - invalid commentId (not a UUID)
+ *   - missing commentId
+ *
+ * These stay as unit tests because they test input-parsing boundaries that
+ * require no real DB or auth infrastructure.
  */
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import {
-  addCommentAction,
-  editCommentAction,
-  deleteCommentAction,
-} from "~/app/(app)/issues/actions";
+import { describe, it, expect, vi } from "vitest";
+import { deleteCommentAction } from "~/app/(app)/issues/actions";
 
 // Mock Next.js modules
 vi.mock("next/cache", () => ({
@@ -23,34 +23,28 @@ vi.mock("next/cache", () => ({
 
 // Mock Supabase client
 vi.mock("~/lib/supabase/server", () => ({
-  createClient: vi.fn(),
+  createClient: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "user-123" } },
+      }),
+    },
+  })),
 }));
 
-// Mock DB - using factory function to avoid hoisting issues
-vi.mock("~/server/db", () => {
-  const mockWhere = vi.fn().mockResolvedValue(undefined);
-  const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-  const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
-
-  return {
-    db: {
-      update: mockUpdate,
-      query: {
-        issues: {
-          findFirst: vi.fn(),
-        },
-        issueComments: {
-          findFirst: vi.fn(),
-        },
-        userProfiles: {
-          findFirst: vi.fn(),
-        },
-      },
+// Mock DB — these Zod tests bail out before any DB call, but the module must
+// be importable.
+vi.mock("~/server/db", () => ({
+  db: {
+    update: vi.fn(),
+    query: {
+      issues: { findFirst: vi.fn() },
+      issueComments: { findFirst: vi.fn() },
+      userProfiles: { findFirst: vi.fn() },
     },
-  };
-});
+  },
+}));
 
-// Mock schema (needed for eq comparisons)
 vi.mock("~/server/db/schema", () => ({
   issues: { id: "issues.id" },
   issueComments: { id: "issueComments.id" },
@@ -58,21 +52,14 @@ vi.mock("~/server/db/schema", () => ({
   userProfiles: { id: "userProfiles.id" },
 }));
 
-// Mock drizzle-orm
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((field, value) => ({ field, value })),
 }));
 
-// Mock logger
 vi.mock("~/lib/logger", () => ({
-  log: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-// Mock services
 vi.mock("~/services/issues", () => ({
   updateIssueStatus: vi.fn(),
   updateIssueSeverity: vi.fn(),
@@ -82,470 +69,35 @@ vi.mock("~/services/issues", () => ({
   updateIssueComment: vi.fn(),
 }));
 
-import { revalidatePath } from "next/cache";
-import { createClient } from "~/lib/supabase/server";
-import { db } from "~/server/db";
-import { log } from "~/lib/logger";
-import { addIssueComment, updateIssueComment } from "~/services/issues";
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn((_err: unknown, code: string, message: string) =>
+    Promise.resolve({ ok: false as const, code, message })
+  ),
+}));
 
-type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
-
-// Get typed references to the chainable mocks
-function getMockUpdate() {
-  return db.update as Mock;
-}
-
-function getMockSet() {
-  const mockUpdate = getMockUpdate();
-  const result = mockUpdate();
-  return result.set as Mock;
-}
-
-describe("deleteCommentAction - Audit Trail", () => {
-  const validCommentId = "123e4567-e89b-12d3-a456-426614174000";
-  const validIssueId = "987e6543-e21b-12d3-a456-426614174000";
-  const mockUserId = "user-123";
-  const mockAdminId = "admin-456";
-  const initialState = undefined;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe("when user deletes their own comment", () => {
-    beforeEach(() => {
-      // Auth as comment author
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      // Comment exists and belongs to this user
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue({
-        id: validCommentId,
-        issueId: validIssueId,
-        authorId: mockUserId,
-        content: "Original comment content",
-        isSystem: false,
-      } as any);
-
-      // User is a regular member
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "member",
-      } as any);
-
-      // Issue lookup for revalidation
-      vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-        machineInitials: "MM",
-        issueNumber: 1,
-      } as any);
-    });
-
-    it("should convert comment to audit trail with 'User deleted their comment'", async () => {
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(true);
-
-      // Verify db.update was called
-      const mockUpdate = getMockUpdate();
-      expect(mockUpdate).toHaveBeenCalled();
-
-      // Verify the set call has correct structured audit trail event
-      const mockSet = getMockSet();
-      expect(mockSet).toHaveBeenCalledWith({
-        isSystem: true,
-        authorId: null,
-        content: null,
-        eventData: { type: "comment_deleted", deletedBy: "author" },
-        updatedAt: expect.any(Date),
-      });
-
-      // Verify logging
-      expect(log.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          commentId: validCommentId,
-          isOwnComment: true,
-          action: "deleteComment",
-        }),
-        "Comment converted to audit trail"
-      );
-
-      // Verify revalidation
-      expect(revalidatePath).toHaveBeenCalledWith("/m/MM/i/1");
-    });
-  });
-
-  describe("when admin deletes another user's comment", () => {
-    beforeEach(() => {
-      // Auth as admin
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockAdminId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      // Comment exists but belongs to different user
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue({
-        id: validCommentId,
-        issueId: validIssueId,
-        authorId: mockUserId, // Different from admin
-        content: "User's comment content",
-        isSystem: false,
-      } as any);
-
-      // User is admin
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "admin",
-      } as any);
-
-      // Issue lookup for revalidation
-      vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-        machineInitials: "MM",
-        issueNumber: 1,
-      } as any);
-    });
-
-    it("should convert comment to audit trail with 'Comment removed by admin'", async () => {
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(true);
-
-      // Verify the set call has correct structured admin audit event
-      const mockSet = getMockSet();
-      expect(mockSet).toHaveBeenCalledWith({
-        isSystem: true,
-        authorId: null,
-        content: null,
-        eventData: { type: "comment_deleted", deletedBy: "admin" },
-        updatedAt: expect.any(Date),
-      });
-
-      // Verify logging shows isOwnComment: false
-      expect(log.info).toHaveBeenCalledWith(
-        expect.objectContaining({
-          commentId: validCommentId,
-          isOwnComment: false,
-          action: "deleteComment",
-        }),
-        "Comment converted to audit trail"
-      );
-    });
-  });
-
-  describe("authorization checks", () => {
-    it("should return UNAUTHORIZED for unauthenticated user", async () => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
-        },
-      } as unknown as SupabaseClient);
-
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("UNAUTHORIZED");
-      }
-      expect(getMockUpdate()).not.toHaveBeenCalled();
-    });
-
-    it("should return NOT_FOUND for non-existent comment", async () => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue(undefined);
-
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("NOT_FOUND");
-      }
-      expect(getMockUpdate()).not.toHaveBeenCalled();
-    });
-
-    it("should return UNAUTHORIZED for system comments", async () => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      // Comment is a system comment (audit event)
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue({
-        id: validCommentId,
-        issueId: validIssueId,
-        authorId: null,
-        eventData: { type: "status_changed", from: "new", to: "in_progress" },
-        content: null,
-        isSystem: true,
-      } as any);
-
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("UNAUTHORIZED");
-        expect(result.message).toBe("System comments cannot be deleted");
-      }
-      expect(getMockUpdate()).not.toHaveBeenCalled();
-    });
-
-    it("should return UNAUTHORIZED when non-admin tries to delete others comment", async () => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      // Comment belongs to different user
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue({
-        id: validCommentId,
-        issueId: validIssueId,
-        authorId: "other-user-id",
-        content: "Other user's comment",
-        isSystem: false,
-      } as any);
-
-      // Current user is not admin
-      vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
-        role: "member",
-      } as any);
-
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("UNAUTHORIZED");
-      }
-      expect(getMockUpdate()).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("validation", () => {
-    it("should return VALIDATION error for invalid commentId", async () => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      const formData = new FormData();
-      formData.append("commentId", "not-a-uuid");
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("VALIDATION");
-      }
-      expect(getMockUpdate()).not.toHaveBeenCalled();
-    });
-
-    it("should return VALIDATION error for missing commentId", async () => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      const formData = new FormData();
-      // Not appending commentId
-
-      const result = await deleteCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("VALIDATION");
-      }
-      expect(getMockUpdate()).not.toHaveBeenCalled();
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// addCommentAction
-// ---------------------------------------------------------------------------
-
-// Minimal ProseMirror doc with content so docToPlainText returns non-empty.
-const validCommentDoc = {
-  type: "doc",
-  content: [
-    {
-      type: "paragraph",
-      content: [{ type: "text", text: "Hello world" }],
-    },
-  ],
-};
-
-describe("addCommentAction", () => {
-  const validIssueId = "987e6543-e21b-12d3-a456-426614174000";
-  const mockUserId = "user-123";
-  const initialState = undefined;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    vi.mocked(createClient).mockResolvedValue({
-      auth: {
-        getUser: vi.fn().mockResolvedValue({
-          data: { user: { id: mockUserId } },
-        }),
-      },
-    } as unknown as SupabaseClient);
-
-    vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-      machineInitials: "MM",
-      issueNumber: 1,
-    } as any);
-
-    vi.mocked(addIssueComment).mockResolvedValue(undefined as any);
-  });
-
-  it("persists the comment and revalidates the issue page on happy path", async () => {
+describe("deleteCommentAction — input validation (KEEP-unit)", () => {
+  it("should return VALIDATION error for invalid commentId", async () => {
     const formData = new FormData();
-    formData.append("issueId", validIssueId);
-    formData.append("comment", JSON.stringify(validCommentDoc));
+    formData.append("commentId", "not-a-uuid");
 
-    const result = await addCommentAction(initialState, formData);
+    const result = await deleteCommentAction(undefined, formData);
 
-    expect(result.ok).toBe(true);
-    expect(vi.mocked(addIssueComment)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        issueId: validIssueId,
-        userId: mockUserId,
-      })
-    );
-    expect(revalidatePath).toHaveBeenCalledWith("/m/MM/i/1");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// editCommentAction
-// ---------------------------------------------------------------------------
-
-describe("editCommentAction", () => {
-  const validCommentId = "123e4567-e89b-12d3-a456-426614174000";
-  const validIssueId = "987e6543-e21b-12d3-a456-426614174000";
-  const mockUserId = "user-123";
-  const mockAdminId = "admin-456";
-  const initialState = undefined;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    vi.mocked(db.query.issues.findFirst).mockResolvedValue({
-      machineInitials: "MM",
-      issueNumber: 1,
-    } as any);
-
-    vi.mocked(updateIssueComment).mockResolvedValue(undefined as any);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("VALIDATION");
+    }
   });
 
-  describe("when the author edits their own comment", () => {
-    beforeEach(() => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockUserId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
+  it("should return VALIDATION error for missing commentId", async () => {
+    const formData = new FormData();
+    // Not appending commentId
 
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue({
-        id: validCommentId,
-        issueId: validIssueId,
-        authorId: mockUserId,
-        content: "Original content",
-        isSystem: false,
-      } as any);
-    });
+    const result = await deleteCommentAction(undefined, formData);
 
-    it("updates the comment and revalidates the issue page", async () => {
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-      formData.append("comment", JSON.stringify(validCommentDoc));
-
-      const result = await editCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(true);
-      expect(vi.mocked(updateIssueComment)).toHaveBeenCalledWith(
-        expect.objectContaining({ commentId: validCommentId })
-      );
-      expect(revalidatePath).toHaveBeenCalledWith("/m/MM/i/1");
-    });
-  });
-
-  describe("when a non-author (including admin) tries to edit another user's comment", () => {
-    // This covers the E2E assertion that admins see Delete but NOT Edit on
-    // others' comments: the server action enforces this at the action boundary.
-    beforeEach(() => {
-      vi.mocked(createClient).mockResolvedValue({
-        auth: {
-          getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: mockAdminId } },
-          }),
-        },
-      } as unknown as SupabaseClient);
-
-      // Comment belongs to a different user
-      vi.mocked(db.query.issueComments.findFirst).mockResolvedValue({
-        id: validCommentId,
-        issueId: validIssueId,
-        authorId: mockUserId, // different from mockAdminId
-        content: "Another user's comment",
-        isSystem: false,
-      } as any);
-    });
-
-    it("returns UNAUTHORIZED and does not call updateIssueComment", async () => {
-      const formData = new FormData();
-      formData.append("commentId", validCommentId);
-      formData.append("comment", JSON.stringify(validCommentDoc));
-
-      const result = await editCommentAction(initialState, formData);
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.code).toBe("UNAUTHORIZED");
-      }
-      expect(vi.mocked(updateIssueComment)).not.toHaveBeenCalled();
-    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("VALIDATION");
+    }
   });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Wave 4 of the test audit RECLASS effort (PP-x4li.1.4). Migrates the 9 DB-state blocks from `src/test/unit/delete-comment-audit.test.ts` to a new real-PGlite integration file, leaving the 2 pure-Zod validation blocks in the source.

**Why Wave 4 (new infra):** The comment actions (`deleteCommentAction`, `addCommentAction`, `editCommentAction`) had zero integration coverage. The unit file mocked `~/server/db` entirely, so assertions about soft-delete state, `eventData`, and `content=null` were verified against mock call args — not real rows.

## Per-block disposition

**Source file: `src/test/unit/delete-comment-audit.test.ts`** (11 blocks total)

| Block | Disposition | Reason |
|---|---|---|
| `deleteCommentAction` → author deletes own comment | RECLASS | Asserts real DB mutation: `isSystem=true`, `content=null`, `eventData.deletedBy="author"` |
| `deleteCommentAction` → admin deletes other's comment | RECLASS | Asserts real DB mutation: `eventData.deletedBy="admin"` |
| `deleteCommentAction` → unauthenticated | RECLASS | Permission gate + read-only invariant (no row mutated) |
| `deleteCommentAction` → non-existent comment | RECLASS | `NOT_FOUND` from real DB query + read-only invariant |
| `deleteCommentAction` → system comment | RECLASS | Real `isSystem` check from DB + read-only invariant |
| `deleteCommentAction` → non-admin on another user's comment | RECLASS | Real `checkPermission("comments.delete")` matrix path + read-only invariant |
| `deleteCommentAction` → invalid commentId | **KEEP-unit** | Pure Zod schema validation, no DB dependency |
| `deleteCommentAction` → missing commentId | **KEEP-unit** | Pure Zod schema validation, no DB dependency |
| `addCommentAction` → happy path | RECLASS | Asserts real comment row persisted in PGlite (not just mock call arg) |
| `editCommentAction` → author edits own comment | RECLASS | Asserts real `content` update in DB |
| `editCommentAction` → non-author (including admin) | RECLASS | UNAUTHORIZED + read-only invariant (content unchanged) |

## New integration coverage added

**File:** `src/test/integration/issue-comment-actions.test.ts` (9 tests)

- `deleteCommentAction`: 6 tests covering soft-delete state, `eventData.deletedBy` discrimination, and permission denial paths
- `addCommentAction`: 1 test confirming row insertion via real `addIssueComment` service
- `editCommentAction`: 2 tests covering author-edits and non-author denial

## Quality confirmation

- **Real permissions (CORE-ARCH-008):** `deleteCommentAction` uses `checkPermission("comments.delete")` and `checkPermission("comments.delete.any")` — neither `~/lib/permissions/*` module is mocked. The real permission matrix drives allow/deny.
- **Read-only invariants on denied paths:** Every UNAUTHORIZED/NOT_FOUND test asserts the `issueComments` row is unchanged after the rejection (lesson from Wave 3 Copilot review, baked in from the start).
- **No duplicate mocks:** `~/server/db` is routed to PGlite via the canonical `async () => ({ db: await getTestDb() })` pattern. External boundaries (supabase/server, next/cache, next/navigation, notifications, logger, observability/report-error) are mocked at their boundary only.
- **Gate results:** `pnpm run check` green (1202 tests pass). Integration file: 9/9 pass. Unit file: 2/2 pass.

## Test plan

- [x] `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/issue-comment-actions.test.ts --project=integration` — 9 passed
- [x] `pnpm exec vitest run src/test/unit/delete-comment-audit.test.ts --project=unit` — 2 passed
- [x] `pnpm run check` — all 1202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)