### PR TITLE
test(audit): Wave 4 RECLASS machine-watcher tests to PGlite integration (PP-x4li.1.4)

### DIFF
--- a/src/test/integration/machines.test.ts
+++ b/src/test/integration/machines.test.ts
@@ -634,13 +634,6 @@ describe("Machine Watcher Service (PGlite)", () => {
   setupTestDb();
 
   beforeAll(async () => {
-    (globalThis as any).testDb = await getTestDb();
-  });
-
-  let testMachine: { id: string; initials: string };
-  let testUser: { id: string };
-
-  beforeAll(async () => {
     // Re-assign after setupTestDb seeds globalThis (no-op: setupTestDb calls
     // getTestDb() which sets the worker-scoped instance; we assign here so the
     // proxy has a reference before any test runs).

--- a/src/test/integration/machines.test.ts
+++ b/src/test/integration/machines.test.ts
@@ -3,19 +3,76 @@
  *
  * Tests machine queries, mutations, and status derivation with PGlite.
  * Verifies that machine status is correctly derived from associated issues.
+ *
+ * Wave 4 RECLASS additions (PP-x4li.1.4): migrated 3 watcher-service blocks from
+ * src/test/unit/machines.test.ts that required real DB-state assertions
+ * (toggleMachineWatcher watch/unwatch, updateMachineWatchMode persist).
+ * The 3 KEEP-unit blocks (Zod validation, forced DB errors) remain in the unit file.
  */
 
-import { describe, it, expect } from "vitest";
-import { eq } from "drizzle-orm";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { eq, and } from "drizzle-orm";
 import { getTestDb, setupTestDb } from "~/test/setup/pglite";
-import { machines, issues } from "~/server/db/schema";
-import { createTestMachine, createTestIssue } from "~/test/helpers/factories";
+import {
+  machines,
+  issues,
+  userProfiles,
+  machineWatchers,
+} from "~/server/db/schema";
+import {
+  createTestMachine,
+  createTestIssue,
+  createTestUser,
+} from "~/test/helpers/factories";
 import { deriveMachineStatus } from "~/lib/machines/status";
 import { createMachineSchema } from "~/app/(app)/m/schemas";
 import {
   applyMachineFilters,
   type MachineWithDerivedStatus,
 } from "~/lib/machines/filters-queries";
+import {
+  toggleMachineWatcher,
+  updateMachineWatchMode,
+} from "~/services/machines";
+
+// ---------------------------------------------------------------------------
+// DB proxy — routes service-layer `db` imports to the worker-scoped PGlite
+// instance. Only needed by the Machine Watcher Service describe at the bottom.
+// The existing CRUD/status/presence describes use getTestDb() directly and
+// are unaffected by this mock.
+// ---------------------------------------------------------------------------
+vi.mock("~/server/db", () => ({
+  db: {
+    insert: vi.fn((...args: any[]) =>
+      (globalThis as any).testDb.insert(...args)
+    ),
+    update: vi.fn((...args: any[]) =>
+      (globalThis as any).testDb.update(...args)
+    ),
+    delete: vi.fn((...args: any[]) =>
+      (globalThis as any).testDb.delete(...args)
+    ),
+    select: vi.fn((...args: any[]) =>
+      (globalThis as any).testDb.select(...args)
+    ),
+    query: {
+      machineWatchers: {
+        findFirst: vi.fn((...args: any[]) =>
+          (globalThis as any).testDb.query.machineWatchers.findFirst(...args)
+        ),
+      },
+    },
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe("Machine CRUD Operations (PGlite)", () => {
   // Set up worker-scoped PGlite and auto-cleanup after each test
@@ -554,5 +611,155 @@ describe("Machine Presence Filtering (applyMachineFilters)", () => {
     expect(result).toHaveLength(2);
     expect(result.map((m) => m.initials)).toContain("OL");
     expect(result.map((m) => m.initials)).toContain("FF");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Machine Watcher Service (PGlite integration)
+//
+// Wave 4 RECLASS (PP-x4li.1.4): migrated 3 blocks from
+// src/test/unit/machines.test.ts.
+//
+// RECLASS:
+//   - "should watch if not already watching"  → real INSERT into machineWatchers
+//   - "should unwatch if already watching"    → seed + DELETE, assert row gone
+//   - "should update watch mode successfully" → real UPDATE, assert persisted
+//
+// KEPT in unit (forced-error / Zod cases — can't reproduce with real DB):
+//   - toggleMachineWatcher: "should handle DB errors gracefully"
+//   - updateMachineWatchMode: "should validate watch mode"
+//   - updateMachineWatchMode: "should handle DB errors gracefully"
+// ---------------------------------------------------------------------------
+describe("Machine Watcher Service (PGlite)", () => {
+  setupTestDb();
+
+  beforeAll(async () => {
+    (globalThis as any).testDb = await getTestDb();
+  });
+
+  let testMachine: { id: string; initials: string };
+  let testUser: { id: string };
+
+  beforeAll(async () => {
+    // Re-assign after setupTestDb seeds globalThis (no-op: setupTestDb calls
+    // getTestDb() which sets the worker-scoped instance; we assign here so the
+    // proxy has a reference before any test runs).
+    (globalThis as any).testDb = await getTestDb();
+  });
+
+  // Seed a fresh machine + user before each test via direct PGlite writes.
+  // afterEach cleanup is handled by setupTestDb (cleanupTestDb).
+  it("should watch if not already watching", async () => {
+    const db = await getTestDb();
+
+    const [user] = await db
+      .insert(userProfiles)
+      .values(createTestUser())
+      .returning();
+    const [machine] = await db
+      .insert(machines)
+      .values(createTestMachine({ initials: "WT1" }))
+      .returning();
+
+    const result = await toggleMachineWatcher({
+      machineId: machine.id,
+      userId: user.id,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.isWatching).toBe(true);
+      expect(result.value.watchMode).toBe("notify");
+    }
+
+    // Assert a machineWatchers row was inserted in the real DB
+    const row = await db.query.machineWatchers.findFirst({
+      where: and(
+        eq(machineWatchers.machineId, machine.id),
+        eq(machineWatchers.userId, user.id)
+      ),
+    });
+    expect(row).toBeDefined();
+    expect(row?.watchMode).toBe("notify");
+  });
+
+  it("should unwatch if already watching", async () => {
+    const db = await getTestDb();
+
+    const [user] = await db
+      .insert(userProfiles)
+      .values(createTestUser())
+      .returning();
+    const [machine] = await db
+      .insert(machines)
+      .values(createTestMachine({ initials: "WT2" }))
+      .returning();
+
+    // Seed an existing watcher row
+    await db.insert(machineWatchers).values({
+      machineId: machine.id,
+      userId: user.id,
+      watchMode: "subscribe",
+    });
+
+    const result = await toggleMachineWatcher({
+      machineId: machine.id,
+      userId: user.id,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.isWatching).toBe(false);
+      expect(result.value.watchMode).toBe("subscribe");
+    }
+
+    // Assert the row was removed from the real DB
+    const row = await db.query.machineWatchers.findFirst({
+      where: and(
+        eq(machineWatchers.machineId, machine.id),
+        eq(machineWatchers.userId, user.id)
+      ),
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("should update watch mode successfully", async () => {
+    const db = await getTestDb();
+
+    const [user] = await db
+      .insert(userProfiles)
+      .values(createTestUser())
+      .returning();
+    const [machine] = await db
+      .insert(machines)
+      .values(createTestMachine({ initials: "WT3" }))
+      .returning();
+
+    // Seed a watcher row with default notify mode
+    await db.insert(machineWatchers).values({
+      machineId: machine.id,
+      userId: user.id,
+      watchMode: "notify",
+    });
+
+    const result = await updateMachineWatchMode({
+      machineId: machine.id,
+      userId: user.id,
+      watchMode: "subscribe",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.watchMode).toBe("subscribe");
+    }
+
+    // Assert the watch mode was persisted in the real DB
+    const row = await db.query.machineWatchers.findFirst({
+      where: and(
+        eq(machineWatchers.machineId, machine.id),
+        eq(machineWatchers.userId, user.id)
+      ),
+    });
+    expect(row?.watchMode).toBe("subscribe");
   });
 });

--- a/src/test/unit/machines.test.ts
+++ b/src/test/unit/machines.test.ts
@@ -48,41 +48,6 @@ describe("Machines Service", () => {
   });
 
   describe("toggleMachineWatcher", () => {
-    it("should watch if not already watching", async () => {
-      vi.mocked(db.query.machineWatchers.findFirst).mockResolvedValue(
-        undefined
-      );
-
-      const result = await toggleMachineWatcher({ machineId, userId });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value.isWatching).toBe(true);
-        expect(result.value.watchMode).toBe("notify");
-      }
-      expect(db.insert).toHaveBeenCalled();
-      expect(chain.values).toHaveBeenCalledWith({
-        machineId,
-        userId,
-        watchMode: "notify",
-      });
-    });
-
-    it("should unwatch if already watching", async () => {
-      vi.mocked(db.query.machineWatchers.findFirst).mockResolvedValue({
-        watchMode: "subscribe",
-      } as any);
-
-      const result = await toggleMachineWatcher({ machineId, userId });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value.isWatching).toBe(false);
-        expect(result.value.watchMode).toBe("subscribe");
-      }
-      expect(db.delete).toHaveBeenCalled();
-    });
-
     it("should handle DB errors gracefully", async () => {
       vi.mocked(db.query.machineWatchers.findFirst).mockRejectedValue(
         new Error("DB Error")
@@ -98,23 +63,6 @@ describe("Machines Service", () => {
   });
 
   describe("updateMachineWatchMode", () => {
-    it("should update watch mode successfully", async () => {
-      chain.returning.mockResolvedValue([{ userId, machineId }]);
-
-      const result = await updateMachineWatchMode({
-        machineId,
-        userId,
-        watchMode: "subscribe",
-      });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value.watchMode).toBe("subscribe");
-      }
-      expect(db.update).toHaveBeenCalled();
-      expect(chain.set).toHaveBeenCalledWith({ watchMode: "subscribe" });
-    });
-
     it("should validate watch mode", async () => {
       const result = await updateMachineWatchMode({
         machineId,


### PR DESCRIPTION
## Summary

Migrates 3 of 6 machine-watcher service blocks from `src/test/unit/machines.test.ts` to a new `Machine Watcher Service (PGlite)` describe in `src/test/integration/machines.test.ts`. Part of the PP-x4li.1.4 Wave 4 audit cleanup.

## Per-block disposition (6 total → 3 RECLASS, 3 KEEP-unit)

| Block | Decision | Rationale |
|---|---|---|
| `toggleMachineWatcher` — watch if not already watching | **RECLASS** | Asserts a `machineWatchers` row is inserted in the real DB |
| `toggleMachineWatcher` — unwatch if already watching | **RECLASS** | Seeds a watcher row, calls toggle, asserts row is deleted |
| `toggleMachineWatcher` — handle DB errors gracefully | **KEEP-unit** | Forced rejection via mock — cannot reproduce with real DB |
| `updateMachineWatchMode` — update watch mode successfully | **RECLASS** | Seeds a watcher row, asserts `watchMode` persisted via DB query |
| `updateMachineWatchMode` — validate watch mode | **KEEP-unit** | Zod validation fires pre-DB; `db.update` must not be called |
| `updateMachineWatchMode` — handle DB errors gracefully | **KEEP-unit** | Forced rejection via mock — cannot reproduce with real DB |

## New watcher integration coverage

3 new tests in `src/test/integration/machines.test.ts` under `Machine Watcher Service (PGlite)`:
- `should watch if not already watching` — asserts INSERT via `db.query.machineWatchers.findFirst`
- `should unwatch if already watching` — seeds row, asserts DELETE
- `should update watch mode successfully` — asserts UPDATE persisted

## DB wiring

Matches the canonical pattern from `issue-services.test.ts` (Wave 3 exemplar):
- `vi.mock("~/server/db")` proxy at file level forwards all operations to `(globalThis as any).testDb`
- `beforeAll` seeds `globalThis.testDb = await getTestDb()`
- `setupTestDb()` handles worker-scoped PGlite init + `afterEach` cleanup
- No duplicate `vi.mock("~/server/db")` — added once at the top of the integration file; the existing CRUD/status/presence describes use `getTestDb()` directly and are unaffected

## Quality gates

- `pnpm exec vitest run src/test/unit/machines.test.ts --project=unit` — 3 passed
- `FORCE_MEM_PRECHECK=skip pnpm exec vitest run src/test/integration/machines.test.ts --project=integration` — 21 passed (18 existing + 3 new)
- `pnpm run check` — all 1208 tests passed, types + lint clean

## Worktree

Root `main` is untouched. All work in worktree `agent-af738715923f72487` on branch `test/wave4-machines-watcher-reclass-PP-x4li`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)