### PR TITLE
feat(timeline): explicit DEFAULT_TIMELINE_TAGS query seam (PP-8oy0)

### DIFF
--- a/src/app/(app)/m/[initials]/(tabs)/timeline/page.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/timeline/page.tsx
@@ -18,7 +18,11 @@ import {
 import { createClient } from "~/lib/supabase/server";
 import { isMachineIssueEvent } from "~/lib/timeline/machine-event-types";
 import { getMachineTimeline } from "~/lib/timeline/machine-events";
-import { tagSchema, type TimelineTag } from "~/lib/timeline/machine-tags";
+import {
+  DEFAULT_TIMELINE_TAGS,
+  tagSchema,
+  type TimelineTag,
+} from "~/lib/timeline/machine-tags";
 import { db } from "~/server/db";
 import { machines, userProfiles } from "~/server/db/schema";
 
@@ -105,11 +109,16 @@ export default async function MachineTimelinePage({
   const machineOwnerId = machine.ownerId;
   const machineName = machine.name;
 
+  // At the default (no ?tag=), apply the explicit default tag set rather than
+  // omitting the filter — the query seam PP-43q3 needs to default a tag OFF.
+  // Equal to the full tag list today, so results are byte-identical.
+  const effectiveTags = tags.length > 0 ? tags : [...DEFAULT_TIMELINE_TAGS];
+
   // Fetch one extra row so we can detect whether a next page exists without
   // a separate COUNT(*) query. Trim it back to PAGE_SIZE before rendering.
   const fetched = await getMachineTimeline(db, {
     machineId,
-    ...(tags.length > 0 ? { tags } : {}),
+    tags: effectiveTags,
     limit: PAGE_SIZE + 1,
     offset: (currentPage - 1) * PAGE_SIZE,
   });

--- a/src/lib/timeline/machine-tags.test.ts
+++ b/src/lib/timeline/machine-tags.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   TIMELINE_TAGS,
+  DEFAULT_TIMELINE_TAGS,
   RESERVED_TAGS,
   tagSchema,
   userTagSchema,
@@ -21,6 +22,10 @@ describe("machine-tags", () => {
       "note",
       "highlight",
     ]);
+  });
+
+  it("DEFAULT_TIMELINE_TAGS equals the full tag list (until PP-43q3)", () => {
+    expect([...DEFAULT_TIMELINE_TAGS]).toEqual([...TIMELINE_TAGS]);
   });
 
   it("marks lifecycle and issue as reserved", () => {

--- a/src/lib/timeline/machine-tags.ts
+++ b/src/lib/timeline/machine-tags.ts
@@ -29,6 +29,16 @@ export const TIMELINE_TAGS = [
 
 export type TimelineTag = (typeof TIMELINE_TAGS)[number];
 
+/**
+ * The tag set applied when the machine-timeline filter has no explicit `?tag=`
+ * param. Currently equals the full {@link TIMELINE_TAGS} list, so the default
+ * view is byte-identical to "show everything". It exists as a separate explicit
+ * constant so PP-43q3 can later default an individual tag (e.g. `settings`) OFF
+ * by editing this one line without touching the query/filter wiring. KEEP THIS
+ * EQUAL TO `TIMELINE_TAGS` until PP-43q3 deliberately drops a tag.
+ */
+export const DEFAULT_TIMELINE_TAGS = TIMELINE_TAGS;
+
 export const RESERVED_TAGS = [
   "lifecycle",
   "issue",

--- a/src/test/integration/machine-timeline-events.test.ts
+++ b/src/test/integration/machine-timeline-events.test.ts
@@ -10,6 +10,7 @@ import {
   softDeleteMachineComment,
   getMachineTimeline,
 } from "~/lib/timeline/machine-events";
+import { DEFAULT_TIMELINE_TAGS } from "~/lib/timeline/machine-tags";
 import type { ProseMirrorDoc } from "~/lib/tiptap/types";
 
 describe("machine-events helpers (PGlite)", () => {
@@ -336,6 +337,30 @@ describe("machine-events helpers (PGlite)", () => {
 
       expect(rows).toHaveLength(1);
       expect(rows[0].tag).toBe("maintenance");
+    });
+
+    it("omitted filter === DEFAULT_TIMELINE_TAGS (byte-identical default)", async () => {
+      const { db, user, machine } = await seed();
+      for (const tag of ["maintenance", "cleaning", "inspection"] as const) {
+        await createMachineComment(
+          machine.id,
+          {
+            content: { type: "doc", content: [] },
+            tag,
+            authorId: user.id,
+          },
+          db
+        );
+      }
+
+      const omitted = await getMachineTimeline(db, { machineId: machine.id });
+      const withDefault = await getMachineTimeline(db, {
+        machineId: machine.id,
+        tags: [...DEFAULT_TIMELINE_TAGS],
+      });
+
+      expect(omitted.length).toBeGreaterThan(0);
+      expect(withDefault.map((r) => r.id)).toEqual(omitted.map((r) => r.id));
     });
 
     it("includes soft-deleted rows (UI handles tombstone display)", async () => {


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_TIMELINE_TAGS` to `src/lib/timeline/machine-tags.ts` (currently equal to the full `TIMELINE_TAGS` list) — the explicit default tag set for the machine timeline.
- Routes the machine-timeline page's default through it: when there's no `?tag=` param, the `getMachineTimeline` query now applies `DEFAULT_TIMELINE_TAGS` explicitly (via a query-only `effectiveTags`) instead of omitting the filter. The filter chips and pagination URLs still read from the raw parsed `tags`, so there is **zero visible UI change**.
- **Lean precursor for PP-43q3** (Machine Settings), which will default a `settings` tag OFF by editing the one constant. The bead's fuller filter-UI redesign (materialized chips, full-set URL serialization, a shared-`MultiSelect` badge-suppression prop) is deliberately deferred to PP-43q3 — today `DEFAULT == all tags`, so none of that machinery has anything to exercise it, and it would touch a component two other filters share. This PR plants only the constant + query seam.

### Why byte-identical
`timeline_events.tag` is `text().notNull()` with an index on `(machineId, tag)`. For all valid-enum data, `tags = all 10` is equivalent to omitting the filter. The only out-of-enum possibility is a retired legacy `event` row (none in seed/test data); for such a row the SQL `inArray` excludes it slightly earlier than the existing post-LIMIT read-boundary drop — strictly more correct, benign.

## Test Plan

- [x] `pnpm run check` — 1212 unit tests pass (incl. new `DEFAULT_TIMELINE_TAGS` deep-equal guard)
- [x] `pnpm run test:integration` — 272 tests pass (incl. new byte-identicality test: omitted filter === `[...DEFAULT_TIMELINE_TAGS]` by row id/order)
- [x] `tsc --noEmit` clean; build passes
- [ ] CI green

## Related Issues

Bead PP-8oy0. Must merge before PP-43q3 timeline integration (blocks PP-43q3).