### PR TITLE
fix(workflow): quote sem command in heavy-run.sh to stop word-splitting space-containing args (PP-yso5)

### DIFF
--- a/scripts/workflow/heavy-run.sh
+++ b/scripts/workflow/heavy-run.sh
@@ -54,8 +54,15 @@ if ! command -v sem >/dev/null 2>&1 \
   exec "$@"
 fi
 
+# sem re-joins its command argv and re-parses it through a shell, so an argument
+# that legitimately contains a space (e.g. --project='Mobile Chrome' from the
+# `smoke` script) would be word-split into two tokens. Pre-quote each argument
+# with printf %q and hand sem a single string; the shell sem spawns then
+# reconstructs the exact original argv. See PP-yso5.
+quoted_cmd="$(printf '%q ' "$@")"
+
 # --jobs 2:               up to 2 concurrent bare heavy jobs across all worktrees
 # --id pinpoint-heavy:    pool distinct from preflight's (see header — avoids
 #                         a self-deadlock when preflight nests these commands)
 # --fg:                   block synchronously and propagate exit code
-exec sem --jobs 2 --id pinpoint-heavy --fg "$@"
+exec sem --jobs 2 --id pinpoint-heavy --fg "$quoted_cmd"


### PR DESCRIPTION
## Summary

- `scripts/workflow/heavy-run.sh` passed `"$@"` directly to GNU parallel's `sem`, which re-joins its command argv and re-parses it through a shell. An argument that legitimately contains a space — `--project='Mobile Chrome'` / `--project='Mobile Safari'` from the `smoke` script — was re-split into `--project=Mobile` + a stray `Chrome` token, so Playwright failed with `Error: Project(s) "Mobile" not found`.
- This broke `pnpm run smoke` **and** `pnpm run preflight` (smoke is preflight's final sequential step) for every session — both are core pre-commit gates. Introduced by the PP-3vdr preflight rework.
- Fix: pre-quote each argument with `printf %q` and hand `sem` a single string; the shell `sem` spawns then reconstructs the exact original argv.

## Test Plan

- [x] Reproduced the word-split directly (`sem … bash showargs.sh --project="Mobile Chrome"` → `--project=Mobile` + `Chrome`); confirmed `printf %q` single-string form reconstructs the arg intact.
- [x] `heavy-run.sh playwright … --project='Mobile Chrome' --project='Mobile Safari' --list` now resolves all four smoke projects — no more `Project(s) "Mobile" not found`.
- [x] `pnpm run smoke` now sails past project resolution and webServer startup (the bug's failure point); remaining stops were unrelated local-env state, not the wrapper.
- [x] `pnpm run check` green (types, lint, format, shellcheck, 1212 unit tests).

## Related Issues

Closes PP-yso5 (P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)