### PR TITLE
fix(e2e): force dev mode in playwright loadEnvConfig so tests never load .env.production.local

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,15 @@ import { defineConfig, devices } from "@playwright/test";
 
 // Load .env.local using the same loader Next.js uses at runtime.
 // Idempotent — safe if Playwright re-evaluates this config per project.
-loadEnvConfig(process.cwd());
+//
+// `dev: true` is REQUIRED, not cosmetic. @next/env defaults `dev` to false,
+// which makes loadEnvConfig load PRODUCTION env files (.env.production.local
+// first, highest precedence). On a checkout that has a .env.production.local
+// (the root checkout keeps one for prod ops), that silently points the entire
+// E2E harness — including global-setup's `db:reset` / `supabase db reset` /
+// migrate — at PRODUCTION. Forcing dev mode loads .env.local (local stack)
+// and never touches .env.production.local. See PP-yso5 follow-up.
+loadEnvConfig(process.cwd(), true);
 
 // Worktree-aware: PORT is set per-worktree in .env.local by post-checkout hook
 const port = Number(process.env["PORT"] ?? "3000");


### PR DESCRIPTION
## Summary

- `playwright.config.ts` called `loadEnvConfig(process.cwd())` **without** the `dev` arg. `@next/env` defaults `dev` to `false`, which selects **production** env mode and loads `.env.production.local` *first* (highest precedence).
- On any checkout that keeps a `.env.production.local` — the **root checkout intentionally does**, for prod ops like `db:backup` — this silently repointed the whole E2E harness (including `e2e/global-setup.ts`'s destructive `db:reset` / `supabase db reset` / migrate) at the **production** Supabase project. Only a prod auth `401` stopped a real run from proceeding.
- Worktrees never have a `.env.production.local`, so the bug was invisible there and only surfaced running smoke/preflight from the root checkout (discovered chasing PP-yso5).
- **Fix:** pass `dev: true` so the loader uses development mode (`.env.local` → local stack) and never touches `.env.production.local`. Safe for CI, which sets env vars directly (the loader does not override already-set `process.env`).

## Test Plan

- [x] With a throwaway `.env.production.local` present in a worktree: `loadEnvConfig(cwd)` resolved `NEXT_PUBLIC_SUPABASE_URL` to the bogus prod URL; `loadEnvConfig(cwd, true)` resolved to the local `.env.local` URL (`http://localhost:54421`).
- [x] `pnpm run check` green (types, lint, format, shellcheck, 1201 unit tests).
- [x] Confirmed against `@next/env` source: mode = `NODE_ENV==="test" ? "test" : dev ? "development" : "production"`.

## Related Issues

Follow-up to PP-yso5 (root-caused while investigating why root-checkout smoke hit prod Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)