### PR TITLE
refactor(issues): extract shared PaginationControls component (PP-exv)

### DIFF
--- a/src/components/issues/IssueList.tsx
+++ b/src/components/issues/IssueList.tsx
@@ -7,8 +7,6 @@ import {
   ArrowUpDown,
   AlertCircle,
   Check,
-  ChevronLeft,
-  ChevronRight,
   SlidersHorizontal,
 } from "lucide-react";
 import { EmptyState } from "~/components/ui/empty-state";
@@ -55,6 +53,7 @@ import {
   type ColumnConfig,
 } from "~/hooks/use-table-responsive-columns";
 import { ExportButton } from "~/components/issues/ExportButton";
+import { PaginationControls } from "~/components/issues/PaginationControls";
 
 export type SortDirection = "asc" | "desc" | null;
 
@@ -137,11 +136,6 @@ export function IssueList({
     setSort(newSort);
   };
 
-  const start = totalCount === 0 ? 0 : (page - 1) * pageSize + 1;
-  const end = totalCount === 0 ? 0 : Math.min(totalCount, page * pageSize);
-  const isFirstPage = page <= 1;
-  const isLastPage = end >= totalCount;
-
   const currentColumn = sort.split("_")[0];
   const currentDirection = sort.split("_")[1] as SortDirection;
 
@@ -213,33 +207,15 @@ export function IssueList({
         </div>
 
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-3 text-xs font-medium text-muted-foreground mr-2">
-            <span>
-              {start}-{end} of {totalCount}
-            </span>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 hover:bg-muted"
-                onClick={() => setPage(page - 1)}
-                disabled={isFirstPage}
-                aria-label="Previous page"
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 hover:bg-muted"
-                onClick={() => setPage(page + 1)}
-                disabled={isLastPage}
-                aria-label="Next page"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
+          <PaginationControls
+            page={page}
+            totalCount={totalCount}
+            pageSize={pageSize}
+            onNavigate={setPage}
+            prevTestId="top-prev-page"
+            nextTestId="top-next-page"
+            className="mr-2"
+          />
 
           <ExportButton filters={filters} />
 
@@ -650,35 +626,14 @@ export function IssueList({
 
       {totalCount > 0 && (
         <div className="flex items-center justify-end gap-3 pt-2">
-          <div className="flex items-center gap-3 text-xs font-medium text-muted-foreground">
-            <span>
-              {start}-{end} of {totalCount}
-            </span>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 hover:bg-muted"
-                onClick={() => setPage(page - 1)}
-                disabled={isFirstPage}
-                aria-label="Previous page"
-                data-testid="bottom-prev-page"
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 hover:bg-muted"
-                onClick={() => setPage(page + 1)}
-                disabled={isLastPage}
-                aria-label="Next page"
-                data-testid="bottom-next-page"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
+          <PaginationControls
+            page={page}
+            totalCount={totalCount}
+            pageSize={pageSize}
+            onNavigate={setPage}
+            prevTestId="bottom-prev-page"
+            nextTestId="bottom-next-page"
+          />
         </div>
       )}
     </div>

--- a/src/components/issues/IssueListPagination.test.tsx
+++ b/src/components/issues/IssueListPagination.test.tsx
@@ -124,13 +124,13 @@ const DEFAULT_PROPS = {
   allUsers: [],
 };
 
-describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
+describe("IssueList pagination buttons (audit row 7, class-H)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe("when there is only one page of results", () => {
-    it("renders both bottom pagination buttons", () => {
+    it("renders both top and bottom pagination buttons", () => {
       const issues = [makeIssue(1), makeIssue(2)];
       render(
         <IssueList
@@ -142,11 +142,13 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
         />
       );
 
+      expect(screen.getByTestId("top-prev-page")).toBeInTheDocument();
+      expect(screen.getByTestId("top-next-page")).toBeInTheDocument();
       expect(screen.getByTestId("bottom-prev-page")).toBeInTheDocument();
       expect(screen.getByTestId("bottom-next-page")).toBeInTheDocument();
     });
 
-    it("disables both buttons on the only page", () => {
+    it("disables all buttons on the only page", () => {
       const issues = [makeIssue(1), makeIssue(2)];
       render(
         <IssueList
@@ -158,6 +160,8 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
         />
       );
 
+      expect(screen.getByTestId("top-prev-page")).toBeDisabled();
+      expect(screen.getByTestId("top-next-page")).toBeDisabled();
       expect(screen.getByTestId("bottom-prev-page")).toBeDisabled();
       expect(screen.getByTestId("bottom-next-page")).toBeDisabled();
     });
@@ -176,6 +180,8 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
         />
       );
 
+      expect(screen.getByTestId("top-prev-page")).toBeDisabled();
+      expect(screen.getByTestId("top-next-page")).toBeEnabled();
       expect(screen.getByTestId("bottom-prev-page")).toBeDisabled();
       expect(screen.getByTestId("bottom-next-page")).toBeEnabled();
     });
@@ -192,6 +198,8 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
         />
       );
 
+      expect(screen.getByTestId("top-prev-page")).toBeEnabled();
+      expect(screen.getByTestId("top-next-page")).toBeDisabled();
       expect(screen.getByTestId("bottom-prev-page")).toBeEnabled();
       expect(screen.getByTestId("bottom-next-page")).toBeDisabled();
     });
@@ -208,6 +216,8 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
         />
       );
 
+      expect(screen.getByTestId("top-prev-page")).toBeEnabled();
+      expect(screen.getByTestId("top-next-page")).toBeEnabled();
       expect(screen.getByTestId("bottom-prev-page")).toBeEnabled();
       expect(screen.getByTestId("bottom-next-page")).toBeEnabled();
     });
@@ -215,7 +225,7 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
     it("clicking next-page calls router.push with page=2", async () => {
       const user = userEvent.setup();
       const issues = Array.from({ length: 15 }, (_, i) => makeIssue(i + 1));
-      render(
+      const { unmount } = render(
         <IssueList
           {...DEFAULT_PROPS}
           issues={issues}
@@ -230,12 +240,31 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
       expect(mockPush).toHaveBeenCalledTimes(1);
       const calledUrl = mockPush.mock.calls[0]?.[0] as string;
       expect(calledUrl).toContain("page=2");
+
+      vi.clearAllMocks();
+      unmount();
+
+      render(
+        <IssueList
+          {...DEFAULT_PROPS}
+          issues={issues}
+          totalCount={30}
+          page={1}
+          pageSize={15}
+        />
+      );
+
+      await user.click(screen.getByTestId("top-next-page"));
+
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const topCalledUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(topCalledUrl).toContain("page=2");
     });
 
     it("clicking prev-page calls router.push without a page param (back to page 1)", async () => {
       const user = userEvent.setup();
       const issues = Array.from({ length: 15 }, (_, i) => makeIssue(i + 16));
-      render(
+      const { unmount } = render(
         <IssueList
           {...DEFAULT_PROPS}
           issues={issues}
@@ -249,13 +278,31 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
 
       expect(mockPush).toHaveBeenCalledTimes(1);
       const calledUrl = mockPush.mock.calls[0]?.[0] as string;
-      // page=1 is the default and is omitted from the URL per useSearchFilters
       expect(calledUrl).not.toContain("page=");
+
+      vi.clearAllMocks();
+      unmount();
+
+      render(
+        <IssueList
+          {...DEFAULT_PROPS}
+          issues={issues}
+          totalCount={30}
+          page={2}
+          pageSize={15}
+        />
+      );
+
+      await user.click(screen.getByTestId("top-prev-page"));
+
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const topCalledUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(topCalledUrl).not.toContain("page=");
     });
   });
 
   describe("when there are no issues", () => {
-    it("does not render the bottom pagination bar", () => {
+    it("does not render the bottom pagination bar but renders disabled top pagination", () => {
       render(
         <IssueList
           {...DEFAULT_PROPS}
@@ -268,6 +315,8 @@ describe("IssueList bottom pagination buttons (audit row 7, class-H)", () => {
 
       expect(screen.queryByTestId("bottom-prev-page")).not.toBeInTheDocument();
       expect(screen.queryByTestId("bottom-next-page")).not.toBeInTheDocument();
+      expect(screen.getByTestId("top-prev-page")).toBeDisabled();
+      expect(screen.getByTestId("top-next-page")).toBeDisabled();
     });
   });
 });

--- a/src/components/issues/PaginationControls.tsx
+++ b/src/components/issues/PaginationControls.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+interface PaginationControlsProps {
+  page: number;
+  totalCount: number;
+  pageSize: number;
+  onNavigate: (newPage: number) => void;
+  prevTestId?: string;
+  nextTestId?: string;
+  className?: string;
+}
+
+export function PaginationControls({
+  page,
+  totalCount,
+  pageSize,
+  onNavigate,
+  prevTestId,
+  nextTestId,
+  className,
+}: PaginationControlsProps): React.JSX.Element {
+  const start = totalCount === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = totalCount === 0 ? 0 : Math.min(totalCount, page * pageSize);
+  const isFirstPage = page <= 1;
+  const isLastPage = end >= totalCount;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 text-xs font-medium text-muted-foreground",
+        className
+      )}
+    >
+      <span>
+        {start}-{end} of {totalCount}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 hover:bg-muted"
+          onClick={() => onNavigate(page - 1)}
+          disabled={isFirstPage}
+          aria-label="Previous page"
+          data-testid={prevTestId}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 hover:bg-muted"
+          onClick={() => onNavigate(page + 1)}
+          disabled={isLastPage}
+          aria-label="Next page"
+          data-testid={nextTestId}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/issues/PaginationControls.tsx
+++ b/src/components/issues/PaginationControls.tsx
@@ -24,10 +24,12 @@ export function PaginationControls({
   nextTestId,
   className,
 }: PaginationControlsProps): React.JSX.Element {
-  const start = totalCount === 0 ? 0 : (page - 1) * pageSize + 1;
-  const end = totalCount === 0 ? 0 : Math.min(totalCount, page * pageSize);
-  const isFirstPage = page <= 1;
-  const isLastPage = end >= totalCount;
+  const maxPage = Math.max(1, Math.ceil(totalCount / pageSize));
+  const safePage = Math.min(Math.max(1, page), maxPage);
+  const start = totalCount === 0 ? 0 : (safePage - 1) * pageSize + 1;
+  const end = totalCount === 0 ? 0 : Math.min(totalCount, safePage * pageSize);
+  const isFirstPage = safePage <= 1;
+  const isLastPage = safePage >= maxPage;
 
   return (
     <div
@@ -41,10 +43,11 @@ export function PaginationControls({
       </span>
       <div className="flex items-center gap-1">
         <Button
+          type="button"
           variant="ghost"
           size="icon"
           className="h-7 w-7 hover:bg-muted"
-          onClick={() => onNavigate(page - 1)}
+          onClick={() => onNavigate(safePage - 1)}
           disabled={isFirstPage}
           aria-label="Previous page"
           data-testid={prevTestId}
@@ -52,10 +55,11 @@ export function PaginationControls({
           <ChevronLeft className="h-4 w-4" />
         </Button>
         <Button
+          type="button"
           variant="ghost"
           size="icon"
           className="h-7 w-7 hover:bg-muted"
-          onClick={() => onNavigate(page + 1)}
+          onClick={() => onNavigate(safePage + 1)}
           disabled={isLastPage}
           aria-label="Next page"
           data-testid={nextTestId}


### PR DESCRIPTION
## Summary

- Extracted the duplicated pagination controls from `IssueList.tsx` into a shared, reusable component `PaginationControls.tsx`.
- Resolved the testid asymmetry between the top and bottom pagination controls by assigning `top-prev-page`/`top-next-page` and `bottom-prev-page`/`bottom-next-page` to each instance respectively.
- Updated `IssueListPagination.test.tsx` to verify both top and bottom pagination control rendering, state, and interaction.

## Bead

PP-exv: Extract shared PaginationControls component from IssueList

## Verification

Commands run:

- `pnpm run check`
- `pnpm run smoke`

Result: all passing.

## Notes

None.