### PR TITLE
feat(huddle): add session kickoff posts + default participation

### DIFF
--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -167,6 +167,8 @@ When the hook finds new comments since this worktree's last cursor, it injects t
 
 Comments signed by your own session (matching `—<YourName>` or `—Claude-<YourName>`) are filtered out — you won't see your own posts re-injected.
 
+**Peer-response etiquette:** when a peer's kickoff or update scrolls by, reply only if you have _specific relevant context_ — a conflict with what they're touching, a gotcha you hit there, a related in-flight branch or bead. Don't ack-spam ("sounds good", "noted") — silence is the correct response when you have nothing concrete to add.
+
 ### Throttle override
 
 Edit `.claude/settings.json` and update `HUDDLE_THROTTLE_SECONDS=180` on the PostToolUse hook command line. Setting it to `0` polls on every tool call — useful for debugging only. To stop PostToolUse polling entirely, remove the entire PostToolUse entry from `.claude/settings.json` (UserPromptSubmit polling continues regardless).
@@ -180,6 +182,7 @@ Edit `.claude/settings.json` and update `HUDDLE_THROTTLE_SECONDS=180` on the Pos
 
 **What still requires a manual post** (the judgment calls automation can't make):
 
+- **A session kickoff** — once per session, after you understand the goal, for substantive work or investigations (not trivial Q&A or one-line fixes): "Starting: <what> in <area/branch>. Ping me if you have context." This lets parallel sessions learn about your work early — before something ships — so anyone with a relevant gotcha, conflict, or in-flight branch can chime in.
 - A bead you filed for a non-obvious finding: "Filed PP-xxx: <finding>."
 - A coordination need — file/area conflict risk: "Working on <file/area> in <branch>; flag if conflict."
 
@@ -196,7 +199,7 @@ Things NOT worth posting:
 
 - Every single commit
 - Internal debugging chatter
-- "I started working on X" (merges and PR-opens are already auto-posted)
+- A _bare_ status ping with no scope or invitation ("I started working on X") — that's noise. But a **scoped kickoff with an invitation** (specific area/branch + "ping me if you have context") **is** worth posting, once per session, for substantive work — see "What still requires a manual post" above.
 
 Sign with `—<YourFullRegisteredName>` (em-dash + your registered name). The self-filter matches this suffix to suppress your own echoes.
 

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -184,11 +184,16 @@ if [[ -n "$NAME" ]]; then
   # Resolve today_bead_id for the copy-paste command (fail-open: fall back to placeholder)
   _TODAY_ID_REG=$(huddle_today_bead_id 2>/dev/null) || _TODAY_ID_REG="<today-bead-id>"
   [[ -n "$_TODAY_ID_REG" ]] || _TODAY_ID_REG="<today-bead-id>"
-  printf 'Post a coordination update when you:\n'
-  printf '  - File a bead for a non-obvious finding: "Filed PP-xxx: <finding>. —<YourName>"\n'
-  printf '  - Touch an area others may conflict on: "Working on <file/area> in <branch>; flag if conflict. —<YourName>"\n'
-  printf '  (Merges and PR opens are auto-posted — no manual action needed for those.)\n\n'
+  printf 'Once you understand what this session is tackling — and it'\''s real work or an\n'
+  printf 'investigation (not a quick question or one-line fix) — post a ONE-LINE kickoff to\n'
+  printf 'today'\''s bead, once, so parallel sessions know and anyone with context can chime in:\n'
+  printf '    bd comments add %s "Starting: <what> in <area/branch>. Ping me if you have context. —%s"\n\n' "$_TODAY_ID_REG" "$NAME"
+  printf 'Also post when you: file a bead for a non-obvious finding ("Filed PP-xxx: <finding>"),\n'
+  printf 'or touch an area others may conflict on ("Working on <file/area> in <branch>; flag if conflict").\n'
+  printf '  (Merges and PR opens are auto-posted — no manual action needed for those.)\n'
   printf '    bd comments add %s "Your update. —%s"\n\n' "$_TODAY_ID_REG" "$NAME"
+  printf 'If a peer'\''s kickoff scrolls by and you have specific relevant context — a conflict,\n'
+  printf 'a gotcha, a related in-flight branch/bead — reply with it; don'\''t ack-spam.\n\n'
   # shellcheck disable=SC2016  # backticks are literal Markdown
   printf 'Full reference: `.agents/skills/pinpoint-huddle/SKILL.md`\n'
 else
@@ -209,7 +214,9 @@ else
   printf 'The harness prefix lets Tim see "two Claudes and one Antigravity are running."\n\n'
   printf 'Register with:\n'
   printf '    bash scripts/hooks/huddle-whoami.sh register <YourName> %s\n\n' "$SESSION_ID"
-  printf 'If the name is taken, the helper suggests variations.\n'
+  printf 'If the name is taken, the helper suggests variations.\n\n'
+  printf 'After registering, post a one-line kickoff to today'\''s bead describing what this\n'
+  printf 'session is tackling (skip it for trivial questions or one-line fixes).\n'
   # shellcheck disable=SC2016  # backticks are literal Markdown
   printf 'Full reference: `.agents/skills/pinpoint-huddle/SKILL.md`\n'
 fi


### PR DESCRIPTION
## What

Makes huddle participation **default behavior**: parallel agent sessions now post a one-line **kickoff** to today's coordination bead once they understand the session goal — so peers learn about in-flight work *before* something ships, and anyone with relevant context (a conflict, a gotcha, a related branch/bead) can chime in.

Implements the approved plan at `.claude/plans/glittery-spinning-candy.md`.

## Changes

**`scripts/hooks/huddle-session-start.sh`** (the ~300-token block injected at every session start):
- **Registered-name branch:** kickoff now leads — a one-line directive to post a scoped kickoff (`bd comments add <today> "Starting: <what> in <area/branch>. Ping me if you have context. —<Name>"`), once per session, for substantive work/investigations only (skip trivial Q&A and one-line fixes). The existing filed-bead / conflict-area cases are condensed below it, the "merges & PR opens auto-posted" note is kept, and peer etiquette is added (reply only with specific relevant context; no ack-spam). Existing `$NAME` / today-bead-ID interpolation reused.
- **Registration-needed branch:** one extra line after the `register` command telling the freshly-registered session to post a kickoff (skip for trivial questions / one-line fixes).
- Additions kept tight — a handful of `printf` lines, preserving the token-efficiency rationale behind the original design.

**`pinpoint-huddle` skill** (canonical `.agents/skills/pinpoint-huddle/SKILL.md`; `.claude/skills` is a symlink to it):
- Resolves the contradiction where "I started working on X" was listed under *Things NOT worth posting* while the hook now asks for a kickoff.
- "How to post coordination updates" → kickoff added as the first manual-post case.
- "Things NOT worth posting" → reworded so a *bare* status ping is still noise, but a **scoped kickoff with an invitation** is worth posting (cross-referenced).
- Peer-response etiquette added near the poll/self-filter discussion.

This is harness-wide: Claude Code, Antigravity, and Codex all call the same shared hook script.

## Out of scope (per plan)

No new hook machinery / per-session kickoff marker; no change to `huddle-poll.sh` injection format; the dated design-spec record was left untouched.

## Verification

- Registered-path and registration-path hook output rendered correctly (kickoff directive + command + peer etiquette; correct `$NAME` and today-bead-ID interpolation). `source=compact` still suppresses output (0 bytes).
- shellcheck clean on the edited script.
- `pnpm run check` passed (137 test files, 1198 tests; includes shellcheck + the pytest hook harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)