### PR TITLE
fix(report): bound report route + flush Sentry before exit (PP-2053.1)

### DIFF
--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import * as Sentry from "@sentry/nextjs";
 import { redirect } from "next/navigation";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { revalidatePath } from "next/cache";
@@ -406,6 +407,15 @@ export async function submitPublicIssueAction(
     return {
       error: "Unable to submit the issue. Please try again.",
     };
+  } finally {
+    // Flush queued Sentry events before the serverless function returns and the
+    // instance can be frozen/reclaimed. Without this, an error captured by the
+    // catch above (or any best-effort reportError on this request) can be
+    // dropped on exit — the silence that hid the Doodle Bug incident. With no
+    // events pending this settles in a microtask; when events are queued it
+    // waits up to 2s to send them — the intended trade for guaranteed delivery
+    // on this low-frequency submit path. (PP-2053.1)
+    await Sentry.flush(2000);
   }
 }
 

--- a/src/app/(app)/report/page.tsx
+++ b/src/app/(app)/report/page.tsx
@@ -13,6 +13,13 @@ import { getRecentIssuesAction, type RecentIssueData } from "./actions";
 // Avoid SSG hitting Supabase during builds that run parallel to db resets
 export const dynamic = "force-dynamic";
 
+// Bound the route (which hosts the report Server Action) so a slow submission
+// fails fast as a deterministic 504 rather than an opaque platform SIGKILL —
+// giving submitPublicIssueAction's catch + Sentry.flush a chance to run. This
+// is the interim guard for the silent-failure class (incident: Doodle Bug).
+// (PP-2053.1)
+export const maxDuration = 60;
+
 export default async function PublicReportPage({
   searchParams,
 }: {


### PR DESCRIPTION
## What

Interim observability guard (epic **PP-2053**, bead **PP-2053.1**) for the silent issue-submission failure class surfaced by the **Doodle Bug** incident: a slow email HTTP call inside the `createIssue` transaction let the serverless function be SIGKILLed before `COMMIT` and before the action's `catch` ran — so the rollback (lost report) reached no Sentry alert.

## Changes

- **`report/page.tsx`** — `export const maxDuration = 60` so the route (which hosts the report Server Action) fails at a known ceiling instead of an opaque platform kill. Matches the existing cron route.
- **`report/actions.ts`** — `await Sentry.flush(2000)` in a `finally` around `submitPublicIssueAction`, so an error captured by the `catch` (or any best-effort `reportError` on the request) is sent before the function returns and the instance is reclaimed.

## Scope / why interim

This does **not** move the email out of the transaction — that's the dedicated refactor (PP-2053.2 / .3). This bead is purely the alert net so the failure class is observable *now*. `maxDuration` governs the whole route segment (page render + action); there's no Next.js lever to scope it to the action alone, and 60 s is a deliberate ceiling.

## Verification

`pnpm run check` green (137 files, 1198 tests); pre-commit (eslint/prettier/typecheck) clean. The platform-SIGKILL flush path can't be unit-tested (documented in the bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)