### PR TITLE
test: /preview controller live check (throwaway)

### DIFF
--- a/docs/.preview-smoke-test.md
+++ b/docs/.preview-smoke-test.md
@@ -1,0 +1,3 @@
+# Preview pipeline smoke test
+
+Throwaway PR to validate the on-demand `/preview` controller (create → migrate → seed → Vercel wire → TTL). Safe to close.


### PR DESCRIPTION
Throwaway PR to validate the on-demand preview controller end-to-end (the live spike for #1511). I'll comment `/preview`, verify the branch/migrate/seed/Vercel-wire pipeline + sticky comment, then tear it down. Safe to close.