### PR TITLE
fix(issues): replace silent not-found redirect with notFound() + scoped page (PP-2053.9)

### DIFF
--- a/src/app/(app)/m/[initials]/i/[issueNumber]/not-found.test.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/not-found.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import IssueNotFound from "./not-found";
+
+/**
+ * Thin render smoke test for the issue-level not-found page (PP-2053.9).
+ *
+ * Verifies that the component:
+ *  - renders without throwing
+ *  - shows the actionable user-facing message
+ *  - exposes the two CTA links (report + browse)
+ *  - does NOT expose any internal detail or PII (CORE-SEC-007)
+ */
+describe("IssueNotFound", () => {
+  it("renders the not-found page with actionable copy and links", () => {
+    render(<IssueNotFound />);
+
+    expect(
+      screen.getByRole("heading", { name: /issue not found/i })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/report may not have been saved/i)
+    ).toBeInTheDocument();
+
+    const reportLink = screen.getByRole("link", { name: /report an issue/i });
+    expect(reportLink).toBeInTheDocument();
+    expect(reportLink).toHaveAttribute("href", "/report");
+
+    const browseLink = screen.getByRole("link", { name: /browse all issues/i });
+    expect(browseLink).toBeInTheDocument();
+    expect(browseLink).toHaveAttribute("href", "/issues");
+  });
+
+  it("does not expose internal identifiers or email addresses (CORE-SEC-007)", () => {
+    const { container } = render(<IssueNotFound />);
+    // No emails, no database IDs, no stack trace fragments
+    expect(container.textContent).not.toMatch(/@/);
+    expect(container.textContent).not.toMatch(/uuid|id=|Error:|stack/i);
+  });
+});

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/not-found.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/not-found.tsx
@@ -1,0 +1,42 @@
+import type React from "react";
+import Link from "next/link";
+
+import { Button } from "~/components/ui/button";
+
+/**
+ * Scoped 404 for the issue detail segment.
+ *
+ * Shown when an issue number is invalid or the issue does not exist in the
+ * database (e.g. a rolled-back submission). Offers the user a direct link to
+ * the report page so they can re-submit without hunting for it.
+ *
+ * Note on machine initials: Next.js does not pass route params to not-found.tsx.
+ * The report link therefore falls back to the generic /report page rather than
+ * the machine-scoped /report?machine=<initials>. This is intentional — wiring
+ * initials reliably from a not-found boundary would require undocumented
+ * internal headers. A generic report link is the safest choice here; the
+ * machine picker on /report lets the user select the right machine.
+ */
+export default function IssueNotFound(): React.JSX.Element {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4">
+      <div className="max-w-md text-center">
+        <h1 className="text-6xl font-bold text-muted-foreground/20">404</h1>
+        <h2 className="mt-4 text-2xl font-semibold">Issue not found</h2>
+        <p className="mt-3 text-muted-foreground">
+          This issue could not be found. If you received an email link, the
+          report may not have been saved — please re-submit.
+        </p>
+        {/* sm-structural-allow: standalone full-width error page, viewport breakpoint is correct */}
+        <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <Button asChild>
+            <Link href="/report">Report an issue</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/issues">Browse all issues</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/page.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
@@ -67,7 +67,7 @@ export default async function IssueDetailPage({
   const issueNum = parseInt(issueNumber, 10);
 
   if (isNaN(issueNum) || issueNum < 1) {
-    redirect(`/m/${initials}`);
+    notFound();
   }
 
   // CORE-PERF-003: parallelize what's safe before role is known; the roster
@@ -157,7 +157,7 @@ export default async function IssueDetailPage({
   ]);
 
   if (!issue) {
-    redirect(`/m/${initials}`);
+    notFound();
   }
 
   const issueWithRelations = issue as unknown as IssueWithAllRelations;


### PR DESCRIPTION
## Summary

- Replace both `redirect(...)` calls in the issue detail page (`/m/[initials]/i/[issueNumber]/page.tsx`) with `notFound()` — the invalid-issue-number guard (~line 69) and the missing-issue guard (~line 159)
- Add a scoped `not-found.tsx` at the same segment level with actionable copy: "This issue could not be found. If you received an email link, the report may not have been saved — please re-submit", plus links to `/report` and `/issues`
- Cover the component with a thin RTL smoke test confirming rendering, copy, and that no PII/internal identifiers are exposed (CORE-SEC-007)

## Params decision: `initials` in not-found.tsx

Next.js does not pass route params to `not-found.tsx` components. Two options were considered:

1. **Parse `initials` from `headers()` / request URL** — fragile without middleware explicitly setting a pathname header; the app has no root `middleware.ts`, so no `x-pathname` is set. Using undocumented internal headers (e.g. `x-invoke-path`) is an implementation detail that can break across Next.js versions.
2. **Generic `/report` link** — always safe, always correct, always renders without async calls. The task explicitly noted this was acceptable.

Option 2 was chosen. The `/report` page has a machine picker, so users can select the right machine after landing there. The `not-found.tsx` is synchronous (no `async`), which is simpler and avoids adding a `next/headers` dependency that could complicate future testing.

## Test plan

- [x] `pnpm run check` passes (138 test files, 1200 tests, typecheck clean)
- [x] Not-found smoke renders: heading, copy, both links, no PII leak
- [ ] Manual: navigate to `/m/DDLBG/i/9999` — should show the 404 page, not silently redirect to `/m/DDLBG`
- [ ] Manual: navigate to `/m/DDLBG/i/abc` — same

Part of the Doodle Bug epic (PP-2053).

🤖 Generated with [Claude Code](https://claude.com/claude-code)