### PR TITLE
fix(settings): no redirect loop on missing profile (PP-etip)

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,7 +1,8 @@
 import type React from "react";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createClient } from "~/lib/supabase/server";
 import { getLoginUrl } from "~/lib/url";
+import { reportError } from "~/lib/observability/report-error";
 import { db } from "~/server/db";
 import {
   userProfiles,
@@ -36,8 +37,16 @@ export default async function SettingsPage(): Promise<React.JSX.Element> {
   });
 
   if (!profile) {
-    // Should not happen due to trigger, but handle gracefully
-    redirect(getLoginUrl("/settings"));
+    // Data-integrity anomaly: auth.users row exists but handle_new_user trigger
+    // did not create the user_profiles row. Redirecting to login would send the
+    // authenticated user into an infinite loop (login → already-authed → /settings
+    // → no profile → login again). Report to Sentry so the gap is visible, then
+    // render a 404 rather than looping.
+    reportError(new Error("Authenticated user has no user_profiles row"), {
+      action: "settings-page.missing-profile",
+      userId: user.id,
+    });
+    notFound();
   }
 
   // Fetch notification preferences

--- a/src/app/(app)/settings/settings-missing-profile.test.tsx
+++ b/src/app/(app)/settings/settings-missing-profile.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Integration test: authenticated user with no user_profiles row.
+ *
+ * Regression for PP-etip: the previous code redirected an authenticated user
+ * to the login URL when their profile row was missing, causing an infinite
+ * redirect loop (login → already-authed → /settings → no profile → login…).
+ *
+ * The correct behaviour is:
+ *   1. Call reportError so the data-integrity gap is visible in Sentry.
+ *   2. Call notFound() to render a 404 — no login redirect.
+ *
+ * Bug class: A (auth/route guard). Cheapest catching layer: integration,
+ * following the pattern in machine-info-tab-auth.test.tsx.
+ */
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { authUsers } from "~/server/db/schema";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+
+// ── Mocks (must be declared before dynamic imports) ────────────────────────
+
+const mockGetUser = vi.fn();
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: () => Promise.resolve(new Headers([["host", "localhost:3000"]])),
+  cookies: () => Promise.resolve({ get: () => undefined }),
+}));
+
+const mockNotFound = vi.fn(() => {
+  // Next.js notFound() throws internally; simulate that so the page stops.
+  throw new Error("NEXT_NOT_FOUND");
+});
+const mockRedirect = vi.fn();
+vi.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+const mockReportError = vi.fn();
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+  reportAuthError: vi.fn(),
+  serverActionError: vi.fn(),
+}));
+
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  const db = await getTestDb();
+  return { db };
+});
+
+// UI components — not exercised in the missing-profile path (notFound throws
+// before rendering), but must be resolvable at import time.
+vi.mock("~/lib/discord/config", () => ({
+  isDiscordIntegrationEnabled: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("~/lib/auth/internal-accounts", () => ({
+  isInternalAccount: vi.fn().mockReturnValue(false),
+}));
+vi.mock("~/app/(app)/settings/profile-form", () => ({
+  ProfileForm: () => null,
+}));
+vi.mock(
+  "~/app/(app)/settings/connected-accounts/connected-accounts-section",
+  () => ({
+    ConnectedAccountsSection: () => null,
+  })
+);
+vi.mock(
+  "~/app/(app)/settings/notifications/notification-preferences-form",
+  () => ({
+    NotificationPreferencesForm: () => null,
+  })
+);
+vi.mock("~/app/(app)/settings/change-password-section", () => ({
+  ChangePasswordSection: () => null,
+}));
+vi.mock("~/app/(app)/settings/delete-account-section", () => ({
+  DeleteAccountSection: () => null,
+}));
+vi.mock("~/app/(app)/settings/account-deletion", () => ({
+  getReassignmentTargets: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("~/components/ui/separator", () => ({ Separator: () => null }));
+vi.mock("~/components/layout/PageContainer", () => ({
+  PageContainer: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("~/components/layout/PageHeader", () => ({ PageHeader: () => null }));
+vi.mock("~/lib/cookies/preferences", () => ({
+  getLastIssuesPath: vi.fn().mockResolvedValue("/issues"),
+}));
+
+import type React from "react";
+
+// Import AFTER all vi.mock() declarations.
+const { default: SettingsPage } = await import("~/app/(app)/settings/page");
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("SettingsPage — authenticated user with missing profile (PP-etip)", () => {
+  setupTestDb();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls notFound() and reportError — does NOT redirect to login", async () => {
+    const userId = randomUUID();
+    const email = `missing-profile-${userId}@test.com`;
+
+    // Seed auth.users but intentionally omit user_profiles — the exact
+    // scenario where the trigger failed to create the row.
+    const db = await getTestDb();
+    await db.insert(authUsers).values({ id: userId, email });
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: userId, email } } });
+
+    // The page should throw via notFound() — catch it so the test can assert.
+    await expect(SettingsPage()).rejects.toThrow("NEXT_NOT_FOUND");
+
+    // reportError must have been called to surface this in Sentry.
+    expect(mockReportError).toHaveBeenCalledOnce();
+    const [errorArg, contextArg] = mockReportError.mock.calls[0];
+    expect(errorArg).toBeInstanceOf(Error);
+    expect((errorArg as Error).message).toMatch(/user_profiles/i);
+    expect(contextArg).toMatchObject({
+      action: "settings-page.missing-profile",
+      userId,
+    });
+
+    // The redirect to login must NOT have been called — that's the loop trigger.
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects unauthenticated visitors to login (control path unaffected)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    // The page hits the !user guard and calls redirect() normally.
+    // redirect() in Next.js throws internally too.
+    mockRedirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    await expect(SettingsPage()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mockRedirect).toHaveBeenCalledOnce();
+    expect(mockRedirect.mock.calls[0][0]).toMatch(/login|signin/i);
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(mockReportError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem (PP-etip)

An authenticated user whose `user_profiles` row is missing (the `handle_new_user` trigger didn't create it) was redirected to the login URL by `settings/page.tsx`. Because they're already authenticated, login bounced them straight back to `/settings`, which again found no profile and redirected to login — an **infinite redirect loop**.

## Fix

Replace the login redirect on the missing-profile branch with:
- `reportError(...)` — surface the data-integrity gap in Sentry (it indicates the trigger failed), and
- `notFound()` — render a terminal 404 instead of looping.

The unauthenticated control path (`!user` → login redirect) is unchanged.

Chose the **terminal-error** approach over inline profile-healing: healing would duplicate the `handle_new_user` trigger logic in app code, and a missing row is a genuine anomaly worth a Sentry signal + manual look rather than silent self-repair.

## Tests

`settings-missing-profile.test.tsx` (integration, PGlite): asserts the missing-profile path calls `notFound()` + `reportError` and does **not** redirect to login; plus a control test that the unauthenticated path still redirects to login.

`pnpm run check` green (142 files, 1227 tests).

Traces to the PP-2053 (Doodle Bug) lessons-learned sweep (L2).