### PR TITLE
fix(report): skip duplicate image insert on idempotent retry + surface silent image failures (PP-u0v1, PP-34gz)

### DIFF
--- a/src/app/(app)/issues/actions.ts
+++ b/src/app/(app)/issues/actions.ts
@@ -21,7 +21,10 @@ import {
   issueImages,
 } from "~/server/db/schema";
 import { log } from "~/lib/logger";
-import { serverActionError } from "~/lib/observability/report-error";
+import {
+  reportError,
+  serverActionError,
+} from "~/lib/observability/report-error";
 import {
   updateIssueStatusSchema,
   updateIssueSeveritySchema,
@@ -675,7 +678,12 @@ export async function addCommentAction(
       );
     } catch (e) {
       log.error({ err: e, issueId }, "Failed to parse comment images metadata");
-      // Non-blocking, but log it
+      reportError(e, {
+        action: "parseCommentImagesMetadata",
+        issueId,
+        bestEffort: true,
+      });
+      // Non-blocking — the comment still posts, but images are silently dropped
     }
   }
 

--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -266,7 +266,7 @@ export async function submitPublicIssueAction(
     "Submitting unified issue report..."
   );
   try {
-    const { issue, deliveryPlan } = await createIssue({
+    const { issue, deliveryPlan, deduped } = await createIssue({
       title,
       description: description ?? null,
       machineInitials: machine.initials,
@@ -296,54 +296,75 @@ export async function submitPublicIssueAction(
         const rawJson = JSON.parse(imagesMetadataStr) as unknown;
         const imagesMetadata = imagesMetadataArraySchema.parse(rawJson);
 
-        // Validate count respects limits (security measure against manual JSON editing)
-        const limit = reportedBy
-          ? BLOB_CONFIG.LIMITS.AUTHENTICATED_USER_MAX
-          : BLOB_CONFIG.LIMITS.PUBLIC_USER_MAX;
-
-        if (imagesMetadata.length > limit) {
-          log.warn(
-            { issueId: issue.id, count: imagesMetadata.length, limit },
-            "Blocked attempt to link too many images"
-          );
-          return {
-            error: `Too many images. Maximum ${limit} images allowed.`,
-          };
-        }
-
-        if (imagesMetadata.length > 0) {
-          log.info(
-            { issueId: issue.id, count: imagesMetadata.length },
-            "Linking images to issue..."
-          );
-          try {
-            await db.insert(issueImages).values(
-              imagesMetadata.map((img) => ({
-                issueId: issue.id,
-                uploadedBy: reportedBy,
-                fullImageUrl: img.blobUrl,
-                fullBlobPathname: img.blobPathname,
-                fileSizeBytes: img.fileSizeBytes,
-                mimeType: img.mimeType,
-                originalFilename: img.originalFilename,
-              }))
+        // On an idempotent retry the existing issue already has its images linked.
+        // The blobs uploaded for this retry attempt are redundant duplicates — clean
+        // them up and skip the DB insert to prevent duplicate issue_images rows.
+        // (PP-u0v1)
+        if (deduped) {
+          if (imagesMetadata.length > 0) {
+            log.info(
+              { issueId: issue.id, count: imagesMetadata.length },
+              "Idempotent retry — cleaning up redundant blobs, skipping image link"
             );
-          } catch (dbError) {
-            log.error(
-              {
-                err: dbError instanceof Error ? dbError.message : dbError,
-                issueId: issue.id,
-                orphanedBlobs: imagesMetadata.map((img) => img.blobPathname),
-              },
-              "Database failed to link images to issue. Cleaning up orphaned blobs."
-            );
-            // Immediate cleanup of orphaned blobs
             await Promise.allSettled(
               imagesMetadata.map((img) => deleteFromBlob(img.blobPathname))
             );
-            // Don't return error here - issue was already created successfully
-            // User will be redirected, but images won't appear on the issue
-            // TODO: Consider implementing a flash message system to show warning
+          }
+        } else {
+          // Validate count respects limits (security measure against manual JSON editing)
+          const limit = reportedBy
+            ? BLOB_CONFIG.LIMITS.AUTHENTICATED_USER_MAX
+            : BLOB_CONFIG.LIMITS.PUBLIC_USER_MAX;
+
+          if (imagesMetadata.length > limit) {
+            log.warn(
+              { issueId: issue.id, count: imagesMetadata.length, limit },
+              "Blocked attempt to link too many images"
+            );
+            return {
+              error: `Too many images. Maximum ${limit} images allowed.`,
+            };
+          }
+
+          if (imagesMetadata.length > 0) {
+            log.info(
+              { issueId: issue.id, count: imagesMetadata.length },
+              "Linking images to issue..."
+            );
+            try {
+              await db.insert(issueImages).values(
+                imagesMetadata.map((img) => ({
+                  issueId: issue.id,
+                  uploadedBy: reportedBy,
+                  fullImageUrl: img.blobUrl,
+                  fullBlobPathname: img.blobPathname,
+                  fileSizeBytes: img.fileSizeBytes,
+                  mimeType: img.mimeType,
+                  originalFilename: img.originalFilename,
+                }))
+              );
+            } catch (dbError) {
+              log.error(
+                {
+                  err: dbError instanceof Error ? dbError.message : dbError,
+                  issueId: issue.id,
+                  orphanedBlobs: imagesMetadata.map((img) => img.blobPathname),
+                },
+                "Database failed to link images to issue. Cleaning up orphaned blobs."
+              );
+              reportError(dbError, {
+                action: "linkIssueImages",
+                issueId: issue.id,
+                bestEffort: true,
+              });
+              // Immediate cleanup of orphaned blobs
+              await Promise.allSettled(
+                imagesMetadata.map((img) => deleteFromBlob(img.blobPathname))
+              );
+              // Don't return error here - issue was already created successfully
+              // User will be redirected, but images won't appear on the issue
+              // TODO: Consider implementing a flash message system to show warning
+            }
           }
         }
       } catch (parseError) {
@@ -354,6 +375,11 @@ export async function submitPublicIssueAction(
           },
           "Failed to parse images metadata"
         );
+        reportError(parseError, {
+          action: "parseIssueImagesMetadata",
+          issueId: issue.id,
+          bestEffort: true,
+        });
         // Non-blocking for the user
       }
     }

--- a/src/services/issues.ts
+++ b/src/services/issues.ts
@@ -159,7 +159,16 @@ export async function createIssue({
   assignedTo,
   autoWatchReporter = true,
   idempotencyKey,
-}: CreateIssueParams): Promise<{ issue: Issue; deliveryPlan: DeliveryPlan }> {
+}: CreateIssueParams): Promise<{
+  issue: Issue;
+  deliveryPlan: DeliveryPlan;
+  /**
+   * `true` when the idempotency key matched a prior successful submission and
+   * the existing issue was returned without any new writes. The caller MUST
+   * skip post-insert side effects (e.g. linking images) to avoid duplicates.
+   */
+  deduped: boolean;
+}> {
   // Resolve channels outside the transaction to avoid an HTTP round-trip
   // (Supabase Vault RPC) inside the DB connection window (PP-rfc).
   const channels = await getChannels();
@@ -181,7 +190,11 @@ export async function createIssue({
           { issueId: existing.id, idempotencyKey, action: "createIssue" },
           "Idempotent retry — returning existing issue, no new write"
         );
-        return { issue: existing, deliveryPlan: { deliveries: [] } };
+        return {
+          issue: existing,
+          deliveryPlan: { deliveries: [] },
+          deduped: true,
+        };
       }
     }
 
@@ -249,7 +262,11 @@ export async function createIssue({
             { issueId: winner.id, idempotencyKey, action: "createIssue" },
             "Idempotency conflict on insert — returning race winner"
           );
-          return { issue: winner, deliveryPlan: { deliveries: [] } };
+          return {
+            issue: winner,
+            deliveryPlan: { deliveries: [] },
+            deduped: true,
+          };
         }
       }
       throw new Error("Issue creation failed");
@@ -384,7 +401,7 @@ export async function createIssue({
       });
     }
 
-    return { issue, deliveryPlan: { deliveries } };
+    return { issue, deliveryPlan: { deliveries }, deduped: false };
   });
 }
 

--- a/src/test/integration/issue-services.test.ts
+++ b/src/test/integration/issue-services.test.ts
@@ -370,8 +370,10 @@ describe("Issue Service Functions (Integration)", () => {
       };
 
       // First submission creates the row and plans a notification.
-      const { issue: first } = await createIssue(params);
+      const { issue: first, deduped: firstDeduped } = await createIssue(params);
       expect(first.idempotencyKey).toBe(idempotencyKey);
+      // Fresh insert: deduped must be false.
+      expect(firstDeduped).toBe(false);
       const planCallsAfterFirst = vi.mocked(planNotification).mock.calls.length;
       expect(planCallsAfterFirst).toBeGreaterThan(0);
 
@@ -383,9 +385,16 @@ describe("Issue Service Functions (Integration)", () => {
       });
 
       // Retry with the SAME key returns the existing issue.
-      const { issue: second, deliveryPlan } = await createIssue(params);
+      const {
+        issue: second,
+        deliveryPlan,
+        deduped,
+      } = await createIssue(params);
       expect(second.id).toBe(first.id);
       expect(second.issueNumber).toBe(first.issueNumber);
+
+      // deduped flag MUST be true on a retry so callers can skip side effects.
+      expect(deduped).toBe(true);
 
       // No second counter increment.
       const machineAfterSecond = await db.query.machines.findFirst({

--- a/src/test/integration/report-image-dedup.test.ts
+++ b/src/test/integration/report-image-dedup.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration test: idempotent retry must NOT link duplicate issue_images rows
+ * (PP-u0v1) and must clean up the retry's freshly-uploaded blobs.
+ *
+ * Bug: createIssue returns the existing issue on a same-key retry, but
+ * report/actions.ts was unconditionally running db.insert(issueImages)
+ * afterwards → each photo appeared twice on the deduplicated issue.
+ *
+ * Fix: createIssue now returns `deduped: boolean`. The action skips the DB
+ * insert when true and instead deletes the redundant blobs.
+ *
+ * Test layer: Integration (PGlite + direct action call) — class B/I.
+ * Matches the cheapest layer that catches this bug class (CORE-TEST-005).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import {
+  issues,
+  issueImages,
+  machines,
+  userProfiles,
+} from "~/server/db/schema";
+import { createTestUser, createTestMachine } from "~/test/helpers/factories";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+
+// ---------------------------------------------------------------------------
+// External-boundary mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+  cookies: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// Run after() callbacks inline so post-commit effects execute synchronously.
+vi.mock("next/server", () => ({
+  after: (cb: () => unknown) => {
+    void cb();
+  },
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/security/turnstile", () => ({
+  verifyTurnstileToken: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("~/lib/rate-limit", () => ({
+  checkPublicIssueLimit: vi.fn().mockResolvedValue({ success: true, reset: 0 }),
+  getClientIp: vi.fn().mockResolvedValue("127.0.0.1"),
+  formatResetTime: vi.fn().mockReturnValue("0s"),
+}));
+
+// Authenticated as a member user; overridden per-test where needed.
+const mockGetUser = vi.fn();
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+vi.mock("~/lib/notifications", () => ({
+  planNotification: vi.fn().mockResolvedValue({ deliveries: [] }),
+  dispatchNotification: vi.fn().mockResolvedValue(undefined),
+  getChannels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+  serverActionError: vi.fn(),
+}));
+
+// deleteFromBlob is the Vercel Blob deletion helper — mock at its boundary.
+const mockDeleteFromBlob = vi.fn().mockResolvedValue(undefined);
+vi.mock("~/lib/blob/client", () => ({
+  deleteFromBlob: mockDeleteFromBlob,
+}));
+
+// Route production `db` to PGlite.
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  const db = await getTestDb();
+  return { db };
+});
+
+// Lazy import AFTER mocks are wired up.
+const { submitPublicIssueAction } = await import("~/app/(app)/report/actions");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal valid FormData for submitPublicIssueAction. */
+function makeFormData(opts: {
+  machineId: string;
+  idempotencyKey?: string;
+  imagesMetadata?: {
+    blobUrl: string;
+    blobPathname: string;
+    fileSizeBytes: number;
+    mimeType: string;
+    originalFilename: string;
+  }[];
+}): FormData {
+  const fd = new FormData();
+  fd.set("machineId", opts.machineId);
+  fd.set("title", "Dedup image test issue");
+  fd.set("severity", "minor");
+  fd.set("frequency", "intermittent");
+  if (opts.idempotencyKey) {
+    fd.set("idempotencyKey", opts.idempotencyKey);
+  }
+  if (opts.imagesMetadata) {
+    fd.set("imagesMetadata", JSON.stringify(opts.imagesMetadata));
+  }
+  return fd;
+}
+
+// blobUrl must satisfy imageMetadataSchema's refine: a Vercel Blob host.
+const TEST_IMAGE = {
+  blobUrl: "https://teststore.public.blob.vercel-storage.com/img1.jpg",
+  blobPathname: "images/img1.jpg",
+  fileSizeBytes: 12345,
+  mimeType: "image/jpeg",
+  originalFilename: "photo.jpg",
+};
+
+const RETRY_IMAGE = {
+  blobUrl: "https://teststore.public.blob.vercel-storage.com/img2.jpg",
+  blobPathname: "images/img2.jpg",
+  fileSizeBytes: 9999,
+  mimeType: "image/jpeg",
+  originalFilename: "photo-retry.jpg",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("report action — idempotent retry image handling (PP-u0v1)", () => {
+  setupTestDb();
+
+  let machineId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const db = await getTestDb();
+    userId = randomUUID();
+    machineId = randomUUID();
+
+    await db
+      .insert(userProfiles)
+      .values(createTestUser({ id: userId, role: "member" }));
+
+    await db.insert(machines).values(
+      createTestMachine({
+        id: machineId,
+        initials: "RID",
+        name: "Retry Image Dedup Machine",
+        ownerId: userId,
+      })
+    );
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: userId } } });
+  });
+
+  it("first submission links images to the issue (control: deduped=false path)", async () => {
+    const db = await getTestDb();
+    const idempotencyKey = randomUUID();
+
+    await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({
+        machineId,
+        idempotencyKey,
+        imagesMetadata: [TEST_IMAGE],
+      })
+    );
+
+    const issue = await db.query.issues.findFirst({
+      where: eq(issues.machineInitials, "RID"),
+    });
+    expect(issue).toBeDefined();
+
+    const linked = await db
+      .select()
+      .from(issueImages)
+      .where(eq(issueImages.issueId, issue!.id));
+
+    expect(linked).toHaveLength(1);
+    expect(linked[0]?.fullImageUrl).toBe(TEST_IMAGE.blobUrl);
+    // No blob cleanup on fresh insert.
+    expect(mockDeleteFromBlob).not.toHaveBeenCalled();
+  });
+
+  it("idempotent retry does NOT add duplicate issueImages rows (PP-u0v1)", async () => {
+    const db = await getTestDb();
+    const idempotencyKey = randomUUID();
+
+    // First submission: creates the issue and links 1 image.
+    await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({
+        machineId,
+        idempotencyKey,
+        imagesMetadata: [TEST_IMAGE],
+      })
+    );
+
+    const issue = await db.query.issues.findFirst({
+      where: eq(issues.machineInitials, "RID"),
+    });
+    expect(issue).toBeDefined();
+
+    const afterFirst = await db
+      .select()
+      .from(issueImages)
+      .where(eq(issueImages.issueId, issue!.id));
+    expect(afterFirst).toHaveLength(1);
+
+    // Retry with the SAME idempotency key, carrying a fresh image upload.
+    vi.clearAllMocks();
+    await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({
+        machineId,
+        idempotencyKey,
+        imagesMetadata: [RETRY_IMAGE],
+      })
+    );
+
+    // Still exactly one row — the retry must not insert a second image.
+    const afterRetry = await db
+      .select()
+      .from(issueImages)
+      .where(eq(issueImages.issueId, issue!.id));
+    expect(afterRetry).toHaveLength(1);
+    expect(afterRetry[0]?.fullImageUrl).toBe(TEST_IMAGE.blobUrl);
+
+    // The retry's redundant blob must be cleaned up.
+    expect(mockDeleteFromBlob).toHaveBeenCalledWith(RETRY_IMAGE.blobPathname);
+  });
+
+  it("idempotent retry without images does not call deleteFromBlob", async () => {
+    const db = await getTestDb();
+    const idempotencyKey = randomUUID();
+
+    // First submission with an image.
+    await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({
+        machineId,
+        idempotencyKey,
+        imagesMetadata: [TEST_IMAGE],
+      })
+    );
+
+    vi.clearAllMocks();
+
+    // Retry carries NO images (e.g. form was cleared on the retry attempt).
+    await submitPublicIssueAction(
+      { error: "" },
+      makeFormData({
+        machineId,
+        idempotencyKey,
+        // no imagesMetadata
+      })
+    );
+
+    expect(mockDeleteFromBlob).not.toHaveBeenCalled();
+
+    // Original image still linked.
+    const issue = await db.query.issues.findFirst({
+      where: eq(issues.machineInitials, "RID"),
+    });
+    const images = await db
+      .select()
+      .from(issueImages)
+      .where(eq(issueImages.issueId, issue!.id));
+    expect(images).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Two related PP-2053 follow-ups in one PR (both touch `report/actions.ts`).

## PP-u0v1 — duplicate images on idempotent retry

`createIssue` returns the **existing** issue on a same-key idempotent retry (the PP-2053.7 dedup), but `report/actions.ts` then ran `db.insert(issueImages)` **unconditionally** — so every photo was re-inserted on the already-existing issue → duplicate photos. `issue_images` has no unique constraint to stop it.

**Fix:** `createIssue` now returns `deduped: boolean` — `true` at both dedup return points (pre-SELECT hit and race-winner fallback), `false` on the fresh insert. When `deduped`, the report action **skips** the image insert and **deletes the retry's freshly-uploaded blobs** (redundant duplicates of what's already linked) instead of leaking them. The normal path (limit check + insert + on-error cleanup) is unchanged.

## PP-34gz — silent image failures

Three catch blocks logged with `log.error` only and never called `reportError`, so Sentry never saw them — same invisibility class as the original PP-2053 incident. Added `reportError` (bestEffort) to: the comment-image parse catch (`issues/actions.ts`), the issue-image DB-insert catch, and the issue-image parse catch (`report/actions.ts`). All remain non-blocking.

## Tests

- `report-image-dedup.test.ts` (integration): same-key retry adds **no** duplicate `issue_images` rows + cleans up the redundant blob; control path links one image; retry-without-images doesn't call `deleteFromBlob`.
- `issue-services.test.ts`: asserts the `deduped` flag.

Local gates green: `pnpm run check` (141 files, 1225 unit) + `pnpm run test:integration` (27 files, 311).

Traces to the PP-2053 (Doodle Bug) lessons-learned sweep.