### PR TITLE
fix(ci): drop unshareable URL from preview sticky comment

### DIFF
--- a/scripts/workflow/preview/preview-status.sh
+++ b/scripts/workflow/preview/preview-status.sh
@@ -26,22 +26,22 @@ footer='Comment `/preview extend` for +48h · `/preview stop` to tear down.'
 case "$state" in
   active)
     branch="${2:?branch required}"
-    url="${3:?url required}"
+    # $3 (preview URL) is accepted for call-site compatibility but intentionally
+    # NOT shown: the deployment is protection-gated, so the bare alias is not
+    # shareable. The URL still appears in the workflow run log; reviewers are
+    # handed a Vercel shareable link (with its ?_vercel_share token) generated
+    # manually — that token must never land in a public PR comment.
     expires="${4:?expires required}"
-    printf '🔮 Preview active — %s\n' "$url"
+    printf '🔮 Preview active\n'
     printf 'DB: Supabase branch `%s` · Expires: %s\n' "$branch" "$expires"
     printf '%s\n' "$footer"
     ;;
 
   extended)
     branch="${2:?branch required}"
-    url="${3:-}"
+    # $3 (preview URL) accepted for compatibility but not shown — see `active`.
     expires="${4:?expires required}"
-    if [[ -n "$url" ]]; then
-      printf '🔮 Preview active — %s\n' "$url"
-    else
-      printf '🔮 Preview active\n'
-    fi
+    printf '🔮 Preview active\n'
     printf 'DB: Supabase branch `%s` · Expires: %s\n' "$branch" "$expires"
     printf '%s\n' "$footer"
     ;;


### PR DESCRIPTION
The preview sticky comment posted the bare branch-alias URL. But preview deployments are **protection-gated**, so that URL isn't usable by a reviewer — sharing requires a Vercel shareable link (`?_vercel_share=<token>`), and that token must never be posted in a public PR comment. The bare URL was therefore dead weight (looks shareable, isn't), and Tim generates the share link manually anyway.

**Change:** `preview-status.sh` `active`/`extended` states no longer print the URL. DB branch + expiry + the `/preview extend`·`/preview stop` footer stay. The URL still appears in the workflow **run log** for collaborators who need the deployment identity.

Rendered:
```
🔮 Preview active
DB: Supabase branch `pr-1388` · Expires: 2026-06-16T03:41Z
Comment `/preview extend` for +48h · `/preview stop` to tear down.
```

Verified by running the script for both states (URL arg passed, not shown); shellcheck clean.