### PR TITLE
chore(observability): reportError on silent write-path catches (PP-ed4a)

### DIFF
--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -378,6 +378,11 @@ export async function signupAction(
         },
         "Failed to record terms acceptance timestamp"
       );
+      reportError(termsError, {
+        action: "signup.termsAcceptance",
+        userId: data.user.id,
+        bestEffort: true,
+      });
     }
 
     // Check if email confirmation is required (user created but no session)

--- a/src/lib/auth/profile.ts
+++ b/src/lib/auth/profile.ts
@@ -10,6 +10,7 @@ import {
 import { eq, and, isNull } from "drizzle-orm";
 import type { User } from "@supabase/supabase-js";
 import { log } from "~/lib/logger";
+import { reportError } from "~/lib/observability/report-error";
 import type { UserRole } from "~/lib/types";
 
 /**
@@ -162,6 +163,11 @@ export async function ensureUserProfile(user: User): Promise<void> {
       },
       "Failed to auto-heal user profile"
     );
+    reportError(error, {
+      action: "ensureUserProfile",
+      userId: user.id,
+      bestEffort: true,
+    });
     // We don't throw here to avoid crashing the page, but the subsequent queries might fail
     // or the user might see a degraded experience.
   }

--- a/src/server/actions/images.ts
+++ b/src/server/actions/images.ts
@@ -21,6 +21,7 @@ import {
 } from "~/lib/rate-limit";
 import { eq, count, and, isNull } from "drizzle-orm";
 import { log } from "~/lib/logger";
+import { reportError } from "~/lib/observability/report-error";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 
 const uploadSchema = z.object({
@@ -247,6 +248,10 @@ export async function uploadIssueImage(formData: FormData): Promise<
         },
         "DB insert failed for image, cleaning up blob"
       );
+      reportError(caughtErr, {
+        action: "uploadIssueImage.dbInsert",
+        blobPathname: uploadedBlobPathname,
+      });
       // Step 4: Actual cleanup
       if (uploadedBlobPathname) {
         await deleteFromBlob(uploadedBlobPathname);


### PR DESCRIPTION
## Summary

PP-ed4a: Three write-path catch blocks logged with `log.error` only, leaving Sentry completely blind to these failure classes — same invisibility gap that surfaced in the PP-2053 incident. Adds `reportError` alongside the existing `log.error` in each.

**Catches fixed:**
- `src/app/(auth)/actions.ts` — signup ToS acceptance `db.update(userProfiles)` catch (`bestEffort: true`, non-blocking — signup continues even if the timestamp write fails)
- `src/lib/auth/profile.ts` — `ensureUserProfile` multi-write catch covering `db.insert(userProfiles)`, `db.insert(notificationPreferences)`, guest/invited-user transfers, `db.insert(issueWatchers)` (`bestEffort: true`, non-blocking — page load continues)
- `src/server/actions/images.ts` — `uploadIssueImage` DB insert (`db.insert(issueImages)`) catch (not `bestEffort` — this returns an error to the caller)

**Explicitly not touched** (per scope discipline): image catches in `report/actions.ts` and comment-image catch in `issues/actions.ts` — those are covered by in-flight PR #1541. Export filter persistence target was not found (filters are client-side localStorage only; `export-action.ts` already uses `serverActionError`).

## Test plan

- `pnpm run check` passes (1225 unit tests + 70 pytest + typecheck + lint all green)
- No new tests added: all three catches are in deeply-nested error paths that require extensive mocking of unrelated modules (Supabase auth, full DB setup, blob client, rate limiting) to reach. The catch bodies are trivially correct by inspection — `reportError(error, { action, ...context, bestEffort })` with no control flow change. Per CORE-TEST-005 (test at cheapest layer), the verification cost exceeds the value here.
- CI will run the full integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)