### PR TITLE
fix(flaky): authenticate supabase/setup-cli to prevent rate-limit CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,7 @@ jobs:
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
           version: latest
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -559,6 +560,7 @@ jobs:
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
           version: latest
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -614,6 +616,7 @@ jobs:
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
           version: latest
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # ratchet:actions/cache@v5.0.5
@@ -695,6 +698,7 @@ jobs:
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
           version: latest
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # ratchet:actions/cache@v5.0.5
@@ -776,6 +780,7 @@ jobs:
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
           version: latest
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # ratchet:actions/cache@v5.0.5
@@ -858,6 +863,7 @@ jobs:
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
           version: latest
+          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # ratchet:actions/cache@v5.0.5


### PR DESCRIPTION
## Summary

- **Root cause**: `supabase/setup-cli` resolves `version: latest` via an unauthenticated GitHub releases API call. The unauthenticated rate limit is 60 req/hr per runner IP. When 6 jobs all hit it simultaneously (Verify Migrations, Supabase Integration Tests, E2E Smoke×2, E2E Full, E2E Comprehensive), the burst trips the limit.
- **Flaky evidence**: SHA `a9ce59fc6e30` on `feat/machine-settings-tab-scaffold-PP-43q3` — `E2E Full Tests (Chromium)` failed attempt 1 with `Failed to resolve latest Supabase CLI release: rate limit exceeded`, passed attempt 2 without any code change. A related transient musl-detection false-positive hit `Verify Migrations` on 2026-06-13 (SHA `6043d0d7ce5d`), same action, same step.
- **Fix**: Add `SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}` to all 6 `supabase/setup-cli` steps. Authenticated calls use the 5,000 req/hr limit — orders of magnitude above any PR burst.

## Flakiness report context

**Scanned**: 90 CI workflow runs across pages 1–3 (2026-06-07 → 2026-06-14), 1,227 unit/integration tests consistently passing.

**Confirmed flaky scenario** (same SHA, pass + fail):
| Job | SHA | Attempt 1 | Attempt 2 | Run |
|-----|-----|-----------|-----------|-----|
| E2E Full Tests (Chromium) | `a9ce59fc6e30` | ❌ rate limit | ✅ pass | [27287735743](https://github.com/timothyfroehlich/PinPoint/actions/runs/27287735743) |

**Related transient failure** (different SHA, no rerun attempted):
| Job | SHA | Failure | Date |
|-----|-----|---------|------|
| Verify Migrations | `6043d0d7ce5d` | musl false-positive in `supabase/setup-cli` | 2026-06-13 |

**Not flaky** (deterministic):
- `pnpm audit`: 4 known vulnerabilities in `esbuild@0.28.0` (GHSA-gv7w-rqvm-qjhr, 2 HIGH, 2 LOW) — needs a separate dependency update.

## Test plan

- [ ] CI passes on this PR (all 6 Supabase CLI setup steps now authenticate)
- [ ] Verify no new `rate limit exceeded` errors in Setup Supabase CLI logs
- [ ] Note: the `pnpm audit` failures will still appear until esbuild is updated (tracked separately)

https://claude.ai/code/session_016W2MzQPEZD3rrtg3ivXW8r

---
_Generated by [Claude Code](https://claude.ai/code/session_016W2MzQPEZD3rrtg3ivXW8r)_