### PR TITLE
docs: changelog week of June 8, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 124, "lastUpdated": "2026-05-31" }
+{ "totalEntries": 130, "lastUpdated": "2026-06-14" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,18 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## June 8, 2026
+
+### Bug Fixes
+
+- Notification emails and Discord DMs are now reliably sent after an issue is saved — a bug could silently skip them if anything went wrong during the save process
+- Submitting an issue report now handles connection failures gracefully; retrying a failed submission no longer creates a duplicate issue
+- Images attached to a retried issue report are no longer duplicated or silently dropped
+- Notification emails are no longer sent twice when the delivery system retries after a hiccup
+- Navigating to an issue that no longer exists now shows a proper "page not found" message instead of silently redirecting you elsewhere
+- Opening the Settings page no longer causes an infinite redirect loop if your account profile is incomplete
+
+---
+
 ## June 1, 2026
 
 ### New Features


### PR DESCRIPTION
Weekly user-facing changelog entry for the week of June 8, 2026.

## What's in this entry

Six bug fix bullets, all from the PP-2053 reliability wave and follow-on fixes. No net-new user-facing features this week (CI preview infrastructure, dep bumps, and the agent huddle feature were all excluded as non-user-facing).

### Bug Fixes

- Notification emails and Discord DMs are now reliably sent after an issue is saved — silent-skip bug fixed (#1523, #1525, #1531)
- Submitting an issue report now handles connection failures gracefully; retrying a failed submission no longer creates a duplicate issue (#1534, #1536)
- Images attached to a retried issue report are no longer duplicated or silently dropped (#1541)
- Notification emails are no longer sent twice when the delivery system retries after a hiccup (#1539)
- Navigating to an issue that no longer exists now shows a proper "page not found" message instead of silently redirecting you elsewhere (#1532)
- Opening the Settings page no longer causes an infinite redirect loop if your account profile is incomplete (#1540)

## Excluded PRs (non-user-facing)

- #1508 — CI/CD: remove Copilot reviewer
- #1511, #1524, #1538, #1543 — CI: on-demand preview branch infrastructure
- #1513, #1514, #1515, #1518, #1521, #1537, #1542 — dependency bumps
- #1517 — internal agent huddle coordination
- #1526 — regression test only
- #1528, #1533 — developer tooling (runtime tripwire, ESLint rule)
- #1529, #1535, #1544 — observability/Sentry infrastructure
- #1530 — admin-only Discord Vault transaction fix (too narrow for the general changelog)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nw2We3ZThsgM4DMh8qM32)_