### PR TITLE
chore(arch): harden CORE-ARCH-011 side-effect guards (PP-lbqh)

### DIFF
--- a/eslint-rules/no-side-effects-in-transaction.mjs
+++ b/eslint-rules/no-side-effects-in-transaction.mjs
@@ -53,7 +53,23 @@
 const TX_CALLBACK_PREFIX =
   'CallExpression[callee.type="MemberExpression"][callee.property.name="transaction"][callee.object.name=/^(db|tx)$/] > :matches(ArrowFunctionExpression, FunctionExpression)';
 
-/** Side-effect helpers banned by bare identifier when called inside a transaction. */
+/**
+ * Side-effect helpers banned by bare identifier when called inside a transaction.
+ *
+ * Two-layer enforcement (PP-lbqh):
+ *  1. Static  — this list (ESLint rule, catches direct inline calls at lint time).
+ *               Limitation: cannot follow aliased imports or indirect callbacks.
+ *  2. Runtime — `assertNotInTransaction()` in src/server/db/transaction-context.ts,
+ *               called at the top of each side-effecting wrapper. Backstops every
+ *               path the static rule can't see.
+ * When adding a new side-effect entry point, update BOTH layers:
+ *  • Add the function name here, AND
+ *  • Add `assertNotInTransaction("<name>")` at the top of the new function.
+ * `isDiscordIntegrationEnabled` is guarded at runtime but intentionally omitted
+ * here: it's not imported by name at typical call sites (the settings page uses
+ * it through the Discord module, not inline inside a transaction callback), so a
+ * static identifier match would add noise with negligible benefit.
+ */
 export const SIDE_EFFECT_CALLEES = [
   "sendEmail",
   "sendDm",

--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -21,7 +21,11 @@ import { z } from "zod";
 import { eq, and } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { log } from "~/lib/logger";
-import { createNotification, getChannels } from "~/lib/notifications";
+import {
+  planNotification,
+  dispatchNotification,
+  getChannels,
+} from "~/lib/notifications";
 import {
   reportError,
   serverActionError,
@@ -320,19 +324,21 @@ export async function createMachineAction(
       if (targetActive) {
         try {
           const channels = await getChannels();
-          await createNotification(
-            {
-              type: "machine_ownership_changed",
-              resourceId: machine.id,
-              resourceType: "machine",
-              actorId: user.id,
-              includeActor: false,
-              machineName: machine.name,
-              newStatus: "added",
-              additionalRecipientIds: [forcePromoteUserId],
-            },
-            undefined,
-            channels
+          await dispatchNotification(
+            await planNotification(
+              {
+                type: "machine_ownership_changed",
+                resourceId: machine.id,
+                resourceType: "machine",
+                actorId: user.id,
+                includeActor: false,
+                machineName: machine.name,
+                newStatus: "added",
+                additionalRecipientIds: [forcePromoteUserId],
+              },
+              undefined,
+              channels
+            )
           );
         } catch (sideEffectError: unknown) {
           reportError(sideEffectError, {
@@ -705,37 +711,41 @@ export async function updateMachineAction(
                 eq(machineWatchers.userId, oldOwnerId)
               )
             );
-          await createNotification(
-            {
-              type: "machine_ownership_changed",
-              resourceId: machine.id,
-              resourceType: "machine",
-              actorId: user.id,
-              includeActor: false,
-              machineName: machine.name,
-              newStatus: "removed",
-              additionalRecipientIds: [oldOwnerId],
-            },
-            undefined,
-            channels
+          await dispatchNotification(
+            await planNotification(
+              {
+                type: "machine_ownership_changed",
+                resourceId: machine.id,
+                resourceType: "machine",
+                actorId: user.id,
+                includeActor: false,
+                machineName: machine.name,
+                newStatus: "removed",
+                additionalRecipientIds: [oldOwnerId],
+              },
+              undefined,
+              channels
+            )
           );
         }
 
         // Notify new owner
         if (machineOwnerId && machineOwnerId !== oldOwnerId) {
-          await createNotification(
-            {
-              type: "machine_ownership_changed",
-              resourceId: machine.id,
-              resourceType: "machine",
-              actorId: user.id,
-              includeActor: false,
-              machineName: machine.name,
-              newStatus: "added",
-              additionalRecipientIds: [machineOwnerId],
-            },
-            undefined,
-            channels
+          await dispatchNotification(
+            await planNotification(
+              {
+                type: "machine_ownership_changed",
+                resourceId: machine.id,
+                resourceType: "machine",
+                actorId: user.id,
+                includeActor: false,
+                machineName: machine.name,
+                newStatus: "added",
+                additionalRecipientIds: [machineOwnerId],
+              },
+              undefined,
+              channels
+            )
           );
         }
       } catch (sideEffectError: unknown) {
@@ -895,35 +905,39 @@ export async function updateMachineAction(
         const channels = await getChannels();
 
         if (oldOwnerId && oldOwnerId !== finalOwnerId) {
-          await createNotification(
-            {
-              type: "machine_ownership_changed",
-              resourceId: machine.id,
-              resourceType: "machine",
-              actorId: user.id,
-              includeActor: false,
-              machineName: machine.name,
-              newStatus: "removed",
-              additionalRecipientIds: [oldOwnerId],
-            },
-            undefined,
-            channels
+          await dispatchNotification(
+            await planNotification(
+              {
+                type: "machine_ownership_changed",
+                resourceId: machine.id,
+                resourceType: "machine",
+                actorId: user.id,
+                includeActor: false,
+                machineName: machine.name,
+                newStatus: "removed",
+                additionalRecipientIds: [oldOwnerId],
+              },
+              undefined,
+              channels
+            )
           );
         }
         if (finalOwnerId && finalOwnerId !== oldOwnerId) {
-          await createNotification(
-            {
-              type: "machine_ownership_changed",
-              resourceId: machine.id,
-              resourceType: "machine",
-              actorId: user.id,
-              includeActor: false,
-              machineName: machine.name,
-              newStatus: "added",
-              additionalRecipientIds: [finalOwnerId],
-            },
-            undefined,
-            channels
+          await dispatchNotification(
+            await planNotification(
+              {
+                type: "machine_ownership_changed",
+                resourceId: machine.id,
+                resourceType: "machine",
+                actorId: user.id,
+                includeActor: false,
+                machineName: machine.name,
+                newStatus: "added",
+                additionalRecipientIds: [finalOwnerId],
+              },
+              undefined,
+              channels
+            )
           );
         }
       } catch (sideEffectError: unknown) {

--- a/src/lib/discord/config.ts
+++ b/src/lib/discord/config.ts
@@ -118,6 +118,10 @@ export async function getDiscordTokenForAdmin(): Promise<string | null> {
  * so a misconfigured Discord integration can't break unrelated pages.
  */
 export async function isDiscordIntegrationEnabled(): Promise<boolean> {
+  // CORE-ARCH-011 tripwire: this function issues a Supabase HTTP round-trip and
+  // must not run inside a DB transaction. See getDiscordConfig() above for the
+  // same guard applied to the full Vault-decrypt path. (PP-lbqh)
+  assertNotInTransaction("isDiscordIntegrationEnabled");
   try {
     const supabase = createAdminClient();
     const { data, error } = await supabase

--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -356,18 +356,22 @@ export async function dispatchNotification(plan: DeliveryPlan): Promise<void> {
 }
 
 /**
- * Backward-compatible one-shot: plan inside `tx`, then immediately dispatch.
- * Retained for callers not yet split into plan / post-commit-dispatch and for
- * tests. NOTE: when `tx` is a live transaction this still sends before commit —
- * transactional callers should instead call `planNotification` inside the
- * transaction and `dispatchNotification` after it resolves. (PP-2053.2)
+ * One-shot convenience: plan against the default DB handle, then immediately
+ * dispatch. Intended for post-commit call sites — there is no active transaction
+ * at the call point and no need to pass a specific DB handle.
+ *
+ * The former `tx` and `preResolvedChannels` parameters have been removed
+ * (PP-lbqh / CORE-ARCH-011). The `tx` parameter was a latent footgun: a caller
+ * passing a live transaction would have dispatched email / Discord BEFORE commit,
+ * re-introducing the Doodle Bug (PP-2053). Call sites that need to query from a
+ * specific DB handle (e.g. integration tests using PGlite, or the two-phase
+ * plan/dispatch split) should call `planNotification(props, db)` directly and
+ * then `dispatchNotification(plan)` after the transaction resolves.
  */
 export async function createNotification(
-  props: CreateNotificationProps,
-  tx: DbTransaction = db,
-  preResolvedChannels?: readonly NotificationChannel[]
+  props: CreateNotificationProps
 ): Promise<void> {
-  const plan = await planNotification(props, tx, preResolvedChannels);
+  const plan = await planNotification(props);
   await dispatchNotification(plan);
 }
 

--- a/src/server/db/transaction-context.ts
+++ b/src/server/db/transaction-context.ts
@@ -17,6 +17,19 @@ import { AsyncLocalStorage } from "node:async_hooks";
  * `assertNotInTransaction(...)` on entry; if the flag is set, they throw.
  * Any reintroduction of a pre-commit external call therefore fails loudly in
  * dev, test, and CI instead of silently shipping to production.
+ *
+ * Two-layer enforcement (PP-lbqh):
+ *  1. Static  — ESLint rule `pinpoint/no-side-effects-in-transaction` in
+ *               `eslint-rules/no-side-effects-in-transaction.mjs`. Catches
+ *               direct, inline calls by identifier at lint/CI time.
+ *               Limitation: cannot follow aliased imports or indirect callbacks.
+ *  2. Runtime — `assertNotInTransaction()` called at the top of each
+ *               side-effecting wrapper (sendEmail, sendDm, uploadToBlob,
+ *               deleteFromBlob, getDiscordConfig, isDiscordIntegrationEnabled).
+ *               Backstops every path the static rule can't see.
+ * Keep both layers in sync when adding a new side-effect entry point: add the
+ * function name to `SIDE_EFFECT_CALLEES` in the ESLint rule AND add an
+ * `assertNotInTransaction(...)` call inside the new function.
  */
 const transactionStorage = new AsyncLocalStorage<true>();
 

--- a/src/test/integration/database-queries.test.ts
+++ b/src/test/integration/database-queries.test.ts
@@ -199,7 +199,8 @@ describe("Database Queries (PGlite)", () => {
 
     it("should create notification using library function (integration)", async () => {
       const db = await getTestDb();
-      const { createNotification } = await import("~/lib/notifications");
+      const { planNotification, dispatchNotification } =
+        await import("~/lib/notifications");
 
       // Create user
       const user = {
@@ -230,19 +231,15 @@ describe("Database Queries (PGlite)", () => {
         .values(
           createTestIssue(testMachine.initials, {
             issueNumber: 1,
-            reportedBy: user.id, // Reported by same user, but global watch should still notify?
-            // Actually createNotification logic excludes actor unless includeActor is true.
-            // In this test call below, actorId is passed as user.id.
-            // But wait, if actorId == user.id, they are excluded.
-            // Let's make reportedBy someone else to avoid confusion, OR use includeActor: true if that's the intent.
-            // The test passes actorId: user.id.
+            // Actor is someone else so the global-watch user is not excluded
             assignedTo: null,
           })
         )
         .returning();
 
-      // Create notification
-      await createNotification(
+      // Plan notification against the test DB handle, then dispatch.
+      // (createNotification no longer accepts a tx arg — PP-lbqh / CORE-ARCH-011)
+      const plan = await planNotification(
         {
           type: "new_issue",
           resourceId: issue.id,
@@ -251,12 +248,10 @@ describe("Database Queries (PGlite)", () => {
           includeActor: false, // Exclude actor to test global watch behavior
           issueTitle: "Test Issue",
           machineName: "Test Machine",
-          issueContext: {
-            assignedToId: null,
-          },
         },
         db
       );
+      await dispatchNotification(plan);
 
       // Verify
       const results = await db.query.notifications.findMany({

--- a/src/test/integration/notifications.test.ts
+++ b/src/test/integration/notifications.test.ts
@@ -1073,27 +1073,31 @@ describe("notification delivery (planNotification + dispatchNotification)", () =
       });
 
       // First comment notification — distinct event id
-      await createNotification(
-        {
-          type: "new_comment",
-          resourceId: issue.id,
-          resourceType: "issue",
-          commentContent: "First comment",
-          eventId: "comment-uuid-aaa",
-        },
-        db
+      await dispatchNotification(
+        await planNotification(
+          {
+            type: "new_comment",
+            resourceId: issue.id,
+            resourceType: "issue",
+            commentContent: "First comment",
+            eventId: "comment-uuid-aaa",
+          },
+          db
+        )
       );
 
       // Second comment notification — different event id (different logical event)
-      await createNotification(
-        {
-          type: "new_comment",
-          resourceId: issue.id,
-          resourceType: "issue",
-          commentContent: "Second comment",
-          eventId: "comment-uuid-bbb",
-        },
-        db
+      await dispatchNotification(
+        await planNotification(
+          {
+            type: "new_comment",
+            resourceId: issue.id,
+            resourceType: "issue",
+            commentContent: "Second comment",
+            eventId: "comment-uuid-bbb",
+          },
+          db
+        )
       );
 
       expect(sendEmail).toHaveBeenCalledTimes(2);
@@ -1140,25 +1144,29 @@ describe("notification delivery (planNotification + dispatchNotification)", () =
       const SAME_EVENT_ID = "comment-uuid-retry-test";
 
       // Simulate two attempts to dispatch the same comment event (retry scenario)
-      await createNotification(
-        {
-          type: "new_comment",
-          resourceId: issue.id,
-          resourceType: "issue",
-          commentContent: "Same comment, first attempt",
-          eventId: SAME_EVENT_ID,
-        },
-        db
+      await dispatchNotification(
+        await planNotification(
+          {
+            type: "new_comment",
+            resourceId: issue.id,
+            resourceType: "issue",
+            commentContent: "Same comment, first attempt",
+            eventId: SAME_EVENT_ID,
+          },
+          db
+        )
       );
-      await createNotification(
-        {
-          type: "new_comment",
-          resourceId: issue.id,
-          resourceType: "issue",
-          commentContent: "Same comment, retry attempt",
-          eventId: SAME_EVENT_ID,
-        },
-        db
+      await dispatchNotification(
+        await planNotification(
+          {
+            type: "new_comment",
+            resourceId: issue.id,
+            resourceType: "issue",
+            commentContent: "Same comment, retry attempt",
+            eventId: SAME_EVENT_ID,
+          },
+          db
+        )
       );
 
       expect(sendEmail).toHaveBeenCalledTimes(2);

--- a/src/test/integration/notifications.test.ts
+++ b/src/test/integration/notifications.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import {
-  createNotification,
   planNotification,
   dispatchNotification,
   type DeliveryPlan,
@@ -48,7 +47,7 @@ vi.mock("~/lib/observability/report-error", async (importOriginal) => {
   return { ...actual, reportError: vi.fn() };
 });
 
-describe("createNotification (Integration)", () => {
+describe("notification delivery (planNotification + dispatchNotification)", () => {
   setupTestDb();
 
   beforeEach(() => {
@@ -77,16 +76,18 @@ describe("createNotification (Integration)", () => {
       userId: actor.id,
     });
 
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: false, // Explicitly test actor exclusion
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: false, // Explicitly test actor exclusion
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     // Verify no notification created
@@ -124,15 +125,17 @@ describe("createNotification (Integration)", () => {
       inAppNotifyOnNewComment: true,
     });
     // Don't specify includeActor - should default to true
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     // Verify actor receives notification (new default behavior)
@@ -187,16 +190,18 @@ describe("createNotification (Integration)", () => {
         },
       });
 
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: false, // Exclude actor to test recipient preferences
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: false, // Exclude actor to test recipient preferences
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     const result = await db.query.notifications.findMany();
@@ -247,16 +252,18 @@ describe("createNotification (Integration)", () => {
         },
       });
 
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: false, // Exclude actor to test recipient granular toggles
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: false, // Exclude actor to test recipient granular toggles
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     const result = await db.query.notifications.findMany();
@@ -307,15 +314,17 @@ describe("createNotification (Integration)", () => {
         },
       });
 
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     // Verify in-app insert
@@ -363,18 +372,20 @@ describe("createNotification (Integration)", () => {
       { issueId: issue.id, userId: watcher.id },
     ]);
 
-    await createNotification(
-      {
-        type: "issue_assigned",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: false,
-        additionalRecipientIds: [assignee.id],
-        issueTitle: "Test Issue",
-        machineName: machine.name,
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "issue_assigned",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: false,
+          additionalRecipientIds: [assignee.id],
+          issueTitle: "Test Issue",
+          machineName: machine.name,
+        },
+        db
+      )
     );
 
     // Only the assignee should be notified, not the watcher
@@ -411,18 +422,20 @@ describe("createNotification (Integration)", () => {
     });
 
     // Self-assignment: actor assigns to themselves
-    await createNotification(
-      {
-        type: "issue_assigned",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: false,
-        additionalRecipientIds: [actor.id],
-        issueTitle: "Test Issue",
-        machineName: machine.name,
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "issue_assigned",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: false,
+          additionalRecipientIds: [actor.id],
+          issueTitle: "Test Issue",
+          machineName: machine.name,
+        },
+        db
+      )
     );
 
     // No notifications — actor is the only recipient and is excluded
@@ -464,16 +477,18 @@ describe("createNotification (Integration)", () => {
     });
 
     // Actor comments on issue they're watching — with includeActor: true (default)
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: true,
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: true,
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     // No notifications should be created — actor is suppressed
@@ -513,16 +528,18 @@ describe("createNotification (Integration)", () => {
       inAppNotifyOnNewComment: true,
     });
 
-    await createNotification(
-      {
-        type: "new_comment",
-        resourceId: issue.id,
-        resourceType: "issue",
-        actorId: actor.id,
-        includeActor: true,
-        commentContent: "Test comment",
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_comment",
+          resourceId: issue.id,
+          resourceType: "issue",
+          actorId: actor.id,
+          includeActor: true,
+          commentContent: "Test comment",
+        },
+        db
+      )
     );
 
     // Actor should receive notification since suppressOwnActions is false
@@ -565,15 +582,17 @@ describe("createNotification (Integration)", () => {
       .values(createTestIssue(machine.initials, { issueNumber: 1 }))
       .returning();
 
-    await createNotification(
-      {
-        type: "new_issue",
-        resourceId: issue.id,
-        resourceType: "issue",
-        issueTitle: "New Machine Issue",
-        machineName: machine.name,
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_issue",
+          resourceId: issue.id,
+          resourceType: "issue",
+          issueTitle: "New Machine Issue",
+          machineName: machine.name,
+        },
+        db
+      )
     );
 
     // Verify in-app insert
@@ -619,15 +638,17 @@ describe("createNotification (Integration)", () => {
       .values(createTestIssue(machine.initials, { issueNumber: 1 }))
       .returning();
 
-    await createNotification(
-      {
-        type: "new_issue",
-        resourceId: issue.id,
-        resourceType: "issue",
-        issueTitle: issue.title,
-        machineName: machine.name,
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "new_issue",
+          resourceId: issue.id,
+          resourceType: "issue",
+          issueTitle: issue.title,
+          machineName: machine.name,
+        },
+        db
+      )
     );
 
     const notificationsList = await db.query.notifications.findMany({
@@ -664,17 +685,19 @@ describe("createNotification (Integration)", () => {
       inAppEnabled: true,
     });
 
-    await createNotification(
-      {
-        type: "machine_ownership_changed",
-        resourceId: machine.id,
-        resourceType: "machine",
-        actorId: actor.id,
-        machineName: machine.name,
-        newStatus: "added",
-        additionalRecipientIds: [recipient.id],
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "machine_ownership_changed",
+          resourceId: machine.id,
+          resourceType: "machine",
+          actorId: actor.id,
+          machineName: machine.name,
+          newStatus: "added",
+          additionalRecipientIds: [recipient.id],
+        },
+        db
+      )
     );
 
     // Should still notify because ownership changes bypass granular toggles
@@ -719,18 +742,20 @@ describe("createNotification (Integration)", () => {
       inAppEnabled: true,
     });
 
-    await createNotification(
-      {
-        type: "machine_ownership_changed",
-        resourceId: machine.id,
-        resourceType: "machine",
-        actorId: admin.id,
-        includeActor: false,
-        machineName: machine.name,
-        newStatus: "added",
-        additionalRecipientIds: [newOwner.id],
-      },
-      db
+    await dispatchNotification(
+      await planNotification(
+        {
+          type: "machine_ownership_changed",
+          resourceId: machine.id,
+          resourceType: "machine",
+          actorId: admin.id,
+          includeActor: false,
+          machineName: machine.name,
+          newStatus: "added",
+          additionalRecipientIds: [newOwner.id],
+        },
+        db
+      )
     );
 
     // Only the new owner should be notified, not the admin
@@ -767,19 +792,21 @@ describe("createNotification (Integration)", () => {
       // Include the actor in additionalRecipientIds so that includeActor: false
       // is exercised — without this, the actor was never a candidate and the
       // exclusion branch was effectively untested.
-      await createNotification(
-        {
-          type: "mentioned",
-          resourceId: issue.id,
-          resourceType: "issue",
-          actorId: actor.id,
-          includeActor: false,
-          additionalRecipientIds: [actor.id, mentioned.id],
-          issueTitle: "Test issue",
-          machineName: machine.name,
-          formattedIssueId: "MN-01",
-        },
-        db
+      await dispatchNotification(
+        await planNotification(
+          {
+            type: "mentioned",
+            resourceId: issue.id,
+            resourceType: "issue",
+            actorId: actor.id,
+            includeActor: false,
+            additionalRecipientIds: [actor.id, mentioned.id],
+            issueTitle: "Test issue",
+            machineName: machine.name,
+            formattedIssueId: "MN-01",
+          },
+          db
+        )
       );
 
       const result = await db.query.notifications.findMany();
@@ -818,19 +845,21 @@ describe("createNotification (Integration)", () => {
         emailNotifyOnMentioned: true,
       });
 
-      await createNotification(
-        {
-          type: "mentioned",
-          resourceId: issue.id,
-          resourceType: "issue",
-          actorId: actor.id,
-          includeActor: false,
-          additionalRecipientIds: [mentioned.id],
-          issueTitle: "Test issue",
-          machineName: machine.name,
-          formattedIssueId: "MP-01",
-        },
-        db
+      await dispatchNotification(
+        await planNotification(
+          {
+            type: "mentioned",
+            resourceId: issue.id,
+            resourceType: "issue",
+            actorId: actor.id,
+            includeActor: false,
+            additionalRecipientIds: [mentioned.id],
+            issueTitle: "Test issue",
+            machineName: machine.name,
+            formattedIssueId: "MP-01",
+          },
+          db
+        )
       );
 
       const inApp = await db.query.notifications.findMany();


### PR DESCRIPTION
## Summary

PP-2053 lessons-learned **L4** (P3). Hardens the CORE-ARCH-011 side-effect-in-transaction guards against latent footguns found in the lessons sweep. **Zero live violations today** — this is purely defensive.

- **Drop `tx` + `preResolvedChannels` params from `createNotification`** so the type system forbids passing a live transaction (which would have dispatched email/Discord *before* commit — the original Doodle Bug). Call sites that needed pre-resolved channels (`src/app/(app)/m/actions.ts`) switched to the `planNotification` + `dispatchNotification` split (all post-DB, no active transaction).
- **Add `assertNotInTransaction("isDiscordIntegrationEnabled")`** — it issues a Supabase HTTP round-trip and must not run inside a transaction (its sibling `getDiscordConfig` was already guarded).
- **Document the two-layer enforcement** (static ESLint banned-list + runtime tripwire) in both `eslint-rules/no-side-effects-in-transaction.mjs` and `src/server/db/transaction-context.ts`, with explicit keep-in-sync guidance for future side-effect entry points.

## Deviation from the bead

The bead proposed *unifying* the ESLint banned-list and the runtime guard list into a single shared source. That isn't cleanly achievable — the ESLint rule is a standalone `.mjs` loaded by the flat config and can't import the TS runtime module. Instead this PR keeps the two lists but cross-references them with explicit "update BOTH layers" comments. Flagging for review; happy to pursue a shared `.mjs` constants module if you'd prefer true single-source.

## Verification

- `pnpm run check` — green (lint incl. the ESLint rule change, types, format, 1227 unit tests, 70 pytest)
- `src/test/integration/notifications.test.ts` + `database-queries.test.ts` — 30 passing (the two integration files touched; the merge also brought in PP-pfyf idempotency tests, converted to the plan/dispatch split)
- Full preflight (build + full integration + E2E) deferred to CI due to local memory pressure across parallel worktrees.

Closes PP-lbqh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)