### PR TITLE
chore(deps): clear pnpm audit gate — nodemailer 9, undici/js-yaml overrides (PP-6ln1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.0.1",
     "next": "^16.2.6",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.1",
     "pino": "^10.3.1",
     "postgres": "^3.4.9",
     "qrcode": "^1.5.4",
@@ -198,7 +198,9 @@
       "postcss": ">=8.5.10",
       "shell-quote": ">=1.8.4",
       "ws": ">=8.21.0",
-      "vite": ">=8.0.16"
+      "vite": ">=8.0.16",
+      "undici": "^7.28.0",
+      "js-yaml": ">=4.2.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ overrides:
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
+  undici: ^7.28.0
+  js-yaml: '>=4.2.0'
 
 importers:
 
@@ -150,8 +152,8 @@ importers:
         specifier: ^16.2.6
         version: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nodemailer:
-        specifier: ^8.0.5
-        version: 8.0.10
+        specifier: ^9.0.1
+        version: 9.0.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -4513,8 +4515,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -4951,8 +4953,8 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
-  nodemailer@8.0.10:
-    resolution: {integrity: sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   npm-normalize-package-bin@6.0.0:
@@ -5915,12 +5917,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
-    engines: {node: '>=18.17'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -6583,7 +6581,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 10.2.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8879,7 +8877,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 6.26.0
+      undici: 7.28.0
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -10468,7 +10466,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -10489,7 +10487,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -11061,7 +11059,7 @@ snapshots:
 
   node-releases@2.0.47: {}
 
-  nodemailer@8.0.10: {}
+  nodemailer@9.0.1: {}
 
   npm-normalize-package-bin@6.0.0: {}
 
@@ -12233,9 +12231,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.26.0: {}
-
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Why

CI's `pnpm audit --audit-level=high` gate went **RED on `main`** (advisories published 2026-06-17), cascading into **CI Gate** and blocking **every open PR** (#1558–#1562, #1388). This is the root-cause fix the huddle flagged on 2026-06-19; PP-vsdo (the `/audit-override` comment command) is the complementary per-PR escape hatch and is being built separately this session.

## What

| Advisory | Severity | Package | Path | Fix |
|---|---|---|---|---|
| [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) | high | nodemailer `<=9.0.0` | direct | bump `^8.0.5` → `^9.0.1` |
| [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) | high | undici `>=7.23<7.28` | vitest→jsdom | override `^7.28.0` |
| [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) | moderate | js-yaml `<=4.1.1` | @eslint/eslintrc | override `>=4.2.0` |

`pnpm audit` is now **fully clean** (was: 2 high + 2 moderate).

## Risk notes

- **nodemailer 8→9 is a major bump**, but we use it **only for the local/test SMTP transport** (Mailpit) in `src/lib/email/transport.ts` — production email is Resend. The advisory concerns the message-level `raw` option, which we never set. `@types/nodemailer` has no v9 published yet, so it stays `^8.0.0`; typecheck is green against nodemailer 9.
- **undici** is pinned to `^7.28.0` (not `>=`) deliberately — an open-ended bound pulls undici 8.x, which `jsdom@29` was not built against. Staying on the 7.x line keeps jsdom's fetch path intact.
- The `SMTPTransport` is exercised against real Mailpit by `src/test/integration/supabase/email-transport.test.ts` (CI `test-integration-supabase`), which validates the nodemailer 9 bump end-to-end.

## Verification

- `pnpm audit` / `pnpm audit --audit-level=high`: clean ✅
- `pnpm run check` (types, lint, format, 1261 unit + 70 py tests): green ✅
- Full build + integration + integration-supabase + E2E: relying on CI.

PP-6ln1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)