### PR TITLE
[THROWAWAY/DO-NOT-MERGE] validate /audit-override (PP-vsdo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.0.1",
     "next": "^16.2.6",
-    "nodemailer": "^9.0.1",
+    "nodemailer": "^8.0.5",
     "pino": "^10.3.1",
     "postgres": "^3.4.9",
     "qrcode": "^1.5.4",
@@ -198,9 +198,7 @@
       "postcss": ">=8.5.10",
       "shell-quote": ">=1.8.4",
       "ws": ">=8.21.0",
-      "vite": ">=8.0.16",
-      "undici": "^7.28.0",
-      "js-yaml": ">=4.2.0"
+      "vite": ">=8.0.16"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,6 @@ overrides:
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
-  undici: ^7.28.0
-  js-yaml: '>=4.2.0'
 
 importers:
 
@@ -152,8 +150,8 @@ importers:
         specifier: ^16.2.6
         version: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nodemailer:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^8.0.5
+        version: 8.0.11
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -4957,8 +4955,8 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
-  nodemailer@9.0.1:
-    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
+  nodemailer@8.0.11:
+    resolution: {integrity: sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==}
     engines: {node: '>=6.0.0'}
 
   npm-normalize-package-bin@6.0.0:
@@ -5920,6 +5918,10 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -8880,7 +8882,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 7.28.0
+      undici: 6.27.0
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -11067,7 +11069,7 @@ snapshots:
 
   node-releases@2.0.47: {}
 
-  nodemailer@9.0.1: {}
+  nodemailer@8.0.11: {}
 
   npm-normalize-package-bin@6.0.0: {}
 
@@ -12238,6 +12240,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.24.6: {}
+
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
Throwaway PR to validate the `/audit-override` comment command end-to-end (PP-vsdo, feature merged in #1566).

Deliberately reverts #1565's audit fix (nodemailer 9→8, removes undici/js-yaml overrides) so `pnpm audit --audit-level=high` goes RED → CI Gate red. Then `/audit-override` is exercised to confirm it flips the gate green + posts a sticky comment.

**DO NOT MERGE. Will be closed + branch deleted after validation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)