### PR TITLE
feat(config): env-var audit + central required-secret registry (CORE-SEC-009, PP-b3v)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 17. **Accessibility floor** (CORE-A11Y-001..006): skip-to-main link, `motion-reduce:` paired with animations, `<th scope="col">` + `aria-sort` + accessible name on data tables, real `<button>` (never `<div role="button">`), `title` is not a tooltip, `inert` on background regions when a modal opens.
 18. **No side effects inside DB transactions** (CORE-ARCH-011): external/non-transactional effects (HTTP, email, Discord, blob, Vault RPC) never run inside `db.transaction` — fetch inputs before it, deliver effects after commit (`after()` + `planNotification`/`dispatchNotification`). A runtime tripwire throws `SideEffectInTransactionError` if violated. (The Doodle Bug, PP-2053.)
 19. **Respect PinballMap API conduct** (CORE-PBM-001): all PBM access goes through the `~/lib/pinballmap` client seam using the documented JSON API — one sync call/hour, store+reuse tokens (Vault), descriptive User-Agent, 429 backoff, attribution + link-back when rendering PBM data. Never crawl pinballmap.com or reach it from tests. Re-read `docs/external/pinballmap-*` before changing integration code.
+20. **Env vars: central registry + no secret coupling** (CORE-SEC-009): every production-required env var is declared in the `next.config.ts` build registry (`assertVercelDeploymentEnv`) so a missing value fails the Vercel build, not silently degrades. No secret reused as another's fallback; no secret prefixed `NEXT_PUBLIC_`. Catalog + scope matrix: `docs/ENV_VARS.md`.
 
 ### 2.2 Process rules
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,0 +1,158 @@
+# Environment Variables — Catalog, Scope Matrix & Required-Secret Registry
+
+> **Canonical reference for every env var PinPoint reads.** When you add a new
+> env var, update this file _and_ — if it is production-required — the registry
+> in `next.config.ts` (see [CORE-SEC-009](./NON_NEGOTIABLES.md#security)).
+>
+> Audit origin: PP-b3v (triggered by PP-7xt / #1307, the unsubscribe-secret
+> coupling). Last full sweep: 2026-06-20.
+
+## 1. The problem this prevents
+
+Two real failure modes motivated this catalog:
+
+1. **Secret coupling.** The unsubscribe HMAC secret once reused
+   `SUPABASE_SERVICE_ROLE_KEY`, so rotating the Supabase key would have silently
+   invalidated every outstanding unsubscribe link in users' inboxes. (Fixed in
+   #1307 — `UNSUBSCRIBE_SIGNING_SECRET` is now independent.)
+2. **Silent degradation in production.** A missing required secret that only
+   _logs_ or _degrades_ (instead of failing loudly) ships a broken feature to
+   prod undetected — a CAN-SPAM risk for the unsubscribe case.
+
+The countermeasure is **CORE-SEC-009**: every production-required env var is
+declared in a central registry that **fails the Vercel build** when missing,
+and no secret is reused as a fallback for another purpose.
+
+## 2. Validation strategy (the decision)
+
+**Chosen: formalize the build-time registry in `next.config.ts`.** Considered
+and rejected: adopting `@t3-oss/env-nextjs`.
+
+| Option                                                                    | Verdict        | Why                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Expand the `next.config.ts` build assertion into a per-scope registry** | ✅ **Adopted** | Already the right shape — it runs in the Vercel build and can _fail the deploy_, which is the exact guarantee we want. Zero new deps. Naturally expresses "required in Production / Preview / both".                                                                                                                                                                                                                  |
+| Migrate to `@t3-oss/env-nextjs` (Zod schema + type-safe `env.X`)          | ❌ Not now     | Validates at module import (all-or-nothing), which fights our "required in prod, optional in dev/CI, gracefully degrading" reality; would need conditional Zod per var. Doesn't add the Vercel-build-scope gating we already have. Type-safe access is a nice-to-have, not a correctness fix — revisit only if we specifically want typed `env.X` access; it would be its own code migration, not part of this audit. |
+| A second bespoke centralized helper                                       | ❌ Redundant   | Duplicates what `next.config.ts` + `src/lib/supabase/env.ts` already do.                                                                                                                                                                                                                                                                                                                                              |
+
+The registry lives in `next.config.ts` (`assertVercelDeploymentEnv`). It is a
+list of **groups**; a group is satisfied if **any** of its alias names is set
+(models the Supabase-docs-vs-Vercel-integration naming pairs). Two tiers:
+
+- **`REQUIRED_ALL_DEPLOYMENTS`** — must be present in Production _and_ Preview.
+- **`REQUIRED_PRODUCTION_ONLY`** — Production only (Preview resolves these
+  another way, e.g. `NEXT_PUBLIC_SITE_URL` → `VERCEL_URL`).
+
+The assertion is a no-op unless `VERCEL_ENV ∈ {production, preview}`, so local
+and CI builds are unaffected.
+
+## 3. Vercel scope guide ("which scope does my var go in?")
+
+Vercel has four environment scopes. Map each new var like so:
+
+| Scope           | What runs there                   | Rule of thumb                                                                                                                                                                                               |
+| --------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Production**  | `main` → live deploy              | Every var the app needs to function for real users. Secrets live here.                                                                                                                                      |
+| **Preview**     | PR preview deploys                | Tim **mirrors prod secrets** here so previews behave like prod. Env-_specific_ public config (e.g. canonical URL) is **not** mirrored — preview derives it from `VERCEL_URL`.                               |
+| **Development** | `vercel dev` / local `.env.local` | Local stack values (local Supabase, Mailpit ports, dev autologin). Never real prod secrets.                                                                                                                 |
+| **CI**          | GitHub Actions build/test         | Dummy/build-time values from `.env.ci`. `VERCEL_ENV` is unset, so the registry assertion does not fire. Real CI _operations_ secrets (Supabase/Vercel tokens) are GitHub Actions secrets, not app env vars. |
+
+**Sensitivity rule (CORE-SEC-009):** a secret (key, token, password,
+connection string, signing secret) must **never** be prefixed `NEXT_PUBLIC_` —
+that prefix inlines the value into the client bundle.
+
+**No-coupling rule (CORE-SEC-009):** never reuse one secret as the fallback for
+a different purpose. Alias _names for the same value_ (below) are fine;
+_borrowing a different secret_ is not.
+
+## 4. Full catalog
+
+Legend — Required: ✅ required · ⭕ recommended · ⚪ optional / degrades · 🔁 resolved via fallback · — n/a · 🚫 must be absent.
+Sensitivity: 🔴 secret · 🟢 public config.
+
+### 4.1 Production-required secrets (in the build registry)
+
+| Var (aliases)                                                            | Sens. | Prod | Preview        | Dev | CI        | Owner module                                      | Runtime guard                                  |
+| ------------------------------------------------------------------------ | ----- | ---- | -------------- | --- | --------- | ------------------------------------------------- | ---------------------------------------------- |
+| `POSTGRES_URL`                                                           | 🔴    | ✅   | ✅             | ✅  | ✅(dummy) | `src/server/db/index.ts`, `drizzle.config.ts`     | throws at module load                          |
+| `SUPABASE_SERVICE_ROLE_KEY` (`SUPABASE_SECRET_KEY`)                      | 🔴    | ✅   | ✅             | ✅  | ✅(dummy) | `src/lib/supabase/admin.ts`                       | throws when admin client built                 |
+| `UNSUBSCRIBE_SIGNING_SECRET`                                             | 🔴    | ✅   | ✅             | ⚪  | ⚪        | `src/lib/notifications/channels/email-channel.ts` | warns once in prod if absent                   |
+| `NEXT_PUBLIC_SUPABASE_URL` (`SUPABASE_URL`)                              | 🟢    | ✅   | ✅             | ✅  | ✅        | `src/lib/supabase/env.ts`                         | throws in `getSupabaseEnv()`                   |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (`NEXT_PUBLIC_SUPABASE_ANON_KEY`) | 🟢    | ✅   | ✅             | ✅  | ✅        | `src/lib/supabase/env.ts`                         | throws in `getSupabaseEnv()`                   |
+| `NEXT_PUBLIC_SITE_URL`                                                   | 🟢    | ✅   | 🔁`VERCEL_URL` | ⚪  | ✅        | `src/lib/url.ts`                                  | `requireSiteUrl()` throws in prod if localhost |
+
+> `NEXT_PUBLIC_SUPABASE_*` are public (anon/publishable) keys — safe to expose —
+> but still **required** for the app to boot, so they're in the registry.
+
+### 4.2 Production-relevant but not build-gated (degrade or feature-gate)
+
+These intentionally **degrade gracefully** rather than fail the build. Listed so
+the degradation is a known, documented choice — not an oversight.
+
+| Var (aliases)                                             | Sens. | Prod                | Owner module                              | Behavior when absent                                             |
+| --------------------------------------------------------- | ----- | ------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| `POSTGRES_URL_NON_POOLING`                                | 🔴    | ✅(migrations)      | `drizzle.config.ts`                       | throws at migrate time if `POSTGRES_URL` is pooled               |
+| `UPSTASH_REDIS_REST_URL` (`KV_REST_API_URL`)              | 🔴    | ⭕                  | `src/lib/rate-limit.ts`                   | rate limiting disabled; prod logs; non-prod degrades silently    |
+| `UPSTASH_REDIS_REST_TOKEN` (`KV_REST_API_TOKEN`)          | 🔴    | ⭕                  | `src/lib/rate-limit.ts`                   | as above                                                         |
+| `CRON_SECRET`                                             | 🔴    | ⭕                  | `src/app/api/cron/cleanup-blobs/route.ts` | cron endpoint logs error (unprotected)                           |
+| `BLOB_READ_WRITE_TOKEN`                                   | 🔴    | ✅(Vercel-injected) | `src/lib/blob/client.ts`                  | non-prod uses mock storage                                       |
+| `RESEND_API_KEY`                                          | 🔴    | ⚪                  | `src/lib/email/client.ts`                 | falls back to SMTP; auth emails go via Supabase SMTP regardless  |
+| `TURNSTILE_SECRET_KEY` + `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | 🔴/🟢 | ⚪                  | `src/lib/security/turnstile.ts`           | CAPTCHA skipped (widget hidden, server verify passes); prod logs |
+| `DISCORD_CLIENT_ID` + `DISCORD_CLIENT_SECRET`             | 🔴    | ⚪                  | `src/lib/auth/providers.ts`               | Discord OAuth hidden end-to-end                                  |
+| `NEXT_PUBLIC_SENTRY_DSN`                                  | 🟢    | ⭕                  | `src/components/SentryInitializer.tsx`    | Sentry not initialized                                           |
+
+### 4.3 Local / CI / test-only config
+
+| Var (aliases)                                                                   | Sens.         | Scope    | Owner module                               | Notes                                       |
+| ------------------------------------------------------------------------------- | ------------- | -------- | ------------------------------------------ | ------------------------------------------- |
+| `PORT`                                                                          | 🟢            | Dev      | `src/lib/url.ts`, `src/lib/blob/client.ts` | default `3000`                              |
+| `EMAIL_TRANSPORT`                                                               | 🟢            | Dev/CI   | `src/lib/email/client.ts`                  | `smtp` → Mailpit; unset → Resend            |
+| `MAILPIT_PORT` / `MAILPIT_SMTP_PORT` (`INBUCKET_PORT` / `INBUCKET_SMTP_PORT`)   | 🟢            | Dev/CI   | `src/lib/email/client.ts`                  | per-worktree test mail ports                |
+| `DEV_AUTOLOGIN_ENABLED` / `_EMAIL` / `_PASSWORD`                                | 🔴(dev creds) | Dev      | `src/lib/supabase/middleware.ts`           | 🚫 must be absent/`false` in prod           |
+| `PINBALLMAP_MODE`                                                               | 🟢            | All      | `src/lib/pinballmap/config.ts`             | `live` in prod, `mock` elsewhere by default |
+| `MOCK_BLOB_STORAGE`                                                             | 🟢            | Dev/test | `src/lib/blob/client.ts`                   | feature flag                                |
+| `DRIZZLE_FORCE_PRODUCTION`                                                      | 🟢            | Ops      | `drizzle.config.ts`                        | explicit opt-in guard for prod DDL          |
+| `LOG_LEVEL` / `PINPOINT_LOG_DIR`                                                | 🟢            | All      | `src/lib/logger.ts`                        | defaults: `info` / `<cwd>/logs`             |
+| `SKIP_SUPABASE_RESET`, `E2E_DOCKER_READY_ATTEMPTS`, `E2E_DOCKER_READY_DELAY_MS` | 🟢            | CI/test  | `e2e/global-setup.ts`                      | E2E harness tuning                          |
+
+### 4.4 Platform-set (do not manage manually)
+
+`NODE_ENV`, `VERCEL_ENV`, `VERCEL_URL`, `NEXT_RUNTIME`, `CI`, `PLAYWRIGHT_*` —
+injected by Next.js / Vercel / GitHub Actions / Playwright. Read-only inputs.
+
+### 4.5 CI operations secrets (GitHub Actions, not app runtime)
+
+Stored as GitHub Actions secrets, consumed only by workflows (preview branch
+lifecycle, deploys) — never read by the app:
+`GITHUB_TOKEN`, `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `VERCEL_TOKEN`,
+`VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+
+## 5. Alias pairs (same value, two accepted names)
+
+These are **dual _names_ for one value** (Supabase docs vs Vercel integration
+naming) — not coupling. The registry treats each pair as "any one satisfies":
+
+- `NEXT_PUBLIC_SUPABASE_URL` ⇄ `SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` ⇄ `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY` ⇄ `SUPABASE_SECRET_KEY`
+- `UPSTASH_REDIS_REST_URL` ⇄ `KV_REST_API_URL`
+- `UPSTASH_REDIS_REST_TOKEN` ⇄ `KV_REST_API_TOKEN`
+- `MAILPIT_PORT` ⇄ `INBUCKET_PORT`, `MAILPIT_SMTP_PORT` ⇄ `INBUCKET_SMTP_PORT`
+- `POSTGRES_URL_NON_POOLING` is a **distinct** value (session pooler), not an
+  alias of `POSTGRES_URL` (transaction pooler) — see AGENTS.md §7.
+
+**Audit result:** no _dangerous_ couplings remain. The historical
+`UNSUBSCRIBE_SIGNING_SECRET` ↔ `SUPABASE_SERVICE_ROLE_KEY` reuse is fixed; all
+remaining fallbacks are benign same-value aliases.
+
+## 6. Adding a new env var — checklist
+
+1. **Pick the scope(s)** using §3. Default to deny — only the scopes that need it.
+2. **Sensitivity:** secret → never `NEXT_PUBLIC_`; public config → `NEXT_PUBLIC_` only if the browser truly needs it (it ends up in page source).
+3. **No coupling:** give it its own value; never borrow another secret as a fallback (alias _names_ for the same value are fine).
+4. **If production-required:** add it to the registry in `next.config.ts`
+   (`REQUIRED_ALL_DEPLOYMENTS` or `REQUIRED_PRODUCTION_ONLY`), so a missing value
+   fails the build instead of degrading silently.
+5. **Document it here** (the right §4 table) and add it to `.env.example` (and
+   `.env.ci` if the CI build reads it).
+6. **Set it in Vercel** for each chosen scope (Project Settings → Environment
+   Variables).

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -220,6 +220,14 @@ trigger: always_on
 - **Do:** Use `localhost` in `supabase/config.toml`, `.env*`, Playwright `baseURL`, health-check scripts, and any local HTTP endpoint.
 - **Don't:** Use `127.0.0.1:NNNN` for any local URL agents or the dev stack will read. CSP rules and validation checks that intentionally cover both forms are the only exception.
 
+**CORE-SEC-009:** Production-required env vars go in the central build registry; no secret coupling
+
+- **Severity:** High
+- **Why:** A required env var that only logs or degrades when missing ships a broken feature to production undetected (the unsubscribe-link / CAN-SPAM incident, PP-7xt). Reusing one secret as another's fallback means rotating it silently breaks the borrower (the `UNSUBSCRIBE_SIGNING_SECRET` ↔ `SUPABASE_SERVICE_ROLE_KEY` coupling).
+- **Do:** Declare every production-required env var in the registry in `next.config.ts` (`assertVercelDeploymentEnv`) so a missing value **fails the Vercel build**. Give each secret its own value. Catalog every new var in `docs/ENV_VARS.md` with its scope and sensitivity.
+- **Don't:** Rely on runtime logs/graceful degradation for a var that must exist in prod; reuse one secret as a fallback for a different purpose; prefix a secret `NEXT_PUBLIC_` (it inlines into the client bundle). Same-value alias _names_ (e.g. `SUPABASE_SERVICE_ROLE_KEY`/`SUPABASE_SECRET_KEY`) are fine.
+- **Reference:** `docs/ENV_VARS.md` — full catalog, scope matrix, and "adding a new env var" checklist.
+
 ---
 
 ## Performance & Caching

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,22 +2,55 @@ import { withSentryConfig } from "@sentry/nextjs";
 import createMDX from "@next/mdx";
 import type { NextConfig } from "next";
 
-// Fail the Vercel build (rather than deploy and 500 at runtime) when a
-// required production secret is missing. Skipped on local builds and
-// vercel-dev because VERCEL_ENV is only set in Vercel build/runtime
-// environments. Preview deploys are also validated since Tim sets prod
-// secrets in both Production and Preview scopes.
+// Central registry of production-required env vars (CORE-SEC-009). Fails the
+// Vercel build (rather than deploy and 500 / silently degrade at runtime) when
+// a required secret is missing. Skipped on local builds and vercel-dev because
+// VERCEL_ENV is only set in Vercel build/runtime environments. Preview deploys
+// are validated too because Tim mirrors prod secrets into both Production and
+// Preview scopes.
+//
+// Each entry is a group of one or more names that is satisfied if ANY of its
+// names is present — this models the documented alias pairs (Supabase docs vs
+// the Vercel integration naming) without false-failing when the alias is the
+// one that's set. Full catalog + scope matrix: docs/ENV_VARS.md.
+//
+// When you add a new production-required env var, add it here (CORE-SEC-009).
+type RequiredEnvGroup = readonly [primary: string, ...aliases: string[]];
+
+// Required in every deployment scope (Production AND Preview).
+const REQUIRED_ALL_DEPLOYMENTS: readonly RequiredEnvGroup[] = [
+  ["UNSUBSCRIBE_SIGNING_SECRET"],
+  ["POSTGRES_URL"],
+  ["SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_SECRET_KEY"],
+  ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"],
+  ["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+];
+
+// Required in Production only. Preview resolves the canonical site URL from
+// VERCEL_URL (see src/lib/url.ts getSiteUrl), so it is not required there.
+const REQUIRED_PRODUCTION_ONLY: readonly RequiredEnvGroup[] = [
+  ["NEXT_PUBLIC_SITE_URL"],
+];
+
 function assertVercelDeploymentEnv(): void {
   const env = process.env["VERCEL_ENV"];
   if (env !== "production" && env !== "preview") return;
 
-  const required = ["UNSUBSCRIBE_SIGNING_SECRET"];
-  const missing = required.filter((name) => !process.env[name]);
+  const groups =
+    env === "production"
+      ? [...REQUIRED_ALL_DEPLOYMENTS, ...REQUIRED_PRODUCTION_ONLY]
+      : REQUIRED_ALL_DEPLOYMENTS;
+
+  // A group is missing only when NONE of its alias names is set.
+  const missing = groups
+    .filter((group) => !group.some((name) => process.env[name]))
+    .map((group) => group.join(" | "));
   if (missing.length === 0) return;
 
   throw new Error(
     `Deployment aborted: missing required ${env} env var(s): ${missing.join(", ")}. ` +
-      "Set them in Vercel → Project Settings → Environment Variables for the affected scope."
+      "Set them in Vercel → Project Settings → Environment Variables for the affected scope. " +
+      "See docs/ENV_VARS.md (CORE-SEC-009)."
   );
 }
 


### PR DESCRIPTION
## What

Audit of every env var the codebase reads (41 distinct) and a binding rule so a missing production secret **fails the Vercel build** instead of silently degrading. Closes the loop opened by PP-7xt (#1307), where the unsubscribe HMAC secret borrowed `SUPABASE_SERVICE_ROLE_KEY`.

Bead: **PP-b3v**.

## Changes

- **`docs/ENV_VARS.md`** (new) — full catalog with the Vercel scope matrix (Prod/Preview/Dev/CI), sensitivity, owner module, alias pairs, and an "adding a new env var" checklist.
- **`next.config.ts`** — `assertVercelDeploymentEnv` upgraded from a single flat list to a two-tier registry:
  - `REQUIRED_ALL_DEPLOYMENTS` (Prod **and** Preview)
  - `REQUIRED_PRODUCTION_ONLY` (Prod only — Preview resolves e.g. `NEXT_PUBLIC_SITE_URL` from `VERCEL_URL`)
  - **any-of alias groups** so dual-named vars (`SERVICE_ROLE_KEY`/`SECRET_KEY`, `SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_URL`, `PUBLISHABLE_KEY`/`ANON_KEY`) don't false-fail.
- **`CORE-SEC-009`** in `NON_NEGOTIABLES.md` + rule #20 in `AGENTS.md §2.1`.

## Audit result

**No dangerous couplings remain.** The historical `UNSUBSCRIBE_SIGNING_SECRET` ↔ `SUPABASE_SERVICE_ROLE_KEY` reuse is fixed; every other fallback is a benign same-value alias. No follow-up beads filed.

**Validation strategy:** formalize the build-time registry; rejected `@t3-oss/env-nextjs` (import-time all-or-nothing validation fights our required-in-prod / optional-in-dev / graceful-degradation reality; adds no Vercel-build-scope gating we don't already have; type-safe access is nice-to-have, not a correctness fix).

## ⚠️ Review point before merge

The registry now gates **real Vercel Production + Preview builds**. The newly-required set is:

`POSTGRES_URL`, `SUPABASE_SERVICE_ROLE_KEY` (or `SUPABASE_SECRET_KEY`), `UNSUBSCRIBE_SIGNING_SECRET`, `NEXT_PUBLIC_SUPABASE_URL` (or `SUPABASE_URL`), `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (or `ANON_KEY`) in both scopes; `NEXT_PUBLIC_SITE_URL` in Production only.

This relies on the existing `next.config.ts` invariant that **prod secrets are mirrored into the Preview scope**. Please confirm `SUPABASE_SERVICE_ROLE_KEY` is actually set in the **Preview** scope — if it isn't, preview builds would fail and it should move to `REQUIRED_PRODUCTION_ONLY`. (CI is unaffected: `VERCEL_ENV` is unset there, so the assertion no-ops.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)