### PR TITLE
fix(flaky): wait for Radix portal before clicking select option in E2E

### DIFF
--- a/e2e/support/actions.ts
+++ b/e2e/support/actions.ts
@@ -263,8 +263,11 @@ export async function selectOption(
     await expect(option).toBeVisible({ timeout: 5000 });
     await option.dispatchEvent("click");
   } else {
-    // Use force: true because shadcn/ui Select uses a portal where Radix Select dropdown options
-    // can be positioned outside the viewport despite being visible in the DOM
+    // Wait for the Radix Select portal to mount — options aren't in the DOM until the portal
+    // opens (async portal render), so clicking without waiting causes a 30s timeout race.
+    // force:true is still needed because shadcn/ui Select options can be positioned outside
+    // the visible viewport but are still technically "visible" per Playwright's CSS check.
+    await expect(option).toBeVisible({ timeout: 5000 });
     await option.click({ force: true });
   }
 


### PR DESCRIPTION
## Root-cause analysis

**Flaky test:** `Status Overhaul E2E › should create issue and verify all 4 badges`  
**File:** `e2e/full/status-overhaul.spec.ts:24`  
**Confirmed in:** Run [27880367406](https://github.com/timothyfroehlich/PinPoint/actions/runs/27880367406) on branch `feature/user-profiles` (SHA `07051677`, 2026-06-20), where Playwright itself reported `1 flaky` — the test failed on first attempt then passed on automated retry.

**Failure message:**
```
TimeoutError: locator.click: Timeout 30000ms exceeded.
Call log:
  - waiting for getByTestId('status-option-in_progress')
```
Stack: `e2e/support/actions.ts:268` → `selectOption` → `updateIssueField` → `status-overhaul.spec.ts:63`

### What was wrong

`selectOption()` in `e2e/support/actions.ts` has two paths for clicking a dropdown option:

- **`-trigger` path (drawer):** correctly does `await expect(option).toBeVisible({ timeout: 5000 })` *before* dispatching the click.  
- **`-select` path (shadcn/ui Select):** jumped straight to `await option.click({ force: true })` — no prior wait.

Radix Select renders options into a portal appended to `document.body` **asynchronously** after the trigger click. On slow CI runners, the portal hasn't mounted yet by the time `option.click()` fires. `force: true` bypasses actionability checks (visibility, stability) but still waits for the element to *exist in the DOM* — and when it never appears, Playwright times out at 30 s.

The `-trigger` path already had the correct wait; this aligns the `-select` path to the same pattern.

### Fix

```diff
- // Use force: true because shadcn/ui Select uses a portal where Radix Select dropdown options
- // can be positioned outside the viewport despite being visible in the DOM
- await option.click({ force: true });
+ // Wait for the Radix Select portal to mount — options aren't in the DOM until the portal
+ // opens (async portal render), so clicking without waiting causes a 30s timeout race.
+ // force:true is still needed because shadcn/ui Select options can be positioned outside
+ // the visible viewport but are still technically "visible" per Playwright's CSS check.
+ await expect(option).toBeVisible({ timeout: 5000 });
+ await option.click({ force: true });
```

**Blast radius:** `selectOption` (and `updateIssueField`) is shared across 8 spec files. The fix benefits all of them.

## Flaky test report (week of 2026-06-14 to 2026-06-21)

60 CI runs scanned (30 main branch + 30 PR branches).

### Ranked flaky tests

| # | Test | File | Flake rate | Evidence |
|---|------|------|-----------|---------|
| 1 | `Status Overhaul E2E › should create issue and verify all 4 badges` | `e2e/full/status-overhaul.spec.ts:24` | 1 Playwright-reported flaky in 1 run | Run [27880367406](https://github.com/timothyfroehlich/PinPoint/actions/runs/27880367406) (SHA `07051677`) |

No other test-level flakiness detected. Three **infrastructure** flakiness patterns also observed (not tests):
- `Setup Supabase CLI` — GitHub API rate limit downloading the CLI (transient, 2 jobs in run 27880367406)
- `Verify Migrations › Setup Supabase` — Docker startup race (transient, run [27804773605](https://github.com/timothyfroehlich/PinPoint/actions/runs/27804773605), passed on retry)
- `pnpm audit` — npm registry transient timeout (run [27826302470](https://github.com/timothyfroehlich/PinPoint/actions/runs/27826302470), passed on retry)

### Not flaky — deterministic failures also found

- `updateProfileAction › updates the caller's own profile fields` (`src/test/integration/profile-update-action.test.ts`) — test doesn't wrap `NEXT_REDIRECT`; appeared in run [27844074537](https://github.com/timothyfroehlich/PinPoint/actions/runs/27844074537) and was fixed in the next commit on that branch.

## Test plan

- [x] `pnpm run check` passes locally (types, lint, format, unit)
- [ ] CI E2E suite on this PR — the status-overhaul test should no longer appear as flaky
- [ ] Manually verify `selectOption` still works on both the `-select` and `-trigger` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114bnQojdHNrRtrYzFoCAb9

---
_Generated by [Claude Code](https://claude.ai/code/session_0114bnQojdHNrRtrYzFoCAb9)_