### PR TITLE
docs: changelog week of June 15, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 130, "lastUpdated": "2026-06-14" }
+{ "totalEntries": 135, "lastUpdated": "2026-06-21" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,20 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## June 15, 2026
+
+### New Features
+
+- **Member Profiles** — Every member now has a profile page showing their stats (issues reported, comments, machines owned, and issues fixed), bio, owned machines, and recent activity; hover any name in the app to see a quick summary card, and edit your own bio and profile photo from your profile
+- **My Machines Collection View** — Machine owners can now see all their machines in one place; open "My Machines" from the user menu for a combined status overview, all open issues, and a unified activity timeline across your machines
+- **PinballMap Machine Linking** — Admins, technicians, and machine owners can now link each machine to its PinballMap catalog entry using a picker in the create and edit forms; once linked, the machine's manufacturer and year appear on its detail page
+- **Refreshed Machine Page Header** — Machine detail pages now show a colored initials chip in the header, with manufacturer, year, and edition displayed below the name when PinballMap data is available
+
+### Bug Fixes
+
+- Posting a comment and retrying after a connection failure no longer creates a duplicate comment on an issue or machine timeline
+
+---
+
 ## June 8, 2026
 
 ### Bug Fixes


### PR DESCRIPTION
Adds the user-facing changelog entry for the week of June 15–21, 2026.

## What's in this entry

**New Features (4 bullets):**
- **Member Profiles** — Full profile pages (`/u/[id]`) with stats, bio, owned machines, activity feed, hover card (#1572)
- **My Machines Collection View** — Combined overview/issues/timeline across all machines a member owns, linked from the user menu (#1509)
- **PinballMap Machine Linking** — Picker in create/edit forms to link a machine to its PinballMap catalog entry; manufacturer + year appear on the detail page once linked (#1569)
- **Refreshed Machine Page Header** — Colored initials chip + manufacturer/year/edition sub-line when PinballMap data is available (#1573)

**Bug Fixes (1 bullet):**
- Duplicate comment on retry after 504/connection failure — both issue comments and machine timeline comments (#1550)

## PRs excluded

| PR | Reason |
|----|--------|
| #1562 | PinballMap client foundation — explicitly "no user-facing surface yet" |
| #1554 | Tournament notes removal — 1 test joke note in prod; non-event for users |
| #1568, #1567, #1564, #1563 | DB/pooler reliability fixes — internal infra |
| #1566 | `/audit-override` CI command — developer tooling |
| #1545, #1553, #1538, #1543 | CI/preview infrastructure |
| #1570, #1557, #1546 | Docs/agents/changelog-only |
| #1561, #1560, #1558, #1559, #1565, #1556, #1551, #1542 | Dependency bumps |
| #1548 | Architecture hardening — no behavior change |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfcxyxymECDwiFhuLmgr8B)_