### PR TITLE
chore(devex): stop false-positive LSP diagnostics for .claude/worktrees files (PP-8x3c)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,20 +63,26 @@
   },
 
   // Performance Optimization - File Exclusions
+  // .claude/worktrees holds linked git worktrees (full checkouts, git-ignored,
+  // machine-local). Excluding them from the main checkout keeps tsserver from
+  // analyzing their files with this checkout's config — those cross-worktree
+  // diagnostics are false positives (PP-8x3c).
   "files.exclude": {
     "**/.next": true,
     "**/node_modules": true,
     "**/.git": true,
     "**/dist": true,
     "**/.turbo": true,
-    "**/.claude/recycle_bin": true
+    "**/.claude/recycle_bin": true,
+    "**/.claude/worktrees": true
   },
   "search.exclude": {
     "**/.next": true,
     "**/node_modules": true,
     "**/dist": true,
     "**/.turbo": true,
-    "**/.claude/recycle_bin": true
+    "**/.claude/recycle_bin": true,
+    "**/.claude/worktrees": true
   },
   "files.watcherExclude": {
     "**/.git/objects/**": true,
@@ -84,7 +90,8 @@
     "**/node_modules/**": true,
     "**/.next/**": true,
     "**/dist/**": true,
-    "**/.turbo/**": true
+    "**/.turbo/**": true,
+    "**/.claude/worktrees/**": true
   },
 
   // Problem Panel Optimization for @tsconfig/strictest

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "out",
     "dist",
     ".archived_v1",
+    ".claude/worktrees/**/*",
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.spec.ts",


### PR DESCRIPTION
## What

When working in the **main** checkout, the editor's tsserver surfaced false-positive TypeScript diagnostics for files living in linked git worktrees under `.claude/worktrees/**` — unresolved `~/` path aliases, missing `@testing-library/jest-dom` matchers (`toBeInTheDocument`/`toHaveAttribute`), and implicit-`any` on pre-existing catch params.

Those worktrees are full, git-ignored, machine-local checkouts whose own `pnpm run check` is green. The diagnostics were pure cross-worktree noise — and during PP-qk7s orchestration they nearly misled a lead agent into "fixing" code that wasn't actually broken.

## Root cause

This was never a batch-`tsc` problem: TypeScript's wildcard walker already skips dot-directories (`.claude`), so `tsc -p tsconfig.json --listFilesOnly` includes **zero** worktree files. The noise came from the editor's **tsserver**, which discovers/opens files in the workspace tree (including under `.claude/worktrees`) and analyzes them with the wrong project config.

## Fix

- **`.vscode/settings.json`** — add `**/.claude/worktrees` to `files.exclude`, `search.exclude`, and `files.watcherExclude`. `files.exclude` is the load-bearing change: tsserver won't analyze files hidden from the workspace, so the spurious diagnostics stop. This mirrors the existing `.claude/recycle_bin` exclusions.
- **`tsconfig.json`** — add `.claude/worktrees/**/*` to `exclude` as explicit intent / belt-and-suspenders for any tool that expands `include` globs into dot-dirs differently.

## Verification

- Confirmed the resulting `tsc` program is **identical** before and after the tsconfig change (401 files in the worktree, byte-for-byte same file list) — zero real `src` files dropped.
- `pnpm run check` green: types, lint, format, 1317 unit tests, 70 python tests.
- Working inside a worktree directly is unaffected — these exclusions are relative to the main-checkout workspace root.

Closes PP-8x3c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)