### PR TITLE
fix(security): scope addIssueComment idempotency dedup to author+issue; server-only PBM mock (PP-yq8y)

### DIFF
--- a/src/lib/pinballmap/client-mock.ts
+++ b/src/lib/pinballmap/client-mock.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { parseCatalog, parseLocation, parseMachineGroups } from "./parse";
 import locationFixture from "./fixtures/location-26454.json";
 import catalogFixture from "./fixtures/catalog-apc.json";

--- a/src/services/issues.ts
+++ b/src/services/issues.ts
@@ -707,7 +707,11 @@ export async function addIssueComment({
     //    row verbatim with an empty delivery plan — no second notification.
     if (idempotencyKey) {
       const existing = await tx.query.issueComments.findFirst({
-        where: eq(issueComments.idempotencyKey, idempotencyKey),
+        where: and(
+          eq(issueComments.idempotencyKey, idempotencyKey),
+          eq(issueComments.authorId, userId),
+          eq(issueComments.issueId, issueId)
+        ),
       });
       if (existing) {
         log.info(
@@ -741,7 +745,11 @@ export async function addIssueComment({
       // race-winner row with an empty delivery plan. (PP-e5th)
       if (idempotencyKey) {
         const winner = await tx.query.issueComments.findFirst({
-          where: eq(issueComments.idempotencyKey, idempotencyKey),
+          where: and(
+            eq(issueComments.idempotencyKey, idempotencyKey),
+            eq(issueComments.authorId, userId),
+            eq(issueComments.issueId, issueId)
+          ),
         });
         if (winner) {
           log.info(

--- a/src/test/integration/issue-services.test.ts
+++ b/src/test/integration/issue-services.test.ts
@@ -1048,6 +1048,86 @@ describe("Issue Service Functions (Integration)", () => {
       expect(b.comment.id).not.toBe(a.comment.id);
     });
 
+    it("does not leak another user's comment via a reused idempotency key (cross-user/cross-issue)", async () => {
+      const db = await getTestDb();
+
+      // User B is distinct from testUser (User A).
+      const [userB] = await db
+        .insert(userProfiles)
+        .values(
+          createTestUser({
+            id: "00000000-0000-0000-0000-0000000000b2",
+            role: "member",
+          })
+        )
+        .returning();
+
+      // A separate issue, reported by User B.
+      const [issueB] = await db
+        .insert(issues)
+        .values({
+          title: "User B Issue",
+          machineInitials: testMachine.initials,
+          issueNumber: 2,
+          severity: "minor",
+          priority: "low",
+          frequency: "intermittent",
+          status: "new",
+          reportedBy: userB.id,
+        })
+        .returning();
+
+      const sharedKey = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+      // User B records a private comment under the shared key on B's issue.
+      const { comment: bComment } = await addIssueComment({
+        issueId: issueB.id,
+        content: plainTextToDoc("User B private content"),
+        userId: userB.id,
+        idempotencyKey: sharedKey,
+      });
+      expect(bComment.authorId).toBe(userB.id);
+
+      // User A submits a comment to a DIFFERENT issue reusing B's key. The dedup
+      // lookups are scoped to (authorId, issueId), so A's lookups never match
+      // B's row. Because the idempotency_key unique index is global, A's insert
+      // collides and the scoped race-winner lookup finds nothing for A, so the
+      // call rejects rather than returning B's content. Security invariant:
+      // either A gets its own distinct row OR the call throws — B's content is
+      // never returned to A.
+      let aComment:
+        | Awaited<ReturnType<typeof addIssueComment>>["comment"]
+        | undefined;
+      let threw = false;
+      try {
+        const res = await addIssueComment({
+          issueId: testIssue.id,
+          content: plainTextToDoc("User A content"),
+          userId: testUser.id,
+          idempotencyKey: sharedKey,
+        });
+        aComment = res.comment;
+      } catch {
+        threw = true;
+      }
+
+      if (aComment) {
+        expect(aComment.id).not.toBe(bComment.id);
+        expect(aComment.authorId).toBe(testUser.id);
+        expect(aComment.content).not.toEqual(bComment.content);
+      } else {
+        expect(threw).toBe(true);
+      }
+
+      // B's row is untouched and remains the sole owner of the key.
+      const rows = await db.query.issueComments.findMany({
+        where: eq(issueComments.idempotencyKey, sharedKey),
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe(bComment.id);
+      expect(rows[0]?.authorId).toBe(userB.id);
+    });
+
     it("null key skips dedup: two submissions create two rows", async () => {
       const a = await addIssueComment({
         issueId: testIssue.id,


### PR DESCRIPTION
Two findings from Weekly Security Review #1578 (PP-yq8y).

## Finding 1 (Medium) — Cross-user comment content leak via unscoped idempotency key
Both idempotency dedup lookups in `addIssueComment` (`src/services/issues.ts`) — the pre-insert dedup and the race-winner path — matched on `idempotency_key` alone. A user reusing another user's key (leaked/predictable, or reused across issues) would get the **other user's comment row returned to them**, leaking its content across user and issue boundaries with no authorization check.

Both lookups are now scoped to `(idempotencyKey, authorId, issueId)`:
- `authorId` — required; prevents the cross-user leak.
- `issueId` — defense in depth; prevents cross-issue reuse.

The `idempotency_key` unique index is global, so a reused key now collides on insert and the scoped race-winner lookup finds nothing for the caller → the call rejects rather than returning another user's row. The security invariant holds either way: the caller gets their own distinct row or an error, never another user's content.

(`createMachineComment` is unaffected — it uses `ON CONFLICT DO NOTHING` and never returns the existing row.)

## Finding 2 (Minor) — Missing `server-only` guard on PBM client-mock
Added `import "server-only"` as line 1 of `src/lib/pinballmap/client-mock.ts`, matching its `client-live.ts` / `client.ts` siblings, so a client component accidentally importing it now gets a build-time error.

## Test
Adds a PGlite integration regression test (`issue-services.test.ts`) where User B records a comment under a key, then User A reuses it on a different issue — asserts A never receives B's row. **Verified failing without the fix** (A received B's exact comment row) and passing with it.

## Checks
- `pnpm run check` green (types, lint, format, 1317 unit tests, python/shell/yaml).
- New + existing idempotency integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)