### PR TITLE
fix(flaky): machine-timeline 'View all' strict mode violation

### DIFF
--- a/e2e/full/machine-timeline.spec.ts
+++ b/e2e/full/machine-timeline.spec.ts
@@ -105,11 +105,16 @@ test.describe("Machine Timeline (PP-0x98)", () => {
       // events plus a "View all" link into the full timeline (PP-0x98.3).
       await page.goto(`/m/${machineA}`);
 
+      const recentActivity = page.getByRole("region", {
+        name: /recent activity/i,
+      });
       await expect(
-        page.getByRole("heading", { name: /recent activity/i })
+        recentActivity.getByRole("heading", { name: /recent activity/i })
       ).toBeVisible();
 
-      await page.getByRole("link", { name: /view all/i }).click();
+      // Scope to the "Recent activity" region to avoid matching any other
+      // "View all" links that may exist elsewhere on the machine details page.
+      await recentActivity.getByRole("link", { name: /view all/i }).click();
       await page.waitForURL(new RegExp(`/m/${machineA}/timeline$`), {
         timeout: 10_000,
       });


### PR DESCRIPTION
## Summary

- Scopes the `"View all"` link locator in `e2e/full/machine-timeline.spec.ts` to the `<section aria-labelledby="recent-activity-heading">` region, preventing Playwright strict mode violations when the machine details page contains more than one `"View all"` link.

## Root-cause analysis

**Flaky test audit — 2026-06-28 (7-day window: 2026-06-21 to 2026-06-28)**

### Methodology

- Scanned 30 CI workflow runs across all branches; cross-referenced run attempts and SHAs.
- A test is **flaky** by strict definition: the same commit SHA both passed and failed (via retry, re-run, or independent run).

### Findings

**No truly flaky tests found** in the 7-day window. Every failing SHA appeared in exactly one run — no SHA had both a passing and a failing run. All 6 failing runs fell into two categories:

| Category | Runs | Root cause |
|---|---|---|
| Infrastructure: Supabase CLI setup failed | 3 | Intermittent download/startup in GHA — non-code |
| Feature-in-progress test breakage | 2 | `feat/machine-info-tab` branch restructured the machine details page, breaking selectors written before the Info tab existed |
| E2E Supabase startup failure (main) | 1 | One-off infra issue |

### Latent quality issue (this PR)

The closest issue to "flaky" was a **strict mode violation** in the overview Recent-activity test:

```
Error: locator.click: Error: strict mode violation:
  getByRole('link', { name: /view all/i }) resolved to 2 elements
```

The `feat/machine-info-tab` work added a second `"View all"` link elsewhere on the machine details page, making the existing locator non-unique. While it failed consistently (3/3 retries) rather than intermittently, the root cause — an unscoped breadth-first link match — will cause unpredictable failures any time the page gains another `"View all"` link.

### Fix

The `MachineRecentActivity` component renders:

```tsx
<section aria-labelledby="recent-activity-heading">
  …
  <Link href={`/m/${machineInitials}/timeline`}>View all</Link>
  …
</section>
```

A `<section>` with `aria-labelledby` gets the implicit ARIA role `region`. Scoping the locator:

```typescript
// Before (unscoped — matches any "View all" link on the page):
await page.getByRole("link", { name: /view all/i }).click();

// After (scoped to the Recent Activity region):
const recentActivity = page.getByRole("region", { name: /recent activity/i });
await recentActivity.getByRole("link", { name: /view all/i }).click();
```

Zero markup changes required — the `<section aria-labelledby>` pattern was already there.

### Infrastructure note

Supabase CLI setup failed in ~10% of runs (3/30). These are transient GHA network issues, not code problems. No action needed beyond awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JNchvk5N4rBnsR9CNMybE

---
_Generated by [Claude Code](https://claude.ai/code/session_018JNchvk5N4rBnsR9CNMybE)_