### PR TITLE
fix(flaky): promote dialog confirm creates machine and promotes guest to member

### DIFF
--- a/e2e/full/machine-owner-picker.spec.ts
+++ b/e2e/full/machine-owner-picker.spec.ts
@@ -104,11 +104,17 @@ test.describe("Machine Owner Picker — promote-dialog journeys (PP-6oi)", () =>
     // Submit the form
     await page.getByRole("button", { name: /Create Machine/i }).click();
 
-    // Promote dialog should appear — allow extra time for the server action
-    // round-trip + React useEffect cycle (observed slower in Firefox).
+    // Promote dialog should appear after the server action round-trip +
+    // React useEffect cycle. Use the config's own CI-aware `expect.timeout`
+    // (30s in CI, 10s locally) instead of a hardcoded value — a fixed 15s
+    // override here previously undercut the CI default by half, right where
+    // Mobile Safari/Mobile Chrome + parallel-worker contention need the most
+    // margin (PP flaky-test report 2026-07-05: this assertion was the #1
+    // flakiest test in CI over the prior week, including one run where it
+    // failed all 3 attempts — original + 2 retries — at the 15s mark).
     await expect(
       page.getByRole("heading", { name: /Promote to member and assign/i })
-    ).toBeVisible({ timeout: 15000 });
+    ).toBeVisible();
 
     // Dialog should show "(GUEST)" badge
     const promoteDialog = page.getByRole("dialog").filter({
@@ -150,17 +156,18 @@ test.describe("Machine Owner Picker — promote-dialog journeys (PP-6oi)", () =>
     // Submit
     await page.getByRole("button", { name: /Create Machine/i }).click();
 
-    // Promote dialog should appear — allow extra time for server round-trip.
+    // Promote dialog should appear after the server action round-trip. Rely
+    // on the config's CI-aware `expect.timeout` (see comment on the sibling
+    // assertion above) rather than a hardcoded override that undercuts it.
     await expect(
       page.getByRole("heading", { name: /Promote to member and assign/i })
-    ).toBeVisible({ timeout: 15000 });
+    ).toBeVisible();
 
     await page.getByRole("button", { name: /Promote and assign/i }).click();
 
-    // Should redirect to machine detail page
-    await expect(page).toHaveURL(new RegExp(`/m/${machineInitials}`), {
-      timeout: 15000,
-    });
+    // Should redirect to machine detail page — same reasoning: let this
+    // inherit the global CI-aware expect timeout instead of a hardcoded 15s.
+    await expect(page).toHaveURL(new RegExp(`/m/${machineInitials}`));
     await expect(
       page.getByRole("heading", { name: `Owner Picker Confirm ${testId}` })
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Weekly flaky-test scan of CI runs from the last 7 days on `main` (and PR branches feeding into it). Full ranked report below. This PR fixes the #1 flakiest test.

## Root-cause analysis (the fix)

**Test:** `e2e/full/machine-owner-picker.spec.ts:126` → *Machine Owner Picker — promote-dialog journeys (PP-6oi) › promote dialog confirm creates machine and promotes guest to member*

**Evidence it's the worst offender this week:**
- Run [28718046579](https://github.com/timothyfroehlich/PinPoint/actions/runs/28718046579/job/85163028785) (main, `913f7fff`) — Playwright's own summary reports **4 flaky**, including `[Mobile Safari] machine-owner-picker.spec.ts:126:3` (failed once, passed on Playwright's internal retry).
- Run [28709215184](https://github.com/timothyfroehlich/PinPoint/actions/runs/28709215184/job/85140100235) (main, `fcf31c30`) — **6 flaky**, including both `[Mobile Chrome]` and `[Mobile Safari]` variants of the same test.
- Run [28714816089](https://github.com/timothyfroehlich/PinPoint/actions/runs/28714816089/job/85154502197) (dependabot ratchet PR, `9b12478c`) — **hard, non-recovering failure**: original attempt + Retry #1 + Retry #2 *all* failed identically on `[chromium]`:
  ```
  Error: expect(locator).toBeVisible() failed
  Locator: getByRole('heading', { name: /Promote to member and assign/i })
  Expected: visible / Timeout: 15000ms
  ```
  This PR only touched GitHub Actions SHA-pinning — unrelated to the test — confirming this is collateral flakiness, not a real regression.

**Root cause:** `playwright.config.ts` sets a CI-aware `expect.timeout` (**30s in CI**, 10s locally) and gives the `Mobile Safari` project extra retries + a longer overall test timeout specifically because mobile emulation + parallel-worker contention are slower. But `machine-owner-picker.spec.ts` hardcoded `{ timeout: 15000 }` on exactly the assertions that flake — the promote-dialog heading wait and the post-confirm redirect wait. That override **undercut the environment's own default by half**, right where the extra margin was needed most. This explains both classes of failure:
- Transient slowness under ~15s but under 30s → Playwright's automatic retry recovers it (the "N flaky" runs).
- Sustained CI load pushing every attempt past even the retries → the one hard 3/3 failure.

**Fix:** removed the three `{ timeout: 15000 }` overrides so these assertions inherit the config's own environment-aware default instead of a fixed value that quietly shrank it.

**Verification:** typecheck (`tsgo`), ESLint, Prettier, and the full unit suite (1306 tests) all pass. I could **not** exercise this Playwright spec live in this sandbox — no Docker daemon is available here for the local Supabase stack (`docker info` fails to reach `dockerd`), so there's no way to spin up the app + DB for an E2E run. Flagging this explicitly rather than claiming a local E2E pass that didn't happen; CI (which already runs this spec on every PR) is the first real exercise of the fix, and worth watching once this PR's CI runs.

## Other recurring flaky signals seen this week (not fixed in this PR — same undercut-timeout pattern, logged as follow-up)

The same three main-branch "E2E Comprehensive Tests (Post-Merge)" runs above each report a nonzero Playwright `flaky` count, with several other specs recurring across commits/browsers, all navigation/element-timeout races on **Mobile Safari / Mobile Chrome**:
- `e2e/full/machine-timeline.spec.ts:139` — admin reassign journey — `TimeoutError` waiting for `issue-actions-menu-trigger`
- `e2e/full/rich-text.spec.ts:24` — rich text + mentions — `toHaveURL` never settles on `/m/TUV/i/1`
- `e2e/full/technician-role.spec.ts:60` — Technician can create a machine — `toHaveURL` never settles on `/m/TC7283`
- Also seen: `machine-with-invite.spec.ts:29`, `public-reporting-extended.spec.ts:121`, `issue-list-extended.spec.ts:175`, `invite-signup.spec.ts:130`, `form-resets.spec.ts`, `status-overhaul.spec.ts:24`

These look like the same anti-pattern (hardcoded per-assertion timeouts below the CI default) repeated across specs, but I didn't diff every file this week — filing a follow-up bead to sweep the E2E suite for the same undercut-timeout pattern is worth doing separately rather than folding into this PR.

**CI infra flake (not a test):** `supabase/setup-cli` hit a GitHub API rate limit twice this week (runs [28714316725](https://github.com/timothyfroehlich/PinPoint/actions/runs/28714316725/job/85153022438), [28633842520](https://github.com/timothyfroehlich/PinPoint/actions/runs/28633842520/job/84916424467)) — `Failed to resolve latest Supabase CLI release: rate limit exceeded`. Not a test flake, but worth knowing about if CI setup jobs start failing more often.

**Dependabot failures this week were not genuine breaks:** both the ratchet PR and a TS7-nightly-bump PR failed due to the flakes above (owner-picker E2E, and the Supabase CLI rate limit respectively) — neither dependency bump actually caused an incompatibility.

**Cancelled main-branch runs this week** (4 of them) were confirmed as concurrency-group cancellations from rapid successive pushes, not test failures — no assertion failed before cancellation in any of them.

**`ci-legacy.yml`** is dormant — only 2 runs total, both from 2025-07-20, not a factor in current CI.

## Test plan

- [x] `pnpm exec eslint e2e/full/machine-owner-picker.spec.ts`
- [x] `pnpm exec prettier --check e2e/full/machine-owner-picker.spec.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (full unit suite, 1306 tests)
- [ ] Watch this PR's own CI run of `machine-owner-picker.spec.ts` across all projects (chromium/firefox/Mobile Chrome/Mobile Safari) — first live exercise of the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_013LzqEJCLCBB3Nk2HndA4gd)_