### PR TITLE
feat(hooks): attribute agent bd writes via BEADS_ACTOR (PP-140e.9)

### DIFF
--- a/.claude/hooks/inject-beads-actor.cjs
+++ b/.claude/hooks/inject-beads-actor.cjs
@@ -109,13 +109,20 @@ async function main() {
   // Prepend an export so attribution covers compound/piped commands.
   const modified = `export BEADS_ACTOR="${name}"; ${command}`;
 
-  // Rewrite the command WITHOUT emitting a permissionDecision: returning
-  // "allow" would short-circuit the remaining permission checks and downstream
-  // blocking hooks. We only want the input rewrite, not to change the
-  // permission posture — bd commands still flow through the normal allowlist.
+  // Emit permissionDecision: "allow" alongside updatedInput. A PreToolUse
+  // updatedInput is only applied when it rides on a permission result, and a
+  // hook produces a permission result ONLY when it emits a permissionDecision
+  // (verified against bundled Claude Code v2.1.201) — so we MUST return "allow"
+  // for the command rewrite to take effect. This matches the
+  // normalize-workspace-paths.cjs precedent. Tradeoff: "allow" auto-approves
+  // the matched bd command; that is consistent with normalize-workspace-paths,
+  // and the block-* deny hooks still fire (deny > allow), so no safety
+  // regression.
   const decision = {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      permissionDecisionReason: `Injected BEADS_ACTOR="${name}" so this agent's bd writes are attributed to it, not to Tim.`,
       updatedInput: { ...input.tool_input, command: modified },
     },
   };

--- a/.claude/hooks/inject-beads-actor.cjs
+++ b/.claude/hooks/inject-beads-actor.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook: attribute agent-initiated `bd` (beads) writes to the agent.
+ *
+ * `bd` stamps every write with an actor resolved as:
+ *   --actor flag > $BEADS_ACTOR > git config user.name > $USER
+ * On this machine BEADS_ACTOR is unset, so agent `bd` writes fall through to
+ * git user.name = "Tim Froehlich" — indistinguishable from Tim's own writes.
+ *
+ * Key insight: this hook ONLY ever fires for agent-initiated Bash tool calls.
+ * Tim's own terminal `bd` commands never pass through a Claude Code PreToolUse
+ * hook. So every command seen here is agent-initiated and should be attributed
+ * to an agent (its huddle identity, e.g. `Claude-DevxReview`) — never to Tim.
+ *
+ * We resolve the agent's huddle name from the shared session-names.json map
+ * (keyed by session_id) and prepend `export BEADS_ACTOR="<name>";` so the
+ * attribution covers compound/piped commands (a bare `BEADS_ACTOR=x bd …`
+ * prefix would only apply to the first segment of `bd … && …`).
+ *
+ * Fail-open: any error → let the command through unmodified. NEVER block or
+ * fail a bd command because of this hook.
+ *
+ * Note: normalize-workspace-paths.cjs is the only other hook that returns
+ * updatedInput. In practice bd commands don't carry absolute workspace paths,
+ * so the two never rewrite the same command; both operate on the original
+ * input.tool_input.command and don't depend on chaining between them.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// Resolve the agent's huddle name from <main-worktree>/.agents/huddle/session-names.json.
+// Mirrors huddle_state_dir() in scripts/hooks/huddle-lib.sh. Fail-open: on ANY
+// error or a missing/invalid name, return the literal "Claude" — never unset,
+// never "Tim Froehlich".
+function resolveActor(sessionId, cwd) {
+  const fallback = "Claude";
+  try {
+    const { execSync } = require("child_process");
+    const commonDir = execSync("git rev-parse --git-common-dir", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!commonDir) {
+      return fallback;
+    }
+    const absCommon = path.isAbsolute(commonDir)
+      ? commonDir
+      : path.resolve(cwd, commonDir);
+    const mainRoot = path.dirname(absCommon);
+    const namesFile = path.join(
+      mainRoot,
+      ".agents",
+      "huddle",
+      "session-names.json"
+    );
+    const map = JSON.parse(fs.readFileSync(namesFile, "utf8"));
+    const name = map[sessionId];
+    // Huddle names are already constrained to this charset by huddle-whoami.sh;
+    // re-validate defensively before injecting into a shell command.
+    if (typeof name === "string" && /^[A-Za-z0-9_-]+$/.test(name)) {
+      return name;
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function main() {
+  let inputData = "";
+  for await (const chunk of process.stdin) {
+    inputData += chunk;
+  }
+
+  if (!inputData.trim()) {
+    process.exit(0);
+  }
+
+  let input;
+  try {
+    input = JSON.parse(inputData);
+  } catch {
+    process.exit(0);
+  }
+
+  const command = input.tool_input?.command;
+  if (!command) {
+    process.exit(0);
+  }
+
+  // Fire only when `bd` is invoked as a command word: at the start of the
+  // command or immediately after a shell command separator (newline, ;, &&,
+  // ||, |, or `(`), followed by a word boundary.
+  if (!/(?:^|\n|;|&&|\|\||\||\()\s*bd\b/.test(command)) {
+    process.exit(0);
+  }
+
+  // Respect explicit attribution — if the command already sets BEADS_ACTOR or
+  // passes --actor, don't double-set.
+  if (/BEADS_ACTOR=/.test(command) || /--actor(?:[=\s]|$)/.test(command)) {
+    process.exit(0);
+  }
+
+  const cwd = input.cwd || process.cwd();
+  const name = resolveActor(input.session_id, cwd);
+
+  // Prepend an export so attribution covers compound/piped commands.
+  const modified = `export BEADS_ACTOR="${name}"; ${command}`;
+
+  // Rewrite the command WITHOUT emitting a permissionDecision: returning
+  // "allow" would short-circuit the remaining permission checks and downstream
+  // blocking hooks. We only want the input rewrite, not to change the
+  // permission posture — bd commands still flow through the normal allowlist.
+  const decision = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: { ...input.tool_input, command: modified },
+    },
+  };
+  process.stdout.write(JSON.stringify(decision));
+  process.exit(0);
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[inject-beads-actor] Hook error: ${err?.message ?? err}\n`
+  );
+  process.exit(0);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,11 @@
           },
           {
             "type": "command",
+            "command": "node .claude/hooks/inject-beads-actor.cjs",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "node .claude/hooks/block-bad-shell-patterns.cjs",
             "timeout": 5000
           },


### PR DESCRIPTION
## Summary

Adds a Claude Code PreToolUse hook — `.claude/hooks/inject-beads-actor.cjs` — that attributes agent-initiated `bd` (beads) writes to the agent instead of "Tim Froehlich".

`bd` resolves its actor as `--actor` > `$BEADS_ACTOR` > `git config user.name` > `$USER`. `BEADS_ACTOR` is unset on this machine, so every agent `bd` write fell through to `git user.name` = "Tim Froehlich", making agent writes indistinguishable from Tim's own.

**Key insight:** this hook only ever fires for agent-initiated Bash calls. Tim's own terminal `bd` commands never pass through a Claude Code PreToolUse hook. So every command the hook sees is agent-initiated and is attributed to an agent — never to Tim.

### What the hook does
1. Reads the PreToolUse JSON from stdin; fails open (exit 0, no output) on empty/unparseable input or a missing command.
2. Fires only when `bd` appears as a **command word** — start of string or immediately after a shell separator (`\n ; && || | (`), on a word boundary. `bderp`, paths, etc. don't match.
3. Skips if the command already sets `BEADS_ACTOR=` or passes `--actor` — respects explicit attribution.
4. Resolves the agent name from `<main-worktree>/.agents/huddle/session-names.json` (flat `{session_id: name}` map), locating the main worktree via `git rev-parse --git-common-dir` exactly like `huddle_state_dir()` in `scripts/hooks/huddle-lib.sh`. Falls back to the literal `"Claude"` on any error, and defensively re-validates the name against `^[A-Za-z0-9_-]+$` before injecting it. Never unset, never "Tim Froehlich".
5. Rewrites the command by prepending `export BEADS_ACTOR="<name>"; ` — an `export` (not a bare `VAR=x bd …` prefix) so attribution covers compound/piped commands.

Wired into the first `Bash` PreToolUse block, right after `normalize-workspace-paths.cjs`.

## permissionDecision decision (corrected)

**The hook emits `permissionDecision: "allow"` + `permissionDecisionReason` alongside `updatedInput`, matching the `normalize-workspace-paths.cjs` precedent.**

Mechanism finding: a PreToolUse `updatedInput` is only applied when it rides on a **permission result**, and a PreToolUse hook produces a permission result **only when it emits a `permissionDecision`** (verified against the bundled Claude Code v2.1.201 binary). An earlier iteration of this PR omitted `permissionDecision` to avoid over-granting — but that shape is a **silent no-op**: the rewrite is dropped and `bd` keeps stamping "Tim Froehlich". So emitting `"allow"` is required for the rewrite to take effect.

Tradeoff: `"allow"` auto-approves the matched `bd` command (consistent with `normalize-workspace-paths.cjs`, which does the same). This is not a safety regression — the downstream `block-*` deny hooks still fire because **deny outranks allow**, so a dangerous command is still blocked.

## Testing

Node `.cjs` PreToolUse hooks have **no** existing test harness (`pnpm run check:pytest` covers only python/bash hooks under `scripts/tests/`), so per the task I did not invent one and instead verified via manual stdin. Transcript (post-correction — output now includes `permissionDecision: "allow"` + reason):

\`\`\`
=== 1: bd, session not in map -> Claude fallback ===
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Injected BEADS_ACTOR=\"Claude\" so this agent's bd writes are attributed to it, not to Tim.","updatedInput":{"command":"export BEADS_ACTOR=\"Claude\"; bd close PP-x"}}}
=== 2: compound bd ... && git status ===
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Injected BEADS_ACTOR=\"Claude\" so this agent's bd writes are attributed to it, not to Tim.","updatedInput":{"command":"export BEADS_ACTOR=\"Claude\"; bd close PP-x && git status"}}}
=== 3: skip explicit BEADS_ACTOR= (expect NO output) ===
[exit 0]
=== 4: skip --actor (expect NO output) ===
[exit 0]
=== 5: non-bd git status (expect NO output) ===
[exit 0]
=== 6 (real): live session_id -> Claude-DevxReview ===
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Injected BEADS_ACTOR=\"Claude-DevxReview\" so this agent's bd writes are attributed to it, not to Tim.","updatedInput":{"command":"export BEADS_ACTOR=\"Claude-DevxReview\"; bd update PP-y --status open"}}}
\`\`\`

Case 6 confirms real resolution: from a linked worktree, `git rev-parse --git-common-dir` returns `/Users/froeht/Code/PinPoint/.git`, dirname → the main root, and the live `session-names.json` resolves the session_id to `Claude-DevxReview`.

`pnpm run check` — **PASS** (exit 0): types, lint, format, 1306 unit tests, 70 pytest hook tests. Hooks/config only, so `check` is the appropriate floor (no preflight needed).

## Scope
Claude Code only. Antigravity/`.gemini`/`.agents/hooks` coverage is a separate follow-up (not in this PR). No changes to `git config user.name`, `$USER`, global env, or huddle scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)