### PR TITLE
test(permissions): tighten technician-denial assertion (Stryker finding, PP-x4li.2)

### DIFF
--- a/src/test/unit/permissions-helpers.test.ts
+++ b/src/test/unit/permissions-helpers.test.ts
@@ -226,7 +226,11 @@ describe("getPermissionDeniedReason", () => {
 
   it("should return admin message for technician role denial", () => {
     const reason = getPermissionDeniedReason("admin.access", "technician");
-    expect(reason).toContain("admin");
+    // Both this message and the member-role message contain "admin" as a
+    // substring ("Technicians or admins...") — assert the distinguishing
+    // prefix so a regression that falls through to the wrong branch is caught
+    // (found via Stryker mutation audit, PP-x4li.2).
+    expect(reason).toContain("Only admins");
   });
 
   it("should return ownership message for ownership denial", () => {


### PR DESCRIPTION
## Summary

- Tightens one permissions-helper test assertion surfaced by the one-time Stryker mutation audit (PP-x4li.2). The "technician role denial" test asserted `toContain("admin")`, but the wrong (member-branch) message *also* contains "admin" as a substring ("Technicians or admins…"), so a real regression — technician denial falling through to the member message — would silently pass. Now asserts the distinguishing prefix `toContain("Only admins")`.
- **Slimmed from the original Stryker-audit PR.** The Stryker scaffolding (`stryker.config.mjs`, `vitest.stryker.config.ts`, `@stryker-mutator/*` deps, `test:mutation:permissions` script) is intentionally **not** committed: the audit was a one-time value audit, "not a standing CI gate" per PP-x4li.2, and epic PP-x4li owns no `package.json`/script changes. Aligns with the config-simplification direction.

## Test Plan

- [x] `pnpm exec vitest run src/test/unit/permissions-helpers.test.ts` → 63 passed
- [x] Confirms `getPermissionDeniedReason("admin.access", "technician")` contains "Only admins"

Related: PP-x4li.2