### PR TITLE
fix(hooks): try GNU stat before BSD stat in orphan-sweep throttle

### DIFF
--- a/.claude/hooks/session-start-orphan-sweep.sh
+++ b/.claude/hooks/session-start-orphan-sweep.sh
@@ -32,7 +32,11 @@ throttle_seconds=$((6 * 60 * 60))
 mkdir -p "$throttle_dir" 2>/dev/null || exit 0
 
 if [[ -f "$throttle_file" ]]; then
-  last=$(stat -f %m "$throttle_file" 2>/dev/null || stat -c %Y "$throttle_file" 2>/dev/null || echo 0)
+  # GNU stat first: GNU `-f` is a valid (different) flag that silently "succeeds"
+  # with unrelated filesystem-status text instead of erroring, so trying it first
+  # would poison $last on Linux. BSD stat has no `-c`, so it fails cleanly there,
+  # making this order safe on both.
+  last=$(stat -c %Y "$throttle_file" 2>/dev/null || stat -f %m "$throttle_file" 2>/dev/null || echo 0)
   now=$(date +%s)
   age=$((now - last))
   if (( age < throttle_seconds )); then


### PR DESCRIPTION
## Summary
- The `session-start-orphan-sweep.sh` SessionStart hook was failing with `line 37: File: unbound variable` on Bazzite/Linux (GNU coreutils), while working fine on macOS.
- Root cause: the throttle check tried `stat -f %m` first, assuming it would fail on Linux and fall through to `stat -c %Y`. But GNU stat's `-f` flag is a *valid* (different) flag — filesystem-status mode — so it "succeeds" and dumps unrelated verbose filesystem text instead of erroring on the invalid `%m` directive. That garbage became `$last`, and `$((now - last))` then tried to evaluate the leading word "File" as a variable, tripping `set -u`.
- Fix: reorder to try GNU-style `stat -c %Y` first, then BSD-style `stat -f %m` as fallback. Safe on both platforms — each flavor fails cleanly when its syntax doesn't match, so the ordering only matters for which one is tried first and succeeds correctly.

## Test plan
- [x] Reproduced the crash locally on Bazzite: `bash -x .claude/hooks/session-start-orphan-sweep.sh` showed `last` getting set to a multi-line `stat -f` filesystem dump, then failing on the arithmetic line.
- [x] Confirmed fix: same trace now shows `stat -c %Y` succeeding cleanly, `age` computed correctly, script exits 0.
- [x] `shellcheck` clean on the modified script.
- [x] Grepped repo for other `stat -f`/`stat -c` cross-platform usages — this was the only occurrence.
- [x] `pnpm run check` (pre-commit hooks) passed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)