### PR TITLE
fix(test-types): use vi.stubEnv for NODE_ENV in tests (PP-tka5)

### DIFF
--- a/.tsc-baseline.json
+++ b/.tsc-baseline.json
@@ -52,48 +52,6 @@
       "count": 1,
       "message": "Object literal may only specify known properties, and 'data' does not exist in type '{ ok: true; value: { userId: string; }; }'."
     },
-    "1a0d412fd45d208f1a7b502d9a73b7d285def3e3": {
-      "file": "src/app/api/test-data/cleanup/route.test.ts",
-      "code": "TS2540",
-      "count": 1,
-      "message": "Cannot assign to 'NODE_ENV' because it is a read-only property."
-    },
-    "b168c1c0d4984f54d3520005fca52f499a50e316": {
-      "file": "src/components/machines/settings/SettingsSetCard.tsx",
-      "code": "TS2307",
-      "count": 1,
-      "message": "Cannot find module '@dnd-kit/core' or its corresponding type declarations."
-    },
-    "8408a05447c318a6c54ef7a77adca9cd8777c244": {
-      "file": "src/components/machines/settings/SettingsSetCard.tsx",
-      "code": "TS2307",
-      "count": 1,
-      "message": "Cannot find module '@dnd-kit/sortable' or its corresponding type declarations."
-    },
-    "f5757bbb84cc51a95905d82fa0680b2e6608f132": {
-      "file": "src/components/machines/settings/SettingsSetCard.tsx",
-      "code": "TS2307",
-      "count": 1,
-      "message": "Cannot find module '@dnd-kit/modifiers' or its corresponding type declarations."
-    },
-    "ef0464d72d929bc03cb4c4ad0ac1d26fd8c6d1a2": {
-      "file": "src/components/machines/settings/SettingsTab.tsx",
-      "code": "TS2307",
-      "count": 1,
-      "message": "Cannot find module '@dnd-kit/sortable' or its corresponding type declarations."
-    },
-    "008796def1ca8184153989aa0beff92dcfe4d29a": {
-      "file": "src/components/machines/settings/SortableSection.tsx",
-      "code": "TS2307",
-      "count": 1,
-      "message": "Cannot find module '@dnd-kit/sortable' or its corresponding type declarations."
-    },
-    "0014612dd1f689ce1fc5991ca0ea2ba608590af4": {
-      "file": "src/components/machines/settings/SortableSection.tsx",
-      "code": "TS2307",
-      "count": 1,
-      "message": "Cannot find module '@dnd-kit/utilities' or its corresponding type declarations."
-    },
     "5893b201affa593c810a2ea73ec871bb7835b362": {
       "file": "src/lib/blob/cleanup.test.ts",
       "code": "TS2352",
@@ -106,23 +64,11 @@
       "count": 4,
       "message": "Type 'Mock<Procedure | Constructable>' is not assignable to type '((v: any) => void) | undefined'."
     },
-    "45b333ce5cc8136e8f9712480a6ef777a2ded0b3": {
+    "e948226ef61a5ef00c2773c2cbf6a35a381e62c5": {
       "file": "src/lib/issues/owner.test.ts",
       "code": "TS2322",
       "count": 3,
-      "message": "Type '{ id: string; name: string; owner: { id: string; name: string; } | null; invitedOwner: { id: string; name: string; } | null; }' is not assignable to type 'Pick<{ id: string; name: string; createdAt: Date; updatedAt: Date; initials: string; nextIssueNumber: number; ownerId: string | null; invitedOwnerId: string | null; description: ProseMirrorDoc | null; ... 10 more ...; ipdbId: number | null; }, \"id\" | ... 1 more ... | \"ownerRequirements\"> & { ...; }'."
-    },
-    "391bb83eff1684f39caa6f1fa9071a29bccf4a8e": {
-      "file": "src/lib/security/turnstile.test.ts",
-      "code": "TS2540",
-      "count": 2,
-      "message": "Cannot assign to 'NODE_ENV' because it is a read-only property."
-    },
-    "d738f05c3e45b8a147991bb06df40d3fe6775f11": {
-      "file": "src/lib/supabase/middleware.test.ts",
-      "code": "TS2540",
-      "count": 1,
-      "message": "Cannot assign to 'NODE_ENV' because it is a read-only property."
+      "message": "Type '{ id: string; name: string; owner: { id: string; name: string; } | null; invitedOwner: { id: string; name: string; } | null; }' is not assignable to type 'Pick<{ name: string; id: string; createdAt: Date; updatedAt: Date; initials: string; nextIssueNumber: number; ownerId: string | null; invitedOwnerId: string | null; description: ProseMirrorDoc | null; ... 10 more ...; ipdbId: number | null; }, \"name\" | ... 1 more ... | \"ownerRequirements\"> & { ...; }'."
     },
     "ac734c26f079a0383a4515d857f329c3da8b60b1": {
       "file": "src/server/actions/images.test.ts",
@@ -172,17 +118,11 @@
       "count": 1,
       "message": "Conversion of type 'undefined' to type '{ botTokenVaultId?: string | undefined; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
     },
-    "e3e6c847bc4e8b9b8eca05ab4477b486aa7776ad": {
+    "d5f9ffde938f24a27139e8fc8eda62208ce6eabd": {
       "file": "src/test/integration/admin/user-management.test.ts",
       "code": "TS2345",
       "count": 1,
-      "message": "Argument of type '\"user\"' is not assignable to parameter of type '\"guest\" | \"member\" | \"technician\" | \"admin\"'."
-    },
-    "bb258a57b75541208dffd2dfdfebc353f0c1d2fc": {
-      "file": "src/test/integration/api/client-logs.route.test.ts",
-      "code": "TS2540",
-      "count": 6,
-      "message": "Cannot assign to 'NODE_ENV' because it is a read-only property."
+      "message": "Argument of type '\"user\"' is not assignable to parameter of type '\"admin\" | \"technician\" | \"member\" | \"guest\"'."
     },
     "73fc9c6b7165b29215abceca1b1903afef6e6c04": {
       "file": "src/test/integration/avatar-upload-action.test.ts",
@@ -280,11 +220,11 @@
       "count": 10,
       "message": "'props' is possibly 'undefined'."
     },
-    "4168547bedd9b91208cb25ead78c9ec6d0b3b10b": {
+    "219c3f773b594bedad5dc52cc7f8bb63c57a53d6": {
       "file": "src/test/integration/machine-owner-promotion.test.ts",
       "code": "TS2345",
       "count": 1,
-      "message": "Argument of type '(callback: (tx: PgliteDatabase<typeof import(\"~/server/db/schema\")>) => Promise<unknown>) => Promise<unknown>' is not assignable to parameter of type '(transaction: (tx: PgTransaction<PgliteQueryResultHKT, typeof import(\"./src/server/db/schema\"), ExtractTablesWithRelations<typeof import(\"./src/server/db/schema\")>>) => Promise<...>...'."
+      "message": "Argument of type '(callback: (tx: PgliteDatabase<typeof import(\"~/server/db/schema\")>) => Promise<unknown>) => Promise<unknown>' is not assignable to parameter of type '(transaction: (tx: PgTransaction<PgliteQueryResultHKT, typeof import(\"./src/server/db/schema\"), ExtractTablesWithRelations<typeof import(\"./src/server/db/schema\")>>) => Promis...'."
     },
     "874d3f80ead79635d0637ce80bb8b9228808f72e": {
       "file": "src/test/integration/machine-settings-actions.test.ts",
@@ -406,11 +346,11 @@
       "count": 1,
       "message": "Unused '@ts-expect-error' directive."
     },
-    "9ed7247b8cb1694eceb9339364ffd49f6a696647": {
+    "8b0953bdf2a95da0db046f94f2cdc26ff3887693": {
       "file": "src/test/integration/supabase/machine-text-fields.test.ts",
       "code": "TS2322",
       "count": 5,
-      "message": "Type 'string' is not assignable to type 'ProseMirrorDoc | SQL<unknown> | PgColumn<ColumnBaseConfig<ColumnDataType, string>, {}, {}> | null | undefined'."
+      "message": "Type 'string' is not assignable to type 'SQL<unknown> | PgColumn<ColumnBaseConfig<ColumnDataType, string>, {}, {}> | ProseMirrorDoc | null | undefined'."
     },
     "67ed3b5a6fb898d6ba1eee2542b4cb9094742608": {
       "file": "src/test/integration/supabase/timeline-invited-conversion.test.ts",
@@ -436,11 +376,11 @@
       "count": 1,
       "message": "A type predicate's type must be assignable to its parameter's type."
     },
-    "9c672ad82aba9bf60cfe9ece97d029ee9c1c0f6b": {
+    "54783305bbe07dacf35ac9ea7e48937db508d756": {
       "file": "src/test/setup/cleanup.ts",
       "code": "TS2345",
       "count": 7,
-      "message": "Argument of type 'PgTableWithColumns<{ name: \"users\"; schema: \"auth\"; columns: { id: PgColumn<{ name: \"id\"; tableName: \"users\"; dataType: \"string\"; columnType: \"PgUUID\"; data: string; driverParam: string; notNull: true; hasDefault: false; ... 6 more ...; generated: undefined; }, {}, {}>; email: PgColumn<...>; }; dialect: \"pg\"; }> | ....' is not assignable to parameter of type 'PgTable<TableConfig>'."
+      "message": "Argument of type 'PgTableWithColumns<{ name: \"user_profiles\"; schema: undefined; columns: { id: PgColumn<{ name: \"id\"; tableName: \"user_profiles\"; dataType: \"string\"; columnType: \"PgUUID\"; data: string; driverParam: string; notNull: true; ... 7 more ...; generated: undefined; }, {}, {}>; ... 11 more ...; updatedAt: PgColumn<...>; }; ...' is not assignable to parameter of type 'PgTable<TableConfig>'."
     },
     "2b16d5e5a6f4dda6617271ee065a00fb44c71321": {
       "file": "src/test/unit/cleanup-helper.test.ts",
@@ -460,23 +400,23 @@
       "count": 3,
       "message": "Type '{ readonly key: \"stern\"; readonly label: \"Stern\"; readonly doc: { readonly type: \"doc\"; readonly content: readonly [{ readonly type: \"paragraph\"; readonly content: readonly [{ readonly type: \"text\"; readonly text: \"Stern path\"; }]; }]; }; }' is not assignable to type 'SettingsInstructionsPreset'."
     },
-    "6ae1683b152a6c91797c63d70498c574e2ec8a29": {
-      "file": "src/test/unit/components/issues/issue-detail-permissions.test.tsx",
-      "code": "TS2322",
-      "count": 1,
-      "message": "Type '{ id: string; name: string; owner: { id: string; name: string; }; invitedOwner: null; }' is not assignable to type 'Pick<{ id: string; name: string; createdAt: Date; updatedAt: Date; initials: string; nextIssueNumber: number; ownerId: string | null; invitedOwnerId: string | null; description: ProseMirrorDoc | null; ... 10 more ...; ipdbId: number | null; }, \"id\" | ... 1 more ... | \"ownerRequirements\"> & { ...; }'."
-    },
-    "4bd2ed77de9bba86c21a3939258764082c3261c5": {
+    "984c107b96f2f04776bacdd1b666d9e7cdca183b": {
       "file": "src/test/unit/components/issues/IssueFilters.test.tsx",
       "code": "TS2345",
       "count": 1,
-      "message": "Argument of type '\"new\" | \"confirmed\" | \"in_progress\" | \"need_parts\" | \"need_help\" | \"wait_owner\" | \"fixed\" | \"wont_fix\" | \"wai\" | \"no_repro\" | \"duplicate\"' is not assignable to parameter of type '\"new\" | \"confirmed\"'."
+      "message": "Argument of type '\"fixed\" | \"new\" | \"confirmed\" | \"in_progress\" | \"need_parts\" | \"need_help\" | \"wait_owner\" | \"wont_fix\" | \"wai\" | \"no_repro\" | \"duplicate\"' is not assignable to parameter of type '\"new\" | \"confirmed\"'."
     },
-    "553270f1f0b152dc1ea1730f8fd9d5d519ec9d8f": {
+    "c7996dd8b9403f893bbca6c19b7b357656ad6130": {
+      "file": "src/test/unit/components/issues/issue-detail-permissions.test.tsx",
+      "code": "TS2322",
+      "count": 1,
+      "message": "Type '{ id: string; name: string; owner: { id: string; name: string; }; invitedOwner: null; }' is not assignable to type 'Pick<{ name: string; id: string; createdAt: Date; updatedAt: Date; initials: string; nextIssueNumber: number; ownerId: string | null; invitedOwnerId: string | null; description: ProseMirrorDoc | null; ... 10 more ...; ipdbId: number | null; }, \"name\" | ... 1 more ... | \"ownerRequirements\"> & { ...; }'."
+    },
+    "afd6cd559827028969eef647d3a1cd805f158e13": {
       "file": "src/test/unit/components/machines/MachineDetailHeader.test.tsx",
       "code": "TS2719",
       "count": 1,
-      "message": "Type '{ manufacturer: string | null; year: number | null; edition: string | null; backboxImageUrl: string | null; id: string; name: string; createdAt: Date; updatedAt: Date; initials: string; ... 16 more ...; watchers: { ...; }[]; }' is not assignable to type '{ manufacturer: string | null; year: number | null; edition: string | null; backboxImageUrl: string | null; id: string; name: string; createdAt: Date; updatedAt: Date; initials: string; ... 16 more ...; watchers: { ...; }[]; }'. Two different types with this name exist, but they are unrelated."
+      "message": "Type '{ manufacturer: string | null; year: number | null; edition: string | null; backboxImageUrl: string | null; name: string; id: string; createdAt: Date; updatedAt: Date; initials: string; ... 16 more ...; watchers: { ...; }[]; }' is not assignable to type '{ manufacturer: string | null; year: number | null; edition: string | null; backboxImageUrl: string | null; name: string; id: string; createdAt: Date; updatedAt: Date; initials: string; ... 16 more ...; watchers: { ...; }[]; }'. Two different types with this name exist, but they are unrelated."
     },
     "c29d27cfd073ce9a31f7a0f2d6913d1d7d2609d5": {
       "file": "src/test/unit/global-setup.test.ts",

--- a/src/app/api/test-data/cleanup/route.test.ts
+++ b/src/app/api/test-data/cleanup/route.test.ts
@@ -49,6 +49,7 @@ describe("api/test-data/cleanup", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = envBackup;
   });
 
@@ -88,7 +89,7 @@ describe("api/test-data/cleanup", () => {
   });
 
   it("returns 403 in production", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
 
     const response = await POST(makeRequest({}));
 

--- a/src/lib/security/turnstile.test.ts
+++ b/src/lib/security/turnstile.test.ts
@@ -23,19 +23,20 @@ describe("verifyTurnstileToken", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     process.env = originalEnv;
   });
 
   it("returns true when TURNSTILE_SECRET_KEY is not set in development (graceful skip)", async () => {
     delete process.env.TURNSTILE_SECRET_KEY;
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     const result = await verifyTurnstileToken("some-token");
     expect(result).toBe(true);
   });
 
   it("returns false when TURNSTILE_SECRET_KEY is not set in production", async () => {
     delete process.env.TURNSTILE_SECRET_KEY;
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const result = await verifyTurnstileToken("some-token");
     expect(result).toBe(false);
   });

--- a/src/lib/supabase/middleware.test.ts
+++ b/src/lib/supabase/middleware.test.ts
@@ -61,6 +61,7 @@ describe("updateSession autologin", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = envBackup;
   });
 
@@ -148,7 +149,7 @@ describe("updateSession autologin", () => {
   });
 
   it("never attempts autologin in production", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.DEV_AUTOLOGIN_ENABLED = "true";
 
     const supabase = createSupabaseAuthMocks(null, null);

--- a/src/test/integration/api/client-logs.route.test.ts
+++ b/src/test/integration/api/client-logs.route.test.ts
@@ -15,14 +15,12 @@ vi.mock("~/lib/logger", () => ({
 import { POST } from "~/app/api/client-logs/route";
 
 describe("/api/client-logs (integration)", () => {
-  const originalNodeEnv = process.env.NODE_ENV;
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
+    vi.unstubAllEnvs();
   });
 
   const buildRequest = (body: unknown): Request =>
@@ -33,7 +31,7 @@ describe("/api/client-logs (integration)", () => {
     });
 
   it("returns 403 outside development", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
 
     const response = await POST(
       buildRequest({
@@ -48,7 +46,7 @@ describe("/api/client-logs (integration)", () => {
   });
 
   it("rejects invalid payloads with 400", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
 
     const response = await POST(
       buildRequest({
@@ -65,7 +63,7 @@ describe("/api/client-logs (integration)", () => {
   });
 
   it("logs info entries with expected shape", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
 
     const payload = {
       level: "info" as const,
@@ -96,7 +94,7 @@ describe("/api/client-logs (integration)", () => {
   });
 
   it("routes error level entries to log.error", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
 
     const response = await POST(
       buildRequest({
@@ -115,7 +113,7 @@ describe("/api/client-logs (integration)", () => {
   });
 
   it("returns 400 on invalid JSON", async () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
 
     const response = await POST(buildRequest("invalid json"));
     const data = (await response.json()) as { error: string };


### PR DESCRIPTION
## Summary

Part of epic PP-38jq (type-clean the test suite). Fixes the NODE_ENV-mutation root-cause cluster (PP-tka5): direct `process.env.NODE_ENV = "..."` assignment is a TS2540 error under `tsconfig.tests.json` (ProcessEnv keys are readonly).

- Swapped direct mutation for `vi.stubEnv("NODE_ENV", ...)` + `vi.unstubAllEnvs()` in `afterEach`, mirroring the existing `src/lib/url.test.ts` precedent.
- Files touched (the 4 named in PP-tka5):
  - `src/test/integration/api/client-logs.route.test.ts` (6 mutations, incl. the afterEach restore)
  - `src/lib/security/turnstile.test.ts` (2 mutations)
  - `src/lib/supabase/middleware.test.ts` (1 mutation)
  - `src/app/api/test-data/cleanup/route.test.ts` (1 mutation)
- Regenerated `.tsc-baseline.json` via `pnpm run typecheck:tests:save`: 261 → 245 errors. 10 of those are this cluster's NODE_ENV fixes; the other 6 are incidental drops of stale `@dnd-kit` TS2307 entries (unrelated to this bead — those modules now resolve fine in this environment, so the previously-frozen errors no longer reproduce). No error counts increased anywhere.

## Test plan

- [x] `pnpm exec vitest run` on the 4 affected files — 51/51 tests pass
- [x] `pnpm run check` — fully green (typecheck:tests reports "0 new errors found. 245 errors already in baseline.")
- [x] No `.tsc-baseline.json` hand-editing — regenerated only via `typecheck:tests:save`

Refs: PP-tka5, PP-38jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)