### PR TITLE
fix(test-types): replace stale enum values in fixtures (PP-qbnk)

### DIFF
--- a/.tsc-baseline.json
+++ b/.tsc-baseline.json
@@ -16,12 +16,6 @@
       "count": 1,
       "message": "Conversion of type '{ id: string; title: string; issueNumber: number; status: \"new\"; severity: \"minor\"; priority: \"low\"; frequency: \"intermittent\"; createdAt: Date; updatedAt: Date; reportedBy: null; assignedTo: null; closedAt: null; machineInitials: string; }' to type 'IssueCardIssue' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
     },
-    "57947199addd91546cf7c25d70336ab38c2ef7b9": {
-      "file": "src/app/(app)/report/unified-report-form.test.tsx",
-      "code": "TS2322",
-      "count": 11,
-      "message": "Type '{ machinesList: { id: string; name: string; initials: string; }[]; defaultMachineId: undefined; userAuthenticated: boolean; accessLevel: \"public\"; assignees: never[]; initialIssues: never[]; initialMachineInitials: string; }' is not assignable to type 'UnifiedReportFormProps'."
-    },
     "5893b201affa593c810a2ea73ec871bb7835b362": {
       "file": "src/lib/blob/cleanup.test.ts",
       "code": "TS2352",
@@ -64,12 +58,6 @@
       "count": 1,
       "message": "Conversion of type 'undefined' to type '{ botTokenVaultId?: string | undefined; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
     },
-    "e3e6c847bc4e8b9b8eca05ab4477b486aa7776ad": {
-      "file": "src/test/integration/admin/user-management.test.ts",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"user\"' is not assignable to parameter of type '\"guest\" | \"member\" | \"technician\" | \"admin\"'."
-    },
     "05090a2b030174078bc02ef595827568503f2220": {
       "file": "src/test/integration/collections-issues-scope.test.ts",
       "code": "TS2345",
@@ -88,12 +76,6 @@
       "count": 4,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'DbOrTx | undefined'."
     },
-    "3852c6737173e0e0b6f7db759682ceef6aa61d7c": {
-      "file": "src/test/integration/dashboard.test.ts",
-      "code": "TS2820",
-      "count": 1,
-      "message": "Type '\"playable\"' is not assignable to type '\"cosmetic\" | \"minor\" | \"major\" | \"unplayable\" | undefined'. Did you mean '\"unplayable\"'?"
-    },
     "317408be15b8b91333290553023786d454e5c093": {
       "file": "src/test/integration/database-queries.test.ts",
       "code": "TS2345",
@@ -111,12 +93,6 @@
       "code": "TS2345",
       "count": 1,
       "message": "Argument of type 'PgTransaction<PgliteQueryResultHKT, typeof import(\"./src/server/db/schema\"), ExtractTablesWithRelations<typeof import(\"./src/server/db/schema\")>>' is not assignable to parameter of type 'DbOrTx | undefined'."
-    },
-    "76c013a7c16640084dcab521d9b594c993d6079d": {
-      "file": "src/test/integration/issue-detail-permissions.test.ts",
-      "code": "TS2769",
-      "count": 1,
-      "message": "No overload matches this call."
     },
     "8cdec8e43e5f014fadb26b4f3c308db7b85c4592": {
       "file": "src/test/integration/issue-services.test.ts",
@@ -184,12 +160,6 @@
       "count": 1,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'DbOrTx | undefined'."
     },
-    "a324e6d3aa0efda363963d2dfbd6b843eb415831": {
-      "file": "src/test/integration/supabase/images.test.ts",
-      "code": "TS2769",
-      "count": 3,
-      "message": "No overload matches this call."
-    },
     "5fd033a55e655ab3bb0bfea8299f5cda0e8d8780": {
       "file": "src/test/integration/supabase/images.test.ts",
       "code": "TS2322",
@@ -217,7 +187,7 @@
     "d3b6ea1b2ee59598cc4ffe0928397b3f9d20a333": {
       "file": "src/test/integration/supabase/issues.test.ts",
       "code": "TS2769",
-      "count": 6,
+      "count": 1,
       "message": "No overload matches this call."
     },
     "abab087678d80a562f6a46c02f91c7cdd8d75dd5": {
@@ -267,12 +237,6 @@
       "code": "TS2322",
       "count": 3,
       "message": "Type '{ readonly key: \"stern\"; readonly label: \"Stern\"; readonly doc: { readonly type: \"doc\"; readonly content: readonly [{ readonly type: \"paragraph\"; readonly content: readonly [{ readonly type: \"text\"; readonly text: \"Stern path\"; }]; }]; }; }' is not assignable to type 'SettingsInstructionsPreset'."
-    },
-    "984c107b96f2f04776bacdd1b666d9e7cdca183b": {
-      "file": "src/test/unit/components/issues/IssueFilters.test.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"fixed\" | \"new\" | \"confirmed\" | \"in_progress\" | \"need_parts\" | \"need_help\" | \"wait_owner\" | \"wont_fix\" | \"wai\" | \"no_repro\" | \"duplicate\"' is not assignable to parameter of type '\"new\" | \"confirmed\"'."
     }
   }
 }

--- a/src/app/(app)/report/unified-report-form.test.tsx
+++ b/src/app/(app)/report/unified-report-form.test.tsx
@@ -117,7 +117,7 @@ const DEFAULT_PROPS = {
   machinesList: MACHINES,
   defaultMachineId: undefined,
   userAuthenticated: false,
-  accessLevel: "public" as const,
+  accessLevel: "unauthenticated" as const,
   assignees: [],
   initialIssues: [],
   initialMachineInitials: "",

--- a/src/test/integration/admin/user-management.test.ts
+++ b/src/test/integration/admin/user-management.test.ts
@@ -142,7 +142,7 @@ describe("Admin User Management Integration", () => {
     // Mock as Target User
     mockGetUser.mockResolvedValue({ data: { user: targetUser! } });
 
-    await expect(updateUserRole(adminUser!.id, "user")).rejects.toThrow(
+    await expect(updateUserRole(adminUser!.id, "member")).rejects.toThrow(
       "Forbidden: Only admins can perform this action"
     );
   });

--- a/src/test/integration/dashboard.test.ts
+++ b/src/test/integration/dashboard.test.ts
@@ -297,7 +297,7 @@ describe("Dashboard Queries (PGlite)", () => {
       await db.insert(issues).values(
         createTestIssue(machine4.initials, {
           issueNumber: 1,
-          severity: "playable",
+          severity: "minor",
           status: "fixed",
         })
       );

--- a/src/test/integration/issue-detail-permissions.test.ts
+++ b/src/test/integration/issue-detail-permissions.test.ts
@@ -152,7 +152,7 @@ describe("Issue detail permission states (integration)", () => {
         title: "Guest-reported issue",
         severity: "minor",
         priority: "low",
-        frequency: "occasional",
+        frequency: "intermittent",
         status: "new",
         reportedBy: guestReporterId,
       })

--- a/src/test/integration/supabase/images.test.ts
+++ b/src/test/integration/supabase/images.test.ts
@@ -87,7 +87,7 @@ describe("Issue Images Database Operations (PGlite)", () => {
         title: "Test Issue",
         machineInitials: testMachine.initials,
         issueNumber: 1,
-        severity: "playable",
+        severity: "major",
         reportedBy: testUser.id,
       })
       .returning();
@@ -421,7 +421,7 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
         title: "Action Test Issue",
         machineInitials: machine.initials,
         issueNumber: 1,
-        severity: "playable",
+        severity: "major",
         reportedBy: reporterId,
       })
       .returning();
@@ -518,7 +518,7 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
         title: "Perm Test Issue",
         machineInitials: machine.initials,
         issueNumber: 2,
-        severity: "playable",
+        severity: "major",
         reportedBy: reporterId,
       })
       .returning();

--- a/src/test/integration/supabase/issues.test.ts
+++ b/src/test/integration/supabase/issues.test.ts
@@ -57,7 +57,7 @@ describe("Issues CRUD Operations (PGlite)", () => {
           description: plainTextToDoc("Test description"),
           machineInitials: testMachine.initials,
           issueNumber: 1,
-          severity: "playable",
+          severity: "major",
           reportedBy: testUser.id,
           status: "new",
         })
@@ -68,7 +68,7 @@ describe("Issues CRUD Operations (PGlite)", () => {
       expect(issue.description).toEqual(plainTextToDoc("Test description"));
       expect(issue.machineInitials).toBe(testMachine.initials);
       expect(issue.issueNumber).toBe(1);
-      expect(issue.severity).toBe("playable");
+      expect(issue.severity).toBe("major");
       expect(issue.status).toBe("new");
       expect(issue.reportedBy).toBe(testUser.id);
     });
@@ -141,7 +141,7 @@ describe("Issues CRUD Operations (PGlite)", () => {
           title: "Issue 2",
           machineInitials: testMachine.initials,
           issueNumber: 2,
-          severity: "playable",
+          severity: "major",
           status: "in_progress",
           reportedBy: testUser.id,
         },
@@ -223,7 +223,7 @@ describe("Issues CRUD Operations (PGlite)", () => {
           title: "Test Issue",
           machineInitials: testMachine.initials,
           issueNumber: 1,
-          severity: "playable",
+          severity: "major",
           status: "new",
           reportedBy: testUser.id,
         })
@@ -310,7 +310,7 @@ describe("Issues CRUD Operations (PGlite)", () => {
           title: "Test Issue",
           machineInitials: testMachine.initials,
           issueNumber: 1,
-          severity: "playable",
+          severity: "major",
           reportedBy: testUser.id,
         })
         .returning();
@@ -458,7 +458,7 @@ describe("Issues CRUD Operations (PGlite)", () => {
           title: "Member Issue",
           machineInitials: testMachine.initials,
           issueNumber: 1,
-          severity: "playable",
+          severity: "major",
           reportedBy: testUser.id,
         },
         {

--- a/src/test/unit/components/issues/IssueFilters.test.tsx
+++ b/src/test/unit/components/issues/IssueFilters.test.tsx
@@ -90,7 +90,7 @@ describe("IssueFilters", () => {
     // New Group = NEW_STATUSES (new, confirmed)
     // Expected = OPEN_STATUSES without NEW_STATUSES
     const expectedStatuses = OPEN_STATUSES.filter(
-      (s: IssueStatus) => !STATUS_GROUPS.new.includes(s)
+      (s: IssueStatus) => !STATUS_GROUPS.new.some((g) => g === s)
     );
 
     expect(pushMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## What

Cluster **PP-qbnk** under epic **PP-38jq** (type-clean the test suite). Test fixtures inlined enum/literal values that were removed or renamed; each is replaced with a genuinely-current value sourced from the source of truth (Drizzle schema / `AccessLevel` union), not a cast.

| Fixture | Stale | Current | Source of truth |
| --- | --- | --- | --- |
| `unified-report-form.test.tsx` DEFAULT_PROPS `accessLevel` (11) | `"public"` | `"unauthenticated"` | `AccessLevel` union, `src/lib/permissions/matrix.ts` (props have `userAuthenticated: false`) |
| `supabase/issues.test.ts`, `supabase/images.test.ts` `severity` | `"playable"` | `"major"` | `severity` enum `cosmetic\|minor\|major\|unplayable`, `schema.ts` |
| `dashboard.test.ts` `severity` | `"playable"` | `"minor"` | same enum — machine must **not** be major/unplayable so it's excluded from the query; the compiler's `"unplayable"` suggestion would invert the test's intent |
| `issue-detail-permissions.test.ts` `frequency` | `"occasional"` | `"intermittent"` | `frequency` enum `intermittent\|frequent\|constant` |
| `admin/user-management.test.ts` `role` | `"user"` | `"member"` | `role` enum `guest\|member\|technician\|admin` (call throws Forbidden before the role matters) |
| `IssueFilters.test.tsx` status subset | `.includes(s)` | `.some((g) => g === s)` | compares the `"new"\|"confirmed"` group against the full `IssueStatus` union without a cast |

## Result

- Test type-error baseline: **163 → 140** (−23) via `typecheck:tests:save`.
- `.tsc-baseline.json` regenerated by the tool (not hand-edited).
- All 7 affected vitest files pass at runtime (76 tests); `pnpm run check` fully green.
- No new errors surfaced elsewhere. Remaining errors in the two supabase files belong to a separate cluster (Blob/`PutBlobResult` + `UserResponse` mock typing) and are untouched.

Refs PP-qbnk, PP-38jq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)