### PR TITLE
fix(test-types): fix misc tail (transaction-callback typing, blob, stale directives) (PP-38jq.1)

### DIFF
--- a/.tsc-baseline.json
+++ b/.tsc-baseline.json
@@ -4,59 +4,11 @@
     "ignoreMessages": false
   },
   "errors": {
-    "b415e5ab7fec0a8f4916b3debd0690774dfa2b41": {
-      "file": "e2e/global-setup.ts",
-      "code": "TS2339",
-      "count": 1,
-      "message": "Property 'code' does not exist on type 'Error'."
-    },
-    "b5a72af05c83d300ff5fe1219b0876af796e5a46": {
-      "file": "src/app/(app)/m/[initials]/issues-expando.test.tsx",
-      "code": "TS2352",
-      "count": 1,
-      "message": "Conversion of type '{ id: string; title: string; issueNumber: number; status: \"new\"; severity: \"minor\"; priority: \"low\"; frequency: \"intermittent\"; createdAt: Date; updatedAt: Date; reportedBy: null; assignedTo: null; closedAt: null; machineInitials: string; }' to type 'IssueCardIssue' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
-    },
-    "5893b201affa593c810a2ea73ec871bb7835b362": {
-      "file": "src/lib/blob/cleanup.test.ts",
-      "code": "TS2352",
-      "count": 1,
-      "message": "Conversion of type 'Promise<Record<string, unknown>[]>' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
-    },
-    "dfc7f000820bc0a4f7752524a1a7dd94822c76fe": {
-      "file": "src/test/eslint/no-side-effects-in-transaction.test.ts",
-      "code": "TS2578",
-      "count": 1,
-      "message": "Unused '@ts-expect-error' directive."
-    },
-    "c0e94e7977c352f9829d9158e6fc2b31616bd4fe": {
-      "file": "src/test/integration/account-deletion.test.ts",
-      "code": "TS2769",
-      "count": 2,
-      "message": "No overload matches this call."
-    },
     "3b3bb9bd117e7d02ba106c613c4dedd90a6b47ad": {
       "file": "src/test/integration/account-deletion.test.ts",
       "code": "TS2345",
       "count": 5,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'PostgresJsDatabase<typeof import(\"./src/server/db/schema\")> & { $client: Sql<{}>; }'."
-    },
-    "77cc6beff03244fc658f8c3060c1e390610ffccc": {
-      "file": "src/test/integration/admin/discord-integration-actions.test.ts",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '(callback: (tx: unknown) => unknown) => unknown' is not assignable to parameter of type '(callback: (tx: Tx) => unknown) => unknown'."
-    },
-    "4c067ca28342d1a1ad2b05f779f5b32447d6e5f2": {
-      "file": "src/test/integration/admin/discord-integration-actions.test.ts",
-      "code": "TS2493",
-      "count": 1,
-      "message": "Tuple type '[]' of length '0' has no element at index '0'."
-    },
-    "4d4b668663af5dde4a01560925ea0dd3f04216e4": {
-      "file": "src/test/integration/admin/discord-integration-actions.test.ts",
-      "code": "TS2352",
-      "count": 1,
-      "message": "Conversion of type 'undefined' to type '{ botTokenVaultId?: string | undefined; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
     },
     "05090a2b030174078bc02ef595827568503f2220": {
       "file": "src/test/integration/collections-issues-scope.test.ts",
@@ -94,29 +46,11 @@
       "count": 1,
       "message": "Argument of type 'PgTransaction<PgliteQueryResultHKT, typeof import(\"./src/server/db/schema\"), ExtractTablesWithRelations<typeof import(\"./src/server/db/schema\")>>' is not assignable to parameter of type 'DbOrTx | undefined'."
     },
-    "8cdec8e43e5f014fadb26b4f3c308db7b85c4592": {
-      "file": "src/test/integration/issue-services.test.ts",
-      "code": "TS2769",
-      "count": 2,
-      "message": "No overload matches this call."
-    },
-    "219c3f773b594bedad5dc52cc7f8bb63c57a53d6": {
-      "file": "src/test/integration/machine-owner-promotion.test.ts",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '(callback: (tx: PgliteDatabase<typeof import(\"~/server/db/schema\")>) => Promise<unknown>) => Promise<unknown>' is not assignable to parameter of type '(transaction: (tx: PgTransaction<PgliteQueryResultHKT, typeof import(\"./src/server/db/schema\"), ExtractTablesWithRelations<typeof import(\"./src/server/db/schema\")>>) => Promis...'."
-    },
     "874d3f80ead79635d0637ce80bb8b9228808f72e": {
       "file": "src/test/integration/machine-settings-actions.test.ts",
       "code": "TS2345",
       "count": 2,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'DbOrTx'."
-    },
-    "1c007fe3ddc541fdbac1054bcb5ee82cf038c635": {
-      "file": "src/test/integration/machine-settings-actions.test.ts",
-      "code": "TS2339",
-      "count": 1,
-      "message": "Property 'changed' does not exist on type 'SaveResult'."
     },
     "739a74dc7dc2d5861a2149b75633faadbcb86da4": {
       "file": "src/test/integration/machine-timeline-actions.test.ts",
@@ -142,12 +76,6 @@
       "count": 3,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'DbOrTx'."
     },
-    "544101e04a199e246308f45a003c636c358fd829": {
-      "file": "src/test/integration/machine-timeline-permissions.test.ts",
-      "code": "TS2578",
-      "count": 1,
-      "message": "Unused '@ts-expect-error' directive."
-    },
     "08d6f926adecb5d45e67ac332f6af6e8845ef206": {
       "file": "src/test/integration/notifications.test.ts",
       "code": "TS2345",
@@ -160,41 +88,11 @@
       "count": 1,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'DbOrTx | undefined'."
     },
-    "5fd033a55e655ab3bb0bfea8299f5cda0e8d8780": {
-      "file": "src/test/integration/supabase/images.test.ts",
-      "code": "TS2322",
-      "count": 1,
-      "message": "Type '{ data: { user: User; }; error: null; } | { data: { user: null; }; error: AuthError | null; }' is not assignable to type 'UserResponse'."
-    },
-    "a39ad70cc4b1e7eca8cbebc553084f6a0a001c8f": {
-      "file": "src/test/integration/supabase/images.test.ts",
-      "code": "TS2322",
-      "count": 1,
-      "message": "Type 'Promise<{ url: string; pathname: string; size: number; uploadedAt: Date; }>' is not assignable to type 'Promise<PutBlobResult>'."
-    },
-    "10f2617d50d3974e4e34fa25b5fb2a389cbe59dd": {
-      "file": "src/test/integration/supabase/images.test.ts",
-      "code": "TS2353",
-      "count": 1,
-      "message": "Object literal may only specify known properties, and 'size' does not exist in type 'PutBlobResult'."
-    },
     "6a8d331325851ff41f3e7c5a003925125aae1888": {
       "file": "src/test/integration/supabase/issue-filtering.test.ts",
       "code": "TS2345",
       "count": 11,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'PostgresJsDatabase<typeof import(\"./src/server/db/schema\")>'."
-    },
-    "d3b6ea1b2ee59598cc4ffe0928397b3f9d20a333": {
-      "file": "src/test/integration/supabase/issues.test.ts",
-      "code": "TS2769",
-      "count": 1,
-      "message": "No overload matches this call."
-    },
-    "abab087678d80a562f6a46c02f91c7cdd8d75dd5": {
-      "file": "src/test/integration/supabase/issues.test.ts",
-      "code": "TS2578",
-      "count": 1,
-      "message": "Unused '@ts-expect-error' directive."
     },
     "7c2bf505f349115e712cb0825002a3dd797dfd3f": {
       "file": "src/test/integration/timeline-author-scope.test.ts",
@@ -207,36 +105,6 @@
       "code": "TS2345",
       "count": 3,
       "message": "Argument of type 'PgliteDatabase<typeof import(\"./src/server/db/schema\")>' is not assignable to parameter of type 'DbOrTx'."
-    },
-    "1a1f1697e4b5dd7f3535aa3cad41cf74825832de": {
-      "file": "src/test/setup/cleanup.ts",
-      "code": "TS2677",
-      "count": 1,
-      "message": "A type predicate's type must be assignable to its parameter's type."
-    },
-    "54783305bbe07dacf35ac9ea7e48937db508d756": {
-      "file": "src/test/setup/cleanup.ts",
-      "code": "TS2345",
-      "count": 7,
-      "message": "Argument of type 'PgTableWithColumns<{ name: \"user_profiles\"; schema: undefined; columns: { id: PgColumn<{ name: \"id\"; tableName: \"user_profiles\"; dataType: \"string\"; columnType: \"PgUUID\"; data: string; driverParam: string; notNull: true; ... 7 more ...; generated: undefined; }, {}, {}>; ... 11 more ...; updatedAt: PgColumn<...>; }; ...' is not assignable to parameter of type 'PgTable<TableConfig>'."
-    },
-    "2b16d5e5a6f4dda6617271ee065a00fb44c71321": {
-      "file": "src/test/unit/cleanup-helper.test.ts",
-      "code": "TS2339",
-      "count": 1,
-      "message": "Property 'mock' does not exist on type '(url: string, options?: { data?: any; failOnStatusCode?: boolean | undefined; form?: FormData | { [key: string]: string | number | boolean; } | undefined; headers?: { [key: string]: string; } | undefined; ... 5 more ...; timeout?: number | undefined; } | undefined) => Promise<...>'."
-    },
-    "b3759dff81c333522b8208c5e44c3895d62015a9": {
-      "file": "src/test/unit/cleanup-order.test.ts",
-      "code": "TS2554",
-      "count": 1,
-      "message": "Expected 1 arguments, but got 2."
-    },
-    "a16d904be459a092292ba054b564205d82ee35ce": {
-      "file": "src/test/unit/components/InlineEditableFieldPresets.test.tsx",
-      "code": "TS2322",
-      "count": 3,
-      "message": "Type '{ readonly key: \"stern\"; readonly label: \"Stern\"; readonly doc: { readonly type: \"doc\"; readonly content: readonly [{ readonly type: \"paragraph\"; readonly content: readonly [{ readonly type: \"text\"; readonly text: \"Stern path\"; }]; }]; }; }' is not assignable to type 'SettingsInstructionsPreset'."
     }
   }
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -102,7 +102,11 @@ function checkDocker(): void {
       timeout: 5000,
     });
 
-    if (result.error?.code === "ENOENT") {
+    if (
+      result.error &&
+      "code" in result.error &&
+      result.error.code === "ENOENT"
+    ) {
       throw new Error(
         "Docker is not installed.\n" +
           "  Install OrbStack, Docker Desktop, or Docker Engine (whichever your platform supports).\n" +

--- a/src/app/(app)/m/[initials]/issues-expando.test.tsx
+++ b/src/app/(app)/m/[initials]/issues-expando.test.tsx
@@ -34,22 +34,18 @@ vi.mock("~/components/issues/ExportButton", () => ({
   ExportButton: () => <button data-testid="export-csv-button">Export</button>,
 }));
 
-const makeIssue = (id: string, title: string): IssueCardIssue =>
-  ({
-    id,
-    title,
-    issueNumber: 1,
-    status: "new",
-    severity: "minor",
-    priority: "low",
-    frequency: "intermittent",
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    reportedBy: null,
-    assignedTo: null,
-    closedAt: null,
-    machineInitials: "TM",
-  }) as IssueCardIssue;
+const makeIssue = (id: string, title: string): IssueCardIssue => ({
+  id,
+  title,
+  issueNumber: 1,
+  status: "new",
+  severity: "minor",
+  priority: "low",
+  frequency: "intermittent",
+  createdAt: new Date(),
+  machineInitials: "TM",
+  reporterName: null,
+});
 
 const defaultProps = {
   machineName: "Test Machine",

--- a/src/lib/blob/cleanup.test.ts
+++ b/src/lib/blob/cleanup.test.ts
@@ -71,10 +71,10 @@ function chainableSelect(rows: Record<string, unknown>[]) {
   const from = vi.fn().mockReturnValue({ where });
   // Also allow resolution without where (for issueImages query)
   from.mockImplementation(() => {
-    // Return an object that is both thenable and has .where()
+    // Return an object that is both thenable and has .where().
+    // Object.assign attaches `.where` to the promise without an unsafe cast.
     const result = Promise.resolve(rows);
-    (result as Record<string, unknown>).where = where;
-    return result;
+    return Object.assign(result, { where });
   });
   return { from, where };
 }

--- a/src/test/eslint/no-side-effects-in-transaction.test.ts
+++ b/src/test/eslint/no-side-effects-in-transaction.test.ts
@@ -1,5 +1,4 @@
 import { Linter } from "eslint";
-// @ts-expect-error -- type-only parser import has no bundled declarations here
 import typescriptParser from "@typescript-eslint/parser";
 import { describe, expect, it } from "vitest";
 

--- a/src/test/integration/account-deletion.test.ts
+++ b/src/test/integration/account-deletion.test.ts
@@ -24,6 +24,7 @@ import {
   anonymizeUserReferences,
   getReassignmentTargets,
 } from "~/app/(app)/settings/account-deletion";
+import { plainTextToDoc } from "~/lib/tiptap/types";
 import { randomUUID } from "node:crypto";
 
 // ---------------------------------------------------------------------------
@@ -137,7 +138,7 @@ describe("Account Deletion Anonymization (PGlite)", () => {
       .values({
         issueId: issueReported.id,
         authorId: userToDeleteId,
-        content: "I am leaving",
+        content: plainTextToDoc("I am leaving"),
       })
       .returning();
 
@@ -169,7 +170,7 @@ describe("Account Deletion Anonymization (PGlite)", () => {
     });
     expect(anonymizedComment?.authorId).toBeNull();
     // Content should remain
-    expect(anonymizedComment?.content).toBe("I am leaving");
+    expect(anonymizedComment?.content).toEqual(plainTextToDoc("I am leaving"));
 
     const anonymizedImage = await db.query.issueImages.findFirst({
       where: eq(issueImages.issueId, issueReported.id),
@@ -379,7 +380,11 @@ describe("deleteAccountAction — DB integration (PGlite)", () => {
 
     const [comment] = await db
       .insert(issueComments)
-      .values({ issueId: issue.id, authorId: userId, content: "goodbye" })
+      .values({
+        issueId: issue.id,
+        authorId: userId,
+        content: plainTextToDoc("goodbye"),
+      })
       .returning();
 
     // Call the real action — DB hits PGlite, external SDKs are mocked
@@ -404,7 +409,7 @@ describe("deleteAccountAction — DB integration (PGlite)", () => {
       where: eq(issueComments.id, comment.id),
     });
     expect(updatedComment?.authorId).toBeNull();
-    expect(updatedComment?.content).toBe("goodbye"); // content preserved
+    expect(updatedComment?.content).toEqual(plainTextToDoc("goodbye")); // content preserved
 
     const updatedMachine = await db.query.machines.findFirst({
       where: eq(machines.id, machine.id),

--- a/src/test/integration/admin/discord-integration-actions.test.ts
+++ b/src/test/integration/admin/discord-integration-actions.test.ts
@@ -37,7 +37,11 @@ const {
   const mockExecute = vi.fn().mockResolvedValue([]);
   const mockReturning = vi.fn().mockResolvedValue([{ id: "singleton" }]);
   const mockUpdateWhere = vi.fn(() => ({ returning: mockReturning }));
-  const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+  const mockUpdateSet = vi.fn(
+    (_payload: { botTokenVaultId?: string | null }) => ({
+      where: mockUpdateWhere,
+    })
+  );
   const mockUpdate = vi.fn(() => ({ set: mockUpdateSet }));
   const mockFindFirst = vi
     .fn()
@@ -437,16 +441,14 @@ describe("saveDiscordConfig", () => {
         order.push("execute");
         return Promise.resolve([]);
       });
-      mockTransaction.mockImplementation(
-        (callback: (tx: unknown) => unknown) => {
-          order.push("transaction");
-          return callback({
-            query: { discordIntegrationConfig: { findFirst: mockFindFirst } },
-            update: mockUpdate,
-            execute: mockExecute,
-          });
-        }
-      );
+      mockTransaction.mockImplementation((callback) => {
+        order.push("transaction");
+        return callback({
+          query: { discordIntegrationConfig: { findFirst: mockFindFirst } },
+          update: mockUpdate,
+          execute: mockExecute,
+        });
+      });
 
       const fd = makeFormData({
         enabled: "true",
@@ -490,11 +492,7 @@ describe("saveDiscordConfig", () => {
       // race-guard set (botTokenVaultId present in the .set() payload).
       const setPayloads = mockUpdateSet.mock.calls.map((c) => c[0]);
       expect(
-        setPayloads.some(
-          (p) =>
-            (p as { botTokenVaultId?: string }).botTokenVaultId ===
-            "new-vault-id"
-        )
+        setPayloads.some((p) => p.botTokenVaultId === "new-vault-id")
       ).toBe(true);
     });
 

--- a/src/test/integration/issue-services.test.ts
+++ b/src/test/integration/issue-services.test.ts
@@ -904,9 +904,9 @@ describe("Issue Service Functions (Integration)", () => {
         reportedBy: testUser.id,
       });
 
-      const mockFn = planNotification as ReturnType<typeof vi.fn>;
+      const mockFn = vi.mocked(planNotification);
       const mentionCalls = mockFn.mock.calls.filter(
-        ([payload]: [{ type?: string }]) => payload.type === "mentioned"
+        ([payload]) => payload.type === "mentioned"
       );
       expect(mentionCalls).toHaveLength(1);
       expect(mentionCalls[0]?.[0]).toEqual(
@@ -940,9 +940,9 @@ describe("Issue Service Functions (Integration)", () => {
         reportedBy: testUser.id,
       });
 
-      const mockFn = planNotification as ReturnType<typeof vi.fn>;
+      const mockFn = vi.mocked(planNotification);
       const mentionCalls = mockFn.mock.calls.filter(
-        ([payload]: [{ type?: string }]) => payload.type === "mentioned"
+        ([payload]) => payload.type === "mentioned"
       );
       expect(mentionCalls).toHaveLength(0);
     });

--- a/src/test/integration/machine-owner-promotion.test.ts
+++ b/src/test/integration/machine-owner-promotion.test.ts
@@ -229,38 +229,41 @@ describe("Machine Owner Promotion — Server Action Integration (PP-rb8)", () =>
         },
       } as any);
 
-      // Spy on the real transaction to intercept the tx object
+      // Spy on the real transaction to intercept the tx object.
+      // Type the mock/callback with the transaction's own parameter types so
+      // the spy signature matches `db.transaction` exactly (the callback
+      // receives a PgTransaction, not the top-level db).
+      type TxCb = Parameters<typeof db.transaction>[0];
+      type Tx = Parameters<TxCb>[0];
       const originalTransaction = db.transaction.bind(db);
       const transactionSpy = vi
         .spyOn(db, "transaction")
-        .mockImplementationOnce(
-          async (callback: (tx: typeof db) => Promise<unknown>) => {
-            return originalTransaction(async (realTx: typeof db) => {
-              // Wrap the tx: let the first update (role promotion on userProfiles) go
-              // through, then throw on the second update (machines) to simulate a
-              // constraint violation or infrastructure failure mid-transaction.
-              let updateCallCount = 0;
-              const txProxy = new Proxy(realTx, {
-                get(target, prop, receiver) {
-                  if (prop === "update") {
-                    return (...args: Parameters<typeof target.update>) => {
-                      updateCallCount++;
-                      if (updateCallCount > 1) {
-                        // Simulate the machine update failing (e.g. constraint violation)
-                        throw new Error(
-                          "Simulated mid-transaction constraint violation on machines table"
-                        );
-                      }
-                      return target.update(...args);
-                    };
-                  }
-                  return Reflect.get(target, prop, receiver);
-                },
-              });
-              return callback(txProxy);
+        .mockImplementationOnce(async (callback: TxCb) => {
+          return originalTransaction(async (realTx: Tx) => {
+            // Wrap the tx: let the first update (role promotion on userProfiles) go
+            // through, then throw on the second update (machines) to simulate a
+            // constraint violation or infrastructure failure mid-transaction.
+            let updateCallCount = 0;
+            const txProxy = new Proxy(realTx, {
+              get(target, prop, receiver) {
+                if (prop === "update") {
+                  return (...args: Parameters<typeof target.update>) => {
+                    updateCallCount++;
+                    if (updateCallCount > 1) {
+                      // Simulate the machine update failing (e.g. constraint violation)
+                      throw new Error(
+                        "Simulated mid-transaction constraint violation on machines table"
+                      );
+                    }
+                    return target.update(...args);
+                  };
+                }
+                return Reflect.get(target, prop, receiver);
+              },
             });
-          }
-        );
+            return callback(txProxy);
+          });
+        });
 
       const formData = new FormData();
       formData.append("id", machine.id);

--- a/src/test/integration/machine-settings-actions.test.ts
+++ b/src/test/integration/machine-settings-actions.test.ts
@@ -240,6 +240,7 @@ describe("Machine settings Server Actions (PP-43q3)", () => {
       ],
     });
     expect(updated.success).toBe(true);
+    if (!updated.success) return;
     expect(updated.changed).toBe(true);
 
     // The persisted state reflects both changes from the single auto-save call.

--- a/src/test/integration/machine-timeline-permissions.test.ts
+++ b/src/test/integration/machine-timeline-permissions.test.ts
@@ -417,8 +417,6 @@ describe("Machine timeline comment Server Actions (PP-0x98)", () => {
 
       const result = await editMachineCommentAction({
         id: comment.id,
-        // @ts-expect-error — userTagSchema rejects this at runtime; we want
-        // to exercise that path.
         tag: "lifecycle",
         contentJson: EDITED_DOC_JSON,
       });

--- a/src/test/integration/supabase/images.test.ts
+++ b/src/test/integration/supabase/images.test.ts
@@ -361,7 +361,7 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
           error: {
             name: "AuthSessionMissingError",
             message: "Auth session missing!",
-          } as GetUserResult["error"],
+          } as NonNullable<GetUserResult["error"]>,
         };
 
     const auth: Pick<SupabaseClient["auth"], "getUser"> = {
@@ -389,9 +389,11 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
     vi.mocked(uploadToBlob).mockImplementation((_file, pathname) =>
       Promise.resolve({
         url: `https://blob.com/${pathname}`,
+        downloadUrl: `https://blob.com/${pathname}?download=1`,
         pathname,
-        size: 1024,
-        uploadedAt: new Date(),
+        contentType: "image/jpeg",
+        contentDisposition: `inline; filename="${pathname}"`,
+        etag: "mock-etag",
       })
     );
   }
@@ -529,9 +531,11 @@ describe("uploadIssueImage — action integration (PGlite)", () => {
 
     vi.mocked(uploadToBlob).mockResolvedValue({
       url: "https://blob.com/should-not-upload.jpg",
+      downloadUrl: "https://blob.com/should-not-upload.jpg?download=1",
       pathname: "issue-images/should-not-upload.jpg",
-      size: 1024,
-      uploadedAt: new Date(),
+      contentType: "image/jpeg",
+      contentDisposition: 'inline; filename="should-not-upload.jpg"',
+      etag: "mock-etag",
     });
 
     const { uploadIssueImage } = await import("~/server/actions/images");

--- a/src/test/integration/supabase/issues.test.ts
+++ b/src/test/integration/supabase/issues.test.ts
@@ -78,9 +78,10 @@ describe("Issues CRUD Operations (PGlite)", () => {
 
       // Attempt to create issue without machineInitials should fail
       await expect(
+        // @ts-expect-error - deliberately passing null for a NOT NULL column to
+        // assert the runtime constraint rejection (the call has no matching overload).
         db.insert(issues).values({
           title: "Test Issue",
-          // @ts-expect-error - Testing validation
           machineInitials: null,
           issueNumber: 1,
           severity: "minor",

--- a/src/test/setup/cleanup.ts
+++ b/src/test/setup/cleanup.ts
@@ -14,8 +14,12 @@ import { PgTable, getTableConfig } from "drizzle-orm/pg-core";
 import * as schema from "~/server/db/schema";
 
 function buildCleanupOrder(): PgTable[] {
-  // Collect every PgTable export (includes authUsers from pgSchema.table())
-  const tables = Object.values(schema).filter(
+  // Collect every PgTable export (includes authUsers from pgSchema.table()).
+  // Widen to `unknown` first: `Object.values(schema)` infers a union of every
+  // export's concrete type, and `PgTable<TableConfig>` (the guard's predicate
+  // type) is not assignable to that union — so the guard needs an `unknown`
+  // input to narrow cleanly.
+  const tables = Object.values(schema as Record<string, unknown>).filter(
     (v): v is PgTable => v instanceof PgTable
   );
 

--- a/src/test/unit/cleanup-helper.test.ts
+++ b/src/test/unit/cleanup-helper.test.ts
@@ -20,7 +20,7 @@ describe("cleanupTestEntities helper", () => {
     });
 
     expect(request.post).toHaveBeenCalledTimes(1);
-    const postArgs = request.post.mock.calls[0];
+    const postArgs = vi.mocked(request.post).mock.calls[0];
     expect(postArgs[0]).toBe("/api/test-data/cleanup");
     expect(postArgs[1]?.data).toEqual({
       issueIds: [],

--- a/src/test/unit/cleanup-order.test.ts
+++ b/src/test/unit/cleanup-order.test.ts
@@ -46,11 +46,11 @@ describe("getCleanupOrder", () => {
           const tableConfig = getTableConfig(table);
           const referencedConfig = getTableConfig(referenced);
 
-          expect(referencerIdx).toBeLessThan(
-            referencedIdx,
+          expect(
+            referencerIdx,
             `"${tableConfig.name}" (idx ${referencerIdx}) must appear before` +
               ` "${referencedConfig.name}" (idx ${referencedIdx}) because it references it`
-          );
+          ).toBeLessThan(referencedIdx);
         }
       }
     }

--- a/src/test/unit/components/InlineEditableFieldPresets.test.tsx
+++ b/src/test/unit/components/InlineEditableFieldPresets.test.tsx
@@ -4,7 +4,10 @@ import { describe, it, expect, vi } from "vitest";
 import { useState } from "react";
 
 import { InlineEditableField } from "~/components/inline-editable-field";
-import { SETTINGS_INSTRUCTIONS_PRESETS } from "~/lib/machines/settings-instructions-presets";
+import {
+  SETTINGS_INSTRUCTIONS_PRESETS,
+  type SettingsInstructionsPreset,
+} from "~/lib/machines/settings-instructions-presets";
 import { docToPlainText, type ProseMirrorDoc } from "~/lib/tiptap/types";
 
 // Stub the rich-text editor/display so the picker logic is tested without Tiptap.
@@ -265,7 +268,7 @@ describe("InlineEditableField — optimistic clear (B3)", () => {
 });
 
 describe("InlineEditableField — preset overwrite confirm (B2 / Task 11)", () => {
-  const sternPreset = {
+  const sternPreset: SettingsInstructionsPreset = {
     key: "stern",
     label: "Stern",
     doc: {
@@ -274,7 +277,7 @@ describe("InlineEditableField — preset overwrite confirm (B2 / Task 11)", () =
         { type: "paragraph", content: [{ type: "text", text: "Stern path" }] },
       ],
     },
-  } as const;
+  };
 
   it("confirms before a preset overwrites existing editor content", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## What

Cleans up the ~31 **non-DbOrTx** test type-errors under epic **PP-38jq** (bead **PP-38jq.1**). Shrinks the committed `.tsc-baseline.json` from **140 → 108** — the remaining 108 are the DbOrTx seam, left for **PP-ku3l**.

Every error is fixed **at source** (no re-baselining a still-erroring line). No DbOrTx-seam error was touched; a couple were harmlessly re-hashed as unrelated tail errors were removed above them.

### Resolves the main-red PP-8dcg
`machine-owner-promotion.test.ts:237`'s `db.transaction` spy was typed `(callback: (tx: typeof db) => …)`, which doesn't match `db.transaction`'s real signature (it passes a `PgTransaction`, not the top-level db). That error sat at tsc's truncation boundary, so it hashed differently in a worktree vs the main checkout and made **main's local `pnpm run check` red**. Now typed via `Parameters<typeof db.transaction>` so the error disappears entirely.

## Fixes by file
- **test/setup/cleanup.ts** (8) — widen `Object.values(schema)` input to `unknown` so the `v is PgTable` guard narrows cleanly; cascades away all `PgTable`-variance errors.
- **machine-owner-promotion.test.ts** (1) — transaction spy typed via `Parameters<>` (PP-8dcg).
- **supabase/images.test.ts** (3) — `PutBlobResult` shape (drop `size`/`uploadedAt`, add `downloadUrl`/`contentType`/`contentDisposition`/`etag`); `NonNullable` auth-error mock so the `UserResponse` union discriminates.
- **admin/discord-integration-actions.test.ts** (3) — type the update-set payload, let the transaction mock infer its callback type, drop an unsafe cast.
- **account-deletion.test.ts** (2) — `issueComments.content` is a `ProseMirrorDoc` jsonb, not a string; insert via `plainTextToDoc` and assert with `toEqual` (also updated two runtime assertions).
- **issue-services.test.ts** (2) — `vi.mocked(planNotification)` so `mock.calls` is typed.
- **InlineEditableFieldPresets.test.tsx** (3) — annotate `sternPreset` with the preset type instead of `as const`.
- **machine-settings-actions.test.ts** (1) — narrow `SaveResult` before reading `.changed`.
- **cleanup-order / cleanup-helper / blob/cleanup / issues-expando / e2e/global-setup** — assorted: `expect(x, msg)` arg placement, `vi.mocked`, `Object.assign`, exact-shape object, and `"code" in error` narrowing.
- Deleted 3 now-unused `@ts-expect-error` directives.

## Verification
- `npx tsc -p tsconfig.tests.json`: 108 errors, **all DbOrTx-seam, 0 non-DbOrTx**, 0 new.
- `pnpm run typecheck:tests`: `0 new errors found. 108 errors already in baseline.`
- `pnpm run check`: **green** (174 files / 1414 tests).
- Touched vitest files pass at runtime (unit + integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)