### PR TITLE
fix(huddle): verify pre-rotation pull — abort instead of minting daily off a stale counter (PP-1d51)

### DIFF
--- a/scripts/hooks/huddle-rotate.sh
+++ b/scripts/hooks/huddle-rotate.sh
@@ -72,10 +72,28 @@ fi
 do_rotation() {
   set -euo pipefail
 
-  # Pull peer machines' state before the date re-check. If another machine
-  # already rotated and pushed, this pull surfaces today's date and we no-op
-  # below — the cross-machine equivalent of the local-lock peer check. Fail-open.
-  bd dolt pull --quiet >/dev/null 2>&1 || true
+  # Pull peer state before allocating any child id. A stale local child counter
+  # (this machine behind the remote) would mint a colliding daily id → an
+  # unmergeable Dolt conflict across machines (PP-1d51). So this pull is VERIFIED,
+  # not fail-open: if it FAILS on a merge conflict, refuse to rotate rather than
+  # mint the daily bead off a possibly-stale counter. Offline/unreachable stays
+  # fail-open — a single active machine cannot collide, and rotation must still
+  # work without a network.
+  #
+  # If another machine already rotated and pushed cleanly, this pull surfaces
+  # today's date and we no-op below — the cross-machine equivalent of the
+  # local-lock peer check.
+  #
+  # Note: --quiet is dropped deliberately so the conflict message is captured in
+  # pull_out for the conflict check below.
+  local pull_rc=0 pull_out
+  pull_out=$(bd dolt pull 2>&1) || pull_rc=$?
+  if [[ "$pull_rc" -ne 0 ]] && printf '%s' "$pull_out" | grep -qiE 'conflict|operator resolution'; then
+    printf 'huddle-rotate.sh: beads sync has unresolved merge conflicts — refusing to rotate.\n' >&2
+    printf 'Rotating now would allocate the daily bead off a possibly-stale child counter and collide across machines (see PP-1d51).\n' >&2
+    printf 'Resolve the beads Dolt conflict first (bd dolt pull), then re-run rotation.\n' >&2
+    exit 1
+  fi
 
   # Re-check date inside the lock (idempotency: a peer may have rotated first).
   # Reserve `exit 0` for the explicit "already up to date" case below. Anything

--- a/scripts/tests/test_huddle_rotate.py
+++ b/scripts/tests/test_huddle_rotate.py
@@ -1,0 +1,165 @@
+"""Unit tests for the pre-rotation verified pull in scripts/hooks/huddle-rotate.sh.
+
+Regression guard for PP-1d51: on 2026-07-07 the Mac ran a huddle rotation while
+its local beads Dolt had diverged from the remote. The pre-rotation pull failed on
+a merge conflict, but rotation continued fail-open and minted the daily bead off a
+STALE local child counter — producing an id (PP-lt12.38) that already existed on
+the remote, an unmergeable cross-machine Dolt conflict.
+
+The fix makes that pull VERIFIED: if the pull fails AND the output mentions a merge
+conflict, rotation aborts (non-zero exit, clear stderr) before allocating any child
+id. Offline/unreachable (a non-zero pull with no conflict wording) stays fail-open —
+a single active machine cannot collide, and rotation must still work without a
+network.
+
+Each test builds a throwaway git repo (so huddle_state_dir resolves to
+<repo>/.agents/huddle), stubs `bd` on PATH to record its invocations and emit canned
+JSON, runs huddle-rotate.sh as a subprocess, and asserts on the exit code plus
+whether `bd create` was invoked (inspected via the BD_LOG).
+"""
+
+import datetime
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+ROTATE_PATH = Path(__file__).parent.parent / "hooks" / "huddle-rotate.sh"
+ROOT_ID = "PP-lt12"
+
+_YESTERDAY = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+_THIS_MONTH = datetime.date.today().strftime("%Y-%m")
+
+# Root notes whose today_bead.date is YESTERDAY (rotation is needed) and whose
+# monthly month is the current month (no month roll → no monthly create). `bd show`
+# emits a JSON ARRAY whose [0].notes is itself a stringified JSON blob — matching
+# how huddle-rotate.sh / huddle-lib.sh parse `.[0].notes`.
+_ROOT_NOTES = {
+    "schema_version": 1,
+    "today_bead": {"id": "PP-lt12.37", "date": _YESTERDAY},
+    "monthly_bead": {"id": "PP-lt12.34", "month": _THIS_MONTH},
+    "recent_dailies": [{"id": "PP-lt12.37", "date": _YESTERDAY}],
+    "settings": {
+        "n_dailies_to_inject": 5,
+        "day_boundary_tz": "local",
+        "stale_name_cutoff_days": 14,
+    },
+    "last_rotation": f"{_YESTERDAY}T00:00:00Z",
+}
+_ROOT_SHOW = json.dumps([{"id": ROOT_ID, "notes": json.dumps(_ROOT_NOTES)}])
+
+# Stub `bd`: append the full arg list to $BD_LOG, then behave per subcommand.
+#   dolt pull  → print $BD_PULL_OUT (if set), exit ${BD_PULL_RC:-0}
+#   dolt push  → exit 0
+#   show <root> → cat $BD_SHOW_JSON (root-notes array)
+#   children    → emit [] (no existing daily today → rotation would create one)
+#   create      → print a fake minted id, exit 0
+#   everything else (update/comments/close) → exit 0
+BD_STUB = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$BD_LOG"
+case "$1 $2" in
+  "dolt pull")
+    [[ -n "${BD_PULL_OUT:-}" ]] && printf '%s\n' "$BD_PULL_OUT"
+    exit "${BD_PULL_RC:-0}"
+    ;;
+  "dolt push") exit 0 ;;
+esac
+case "$1" in
+  show)     cat "$BD_SHOW_JSON"; exit 0 ;;
+  children) printf '[]\n'; exit 0 ;;
+  create)   printf 'PP-lt12.99\n'; exit 0 ;;
+esac
+exit 0
+"""
+
+
+@pytest.fixture
+def repo() -> Iterator[Path]:
+    """A temp git repo with .agents/huddle/config.json and a stub bd on PATH."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        huddle = root / ".agents" / "huddle"
+        huddle.mkdir(parents=True)
+        (huddle / "config.json").write_text(
+            json.dumps({"schema_version": 1, "root_bead_id": ROOT_ID})
+        )
+        (root / "root_show.json").write_text(_ROOT_SHOW)
+        bindir = root / "bin"
+        bindir.mkdir()
+        bd = bindir / "bd"
+        bd.write_text(BD_STUB)
+        bd.chmod(bd.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        yield root
+
+
+def run_rotate(
+    repo: Path, env_extra: dict[str, str] | None = None
+) -> tuple[int, str, str, str]:
+    """Run huddle-rotate.sh in `repo`. Returns (rc, stdout, stderr, bd_log)."""
+    log = repo / "bd.log"
+    env = os.environ.copy()
+    env["PATH"] = f"{repo / 'bin'}{os.pathsep}{env['PATH']}"
+    env["BD_LOG"] = str(log)
+    env["BD_SHOW_JSON"] = str(repo / "root_show.json")
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        ["bash", str(ROTATE_PATH)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    bd_log = log.read_text() if log.exists() else ""
+    return proc.returncode, proc.stdout, proc.stderr, bd_log
+
+
+def _created(bd_log: str) -> bool:
+    """True iff `bd create` was invoked (a daily was minted)."""
+    return any(line.startswith("create ") for line in bd_log.splitlines())
+
+
+# --- the regression guard --------------------------------------------------
+
+
+def test_rotation_aborts_on_pull_conflict(repo: Path) -> None:
+    # Pull fails with a realistic Dolt merge-conflict message. Rotation must
+    # abort BEFORE minting a daily off a possibly-stale local child counter.
+    conflict = (
+        "merge origin/main: merge conflicts in child_counters, dependencies, "
+        "issues require operator resolution; merge aborted and working set restored"
+    )
+    rc, _out, err, log = run_rotate(repo, {"BD_PULL_RC": "1", "BD_PULL_OUT": conflict})
+    assert rc != 0, "conflicting pull must abort rotation with a non-zero exit"
+    assert "refusing to rotate" in err
+    # The load-bearing assertion: no child id was ever allocated.
+    assert not _created(log), "bd create must NOT run when the pull hit a conflict"
+
+
+# --- clean pull still rotates ----------------------------------------------
+
+
+def test_rotation_proceeds_on_clean_pull(repo: Path) -> None:
+    rc, _out, _err, log = run_rotate(repo, {"BD_PULL_RC": "0"})
+    assert rc == 0, "a clean pull must not block rotation"
+    assert _created(log), "a clean pull must mint the daily bead"
+
+
+# --- offline stays fail-open -----------------------------------------------
+
+
+def test_rotation_proceeds_when_offline(repo: Path) -> None:
+    # Non-zero pull, but a network-style error with NO conflict wording. A single
+    # active machine cannot collide, so rotation must still proceed offline.
+    rc, _out, _err, log = run_rotate(
+        repo,
+        {"BD_PULL_RC": "1", "BD_PULL_OUT": "error: could not connect to remote"},
+    )
+    assert rc == 0, "an offline (non-conflict) pull failure must not block rotation"
+    assert _created(log), "offline rotation must still mint the daily bead"


### PR DESCRIPTION
## The incident (2026-07-07)

The daily huddle rotation (`scripts/hooks/huddle-rotate.sh`) allocates the new daily bead as a child of the coordination root — `bd create --parent "$ROOT_ID"` — which draws the next id from the **local** Dolt `child_counters.last_child`. Immediately before that, `do_rotation()` did a **fail-open** pre-rotation pull:

```bash
bd dolt pull --quiet >/dev/null 2>&1 || true
```

When that pull failed on a **merge conflict** — this machine's local beads Dolt having diverged from the remote — rotation continued anyway and minted the daily off a **stale local child counter**, producing an id that already existed on the remote → an **unmergeable Dolt conflict** across machines.

This actually happened: the Mac minted **PP-lt12.38** as a daily, colliding with the already-existing PP-lt12.38 hardening epic while Mac ↔ Bazzite were out of sync.

## The fix

Make the pre-allocation pull **verified**, not fail-open:

- If the pull **fails** (non-zero) **and** its output mentions a merge conflict (`conflict` / `operator resolution`), **abort** rotation with a clear stderr message and non-zero exit — *before any child id is allocated*.
- **Offline/unreachable stays fail-open** (a non-zero pull with no conflict wording): a single active machine cannot collide, and rotation must still work without a network.
- `--quiet` is dropped on this one pull so the conflict message is captured for the check. The reconcile-net pull at the bottom of the script is left fail-open, unchanged.

## Tests

New `scripts/tests/test_huddle_rotate.py` (stubbed `bd`, script run as a subprocess):

- **`test_rotation_aborts_on_pull_conflict`** — the regression guard: a conflicting pull aborts (non-zero exit, stderr mentions refusing to rotate) and `bd create` is **never** called.
- **`test_rotation_proceeds_on_clean_pull`** — a clean pull mints the daily (exit 0, `bd create` called).
- **`test_rotation_proceeds_when_offline`** — a non-conflict pull failure still mints the daily.

## Scope

Scoped to **fix #1** of PP-1d51. Structural and surface-conflict follow-ups are tracked separately.

## Verification

- `pnpm run check:pytest` — green (83 passed, incl. the 3 new tests)
- `pnpm run check` — green (types, lint, format, shellcheck, ruff, unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)