### PR TITLE
feat(workflow): guarantee every PR head commit is reviewed (PP-7ry3)

### DIFF
--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -34,8 +34,9 @@ Coordinate multiple subagents working in parallel across isolated git worktrees.
 
 # Readiness label + merge: pinpoint-pr-workflow skill Phases 3.4 + 4
 # Apply label via mcp__github__issue_write or `gh pr edit --add-label`
-bash scripts/workflow/merge-pr.sh <PR>                   # Composite gate-then-merge enforcer (--dry-run)
+bash scripts/workflow/merge-pr.sh <PR>                   # Composite gate-then-merge enforcer; 5 gates incl. `reviewed` (--dry-run)
 bash scripts/workflow/merge-pr.sh <PR> --dry-run         # Preview gate evaluation without merging
+bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"  # Post SHA-pinned Claude-review marker (satisfies the `reviewed` gate when Copilot skips)
 
 # Worktree health — covers manually created ../pinpoint-worktrees/* ONLY;
 # agent-created .claude/worktrees/* are handled by the WorktreeRemove hook and not scanned here
@@ -129,7 +130,7 @@ Work bead <ID>. First run `bd show <ID>` && `bd update <ID> --claim` — the bea
 
 ## Quality Gates
 
-Run `pnpm run check` before returning.
+Run `pnpm run check` before returning. Then self-review: run `/code-review` on your own diff (the model-invocable local review — **not** `ultra`, which is user-triggered/billed and you cannot launch) and address serious findings. After your final push, if Copilot hasn't reviewed your head commit within ~10 min, run `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` so the `reviewed` merge gate passes.
 
 ## Return Format
 
@@ -138,6 +139,7 @@ Report back with:
 - **Branch**: <branch name>
 - **PR**: #<number>
 - **CI**: passing/failing/pending
+- **Self-review**: findings addressed / marker posted?
 - **Blockers**: none or description
 ```
 
@@ -193,6 +195,16 @@ mcp__github__issue_write(method: "update", owner, repo, issue_number: <PR>, labe
 ```
 
 Or fallback: `gh pr edit <PR> --add-label ready-for-review`.
+
+### Ensure every PR is reviewed (lead backstop)
+
+The subagent self-reviews its own diff (Phase 3 template), but that can be skipped or Copilot can silently miss the head commit — so the lead re-checks at the merge boundary. Before applying `ready-for-review` or handing a PR to `merge-pr.sh`, confirm the head commit is covered by **either** a Copilot review **or** a SHA-pinned Claude marker (`<!-- pinpoint-claude-review: <head_sha> -->`). If neither covers head:
+
+1. Run `/code-review` on the PR diff — the model-invocable **local** review. (`ultra` is the cloud multi-agent review; it is user-triggered and billed, so the agent cannot launch it.)
+2. Address serious findings (fix → have the subagent push → re-review; a fix re-arms the gate). Decline the rest.
+3. `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` to post the marker.
+
+The `reviewed` gate in `merge-pr.sh` is the hard enforcement — it FAILs the merge if the head commit has no Copilot or Claude review once the 600s Copilot window has elapsed. Running the fallback is how you satisfy it; `--force`-bypassing it defeats the guarantee.
 
 ---
 

--- a/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
+++ b/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
@@ -13,7 +13,7 @@ Work bead {beads_id}. First run `bd show {beads_id}` && `bd update {beads_id} --
 
 ### Quality Gates
 
-Run `pnpm run check` before returning.
+Run `pnpm run check` before returning. Then self-review: run `/code-review` on your own diff (model-invocable **local** review — **not** `ultra`, which is user-triggered/billed and you cannot launch) and address serious findings. After your final push, if Copilot hasn't reviewed your head commit within ~10 min, run `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` so the `reviewed` merge gate passes.
 
 ### Environment Setup
 
@@ -34,6 +34,7 @@ If tests fail with `POSTGRES_URL is not set`:
 - **Branch**: {branch_name}
 - **PR**: #{number}
 - **CI**: passing/failing/pending
+- **Self-review**: findings addressed / marker posted?
 - **Blockers**: none or description
 ```
 

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -177,9 +177,12 @@ Compare:
 If head is newer than the latest Copilot review:
 
 - Elapsed < 600s → wait, Copilot may still be reviewing.
-- Elapsed >= 600s → call `request_copilot_review` once; if no review after another 60s, proceed (per the 10-minute threshold in `_pr-gates.sh`).
+- Elapsed >= 600s (or `request_copilot_review` yields nothing after another 60s) → **run a Claude fallback review instead of proceeding unreviewed.** Copilot silently skips `review_requested` events often enough that "no review" cannot be a merge path (per PR #1342 / #1326). The fallback:
+  1. Run `/code-review` against the PR diff (model-invocable local review — **not** `ultra`, which is user-triggered, billed, and the agent cannot launch).
+  2. Address serious findings the same way you handle Copilot threads: fix → push → re-review. A fix changes the head SHA and re-arms the `reviewed` gate. Consciously decline the rest.
+  3. `bash scripts/workflow/mark-claude-review.sh <PR> "<one-line findings summary>"` — posts the SHA-pinned sticky marker `<!-- pinpoint-claude-review: <head_sha> -->` that the `reviewed` gate detects.
 
-`merge-pr.sh` re-checks this at merge time (the `currency` gate), so the skill version is advisory; the script enforces. But don't tell Tim a PR is "ready" or "done" while this is still pending — waiting for Copilot's review is part of finishing the PR, not an optional extra.
+`merge-pr.sh` enforces this at merge time via the `reviewed` gate (PASSes on a Copilot review OR a SHA-matched Claude marker; WAITs inside the 600s window; FAILs after it with no review of either kind). Unlike the older `currency` gate — which WARN-proceeds on a stale/absent Copilot review — `reviewed` blocks the merge, so the Claude fallback is the way past it, not a bypass. Don't tell Tim a PR is "ready" or "done" while head is still unreviewed — making a review happen is part of finishing the PR, not an optional extra.
 
 ### 3.5 Apply `ready-for-review` label
 
@@ -218,12 +221,14 @@ bash scripts/workflow/merge-pr.sh <PR>
 Flags (stackable, order-independent):
 
 - `--dry-run` — preview only, no action.
-- `--force` — bypass `currency` + `threads` (Copilot) gates. Requires manual permission approval.
+- `--force` — bypass `currency` + `threads` + `reviewed` (review-state) gates. Requires manual permission approval.
 - `--bypass-merge-requirements` — bypass `ci` gate AND pass `--admin` to `gh pr merge`,
   overriding GitHub branch-protection rules. Requires manual permission approval.
 
-Combine `--force --bypass-merge-requirements` to bypass `currency` + `threads` + `ci` together.
+Combine `--force --bypass-merge-requirements` to bypass `currency` + `threads` + `reviewed` + `ci` together.
 The `no_conflict` gate is NEVER bypassable — GitHub rejects conflicting merges regardless of `--admin`.
+
+`merge-pr.sh` evaluates **5 gates**: `ci`, `currency`, `threads`, `reviewed`, `no_conflict`. The `reviewed` gate is the hard backstop that no head commit merges unreviewed — prefer running the Claude fallback (Phase 3.4) to satisfy it over `--force`-bypassing it.
 
 ### 4.2 Interpret output
 
@@ -244,11 +249,13 @@ On all PASS: script captures head SHA, calls `gh pr merge <PR> --squash --match-
 
 ### 4.3 Escape hatches
 
-**`--force`** — for Copilot/review-state issues:
+**`--force`** — for Copilot/review-state issues (bypasses `currency` + `threads` + `reviewed`):
 
-- API failure on the `threads` or `currency` gate where you've manually verified the underlying state is fine
+- API failure on the `threads`, `currency`, or `reviewed` gate where you've manually verified the underlying state is fine
 - Copilot has silently-skipped a merge-from-main commit AND you've reviewed the diff manually
-- You're aware the `threads` or `currency` gates would fail and you're explicitly accepting
+- You're aware the `threads` / `currency` / `reviewed` gates would fail and you're explicitly accepting
+
+Prefer the Claude fallback (Phase 3.4 — run `/code-review` + `mark-claude-review.sh`) over `--force` for a `reviewed`-gate failure: the fallback makes the guarantee true rather than skipping it.
 
 **`--bypass-merge-requirements`** — for CI/branch-protection issues:
 

--- a/scripts/workflow/AGENTS.md
+++ b/scripts/workflow/AGENTS.md
@@ -17,10 +17,21 @@ Scripts are designed for the **PinPoint orchestrator workflow** where multiple s
 
 ### Readiness and Merge
 
-| Script             | Purpose                                                                                                                                    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `merge-pr.sh <PR>` | Re-evaluates the gates (CI, no-conflict) and squash-merges if all pass. Removes ready-for-review label on failure. `--dry-run` to preview. |
-| `_pr-gates.sh`     | Shared bash helper sourced by merge-pr.sh. Defines the gate functions.                                                                     |
+| Script                                 | Purpose                                                                                                                                                                             |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `merge-pr.sh <PR>`                     | Re-evaluates all 5 gates (`ci`, `currency`, `threads`, `reviewed`, `no_conflict`) and squash-merges if all pass. Removes ready-for-review label on failure. `--dry-run` to preview. |
+| `mark-claude-review.sh <PR> [summary]` | Posts/updates a sticky SHA-pinned Claude-review marker comment (`<!-- pinpoint-claude-review: <head_sha> -->`) that satisfies the `reviewed` gate when Copilot skips.               |
+| `_pr-gates.sh`                         | Shared bash helper sourced by merge-pr.sh. Defines the gate functions.                                                                                                              |
+
+### Gates (evaluated by `merge-pr.sh`, defined in `_pr-gates.sh`)
+
+| Gate          | Passes when                                                                                                                                    | Bypass kind |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `ci`          | `CI Gate` check is SUCCESS/NEUTRAL/SKIPPED                                                                                                     | `admin`     |
+| `currency`    | Latest Copilot review covers head (WARN-proceeds if stale past 600s)                                                                           | `force`     |
+| `threads`     | Zero unresolved Copilot review threads                                                                                                         | `force`     |
+| `reviewed`    | Head commit covered by a Copilot review OR a SHA-pinned Claude marker; WAITs inside the 600s window, FAILs after with no review of either kind | `force`     |
+| `no_conflict` | PR is MERGEABLE (never bypassable — GitHub rejects conflicting merges)                                                                         | `none`      |
 
 ## Status Token Vocabulary
 

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -150,7 +150,72 @@ check_unresolved_threads() {
   return 1
 }
 
-# Gate 4: PR has no merge conflict. UNKNOWN returned once; caller may retry.
+# Gate 4: Head commit was reviewed by *someone* — Copilot OR a SHA-pinned Claude
+# review marker. Unlike `currency` (which WARN-proceeds on a stale/absent Copilot
+# review), this gate is the hard backstop: a head commit that no one reviewed
+# cannot merge. The Claude marker is `<!-- pinpoint-claude-review: <head_sha> -->`
+# in a PR conversation comment (posted by mark-claude-review.sh); the SHA pin makes
+# it self-expiring — a later fix changes the head SHA and re-arms the gate.
+#   - Claude marker matches head SHA            → PASS
+#   - Copilot review covers head (review>=head) → PASS
+#   - no review, head age < threshold           → WAIT (still inside Copilot window)
+#   - no review, head age >= threshold          → FAIL
+check_review_happened() {
+  local pr=$1
+  local owner_repo head_sha head_date latest_review elapsed
+  owner_repo=$(_repo_slug)
+
+  # Head SHA + committer date (same idiom as check_copilot_currency).
+  local pr_data
+  pr_data=$(gh pr view "$pr" --json headRefOid)
+  head_sha=$(jq -r '.headRefOid' <<< "$pr_data")
+  head_date=$(gh api "repos/${owner_repo}/commits/${head_sha}" --jq '.commit.committer.date')
+
+  # SHA-pinned Claude review marker in a PR conversation (issue) comment.
+  # Issue-comments endpoint = PR conversation comments; SHA-exact match gives free currency.
+  # Pipe to `jq -rs` (slurp) — same as the reviews query below — because gh's own `--jq`
+  # runs per-page under `--paginate`, which would miss a marker on page 2+ of a busy PR.
+  local marker claude_marked
+  marker="<!-- pinpoint-claude-review: ${head_sha} -->"
+  claude_marked=$(gh api --paginate "repos/${owner_repo}/issues/${pr}/comments" \
+    | jq -rs --arg marker "$marker" \
+        '[.[] | flatten | .[] | select(.body | contains($marker))] | length')
+  if [ "${claude_marked:-0}" -gt 0 ]; then
+    echo "PASS: reviewed: Claude review covers head commit"
+    return 0
+  fi
+
+  # Latest Copilot review timestamp via paginated reviews (jq slurp fixes per-page jq bug).
+  latest_review=$(gh api --paginate "repos/${owner_repo}/pulls/${pr}/reviews" \
+    | jq -rs --argjson logins "$(printf '%s\n' "${COPILOT_LOGINS[@]}" | jq -R . | jq -s .)" \
+        '[.[] | flatten | .[] | select(.user.login as $l | $logins | index($l))] | sort_by(.submitted_at) | last | .submitted_at // empty')
+
+  # macOS vs Linux date parsing with TZ=UTC normalization (mirrors check_copilot_currency).
+  local head_epoch review_epoch=0 now_epoch
+  if date -d "$head_date" +%s >/dev/null 2>&1; then
+    head_epoch=$(date -d "$head_date" +%s)
+    [ -n "$latest_review" ] && review_epoch=$(date -d "$latest_review" +%s)
+  else
+    head_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${head_date%Z}Z" +%s)
+    [ -n "$latest_review" ] && review_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${latest_review%Z}Z" +%s)
+  fi
+  now_epoch=$(date -u +%s)
+
+  if [ -n "$latest_review" ] && [ "$review_epoch" -ge "$head_epoch" ]; then
+    echo "PASS: reviewed: Copilot review covers head commit"
+    return 0
+  fi
+
+  elapsed=$((now_epoch - head_epoch))
+  if [ "$elapsed" -lt "$COPILOT_CURRENCY_THRESHOLD" ]; then
+    echo "WAIT: reviewed: ${elapsed}s since head push, awaiting review"
+    return 2
+  fi
+  echo "FAIL: reviewed: head commit has no Copilot or Claude review"
+  return 1
+}
+
+# Gate 5: PR has no merge conflict. UNKNOWN returned once; caller may retry.
 check_no_merge_conflict() {
   local pr=$1
   local mergeable

--- a/scripts/workflow/mark-claude-review.sh
+++ b/scripts/workflow/mark-claude-review.sh
@@ -40,8 +40,11 @@ marker="${MARKER_PREFIX} ${head_sha} -->"
 full_body="${marker}"$'\n'"Claude review of head ${short_sha} — ${summary}"
 
 # Find an existing sticky comment whose body starts with the marker prefix (any SHA).
+# Pipe to `jq -rs` (slurp) rather than gh's per-page `--jq`, so a marker that landed on
+# page 2+ of a busy PR is still found — otherwise a duplicate sticky marker gets posted.
 existing_id=$(gh api --paginate "repos/${repo}/issues/${pr}/comments" \
-  --jq "map(select(.body | startswith(\"${MARKER_PREFIX}\"))) | .[0].id // empty")
+  | jq -rs --arg prefix "$MARKER_PREFIX" \
+      '[.[] | flatten | .[] | select(.body | startswith($prefix))] | .[0].id // empty')
 
 if [[ -n "$existing_id" ]]; then
   echo "Updating Claude-review marker (id=${existing_id}) on PR #${pr} → head ${short_sha}"

--- a/scripts/workflow/mark-claude-review.sh
+++ b/scripts/workflow/mark-claude-review.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mark-claude-review.sh — attest that a Claude Code review covered the PR's head commit.
+#
+# Posts (or updates in place) a single sticky PR conversation comment carrying a
+# SHA-pinned marker `<!-- pinpoint-claude-review: <head_sha> -->`. The `reviewed`
+# gate in _pr-gates.sh detects this marker and, because the SHA is pinned to the
+# current head, a later fix (new head SHA) invalidates the attestation and forces
+# a fresh review. This is the Claude fallback for when Copilot silently skips.
+#
+# The helper only *attests* — the caller is responsible for having actually run the
+# review first (`/code-review`, the model-invocable local review). Same honesty model
+# as `merge-pr.sh --force`.
+#
+# Usage:
+#   bash scripts/workflow/mark-claude-review.sh <PR> ["one-line findings summary"]
+#
+# Environment:
+#   gh must be authenticated. Repo slug is resolved dynamically via `gh repo view`.
+#
+# Invoked via `bash …` — no executable bit required (committed mode 644).
+
+MARKER_PREFIX="<!-- pinpoint-claude-review:"
+
+pr="${1:-}"
+summary="${2:-no serious findings}"
+
+if [[ -z "$pr" || ! "$pr" =~ ^[0-9]+$ ]]; then
+  echo "usage: mark-claude-review.sh <PR> [\"one-line findings summary\"]" >&2
+  exit 2
+fi
+
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+head_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+short_sha="${head_sha:0:7}"
+
+marker="${MARKER_PREFIX} ${head_sha} -->"
+full_body="${marker}"$'\n'"Claude review of head ${short_sha} — ${summary}"
+
+# Find an existing sticky comment whose body starts with the marker prefix (any SHA).
+existing_id=$(gh api --paginate "repos/${repo}/issues/${pr}/comments" \
+  --jq "map(select(.body | startswith(\"${MARKER_PREFIX}\"))) | .[0].id // empty")
+
+if [[ -n "$existing_id" ]]; then
+  echo "Updating Claude-review marker (id=${existing_id}) on PR #${pr} → head ${short_sha}"
+  gh api \
+    --method PATCH \
+    "repos/${repo}/issues/comments/${existing_id}" \
+    -f body="$full_body" \
+    --jq '.html_url'
+else
+  echo "Posting Claude-review marker on PR #${pr} → head ${short_sha}"
+  gh api \
+    --method POST \
+    "repos/${repo}/issues/${pr}/comments" \
+    -f body="$full_body" \
+    --jq '.html_url'
+fi

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # merge-pr.sh — composite gate-then-merge enforcer.
-# Re-evaluates all 4 PR gates at merge time (TOCTOU safety vs label-time gates),
+# Re-evaluates all 5 PR gates at merge time (TOCTOU safety vs label-time gates),
 # squash-merges with --match-head-commit if all pass, removes ready-for-review label on failure.
 #
 # Usage: merge-pr.sh <PR> [--dry-run] [--force] [--bypass-merge-requirements]
 #   --dry-run                     Print would-do summary, take no action.
-#   --force                       Bypass currency + threads gates.
+#   --force                       Bypass currency + threads + reviewed gates.
 #   --bypass-merge-requirements   Bypass ci gate AND pass --admin to gh pr merge
 #                                 (overrides GitHub branch-protection rules).
-#                                 Combine with --force to bypass currency + threads + ci together.
+#                                 Combine with --force to bypass currency + threads + reviewed + ci together.
 #
 # no_conflict gate is NEVER bypassable — GitHub rejects conflicting merges regardless of --admin.
 # Authorship gate has no bypass; this script operates only on PRs you authored OR PRs authored
@@ -68,7 +68,7 @@ echo "Target: PR #$PR — $PR_TITLE"
 echo "URL: $PR_URL"
 echo "Head SHA: $PR_HEAD_SHA"
 
-# --- Run all 4 gates, collect statuses ---
+# --- Run all 5 gates, collect statuses ---
 # Per-gate bypass kind: "none" (never bypassable), "force" (--force), "admin" (--bypass-merge-requirements).
 GATE_FAILURES=()
 
@@ -110,6 +110,7 @@ run_gate() {
 run_gate ci          check_ci                  admin
 run_gate currency    check_copilot_currency    force
 run_gate threads     check_unresolved_threads  force
+run_gate reviewed    check_review_happened     force
 run_gate no_conflict check_no_merge_conflict   none
 
 # --- Decide ---


### PR DESCRIPTION
## Summary

- Close the hole where a PR could merge with **zero review of its head commit**, and make Claude Code review the reliable fallback when Copilot silently skips its `review_requested` event.
- New force-bypassable `reviewed` gate (`check_review_happened`) in `_pr-gates.sh`: **PASS** when the head commit is covered by a Copilot review **or** a SHA-pinned Claude marker; **WAIT** inside the 600s Copilot window; **FAIL** after it with no review of either kind. This tightens the old `currency` gate's WARN-proceed behavior — a stale/absent Copilot review no longer sails through.
- New `mark-claude-review.sh` (mode 644): posts/updates a single sticky attestation comment keyed on `<!-- pinpoint-claude-review: <head_sha> -->`. The SHA pin makes it self-expiring — a later fix (new head SHA) invalidates it and forces re-review.
- Skill updates: `pinpoint-pr-workflow` (Phase 3.4 Claude fallback + Phase 4 gate list) and `pinpoint-orchestrator` (subagent self-review, lead backstop, scripts ref, `/code-review` vs `ultra` capability note) + `agent-prompt-template.md`.

## Gate semantics

`merge-pr.sh` now evaluates **5 gates**: `ci`, `currency`, `threads`, `reviewed`, `no_conflict`. `--force` bypasses `currency` + `threads` + `reviewed`. The `reviewed` gate is the hard backstop; the intended way past it is running the Claude fallback (`/code-review` + `mark-claude-review.sh`), not `--force`.

## Test Plan

- [x] `pnpm run check` green (types, lint, format, unit, shellcheck)
- [x] `shellcheck` clean on all three scripts
- [x] "5 gates" count consistent across `merge-pr.sh`, `scripts/workflow/AGENTS.md`, and the pr-workflow skill
- [x] jq slurp idiom verified to find a marker on page 2+ of a paginated comment stream (fixed a per-page `--jq` bug caught in self-review)
- [ ] CI green

## Related Issues

PP-7ry3