### PR TITLE
feat(hooks): guard-stack integrity canary (PP-140e.12)

### DIFF
--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook: Guard-stack integrity canary (warn-only, fail-open).
+ *
+ * On 2026-07-05 a settings.json rewrite silently deleted PinPoint's entire
+ * PreToolUse guard-hook stack + the permissions deny/ask block, and the
+ * session ran GUARDLESS for ~1.5h before it was caught. Nothing detected it.
+ *
+ * This canary reads .claude/settings.json at session start and warns (to
+ * stderr) if any expected PreToolUse guard hook is missing from the wired
+ * command strings, or if permissions.deny / permissions.ask have been
+ * stripped. It is PURELY INFORMATIONAL:
+ *   - It NEVER blocks anything and NEVER exits non-zero.
+ *   - Healthy path prints NOTHING (no session noise).
+ *   - Any error (missing/unreadable/malformed settings.json) fails open with
+ *     at most a single one-line skip note to stderr.
+ *
+ * KNOWN LIMITATION: this hook is itself wired in settings.json, so a total
+ * settings.json wipe removes the canary along with the guards — it cannot
+ * detect its own deletion. It catches partial degradation (a rewrite that
+ * drops some hooks / the permissions block) but not a full removal.
+ *
+ * Override: set VERIFY_GUARD_SETTINGS to point at an alternate settings.json
+ * (used by tests to run against a scratch file); defaults to ../settings.json
+ * relative to this hook file.
+ */
+
+// Keep in sync when adding/removing a PreToolUse guard hook.
+const EXPECTED_GUARD_HOOKS = [
+  "block-dangerous-commands.cjs",
+  "normalize-workspace-paths.cjs",
+  "inject-beads-actor.cjs",
+  "block-bad-shell-patterns.cjs",
+  "block-heavy-under-pressure.cjs",
+  "block-direct-merge.cjs",
+  "block-main-worktree-branch-switch.cjs",
+];
+
+function skip(reason) {
+  // Fail-open: a single one-line note, never a stack trace, never non-zero.
+  process.stderr.write(`verify-guard-stack: skipped (${reason})\n`);
+  process.exit(0);
+}
+
+function main() {
+  const path = require("node:path");
+  const fs = require("node:fs");
+
+  const settingsPath =
+    process.env.VERIFY_GUARD_SETTINGS ||
+    path.join(__dirname, "..", "settings.json");
+
+  let raw;
+  try {
+    raw = fs.readFileSync(settingsPath, "utf8");
+  } catch (err) {
+    skip(`cannot read settings.json: ${err && err.code ? err.code : "error"}`);
+    return;
+  }
+
+  let settings;
+  try {
+    settings = JSON.parse(raw);
+  } catch {
+    skip("settings.json is not valid JSON");
+    return;
+  }
+
+  // Collect every wired PreToolUse command string.
+  const preToolUse = settings?.hooks?.PreToolUse;
+  const commands = [];
+  if (Array.isArray(preToolUse)) {
+    for (const entry of preToolUse) {
+      const inner = entry?.hooks;
+      if (!Array.isArray(inner)) continue;
+      for (const h of inner) {
+        if (typeof h?.command === "string") {
+          commands.push(h.command);
+        }
+      }
+    }
+  }
+
+  const missingHooks = EXPECTED_GUARD_HOOKS.filter(
+    (basename) => !commands.some((cmd) => cmd.includes(basename)),
+  );
+
+  // permissions.deny / permissions.ask must both be present, non-empty arrays.
+  const missingPerms = [];
+  const perms = settings?.permissions;
+  const denyOk = Array.isArray(perms?.deny) && perms.deny.length > 0;
+  const askOk = Array.isArray(perms?.ask) && perms.ask.length > 0;
+  if (!denyOk) missingPerms.push("permissions.deny empty/absent");
+  if (!askOk) missingPerms.push("permissions.ask empty/absent");
+
+  if (missingHooks.length === 0 && missingPerms.length === 0) {
+    // Healthy — stay silent.
+    process.exit(0);
+  }
+
+  const parts = [];
+  if (missingHooks.length > 0) {
+    parts.push(`missing PreToolUse hooks: ${missingHooks.join(", ")}`);
+  }
+  if (missingPerms.length > 0) {
+    parts.push(missingPerms.join("; "));
+  }
+
+  process.stderr.write(
+    `⚠️  GUARD STACK DEGRADED — ${parts.join("; ")}. ` +
+      `Restore .claude/settings.json from git before continuing.\n`,
+  );
+  process.exit(0);
+}
+
+try {
+  main();
+} catch (err) {
+  // Last-resort fail-open: a broken canary must never disrupt a session.
+  try {
+    process.stderr.write(
+      `verify-guard-stack: skipped (${err && err.message ? err.message : "unexpected error"})\n`,
+    );
+  } catch {
+    /* ignore */
+  }
+  process.exit(0);
+}

--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -36,15 +36,65 @@ const EXPECTED_GUARD_HOOKS = [
   "block-main-worktree-branch-switch.cjs",
 ];
 
-function skip(reason) {
-  // Fail-open: a single one-line note, never a stack trace, never non-zero.
-  process.stderr.write(`verify-guard-stack: skipped (${reason})\n`);
-  process.exit(0);
+// --- Pure evaluator (unit-testable without fs / exit / printing) -------------
+// Given a parsed settings object, return the list of guard-stack problems as
+// human-readable strings. Empty array === healthy. No IO, no printing, no exit.
+//
+// Problems reported:
+//   - `missing PreToolUse hooks: <basename>, ...` when any EXPECTED_GUARD_HOOKS
+//     basename is absent from every wired PreToolUse command string.
+//   - `permissions.deny empty/absent` / `permissions.ask empty/absent` when
+//     either is not a non-empty array.
+function evaluateGuardStack(settings) {
+  const problems = [];
+
+  // Collect every wired PreToolUse command string.
+  const preToolUse = settings?.hooks?.PreToolUse;
+  const commands = [];
+  if (Array.isArray(preToolUse)) {
+    for (const entry of preToolUse) {
+      const inner = entry?.hooks;
+      if (!Array.isArray(inner)) continue;
+      for (const h of inner) {
+        if (typeof h?.command === "string") {
+          commands.push(h.command);
+        }
+      }
+    }
+  }
+
+  const missingHooks = EXPECTED_GUARD_HOOKS.filter(
+    (basename) => !commands.some((cmd) => cmd.includes(basename)),
+  );
+  if (missingHooks.length > 0) {
+    problems.push(`missing PreToolUse hooks: ${missingHooks.join(", ")}`);
+  }
+
+  // permissions.deny / permissions.ask must both be present, non-empty arrays.
+  const perms = settings?.permissions;
+  const denyOk = Array.isArray(perms?.deny) && perms.deny.length > 0;
+  const askOk = Array.isArray(perms?.ask) && perms.ask.length > 0;
+  if (!denyOk) problems.push("permissions.deny empty/absent");
+  if (!askOk) problems.push("permissions.ask empty/absent");
+
+  return problems;
 }
 
+// --- Hook entrypoint ---------------------------------------------------------
+// Does the IO: resolve path (incl. VERIFY_GUARD_SETTINGS override), read/parse
+// settings, call evaluateGuardStack, print one warning line on problems (else
+// silent), and fail open on any error. Always exits 0.
 function main() {
   const path = require("node:path");
   const fs = require("node:fs");
+
+  // Fail-open helper: a single one-line note, never a stack trace, never
+  // non-zero. Collapse any embedded line breaks so it stays one line.
+  const skip = (reason) => {
+    const oneLine = String(reason).replace(/\s*[\r\n]+\s*/g, " ");
+    process.stderr.write(`verify-guard-stack: skipped (${oneLine})\n`);
+    process.exit(0);
+  };
 
   const settingsPath =
     process.env.VERIFY_GUARD_SETTINGS ||
@@ -66,63 +116,36 @@ function main() {
     return;
   }
 
-  // Collect every wired PreToolUse command string.
-  const preToolUse = settings?.hooks?.PreToolUse;
-  const commands = [];
-  if (Array.isArray(preToolUse)) {
-    for (const entry of preToolUse) {
-      const inner = entry?.hooks;
-      if (!Array.isArray(inner)) continue;
-      for (const h of inner) {
-        if (typeof h?.command === "string") {
-          commands.push(h.command);
-        }
-      }
-    }
-  }
-
-  const missingHooks = EXPECTED_GUARD_HOOKS.filter(
-    (basename) => !commands.some((cmd) => cmd.includes(basename)),
-  );
-
-  // permissions.deny / permissions.ask must both be present, non-empty arrays.
-  const missingPerms = [];
-  const perms = settings?.permissions;
-  const denyOk = Array.isArray(perms?.deny) && perms.deny.length > 0;
-  const askOk = Array.isArray(perms?.ask) && perms.ask.length > 0;
-  if (!denyOk) missingPerms.push("permissions.deny empty/absent");
-  if (!askOk) missingPerms.push("permissions.ask empty/absent");
-
-  if (missingHooks.length === 0 && missingPerms.length === 0) {
+  const problems = evaluateGuardStack(settings);
+  if (problems.length === 0) {
     // Healthy — stay silent.
     process.exit(0);
-  }
-
-  const parts = [];
-  if (missingHooks.length > 0) {
-    parts.push(`missing PreToolUse hooks: ${missingHooks.join(", ")}`);
-  }
-  if (missingPerms.length > 0) {
-    parts.push(missingPerms.join("; "));
+    return;
   }
 
   process.stderr.write(
-    `⚠️  GUARD STACK DEGRADED — ${parts.join("; ")}. ` +
+    `⚠️  GUARD STACK DEGRADED — ${problems.join("; ")}. ` +
       `Restore .claude/settings.json from git before continuing.\n`,
   );
   process.exit(0);
 }
 
-try {
-  main();
-} catch (err) {
-  // Last-resort fail-open: a broken canary must never disrupt a session.
+module.exports = { evaluateGuardStack, main };
+
+// Only run as a hook when invoked directly (not when require()'d by a test).
+if (require.main === module) {
   try {
-    process.stderr.write(
-      `verify-guard-stack: skipped (${err && err.message ? err.message : "unexpected error"})\n`,
-    );
-  } catch {
-    /* ignore */
+    main();
+  } catch (err) {
+    // Last-resort fail-open: a broken canary must never disrupt a session.
+    // Collapse embedded line breaks so the skip note stays a single line.
+    try {
+      const reason = err && err.message ? err.message : "unexpected error";
+      const oneLine = String(reason).replace(/\s*[\r\n]+\s*/g, " ");
+      process.stderr.write(`verify-guard-stack: skipped (${oneLine})\n`);
+    } catch {
+      /* ignore */
+    }
+    process.exit(0);
   }
-  process.exit(0);
 }

--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -120,7 +120,6 @@ function main() {
   if (problems.length === 0) {
     // Healthy — stay silent.
     process.exit(0);
-    return;
   }
 
   process.stderr.write(

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -149,6 +149,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/scripts/hooks/prototype-mode-poll.sh",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/verify-guard-stack.cjs",
+            "timeout": 5000
           }
         ]
       }

--- a/src/test/unit/hooks/verify-guard-stack.test.ts
+++ b/src/test/unit/hooks/verify-guard-stack.test.ts
@@ -1,0 +1,306 @@
+// Unit tests for .claude/hooks/verify-guard-stack.cjs — the SessionStart
+// guard-stack integrity canary.
+//
+// Two layers:
+//   1. Fast path — the pure `evaluateGuardStack(settings)` evaluator is
+//      exercised directly with in-memory fixture objects (no fs / exit / IO).
+//   2. Fail-open contract — a couple of subprocess cases spawn `node` on the
+//      hook with VERIFY_GUARD_SETTINGS pointed at a temp fixture, asserting the
+//      warn-only guarantee (always exit 0, one-line skip note, no stack trace).
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+// Resolve the hook relative to the repo root (process.cwd() in vitest).
+const require = createRequire(import.meta.url);
+const hookPath = path.resolve(
+  process.cwd(),
+  ".claude/hooks/verify-guard-stack.cjs"
+);
+const { evaluateGuardStack } = require(hookPath) as {
+  evaluateGuardStack: (settings: unknown) => string[];
+};
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+const ALL_EXPECTED_HOOKS = [
+  "block-dangerous-commands.cjs",
+  "normalize-workspace-paths.cjs",
+  "inject-beads-actor.cjs",
+  "block-bad-shell-patterns.cjs",
+  "block-heavy-under-pressure.cjs",
+  "block-direct-merge.cjs",
+  "block-main-worktree-branch-switch.cjs",
+];
+
+/** Build a settings object wiring the given hook basenames under PreToolUse. */
+function settingsWithHooks(
+  hookBasenames: string[],
+  perms: { deny?: unknown; ask?: unknown } = {
+    deny: ["Bash(x)"],
+    ask: ["Bash(y)"],
+  }
+): unknown {
+  return {
+    permissions: perms,
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: hookBasenames.map((b) => ({
+            type: "command",
+            command: `node .claude/hooks/${b}`,
+            timeout: 5000,
+          })),
+        },
+      ],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fast path: pure evaluateGuardStack
+// ---------------------------------------------------------------------------
+describe("evaluateGuardStack — healthy", () => {
+  it("reports no problems when all 7 hooks + non-empty permissions present", () => {
+    const settings = settingsWithHooks(ALL_EXPECTED_HOOKS);
+    expect(evaluateGuardStack(settings)).toEqual([]);
+  });
+
+  it("is healthy regardless of how hooks are distributed across matchers", () => {
+    // Split the expected hooks across two PreToolUse matcher entries.
+    const settings = {
+      permissions: { deny: ["Bash(x)"], ask: ["Bash(y)"] },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: ALL_EXPECTED_HOOKS.slice(0, 4).map((b) => ({
+              type: "command",
+              command: `node .claude/hooks/${b}`,
+            })),
+          },
+          {
+            matcher: "Bash|mcp__github__merge_pull_request",
+            hooks: ALL_EXPECTED_HOOKS.slice(4).map((b) => ({
+              type: "command",
+              command: `node .claude/hooks/${b}`,
+            })),
+          },
+        ],
+      },
+    };
+    expect(evaluateGuardStack(settings)).toEqual([]);
+  });
+});
+
+describe("evaluateGuardStack — missing hooks", () => {
+  it("reports exactly the one missing hook basename", () => {
+    const remaining = ALL_EXPECTED_HOOKS.filter(
+      (b) => b !== "block-direct-merge.cjs"
+    );
+    const problems = evaluateGuardStack(settingsWithHooks(remaining));
+    expect(problems).toEqual([
+      "missing PreToolUse hooks: block-direct-merge.cjs",
+    ]);
+  });
+
+  it("lists multiple missing hooks in one problem string", () => {
+    const remaining = ALL_EXPECTED_HOOKS.filter(
+      (b) =>
+        b !== "block-dangerous-commands.cjs" &&
+        b !== "block-main-worktree-branch-switch.cjs"
+    );
+    const problems = evaluateGuardStack(settingsWithHooks(remaining));
+    expect(problems).toEqual([
+      "missing PreToolUse hooks: block-dangerous-commands.cjs, block-main-worktree-branch-switch.cjs",
+    ]);
+  });
+
+  it("reports all hooks missing when PreToolUse is absent entirely", () => {
+    const problems = evaluateGuardStack({
+      permissions: { deny: ["Bash(x)"], ask: ["Bash(y)"] },
+      hooks: {},
+    });
+    expect(problems).toEqual([
+      `missing PreToolUse hooks: ${ALL_EXPECTED_HOOKS.join(", ")}`,
+    ]);
+  });
+});
+
+describe("evaluateGuardStack — permissions", () => {
+  it("reports permissions.deny empty/absent when deny is an empty array", () => {
+    const problems = evaluateGuardStack(
+      settingsWithHooks(ALL_EXPECTED_HOOKS, { deny: [], ask: ["Bash(y)"] })
+    );
+    expect(problems).toEqual(["permissions.deny empty/absent"]);
+  });
+
+  it("reports permissions.ask empty/absent when ask is missing", () => {
+    const problems = evaluateGuardStack(
+      settingsWithHooks(ALL_EXPECTED_HOOKS, { deny: ["Bash(x)"] })
+    );
+    expect(problems).toEqual(["permissions.ask empty/absent"]);
+  });
+
+  it("reports both when the whole permissions block is absent", () => {
+    const problems = evaluateGuardStack({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: ALL_EXPECTED_HOOKS.map((b) => ({
+              type: "command",
+              command: `node .claude/hooks/${b}`,
+            })),
+          },
+        ],
+      },
+    });
+    expect(problems).toEqual([
+      "permissions.deny empty/absent",
+      "permissions.ask empty/absent",
+    ]);
+  });
+});
+
+describe("evaluateGuardStack — combinations", () => {
+  it("reports a missing hook AND emptied permissions together (the 2026-07-05 mode)", () => {
+    const remaining = ALL_EXPECTED_HOOKS.filter(
+      (b) => b !== "block-direct-merge.cjs"
+    );
+    const problems = evaluateGuardStack(
+      settingsWithHooks(remaining, { deny: [], ask: [] })
+    );
+    expect(problems).toEqual([
+      "missing PreToolUse hooks: block-direct-merge.cjs",
+      "permissions.deny empty/absent",
+      "permissions.ask empty/absent",
+    ]);
+  });
+
+  it("treats an empty object as fully degraded", () => {
+    const problems = evaluateGuardStack({});
+    expect(problems).toEqual([
+      `missing PreToolUse hooks: ${ALL_EXPECTED_HOOKS.join(", ")}`,
+      "permissions.deny empty/absent",
+      "permissions.ask empty/absent",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-open contract: subprocess execution of the hook (warn-only guarantee)
+// ---------------------------------------------------------------------------
+const tmpFiles: string[] = [];
+
+function writeTmp(name: string, contents: string): string {
+  const p = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "verify-guard-stack-")),
+    name
+  );
+  fs.writeFileSync(p, contents);
+  tmpFiles.push(p);
+  return p;
+}
+
+/** Run the hook as a subprocess; return { status, stdout, stderr }. */
+function runHook(settingsFile: string | undefined): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const env = { ...process.env };
+  if (settingsFile === undefined) {
+    delete env.VERIFY_GUARD_SETTINGS;
+  } else {
+    env.VERIFY_GUARD_SETTINGS = settingsFile;
+  }
+  // spawnSync captures both stdout and stderr regardless of exit code, so the
+  // warn-only (exit 0) path can still assert on stderr content.
+  const result = spawnSync("node", [hookPath], {
+    env,
+    input: "",
+    encoding: "utf8",
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+afterAll(() => {
+  for (const f of tmpFiles) {
+    try {
+      fs.rmSync(path.dirname(f), { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+describe("verify-guard-stack.cjs subprocess — fail-open contract", () => {
+  it("malformed JSON → exit 0, single-line skip note, no stack trace", () => {
+    const file = writeTmp("settings.json", "{");
+    const { status, stdout, stderr } = runHook(file);
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr.trim()).toBe(
+      "verify-guard-stack: skipped (settings.json is not valid JSON)"
+    );
+    // One line only, and no Node stack-trace markers.
+    expect(stderr.trim().split("\n")).toHaveLength(1);
+    expect(stderr).not.toContain("at ");
+  });
+
+  it("missing settings file → exit 0, single-line skip note", () => {
+    const missing = path.join(
+      os.tmpdir(),
+      "verify-guard-stack-does-not-exist.json"
+    );
+    const { status, stdout, stderr } = runHook(missing);
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr.trim()).toMatch(
+      /^verify-guard-stack: skipped \(cannot read settings\.json: ENOENT\)$/
+    );
+    expect(stderr.trim().split("\n")).toHaveLength(1);
+  });
+
+  it("healthy settings → exit 0, no stdout/stderr noise", () => {
+    const file = writeTmp(
+      "settings.json",
+      JSON.stringify(settingsWithHooks(ALL_EXPECTED_HOOKS), null, 2)
+    );
+    const { status, stdout, stderr } = runHook(file);
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+  });
+
+  it("degraded settings → exit 0 (warn-only) with the GUARD STACK DEGRADED warning", () => {
+    const remaining = ALL_EXPECTED_HOOKS.filter(
+      (b) => b !== "block-direct-merge.cjs"
+    );
+    const file = writeTmp(
+      "settings.json",
+      JSON.stringify(
+        settingsWithHooks(remaining, { deny: [], ask: [] }),
+        null,
+        2
+      )
+    );
+    const { status, stdout, stderr } = runHook(file);
+    expect(status).toBe(0); // never blocks
+    expect(stdout).toBe("");
+    expect(stderr).toContain("GUARD STACK DEGRADED");
+    expect(stderr).toContain("block-direct-merge.cjs");
+    expect(stderr).toContain("permissions.deny empty/absent");
+  });
+});


### PR DESCRIPTION
## Motivation

On **2026-07-05**, a `settings.json` rewrite silently deleted PinPoint's entire PreToolUse guard-hook stack **plus** the `permissions.deny`/`permissions.ask` block. The session then ran **guardless for ~1.5h** before anyone noticed. Nothing in the repo detected the degradation. This PR adds a warn-only canary that surfaces the problem at session start.

## What it does

New SessionStart hook `.claude/hooks/verify-guard-stack.cjs`:

- Reads `.claude/settings.json` (resolved relative to the hook file).
- Collects every wired `hooks.PreToolUse[*].hooks[*].command` string.
- Compares against a hardcoded source-of-truth list of expected guard-hook basenames (`block-dangerous-commands.cjs`, `normalize-workspace-paths.cjs`, `inject-beads-actor.cjs`, `block-bad-shell-patterns.cjs`, `block-heavy-under-pressure.cjs`, `block-direct-merge.cjs`, `block-main-worktree-branch-switch.cjs`). A hook counts as present if any wired command string contains its basename.
- Asserts `permissions.deny` and `permissions.ask` are both present, non-empty arrays.
- On any degradation: prints **one** loud stderr warning naming exactly which hooks / permissions sections are missing, then exits 0.
- Healthy path: prints **nothing** (no session noise).

Wired as the last entry in the existing `hooks.SessionStart` array (append-only; existing orphan-sweep / huddle / prototype-mode entries untouched).

## Warn-only / fail-open guarantee

The hook **never blocks anything** and **never exits non-zero**. Any error — missing, unreadable, or malformed `settings.json` — fails open with at most a single one-line `verify-guard-stack: skipped (<reason>)` note to stderr. The whole body is wrapped so a broken canary can never disrupt a session. It ignores stdin (SessionStart provides no meaningful command).

A `VERIFY_GUARD_SETTINGS` env override points the hook at an alternate settings path (used by tests); it defaults to the real `../settings.json`.

## Known limitation

The canary is itself wired in `settings.json`, so a **total** wipe removes the canary along with the guards — it cannot detect its own deletion. It catches **partial** degradation (a rewrite that drops some hooks or the permissions block), which is the 2026-07-05 failure mode, but not a full removal.

## Verification

- Intact worktree → no output, exit 0.
- Degraded scratch copy (dropped `block-direct-merge.cjs`, emptied permissions) → `⚠️  GUARD STACK DEGRADED — missing PreToolUse hooks: block-direct-merge.cjs; permissions.deny empty/absent; permissions.ask empty/absent. Restore ...`, exit 0.
- Malformed JSON (`{`) and missing file → one-line skip note, exit 0, no stack trace.
- `pnpm run check` passes.

Bead: PP-140e.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)