### PR TITLE
chore(db): advisor housekeeping — unused indexes + FK covering indexes (PP-o60s.5)

### DIFF
--- a/drizzle/0050_empty_meltdown.sql
+++ b/drizzle/0050_empty_meltdown.sql
@@ -1,0 +1,4 @@
+DROP INDEX "idx_issues_priority";--> statement-breakpoint
+DROP INDEX "idx_notif_prefs_global_watch_email";--> statement-breakpoint
+CREATE INDEX "idx_issue_images_comment_id" ON "issue_images" USING btree ("comment_id");--> statement-breakpoint
+CREATE INDEX "idx_issue_images_deleted_by" ON "issue_images" USING btree ("deleted_by");

--- a/drizzle/0050_empty_meltdown.sql
+++ b/drizzle/0050_empty_meltdown.sql
@@ -1,4 +1,0 @@
-DROP INDEX IF EXISTS "idx_issues_priority";--> statement-breakpoint
-DROP INDEX IF EXISTS "idx_notif_prefs_global_watch_email";--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_issue_images_comment_id" ON "issue_images" USING btree ("comment_id");--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "idx_issue_images_deleted_by" ON "issue_images" USING btree ("deleted_by");

--- a/drizzle/0050_empty_meltdown.sql
+++ b/drizzle/0050_empty_meltdown.sql
@@ -1,4 +1,4 @@
-DROP INDEX "idx_issues_priority";--> statement-breakpoint
-DROP INDEX "idx_notif_prefs_global_watch_email";--> statement-breakpoint
-CREATE INDEX "idx_issue_images_comment_id" ON "issue_images" USING btree ("comment_id");--> statement-breakpoint
-CREATE INDEX "idx_issue_images_deleted_by" ON "issue_images" USING btree ("deleted_by");
+DROP INDEX IF EXISTS "idx_issues_priority";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_notif_prefs_global_watch_email";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_issue_images_comment_id" ON "issue_images" USING btree ("comment_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_issue_images_deleted_by" ON "issue_images" USING btree ("deleted_by");

--- a/drizzle/0050_overjoyed_viper.sql
+++ b/drizzle/0050_overjoyed_viper.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS "idx_issues_priority";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_notif_prefs_global_watch_email";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_issue_images_comment_id" ON "issue_images" USING btree ("comment_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_issue_images_deleted_by" ON "issue_images" USING btree ("deleted_by");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_machine_settings_sets_created_by" ON "machine_settings_sets" USING btree ("created_by");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_machine_settings_sets_updated_by" ON "machine_settings_sets" USING btree ("updated_by");

--- a/drizzle/meta/0050_snapshot.json
+++ b/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,2188 @@
+{
+  "id": "bc2da984-d763-4874-89c2-ed1bea2b37e4",
+  "prevId": "c928591a-a93c-4438-9ede-ad593679ddbd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_integration_config": {
+      "name": "discord_integration_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_link": {
+          "name": "invite_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_vault_id": {
+          "name": "bot_token_vault_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_health_status": {
+          "name": "bot_health_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_bot_check_at": {
+          "name": "last_bot_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "discord_integration_config_singleton": {
+          "name": "discord_integration_config_singleton",
+          "value": "id = 'singleton'"
+        },
+        "discord_integration_config_health_check": {
+          "name": "discord_integration_config_health_check",
+          "value": "bot_health_status IN ('unknown', 'healthy', 'degraded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invited_users": {
+      "name": "invited_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "first_name || ' ' || last_name",
+            "type": "stored"
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invite_sent_at": {
+          "name": "invite_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invited_users_email_unique": {
+          "name": "invited_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invited_users_role_check": {
+          "name": "invited_users_role_check",
+          "value": "role IN ('guest', 'member', 'technician', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_comments": {
+      "name": "issue_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_comments_issue_id_created_at": {
+          "name": "idx_issue_comments_issue_id_created_at",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_comments_author_id": {
+          "name": "idx_issue_comments_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_comments_idempotency_key": {
+          "name": "idx_issue_comments_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_comments\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_comments_issue_id_issues_id_fk": {
+          "name": "issue_comments_issue_id_issues_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_comments_author_id_user_profiles_id_fk": {
+          "name": "issue_comments_author_id_user_profiles_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_system_event_data": {
+          "name": "chk_system_event_data",
+          "value": "NOT \"issue_comments\".\"is_system\" OR \"issue_comments\".\"event_data\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_images": {
+      "name": "issue_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_image_url": {
+          "name": "full_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cropped_image_url": {
+          "name": "cropped_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_blob_pathname": {
+          "name": "full_blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cropped_blob_pathname": {
+          "name": "cropped_blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_images_issue_id": {
+          "name": "idx_issue_images_issue_id",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_uploaded_by": {
+          "name": "idx_issue_images_uploaded_by",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_deleted_at": {
+          "name": "idx_issue_images_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_comment_id": {
+          "name": "idx_issue_images_comment_id",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_deleted_by": {
+          "name": "idx_issue_images_deleted_by",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_images_issue_id_issues_id_fk": {
+          "name": "issue_images_issue_id_issues_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_images_comment_id_issue_comments_id_fk": {
+          "name": "issue_images_comment_id_issue_comments_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "issue_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_images_uploaded_by_user_profiles_id_fk": {
+          "name": "issue_images_uploaded_by_user_profiles_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_images_deleted_by_user_profiles_id_fk": {
+          "name": "issue_images_deleted_by_user_profiles_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_watchers": {
+      "name": "issue_watchers",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_issue_watchers_user_id": {
+          "name": "idx_issue_watchers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_watchers_issue_id_issues_id_fk": {
+          "name": "issue_watchers_issue_id_issues_id_fk",
+          "tableFrom": "issue_watchers",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_watchers_user_id_user_profiles_id_fk": {
+          "name": "issue_watchers_user_id_user_profiles_id_fk",
+          "tableFrom": "issue_watchers",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_watchers_issue_id_user_id_pk": {
+          "name": "issue_watchers_issue_id_user_id_pk",
+          "columns": ["issue_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_initials": {
+          "name": "machine_initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'minor'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'intermittent'"
+        },
+        "reported_by": {
+          "name": "reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_reported_by": {
+          "name": "invited_reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_name": {
+          "name": "reporter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_email": {
+          "name": "reporter_email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issues_idempotency_key": {
+          "name": "idx_issues_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issues\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_assigned_to": {
+          "name": "idx_issues_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_reported_by": {
+          "name": "idx_issues_reported_by",
+          "columns": [
+            {
+              "expression": "reported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_status": {
+          "name": "idx_issues_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_created_at": {
+          "name": "idx_issues_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_invited_reported_by": {
+          "name": "idx_issues_invited_reported_by",
+          "columns": [
+            {
+              "expression": "invited_reported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_severity": {
+          "name": "idx_issues_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_machine_initials_machines_initials_fk": {
+          "name": "issues_machine_initials_machines_initials_fk",
+          "tableFrom": "issues",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_initials"],
+          "columnsTo": ["initials"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issues_reported_by_user_profiles_id_fk": {
+          "name": "issues_reported_by_user_profiles_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["reported_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_invited_reported_by_invited_users_id_fk": {
+          "name": "issues_invited_reported_by_invited_users_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "invited_users",
+          "columnsFrom": ["invited_reported_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_assigned_to_user_profiles_id_fk": {
+          "name": "issues_assigned_to_user_profiles_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_issue_number": {
+          "name": "unique_issue_number",
+          "nullsNotDistinct": false,
+          "columns": ["machine_initials", "issue_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reporter_check": {
+          "name": "reporter_check",
+          "value": "(\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NOT NULL AND \"issues\".\"invited_reported_by\" IS NULL AND \"issues\".\"reporter_name\" IS NULL AND \"issues\".\"reporter_email\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NOT NULL AND \"issues\".\"reporter_name\" IS NULL AND \"issues\".\"reporter_email\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NULL AND (\"issues\".\"reporter_name\" IS NOT NULL OR \"issues\".\"reporter_email\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.machine_settings_sets": {
+      "name": "machine_settings_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_preferred": {
+          "name": "is_preferred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_machine_settings_sets_machine": {
+          "name": "idx_machine_settings_sets_machine",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_machine_settings_preferred": {
+          "name": "uniq_machine_settings_preferred",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"machine_settings_sets\".\"is_preferred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_settings_sets_machine_id_machines_id_fk": {
+          "name": "machine_settings_sets_machine_id_machines_id_fk",
+          "tableFrom": "machine_settings_sets",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_settings_sets_created_by_user_profiles_id_fk": {
+          "name": "machine_settings_sets_created_by_user_profiles_id_fk",
+          "tableFrom": "machine_settings_sets",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "machine_settings_sets_updated_by_user_profiles_id_fk": {
+          "name": "machine_settings_sets_updated_by_user_profiles_id_fk",
+          "tableFrom": "machine_settings_sets",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.machine_watchers": {
+      "name": "machine_watchers",
+      "schema": "",
+      "columns": {
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_mode": {
+          "name": "watch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_machine_watchers_user_id": {
+          "name": "idx_machine_watchers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_watchers_machine_id_machines_id_fk": {
+          "name": "machine_watchers_machine_id_machines_id_fk",
+          "tableFrom": "machine_watchers",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_watchers_user_id_user_profiles_id_fk": {
+          "name": "machine_watchers_user_id_user_profiles_id_fk",
+          "tableFrom": "machine_watchers",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "machine_watchers_machine_id_user_id_pk": {
+          "name": "machine_watchers_machine_id_user_id_pk",
+          "columns": ["machine_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_issue_number": {
+          "name": "next_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_owner_id": {
+          "name": "invited_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_requirements": {
+          "name": "owner_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_requests": {
+          "name": "settings_requests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_instructions": {
+          "name": "settings_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_status": {
+          "name": "presence_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_the_floor'"
+        },
+        "pinballmap_machine_id": {
+          "name": "pinballmap_machine_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinballmap_excluded": {
+          "name": "pinballmap_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinballmap_excluded_reason": {
+          "name": "pinballmap_excluded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opdb_id": {
+          "name": "opdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipdb_id": {
+          "name": "ipdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_machines_owner_id": {
+          "name": "idx_machines_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machines_invited_owner_id": {
+          "name": "idx_machines_invited_owner_id",
+          "columns": [
+            {
+              "expression": "invited_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machines_name": {
+          "name": "idx_machines_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machines_owner_id_user_profiles_id_fk": {
+          "name": "machines_owner_id_user_profiles_id_fk",
+          "tableFrom": "machines",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "machines_invited_owner_id_invited_users_id_fk": {
+          "name": "machines_invited_owner_id_invited_users_id_fk",
+          "tableFrom": "machines",
+          "tableTo": "invited_users",
+          "columnsFrom": ["invited_owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machines_initials_unique": {
+          "name": "machines_initials_unique",
+          "nullsNotDistinct": false,
+          "columns": ["initials"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "initials_check": {
+          "name": "initials_check",
+          "value": "initials ~ '^[A-Z0-9]{2,6}$'"
+        },
+        "owner_check": {
+          "name": "owner_check",
+          "value": "(owner_id IS NULL OR invited_owner_id IS NULL)"
+        },
+        "machines_pinballmap_link_exclusive": {
+          "name": "machines_pinballmap_link_exclusive",
+          "value": "NOT (pinballmap_machine_id IS NOT NULL AND pinballmap_excluded)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "suppress_own_actions": {
+          "name": "suppress_own_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_assigned": {
+          "name": "email_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_assigned": {
+          "name": "in_app_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notify_on_status_change": {
+          "name": "email_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_notify_on_status_change": {
+          "name": "in_app_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_new_comment": {
+          "name": "email_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_notify_on_new_comment": {
+          "name": "in_app_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_mentioned": {
+          "name": "email_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_mentioned": {
+          "name": "in_app_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notify_on_new_issue": {
+          "name": "email_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_new_issue": {
+          "name": "in_app_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_watch_new_issues_global": {
+          "name": "email_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_watch_new_issues_global": {
+          "name": "in_app_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_enabled": {
+          "name": "discord_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_assigned": {
+          "name": "discord_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_status_change": {
+          "name": "discord_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_notify_on_new_comment": {
+          "name": "discord_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_notify_on_mentioned": {
+          "name": "discord_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_new_issue": {
+          "name": "discord_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_watch_new_issues_global": {
+          "name": "discord_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_dm_blocked_at": {
+          "name": "discord_dm_blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_profiles_id_fk": {
+          "name": "notification_preferences_user_id_user_profiles_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_profiles_id_fk": {
+          "name": "notifications_user_id_user_profiles_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pinballmap_catalog": {
+      "name": "pinballmap_catalog",
+      "schema": "",
+      "columns": {
+        "pinballmap_machine_id": {
+          "name": "pinballmap_machine_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opdb_id": {
+          "name": "opdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipdb_id": {
+          "name": "ipdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_group_id": {
+          "name": "machine_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pinballmap_catalog_name": {
+          "name": "idx_pinballmap_catalog_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pinballmap_catalog_group": {
+          "name": "idx_pinballmap_catalog_group",
+          "columns": [
+            {
+              "expression": "machine_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.timeline_event_people": {
+      "name": "timeline_event_people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_id": {
+          "name": "invited_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_timeline_event_people_event_id": {
+          "name": "idx_timeline_event_people_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_event_people_invited_id": {
+          "name": "idx_timeline_event_people_invited_id",
+          "columns": [
+            {
+              "expression": "invited_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_event_people_user_id": {
+          "name": "idx_timeline_event_people_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timeline_event_people_event_id_timeline_events_id_fk": {
+          "name": "timeline_event_people_event_id_timeline_events_id_fk",
+          "tableFrom": "timeline_event_people",
+          "tableTo": "timeline_events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_event_people_user_id_user_profiles_id_fk": {
+          "name": "timeline_event_people_user_id_user_profiles_id_fk",
+          "tableFrom": "timeline_event_people",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timeline_event_people_invited_id_invited_users_id_fk": {
+          "name": "timeline_event_people_invited_id_invited_users_id_fk",
+          "tableFrom": "timeline_event_people",
+          "tableTo": "invited_users",
+          "columnsFrom": ["invited_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "timeline_event_people_person_check": {
+          "name": "timeline_event_people_person_check",
+          "value": "(\"timeline_event_people\".\"user_id\" IS NULL OR \"timeline_event_people\".\"invited_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.timeline_events": {
+      "name": "timeline_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_timeline_events_machine_created": {
+          "name": "idx_timeline_events_machine_created",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_machine_tag": {
+          "name": "idx_timeline_events_machine_tag",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_author_id": {
+          "name": "idx_timeline_events_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_deleted_by": {
+          "name": "idx_timeline_events_deleted_by",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_idempotency_key": {
+          "name": "idx_timeline_events_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"timeline_events\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timeline_events_machine_id_machines_id_fk": {
+          "name": "timeline_events_machine_id_machines_id_fk",
+          "tableFrom": "timeline_events",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_events_author_id_user_profiles_id_fk": {
+          "name": "timeline_events_author_id_user_profiles_id_fk",
+          "tableFrom": "timeline_events",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timeline_events_deleted_by_user_profiles_id_fk": {
+          "name": "timeline_events_deleted_by_user_profiles_id_fk",
+          "tableFrom": "timeline_events",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "first_name || ' ' || last_name",
+            "type": "stored"
+          }
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_email_unique": {
+          "name": "user_profiles_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_profiles_discord_user_id_unique": {
+          "name": "user_profiles_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["discord_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_profiles_role_check": {
+          "name": "user_profiles_role_check",
+          "value": "role IN ('guest', 'member', 'technician', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0050_snapshot.json
+++ b/drizzle/meta/0050_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "bc2da984-d763-4874-89c2-ed1bea2b37e4",
+  "id": "d459534e-b805-48fa-8207-d6400d68eee1",
   "prevId": "c928591a-a93c-4438-9ede-ad593679ddbd",
   "version": "7",
   "dialect": "postgresql",
@@ -1001,6 +1001,36 @@
           ],
           "isUnique": true,
           "where": "\"machine_settings_sets\".\"is_preferred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machine_settings_sets_created_by": {
+          "name": "idx_machine_settings_sets_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machine_settings_sets_updated_by": {
+          "name": "idx_machine_settings_sets_updated_by",
+          "columns": [
+            {
+              "expression": "updated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -355,8 +355,8 @@
     {
       "idx": 50,
       "version": "7",
-      "when": 1783641482726,
-      "tag": "0050_empty_meltdown",
+      "when": 1783643245923,
+      "tag": "0050_overjoyed_viper",
       "breakpoints": true
     }
   ]

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1783294492072,
       "tag": "0049_purge_owner_notes_timeline",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1783641482726,
+      "tag": "0050_empty_meltdown",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -578,6 +578,11 @@ export const machineSettingsSets = pgTable(
     onePreferredPerMachine: uniqueIndex("uniq_machine_settings_preferred")
       .on(t.machineId)
       .where(sql`${t.isPreferred}`),
+    // Indexes on the created_by and updated_by FK columns (PP-o60s.5): prod
+    // advisor flagged them as unindexed_foreign_keys. Both FK to user_profiles
+    // with ON DELETE SET NULL, so a profile delete scans this table on each FK.
+    createdByIdx: index("idx_machine_settings_sets_created_by").on(t.createdBy),
+    updatedByIdx: index("idx_machine_settings_sets_updated_by").on(t.updatedBy),
   })
 ).enableRLS();
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -317,8 +317,8 @@ export const issues = pgTable(
     ),
     // Index on severity to optimize "Unplayable Machines" dashboard query and issues filtering
     severityIdx: index("idx_issues_severity").on(t.severity),
-    // Index on priority to optimize issues list filtering
-    priorityIdx: index("idx_issues_priority").on(t.priority),
+    // idx_issues_priority dropped 2026-07-09 (PP-o60s.5): flagged unused_index by prod
+    // advisor and never used in queries. Re-add if priority filtering becomes hot.
   })
 );
 
@@ -629,6 +629,11 @@ export const issueImages = pgTable(
     issueIdIdx: index("idx_issue_images_issue_id").on(t.issueId),
     uploadedByIdx: index("idx_issue_images_uploaded_by").on(t.uploadedBy),
     deletedAtIdx: index("idx_issue_images_deleted_at").on(t.deletedAt),
+    // Covering indexes for the comment_id and deleted_by FKs (PP-o60s.5): prod
+    // advisor flagged them as unindexed_foreign_keys. Needed for cascade deletes
+    // (comment removal) and soft-delete-by-user lookups.
+    commentIdIdx: index("idx_issue_images_comment_id").on(t.commentId),
+    deletedByIdx: index("idx_issue_images_deleted_by").on(t.deletedBy),
   })
 );
 
@@ -774,10 +779,10 @@ export const notificationPreferences = pgTable(
       withTimezone: true,
     }),
   },
-  (t) => ({
-    globalWatchEmailIdx: index("idx_notif_prefs_global_watch_email").on(
-      t.emailWatchNewIssuesGlobal
-    ),
+  (_t) => ({
+    // idx_notif_prefs_global_watch_email dropped 2026-07-09 (PP-o60s.5): flagged
+    // unused_index by prod advisor and never used in queries. The global-watch
+    // fan-out query scans this small table without needing an index.
   })
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -629,7 +629,7 @@ export const issueImages = pgTable(
     issueIdIdx: index("idx_issue_images_issue_id").on(t.issueId),
     uploadedByIdx: index("idx_issue_images_uploaded_by").on(t.uploadedBy),
     deletedAtIdx: index("idx_issue_images_deleted_at").on(t.deletedAt),
-    // Covering indexes for the comment_id and deleted_by FKs (PP-o60s.5): prod
+    // Indexes on the comment_id and deleted_by FK columns (PP-o60s.5): prod
     // advisor flagged them as unindexed_foreign_keys. Needed for cascade deletes
     // (comment removal) and soft-delete-by-user lookups.
     commentIdIdx: index("idx_issue_images_comment_id").on(t.commentId),


### PR DESCRIPTION
## What

Housekeeping pass on the low-priority prod Supabase advisor findings from epic **PP-o60s**. Re-confirmed the advisor set against prod on 2026-07-09 before acting.

### Migration `0050` (index-only DDL, idempotent — `IF EXISTS` / `IF NOT EXISTS`)

| Change | Index | Table | Advisor |
| --- | --- | --- | --- |
| Drop | `idx_issues_priority` | `issues` | `unused_index` — never used |
| Drop | `idx_notif_prefs_global_watch_email` | `notification_preferences` | `unused_index` — never used |
| Add | `idx_issue_images_comment_id` | `issue_images` | `unindexed_foreign_keys` (comment_id) |
| Add | `idx_issue_images_deleted_by` | `issue_images` | `unindexed_foreign_keys` (deleted_by) |
| Add | `idx_machine_settings_sets_created_by` | `machine_settings_sets` | `unindexed_foreign_keys` (created_by) |
| Add | `idx_machine_settings_sets_updated_by` | `machine_settings_sets` | `unindexed_foreign_keys` (updated_by) |

All four added indexes cover FKs to `user_profiles`; the `machine_settings_sets` pair uses `ON DELETE SET NULL`, so a profile delete scans the table on each FK.

### Kept on purpose (unused_index false positives — feature in progress)

- **`idx_timeline_events_deleted_by`** — timeline feature just shipped, no prod usage yet.
- **`idx_pinballmap_catalog_name`** and **`idx_pinballmap_catalog_group`** — back live picker queries in `src/lib/pinballmap/catalog.ts` (name `ilike` search + `machineGroupId` edition lookup) for the in-progress PBM linking feature (PP-o355). Flagged unused only because the catalog isn't populated/exercised in prod yet.

### Not code-actionable (documented, no code change)

- **`auth_db_connections_absolute`** — switching Auth to a percentage-based DB connection strategy is a **Supabase dashboard/config** change (Auth settings), not a migration. **Requires a manual dashboard change.** Left as a follow-up note on bead PP-o60s.5.
- **`extension_in_public` (citext)** — **WONTFIX.** Moving `citext` out of `public` on a live DB is migration-risky and low value; `citext` backs `user_profiles.email` / `invited_users.email`.

### Out of scope (per dispatch)

The 11 INFO `rls_enabled_no_policy` findings are by-design (migration 0034 — RLS enabled, zero policies, Drizzle-superuser access) and were left untouched.

## Testing

- `pnpm db:generate` → "No schema changes" (schema matches migration exactly).
- Full migration replay applies cleanly; verified all four adds present, both drops gone, all three kept indexes intact.
- typecheck, lint, unit, build, and both integration suites green; CI E2E smoke + full green on prior head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)