### PR TITLE
feat(huddle): create daily coordination beads as ephemeral wisps (PP-140e.4)

### DIFF
--- a/scripts/hooks/huddle-bootstrap.sh
+++ b/scripts/hooks/huddle-bootstrap.sh
@@ -217,6 +217,7 @@ TODAY_ID=$(bd create -t task \
   --parent "$ROOT_ID" \
   --title "Huddle daily $TODAY" \
   --description "Active coordination bead for $TODAY. Agents post updates here with their sign-off (e.g. —Claude-WorktreeFix). At midnight rotation, this bead gets a categorized summary in its description and a raw archive in its notes, then closes." \
+  --ephemeral --wisp-type patrol \
   --silent)
 printf '  Today daily:   %s\n' "$TODAY_ID"
 

--- a/scripts/hooks/huddle-rotate.sh
+++ b/scripts/hooks/huddle-rotate.sh
@@ -193,10 +193,14 @@ except Exception:
     | jq -r --arg t "Huddle daily $today" \
       '[ .[] | select(.title==$t and .status!="closed") ] | sort_by(.id) | (.[0].id // "")' 2>/dev/null || echo "")
   if [[ -z "$new_today_id" ]]; then
+    # Ephemeral wisp (PP-140e.4): a daily is a rotating log, not a permanent
+    # artifact — closed dailies stay queryable (recent_dailies reads their
+    # description) but are now eligible for `bd purge` if that's ever run.
     new_today_id=$(bd create -t task \
       --parent "$ROOT_ID" \
       --title "Huddle daily $today" \
       --description "Active coordination bead for $today. Agents post updates here. At midnight rotation this bead gets a categorized summary and closes." \
+      --ephemeral --wisp-type patrol \
       --silent)
   fi
 


### PR DESCRIPTION
## Summary
- Huddle daily coordination beads (created in both `huddle-rotate.sh` and `huddle-bootstrap.sh`) are now created with `--ephemeral --wisp-type patrol` instead of as permanent tasks.
- Rationale: a daily bead is a rotating log, not a permanent artifact. Closed dailies stay queryable (the `recent_dailies` pointer in root notes still reads their description at session start) but are now eligible for `bd purge` if that's ever run — semantically correct without changing current behavior (nothing auto-purges today).
- Monthly beads and the root epic (`PP-lt12`) intentionally stay non-ephemeral — they're the durable rollup.
- Verified manually against the real `bd` v1.1 binary: the wisp dependency-drift fix holds (`--parent` link survives close), `bd purge` reclaims cleanly, and the wisp-type shows up correctly in `bd show`.
- Part of PP-140e.4 (Adopt bd v1.1 workflow features) — this PR covers the wisp-adoption sub-item; the bead stays open until this merges.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_huddle_rotate.py scripts/tests/test_huddle_sync.py` — 13/13 pass (stub doesn't assert on specific flags, so the new flags are transparent)
- [x] `pnpm run check` — clean, no new errors
- [x] Manual dry run against the real `bd` binary: created/closed/purged a wisp with `--parent PP-lt12 --ephemeral --wisp-type patrol`, confirmed parent link + wisp type + purge all behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)