### PR TITLE
fix(ci): pin supabase CLI version and fix setup-cli token input (PP-d5zn)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,8 +497,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
-          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
+          github-token: ${{ github.token }}
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -559,8 +560,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
-          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
+          github-token: ${{ github.token }}
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -615,8 +617,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
-          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
+          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -697,8 +700,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
-          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
+          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -779,8 +783,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
-          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
+          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -862,8 +867,9 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
-          SUPABASE_CLI_GITHUB_TOKEN: ${{ github.token }}
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
+          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0

--- a/.github/workflows/preview-control.yaml
+++ b/.github/workflows/preview-control.yaml
@@ -114,7 +114,8 @@ jobs:
       - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         if: steps.parse.outputs.action == 'start' || steps.parse.outputs.action == 'stop'
         with:
-          version: latest
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061  # ratchet:pnpm/action-setup@v4.2.0
         if: steps.parse.outputs.action == 'start'

--- a/.github/workflows/preview-reaper.yaml
+++ b/.github/workflows/preview-reaper.yaml
@@ -52,7 +52,8 @@ jobs:
 
       - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
 
       - name: Reap preview branches
         run: bash scripts/workflow/preview/preview-reap.sh

--- a/.github/workflows/preview-sync.yaml
+++ b/.github/workflows/preview-sync.yaml
@@ -54,7 +54,8 @@ jobs:
 
       - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
         with:
-          version: latest
+          # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
+          version: 2.109.1
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061  # ratchet:pnpm/action-setup@v4.2.0
         with:


### PR DESCRIPTION
## What

The `Verify Migrations` job — and every other `supabase/setup-cli` call site (9 total) — used `version: latest`, which resolves the newest release via a per-run GitHub API call. That call flakes non-deterministically and false-reds `CI Gate`. It hit **main** twice recently (run `29058831201`; PR #1598 run `28714316725`, which passed on a no-change re-run).

## Fix (two vectors, one fix each)

1. **`version: latest` → pinned `2.109.1`** (current stable, published 2026-07-07). A concrete version makes `supabase/setup-cli` skip `resolveLatestVersion()` entirely and build the download URL directly (`releases/download/v${version}/...`), removing the per-run API resolution. Since `latest` already resolves to `2.109.1` today, this is a no-behavior-change pin. Documented inline (`# Pinned Supabase CLI — bump deliberately`) so future bumps are deliberate.
2. **Bogus token input renamed** — `ci.yml` passed `SUPABASE_CLI_GITHUB_TOKEN`, which `setup-cli@v2.1.1` does **not** accept (valid inputs: `version`, `github-token`). CI logged `Unexpected input(s)` and resolved unauthenticated (60 req/hr/IP). Renamed to `github-token: ${{ github.token }}`.

## Scope

- **`ci.yml`** (6 sites): version pin + token rename.
- **`preview-control.yaml` / `preview-sync.yaml` / `preview-reaper.yaml`** (1 each): version pin only — these never had the bogus token input.
- Retry-wrapper and CLI caching are **explicitly deferred** per PP-d5zn (token-rename + version-pin only).

## Verification

`pnpm run check` (actionlint + yamllint) passes. This is a CI-workflow-only change — no app code.

Bead: PP-d5zn

🤖 Generated with [Claude Code](https://claude.com/claude-code)