### PR TITLE
ci: wire typecheck:tests baseline gate into CI Gate (PP-38jq.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
       - name: Run type checking
         run: pnpm run typecheck
 
+      - name: Run test type checking (baseline gate)
+        run: pnpm run typecheck:tests
+
   lint:
     name: ESLint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `Run test type checking (baseline gate)` step to the existing **TypeScript Type Check** job in `.github/workflows/ci.yml`, running `pnpm run typecheck:tests`.

## Why

CI Gate ran app-only `pnpm run typecheck` (`tsconfig.json`, tests excluded) but never `pnpm run typecheck:tests` (the `tsc -p tsconfig.tests.json | tsc-baseline check` gate). New test-type errors could land on `main` with no CI signal — staying red only on the local `pnpm run check` floor. A 2026-07-05 merge-ordering gap did exactly that for days.

The test-type baseline was just emptied to **0** (PP-ku3l, merged), so this now fails CI on **any** new test-type error.

## How it's wired

The step lives in the existing `typecheck` job, reusing its checkout / node_modules setup. Since the aggregate CI Gate already depends on `typecheck.result`, a test-type regression fails the job — and therefore the gate — with no extra aggregator wiring. Scope kept minimal: no `typecheck:e2e`, no restructuring of other jobs.

## Verification

- `pnpm run typecheck:tests` locally → exit 0 (0 new errors, 0 in baseline).
- `pnpm run check` (includes yamllint + actionlint on the workflow) → exit 0.

Closes PP-38jq.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)