### PR TITLE
fix(db-reset): auto-discover public tables instead of hardcoded drop list (PP-wv4p)

### DIFF
--- a/scripts/force-db-reset.mjs
+++ b/scripts/force-db-reset.mjs
@@ -2,8 +2,9 @@
  * Drops PinPoint-owned database objects in the local Supabase environment.
  *
  * This script is used by `pnpm run db:reset` (and preflight) to ensure a clean
- * slate before reapplying the Drizzle schema. It drops public-schema tables
- * and trigger-helper functions; the auth.users table and its data remain
+ * slate before reapplying the Drizzle schema. It drops every public-schema
+ * table (discovered dynamically from pg_tables) plus PinPoint's trigger-helper
+ * functions; the auth.users table and its data remain
  * intact. (CASCADE on `handle_new_user` does remove our trigger attached to
  * auth.users — that trigger is PinPoint's, not Supabase's.)
  */
@@ -16,26 +17,6 @@ import { assertLocalDatabase } from "./assert-local-db.mjs";
 
 const databaseUrl = resolveScriptDatabaseUrl();
 assertLocalDatabase(databaseUrl);
-
-// Tables live in the public schema; order ensures dependent tables drop first.
-const tables = [
-  "issue_images",
-  "issue_comments",
-  "issue_watchers",
-  "machine_watchers",
-  "notifications",
-  "notification_preferences",
-  "timeline_event_people",
-  "timeline_events",
-  "machine_settings_sets",
-  "issues",
-  "machines",
-  "pinballmap_catalog",
-  "user_profiles",
-  "invited_users",
-  "unconfirmed_users",
-  "discord_integration_config",
-];
 
 // Trigger/helper functions PinPoint creates in the public schema. CASCADE
 // removes dependent triggers — including handle_new_user's trigger on
@@ -50,9 +31,25 @@ const client = createScriptClient(databaseUrl);
 async function dropApplicationObjects() {
   console.log("🧹 Dropping application tables and functions (public schema)...");
 
-  for (const table of tables) {
-    // Use unsafe here only for static table names defined above
-    await client.unsafe(`DROP TABLE IF EXISTS "${table}" CASCADE;`);
+  // Discover every table in the public schema dynamically instead of tracking a
+  // hardcoded list. A static list silently rots: a newly-added table that isn't
+  // on the list survives the drop, then the next fresh migration collides with
+  // it and fails with 42P07 (duplicate_table). (PP-wv4p.)
+  //
+  // Strictly scoped to schemaname = 'public' — Supabase-managed schemas (auth,
+  // storage, realtime, extensions, …) are never touched. CASCADE handles
+  // inter-table dependencies, so drop order does not matter.
+  const publicTables = await client`
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+  `;
+
+  for (const { tablename } of publicTables) {
+    // tablename comes from pg_catalog (our own tables); quote it defensively so
+    // any identifier that needs escaping is handled correctly.
+    const quoted = `"${String(tablename).replace(/"/g, '""')}"`;
+    await client.unsafe(`DROP TABLE IF EXISTS public.${quoted} CASCADE;`);
   }
 
   for (const fn of functions) {


### PR DESCRIPTION
## What

`scripts/force-db-reset.mjs` (used by `pnpm run db:reset`) dropped a **hardcoded list** of public-schema tables before dropping the `drizzle` schema to force a full re-migration. Any newly-added table not appended to the list survived the drop, so the next fresh migration collided with it and failed with `42P07 (duplicate_table)`. CI never caught it because CI starts from an empty DB. Last bit during `pinballmap_catalog` (PP-o355.2), patched there by hand — this is the durable fix.

## How

Replace the static list with **dynamic discovery**: query `pg_tables WHERE schemaname = 'public'` and `DROP TABLE IF EXISTS public.<t> CASCADE` each. `CASCADE` + `IF EXISTS` make drop order irrelevant and the run idempotent.

### Safety
- **Strictly scoped to `schemaname = 'public'`** — Supabase-managed schemas (`auth`, `storage`, `realtime`, `extensions`, …) are never touched.
- Explicit function drops (`handle_new_user`, `get_discord_config`) and `DROP SCHEMA drizzle CASCADE` are **unchanged**.
- The `assert-local-db` guard is **unchanged** and still refuses any non-loopback host.
- Identifiers from `pg_catalog` are double-quote-escaped and schema-qualified.

## Verification (local)
- `pnpm run db:reset` — full reset + all seed steps green, no `42P07`.
- Ran `force-db-reset.mjs` directly against a populated DB: discovered + dropped all public tables (cascaded to `public_profiles_view` and the `auth.users` trigger), and a second run was idempotent (no errors on empty schema).
- Guard test: `POSTGRES_URL=…pooler.supabase.com:6543` → refused with exit 2.
- `pnpm run check` green; `pnpm run preflight` (unlocked): typecheck / lint / unit (1428) / build / integration (380) / **integration:supabase (104, real local DB)** all green. Local smoke E2E auth-setup failed (login not redirecting) — a browser/dev-server auth-environment issue unrelated to this DB-tooling change; CI owns the full E2E suite.

Closes PP-wv4p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)