### PR TITLE
fix(e2e): pagination-safe seed-user lookup + sweep throwaway @example.com users (PP-ph46)

### DIFF
--- a/e2e/full/invite-signup.spec.ts
+++ b/e2e/full/invite-signup.spec.ts
@@ -15,7 +15,7 @@ import { cleanupTestEntities } from "../support/cleanup.js";
 import { seededMachines, TEST_USERS } from "../support/constants.js";
 import { getSignupLink } from "../support/mailpit.js";
 import {
-  getUserIdByEmail,
+  getProfileIdByEmail,
   setMachineOwner,
 } from "../support/supabase-admin.js";
 
@@ -37,7 +37,7 @@ test.describe("User Invitation & Signup Flow", () => {
     // Restore HD machine owner to admin before deleting the test user so the
     // foreign key is valid when the user row is removed.
     if (hdOwnerChanged) {
-      const adminId = await getUserIdByEmail(TEST_USERS.admin.email);
+      const adminId = await getProfileIdByEmail(TEST_USERS.admin.email);
       await setMachineOwner(seededMachines.humptyDumpty.initials, adminId);
       hdOwnerChanged = false;
     }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -215,8 +215,10 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
   // Sweep throwaway invite-signup users (…@example.com) that accumulate in
   // auth.users across runs. Neither db:fast-reset nor /api/test-data/cleanup
   // can delete auth.users rows (the Postgres role lacks the privilege), so
-  // without this they grow unbounded and eventually break paginated auth
-  // lookups (PP-ph46). Non-fatal: a sweep hiccup shouldn't block the suite.
+  // without this they grow unbounded. Once auth.users exceeds one Admin-API
+  // page (GoTrue defaults to 50/page), any *unpaginated* listUsers() email
+  // lookup misses real seed users that fall onto page 2+ (PP-ph46). Non-fatal:
+  // a sweep hiccup shouldn't block the suite.
   //
   // Dynamic import (not static) on purpose: supabase-admin.ts throws at module
   // load if SUPABASE_SERVICE_ROLE_KEY / NEXT_PUBLIC_SUPABASE_URL are unset, and

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -212,6 +212,27 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 
   console.log("✅ Pre-flight checks passed");
 
+  // Sweep throwaway invite-signup users (…@example.com) that accumulate in
+  // auth.users across runs. Neither db:fast-reset nor /api/test-data/cleanup
+  // can delete auth.users rows (the Postgres role lacks the privilege), so
+  // without this they grow unbounded and eventually break paginated auth
+  // lookups (PP-ph46). Non-fatal: a sweep hiccup shouldn't block the suite.
+  //
+  // Dynamic import (not static) on purpose: supabase-admin.ts throws at module
+  // load if SUPABASE_SERVICE_ROLE_KEY / NEXT_PUBLIC_SUPABASE_URL are unset, and
+  // the SKIP_SUPABASE_RESET=true path returns early above without ever needing
+  // it — a top-level import would defeat that skip. Don't convert to static.
+  try {
+    const { cleanupInviteSignupUsers } =
+      await import("./support/supabase-admin.js");
+    const removed = await cleanupInviteSignupUsers();
+    if (removed > 0) {
+      console.log(`🧹 Swept ${removed} throwaway @example.com auth user(s).`);
+    }
+  } catch (error) {
+    console.warn("⚠️  Failed to sweep throwaway auth users:", error);
+  }
+
   // ── Database setup ─────────────────────────────────────────────────
   // All commands below are static strings (no user input) — execSync is safe here.
 

--- a/e2e/smoke/responsive-overflow.spec.ts
+++ b/e2e/smoke/responsive-overflow.spec.ts
@@ -17,7 +17,7 @@ import {
   seededIssue,
   seededMember,
 } from "../support/constants.js";
-import { getUserIdByEmail } from "../support/supabase-admin.js";
+import { getProfileIdByEmail } from "../support/supabase-admin.js";
 
 // Build routes from seeded data so they don't break if seed data changes
 const machineInitials = seededMachines.addamsFamily.initials;
@@ -57,7 +57,7 @@ test.describe("Responsive: no horizontal overflow", () => {
     test.describe("collection pages", () => {
       let collectionBase = "";
       test.beforeAll(async () => {
-        const memberId = await getUserIdByEmail(seededMember.email);
+        const memberId = await getProfileIdByEmail(seededMember.email);
         collectionBase = `/c/owner/${memberId}`;
       });
 

--- a/e2e/support/supabase-admin.ts
+++ b/e2e/support/supabase-admin.ts
@@ -371,13 +371,17 @@ export async function getProfileIdByEmail(email: string): Promise<string> {
  * the auth-js `nextPage`/Link-header derivation, which is unreliable (PP-a4st,
  * the same bug class fixed in prod as #1634). GoTrue caps per_page server-side,
  * so a short-but-non-empty page is NOT necessarily the last one; only an empty
- * page ends the scan. A hard page cap guards against a misbehaving API looping
- * forever. Returns the number of users deleted.
+ * page ends the scan. If the scan hits the hard page cap without ever seeing an
+ * empty page it throws rather than proceed silently — exhausting the cap means
+ * the scan is incomplete, which would leave the DB dirty and hide a pagination/
+ * API fault (reintroducing the exact flake this fixes). Returns the number of
+ * users deleted.
  */
 export async function cleanupInviteSignupUsers(): Promise<number> {
   const perPage = 1000;
   const maxPages = 1000;
   const idsToDelete: string[] = [];
+  let scanComplete = false;
 
   for (let page = 1; page <= maxPages; page++) {
     const { data, error } = await supabaseAdmin.auth.admin.listUsers({
@@ -385,12 +389,23 @@ export async function cleanupInviteSignupUsers(): Promise<number> {
       perPage,
     });
     if (error) throw error;
-    if (data.users.length === 0) break;
+    if (data.users.length === 0) {
+      scanComplete = true;
+      break;
+    }
     for (const user of data.users) {
       if (user.email?.toLowerCase().endsWith("@example.com")) {
         idsToDelete.push(user.id);
       }
     }
+  }
+
+  if (!scanComplete) {
+    throw new Error(
+      `cleanupInviteSignupUsers: auth.users scan hit the ${maxPages}-page cap ` +
+        `without reaching an empty page — scan incomplete, aborting to avoid a ` +
+        `partial sweep. Check the Admin API / pagination.`
+    );
   }
 
   for (const id of idsToDelete) {

--- a/e2e/support/supabase-admin.ts
+++ b/e2e/support/supabase-admin.ts
@@ -27,50 +27,6 @@ const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
 });
 
 /**
- * Auto-confirm a user's email using Supabase Admin API
- *
- * This bypasses the email confirmation flow for E2E tests.
- * The user must already exist (created via signup).
- *
- * **Note**: This helper lists all users to find by email, which is inefficient
- * and won't scale. This is acceptable for E2E tests against local Supabase
- * with a small number of users. For integration tests where the User object
- * is available, use the helper in `src/test/helpers/supabase.ts` instead.
- *
- * @param email - Email address of the user to confirm
- * @throws Error if user not found or confirmation fails
- */
-export async function confirmUserEmail(email: string): Promise<void> {
-  // Get user by email
-  const { data: users, error: listError } =
-    await supabaseAdmin.auth.admin.listUsers();
-
-  if (listError) {
-    throw new Error(`Failed to list users: ${listError.message}`);
-  }
-
-  const user = users.users.find((u) => u.email === email);
-
-  if (!user) {
-    throw new Error(`User not found: ${email}`);
-  }
-
-  // Update user to confirm email
-  const { error: updateError } = await supabaseAdmin.auth.admin.updateUserById(
-    user.id,
-    {
-      email_confirm: true,
-    }
-  );
-
-  if (updateError) {
-    throw new Error(
-      `Failed to confirm email for ${email}: ${updateError.message}`
-    );
-  }
-}
-
-/**
  * Create a test user with verified email
  */
 export async function createTestUser(
@@ -382,21 +338,13 @@ export async function clearMachineField(
 }
 
 /**
- * Get the Supabase auth user ID for a given email address.
- */
-export async function getUserIdByEmail(email: string): Promise<string> {
-  const { data: users, error } = await supabaseAdmin.auth.admin.listUsers();
-  if (error) throw error;
-  const user = users.users.find((u) => u.email === email);
-  if (!user) throw new Error(`User not found: ${email}`);
-  return user.id;
-}
-
-/**
- * Get a user_profiles id by email via a direct DB read. Unlike
- * `getUserIdByEmail` (which pages through the auth admin API and can miss users
- * beyond the first page once the seed grows), this is an exact single-row query
- * against the profiles table.
+ * Get a user_profiles id by email via a direct DB read.
+ *
+ * `user_profiles.id` is the same UUID as the Supabase `auth.users.id` (enforced
+ * by a cross-schema FK), so this returns the auth user id too — use it anywhere
+ * an auth user id is needed. Being an exact single-row query against the profiles
+ * table, it never misses a user regardless of how large `auth.users` grows,
+ * unlike an unpaginated `auth.admin.listUsers()` scan (PP-ph46).
  */
 export async function getProfileIdByEmail(email: string): Promise<string> {
   const { data, error } = await supabaseAdmin
@@ -406,6 +354,50 @@ export async function getProfileIdByEmail(email: string): Promise<string> {
     .single();
   if (error) throw error;
   return data.id;
+}
+
+/**
+ * Delete throwaway invite-signup auth users (emails ending in `@example.com`)
+ * that accumulate in `auth.users` across E2E runs.
+ *
+ * Neither `db:fast-reset` nor the `/api/test-data/cleanup` endpoint can remove
+ * `auth.users` rows — the Postgres role can't DELETE from the auth schema, so
+ * only the Admin API can. Left unswept, these rows pile up unbounded and once
+ * `auth.users` exceeds a page (~50) they broke unpaginated `listUsers()` email
+ * lookups (PP-ph46). Seed users are `@test.com` / `@pinpoint.internal`, so the
+ * `@example.com` filter never touches them.
+ *
+ * Pagination is count-based — we page until an empty page rather than trusting
+ * the auth-js `nextPage`/Link-header derivation, which is unreliable (PP-a4st,
+ * the same bug class fixed in prod as #1634). GoTrue caps per_page server-side,
+ * so a short-but-non-empty page is NOT necessarily the last one; only an empty
+ * page ends the scan. A hard page cap guards against a misbehaving API looping
+ * forever. Returns the number of users deleted.
+ */
+export async function cleanupInviteSignupUsers(): Promise<number> {
+  const perPage = 1000;
+  const maxPages = 1000;
+  const idsToDelete: string[] = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const { data, error } = await supabaseAdmin.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+    if (error) throw error;
+    if (data.users.length === 0) break;
+    for (const user of data.users) {
+      if (user.email?.toLowerCase().endsWith("@example.com")) {
+        idsToDelete.push(user.id);
+      }
+    }
+  }
+
+  for (const id of idsToDelete) {
+    await deleteTestUser(id);
+  }
+
+  return idsToDelete.length;
 }
 
 /**


### PR DESCRIPTION
## What

Two fixes for **PP-ph46**, an E2E flake where `getUserIdByEmail()` threw `User not found` for real seed users once the local `auth.users` table grew past one page.

### Root cause
`e2e/support/supabase-admin.ts` `getUserIdByEmail()` called `supabaseAdmin.auth.admin.listUsers()` with **no pagination** (GoTrue defaults to 50/page) and `.find()`d the email. Once `auth.users` exceeded 50, real seed users (e.g. `member@test.com`) fell off page 1 and the lookup threw. Surfaced by `e2e/smoke/responsive-overflow.spec.ts` on a local DB that had accumulated **144 throwaway `@example.com`** invite-signup accounts — which never get cleaned up because neither `db:fast-reset` nor `/api/test-data/cleanup` can delete `auth.users` rows (the Postgres role lacks the privilege; only the Admin API can).

### Fix 1 — pagination-safe lookup
Migrate both `getUserIdByEmail` callers (`responsive-overflow.spec.ts`, `invite-signup.spec.ts`) to the existing `getProfileIdByEmail()` — a direct single-row read on `user_profiles.email`. `user_profiles.id == auth.users.id` (cross-schema FK), so the returned id is **identical** to what `getUserIdByEmail` returned, but it never misses a user regardless of `auth.users` size. Removes the now-unused `getUserIdByEmail` and the dead `confirmUserEmail` (same unpaginated-`listUsers` footgun).

### Fix 2 — sweep throwaway users
Add `cleanupInviteSignupUsers()`, invoked once from `e2e/global-setup.ts`, that deletes `@example.com` auth users via the Admin API so local DBs stop accumulating them. Pagination is **count-based** (page until an empty page), matching the prod PP-a4st fix (#1634) — the auth-js `nextPage`/Link-header derivation is unreliable. Seed users are `@test.com` / `@pinpoint.internal`, so the `@example.com` filter never touches them. Delete reuses the existing `deleteTestUser` helper; the sweep is non-fatal (a hiccup logs a warning, doesn't block the suite).

## Testing
- `pnpm run check` green (175 files, 1428 unit tests).
- Verified locally: after `global-setup` the DB has exactly the 5 seed users and **0** `@example.com` accounts (sweep runs harmlessly on a clean DB). Direct GoTrue password auth confirmed working.
- The `responsive-overflow` spec only reproduces the original failure on a DB with >50 users; correctness of the swap is guaranteed by construction (`profile.id == auth user id`). Full E2E runs in CI.

## Acceptance criteria (PP-ph46)
- [x] `getUserIdByEmail`/callers resolve a seed user regardless of total `auth.users` count
- [x] responsive-overflow collection-pages smoke no longer depends on page-1 placement
- [x] invite-signup throwaway users are swept each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)