### PR TITLE
fix(auth): resilient, fail-open Turnstile across all 4 auth forms (PP-20yy)

### DIFF
--- a/src/app/(auth)/actions-security.test.ts
+++ b/src/app/(auth)/actions-security.test.ts
@@ -44,15 +44,17 @@ vi.mock("~/lib/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
-// Mock Turnstile — default to passing so existing tests are unaffected.
-// Individual tests can override with mockResolvedValueOnce(false) to test
-// the CAPTCHA-failure branch.
+// Mock Turnstile — auth forms use the fail-open verifier, which by design
+// always allows the submission through (PP-20yy). Default the mock to the
+// happy "verified" outcome; individual tests can override the reason.
 vi.mock("~/lib/security/turnstile", () => ({
-  verifyTurnstileToken: vi.fn().mockResolvedValue(true),
+  verifyTurnstileFailOpen: vi
+    .fn()
+    .mockResolvedValue({ allowed: true, reason: "verified" }),
 }));
 
 import { createClient } from "~/lib/supabase/server";
-import { verifyTurnstileToken } from "~/lib/security/turnstile";
+import { verifyTurnstileFailOpen } from "~/lib/security/turnstile";
 
 describe("Auth Actions Security - Error Handling", () => {
   beforeEach(() => {
@@ -351,37 +353,50 @@ describe("Auth Actions Security - Error Handling", () => {
     }
   });
 
-  it("resetPasswordAction should return CAPTCHA error when verification fails", async () => {
-    vi.mocked(verifyTurnstileToken).mockResolvedValueOnce(false);
+  it("resetPasswordAction fails open: still updates the password when the token is unverifiable", async () => {
+    // PP-20yy: the captcha gate fails open. verifyTurnstileFailOpen never
+    // blocks — a missing/unverifiable token yields allowed:true — so the action
+    // must proceed to updateUser rather than returning a CAPTCHA error.
+    vi.mocked(verifyTurnstileFailOpen).mockResolvedValueOnce({
+      allowed: true,
+      reason: "missing-token",
+    });
 
-    const updateUserMock = vi.fn();
+    const updateUserMock = vi.fn().mockResolvedValue({ error: null });
+    const signOutMock = vi.fn().mockResolvedValue({ error: null });
     vi.mocked(createClient).mockResolvedValue({
       auth: {
         getUser: vi
           .fn()
           .mockResolvedValue({ data: { user: { id: "user-123" } } }),
         updateUser: updateUserMock,
-        signOut: vi.fn(),
+        signOut: signOutMock,
       },
     } as any);
 
     const formData = new FormData();
     formData.set("password", "NewPassword123!");
     formData.set("confirmPassword", "NewPassword123!");
-    formData.set("captchaToken", "invalid-token");
+    // No captchaToken at all — the transient-Turnstile-failure case.
 
-    const result = await resetPasswordAction(undefined, formData);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("CAPTCHA");
-      expect(result.message).toContain("Verification failed");
+    // resetPasswordAction calls redirect("/login") on success, which throws
+    // a NEXT_REDIRECT error in tests.
+    try {
+      await resetPasswordAction(undefined, formData);
+    } catch {
+      // redirect() throws — expected.
     }
-    expect(updateUserMock).not.toHaveBeenCalled();
+
+    expect(updateUserMock).toHaveBeenCalledWith({
+      password: "NewPassword123!",
+    });
   });
 
   it("resetPasswordAction should call updateUser when CAPTCHA verification passes", async () => {
-    vi.mocked(verifyTurnstileToken).mockResolvedValueOnce(true);
+    vi.mocked(verifyTurnstileFailOpen).mockResolvedValueOnce({
+      allowed: true,
+      reason: "verified",
+    });
 
     const updateUserMock = vi.fn().mockResolvedValue({ error: null });
     const signOutMock = vi.fn().mockResolvedValue({ error: null });

--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -33,7 +33,7 @@ import {
   extractCaptchaToken,
   getUserMessageForAuthError,
 } from "~/lib/auth/errors";
-import { verifyTurnstileToken } from "~/lib/security/turnstile";
+import { verifyTurnstileFailOpen } from "~/lib/security/turnstile";
 
 /**
  * Result Types
@@ -145,10 +145,17 @@ export async function loginAction(
       );
     }
 
-    const supabase = await createClient();
-
-    // Extract Turnstile CAPTCHA token for Supabase built-in verification
+    // Verify Turnstile CAPTCHA ourselves (fail-open) rather than delegating to
+    // Supabase's built-in captcha protection. See verifyTurnstileFailOpen for
+    // the intentional availability > strict-captcha tradeoff (PP-20yy).
+    // NOTE: Supabase project-level captcha protection MUST stay disabled for
+    // this path — with it enabled, Supabase would reject the tokenless
+    // submissions this fail-open gate is designed to let through, and it would
+    // also double-spend the single-use token we consume here.
     const captchaToken = extractCaptchaToken(formData);
+    await verifyTurnstileFailOpen(captchaToken ?? "", ip, "login");
+
+    const supabase = await createClient();
 
     // Sign in with Supabase Auth
     // Note: Remember Me is for UX only - SSR sessions persist via cookies
@@ -156,7 +163,6 @@ export async function loginAction(
     const { data, error } = await supabase.auth.signInWithPassword({
       email: authEmail,
       password,
-      ...(captchaToken ? { options: { captchaToken } } : {}),
     });
 
     // Defensive check - Supabase types guarantee user exists if no error,
@@ -297,10 +303,14 @@ export async function signupAction(
       );
     }
 
-    const supabase = await createClient();
-
-    // Extract Turnstile CAPTCHA token for Supabase built-in verification
+    // Fail-open Turnstile verification (PP-20yy). We own verification rather
+    // than delegating to Supabase's built-in captcha protection — see the login
+    // action and verifyTurnstileFailOpen for the tradeoff and the Supabase
+    // config requirement.
     const captchaToken = extractCaptchaToken(formData);
+    await verifyTurnstileFailOpen(captchaToken ?? "", ip, "signup");
+
+    const supabase = await createClient();
 
     // Create user with Supabase Auth
     const { data, error } = await supabase.auth.signUp({
@@ -311,7 +321,6 @@ export async function signupAction(
           first_name: firstName,
           last_name: lastName,
         },
-        ...(captchaToken ? { captchaToken } : {}),
       },
     });
 
@@ -518,10 +527,19 @@ export async function forgotPasswordAction(
       return ok(undefined);
     }
 
-    const supabase = await createClient();
-
-    // Extract Turnstile CAPTCHA token for Supabase built-in verification
+    // Fail-open Turnstile verification (PP-20yy). We own verification rather
+    // than delegating to Supabase's built-in captcha protection — see the login
+    // action and verifyTurnstileFailOpen for the tradeoff and the Supabase
+    // config requirement. (No client IP here: this flow is keyed on email, and
+    // `remoteip` is only an optional additive check for Cloudflare.)
     const captchaToken = extractCaptchaToken(formData);
+    await verifyTurnstileFailOpen(
+      captchaToken ?? "",
+      undefined,
+      "forgot-password"
+    );
+
+    const supabase = await createClient();
 
     const siteUrl = requireSiteUrl("forgot-password");
 
@@ -531,7 +549,6 @@ export async function forgotPasswordAction(
 
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo,
-      ...(captchaToken ? { captchaToken } : {}),
     });
 
     if (error) {
@@ -597,24 +614,16 @@ export async function resetPasswordAction(
   const { password } = parsed.data;
 
   try {
-    // Verify Turnstile CAPTCHA. Unlike signUp/signInWithPassword/resetPasswordForEmail,
-    // Supabase's auth.updateUser() does not accept a captchaToken option, so we must
-    // verify the token ourselves before calling it.
+    // Fail-open Turnstile verification (PP-20yy). Supabase's auth.updateUser()
+    // has no captchaToken option, so this action always verified the token
+    // itself. It now fails open (never blocks) rather than returning a CAPTCHA
+    // error — see verifyTurnstileFailOpen for the availability tradeoff.
     const captchaToken = extractCaptchaToken(formData);
-    const captchaValid = await verifyTurnstileToken(
+    await verifyTurnstileFailOpen(
       captchaToken ?? "",
-      await getClientIp()
+      await getClientIp(),
+      "reset-password"
     );
-    if (!captchaValid) {
-      log.warn(
-        { action: "reset-password" },
-        "Turnstile CAPTCHA verification failed"
-      );
-      return err(
-        "CAPTCHA",
-        "Verification failed. Please refresh the page and try again."
-      );
-    }
 
     const supabase = await createClient();
 

--- a/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -1,25 +1,20 @@
 "use client";
 
-import React, { useActionState, useState, useCallback } from "react";
+import React, { useActionState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { forgotPasswordAction } from "~/app/(auth)/actions";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
+import { useTurnstileGate } from "~/components/security/useTurnstileGate";
 
 export function ForgotPasswordForm(): React.JSX.Element {
   const [state, formAction, isPending] = useActionState(
     forgotPasswordAction,
     undefined
   );
-  const [turnstileToken, setTurnstileToken] = useState("");
-  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
-  const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
-
-  const handleTurnstileVerify = useCallback((token: string) => {
-    setTurnstileToken(token);
-  }, []);
+  const turnstile = useTurnstileGate();
 
   return (
     <form action={formAction} className="space-y-4">
@@ -61,18 +56,27 @@ export function ForgotPasswordForm(): React.JSX.Element {
         />
       </div>
 
-      <input type="hidden" name="captchaToken" value={turnstileToken} />
+      <input type="hidden" name="captchaToken" value={turnstile.token} />
       <TurnstileWidget
-        onVerify={handleTurnstileVerify}
-        onExpire={() => setTurnstileToken("")}
+        onVerify={turnstile.onVerify}
+        onExpire={turnstile.onExpire}
+        onError={turnstile.onError}
       />
+      {turnstile.statusMessage && (
+        <p
+          aria-live="polite"
+          className="text-sm text-muted-foreground text-center"
+        >
+          {turnstile.statusMessage}
+        </p>
+      )}
 
       <Button
         type="submit"
         className="w-full bg-primary text-on-primary hover:bg-primary-container hover:text-on-primary-container"
         size="lg"
         loading={isPending}
-        disabled={isPending || (enforceCaptcha && !turnstileToken)}
+        disabled={isPending || turnstile.submitDisabled}
       >
         Send Reset Link
       </Button>

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react";
 import Link from "next/link";
-import { useActionState, useState, useCallback } from "react";
+import { useActionState, useState } from "react";
 import dynamic from "next/dynamic";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -12,6 +12,7 @@ import { Checkbox } from "~/components/ui/checkbox";
 import { Alert, AlertDescription } from "~/components/ui/alert";
 import { loginAction, type LoginResult } from "~/app/(auth)/actions";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
+import { useTurnstileGate } from "~/components/security/useTurnstileGate";
 
 // Lazily load TestAdminButton to prevent including test credentials in the production bundle
 const TestAdminButton = dynamic(() =>
@@ -31,14 +32,8 @@ export function LoginForm({
     LoginResult | undefined,
     FormData
   >(loginAction, undefined);
-  const [turnstileToken, setTurnstileToken] = useState("");
   const [rememberMe, setRememberMe] = useState(true);
-  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
-  const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
-
-  const handleTurnstileVerify = useCallback((token: string) => {
-    setTurnstileToken(token);
-  }, []);
+  const turnstile = useTurnstileGate();
 
   return (
     <>
@@ -119,11 +114,20 @@ export function LoginForm({
           </Label>
         </div>
 
-        <input type="hidden" name="captchaToken" value={turnstileToken} />
+        <input type="hidden" name="captchaToken" value={turnstile.token} />
         <TurnstileWidget
-          onVerify={handleTurnstileVerify}
-          onExpire={() => setTurnstileToken("")}
+          onVerify={turnstile.onVerify}
+          onExpire={turnstile.onExpire}
+          onError={turnstile.onError}
         />
+        {turnstile.statusMessage && (
+          <p
+            aria-live="polite"
+            className="text-sm text-muted-foreground text-center"
+          >
+            {turnstile.statusMessage}
+          </p>
+        )}
 
         {/* Submit button */}
         <Button
@@ -131,7 +135,7 @@ export function LoginForm({
           className="w-full"
           size="lg"
           loading={isPending}
-          disabled={isPending || (enforceCaptcha && !turnstileToken)}
+          disabled={isPending || turnstile.submitDisabled}
         >
           Sign In
         </Button>

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useActionState, useCallback, useState } from "react";
+import { useActionState, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
 import { PasswordInput } from "~/components/ui/password-input";
@@ -9,6 +9,7 @@ import { Alert, AlertDescription } from "~/components/ui/alert";
 import { PasswordMismatch } from "~/components/password-mismatch";
 import { PasswordStrength } from "~/components/password-strength";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
+import { useTurnstileGate } from "~/components/security/useTurnstileGate";
 import {
   resetPasswordAction,
   type ResetPasswordResult,
@@ -21,13 +22,7 @@ export function ResetPasswordForm(): React.JSX.Element {
   >(resetPasswordAction, undefined);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [turnstileToken, setTurnstileToken] = useState("");
-  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
-  const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
-
-  const handleTurnstileVerify = useCallback((token: string) => {
-    setTurnstileToken(token);
-  }, []);
+  const turnstile = useTurnstileGate();
 
   return (
     <form action={formAction} className="space-y-4">
@@ -90,11 +85,20 @@ export function ResetPasswordForm(): React.JSX.Element {
         />
       </div>
 
-      <input type="hidden" name="captchaToken" value={turnstileToken} />
+      <input type="hidden" name="captchaToken" value={turnstile.token} />
       <TurnstileWidget
-        onVerify={handleTurnstileVerify}
-        onExpire={() => setTurnstileToken("")}
+        onVerify={turnstile.onVerify}
+        onExpire={turnstile.onExpire}
+        onError={turnstile.onError}
       />
+      {turnstile.statusMessage && (
+        <p
+          aria-live="polite"
+          className="text-sm text-muted-foreground text-center"
+        >
+          {turnstile.statusMessage}
+        </p>
+      )}
 
       {/* Submit button */}
       <Button
@@ -102,7 +106,7 @@ export function ResetPasswordForm(): React.JSX.Element {
         className="w-full"
         size="lg"
         loading={isPending}
-        disabled={isPending || (enforceCaptcha && !turnstileToken)}
+        disabled={isPending || turnstile.submitDisabled}
       >
         Update Password
       </Button>

--- a/src/app/(auth)/signup/signup-form.tsx
+++ b/src/app/(auth)/signup/signup-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useActionState, useCallback } from "react";
+import React, { useState, useActionState } from "react";
 import Link from "next/link";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -12,6 +12,7 @@ import { Alert, AlertDescription } from "~/components/ui/alert";
 import { PasswordStrength } from "~/components/password-strength";
 import { signupAction, type SignupResult } from "~/app/(auth)/actions";
 import { TurnstileWidget } from "~/components/security/TurnstileWidget";
+import { useTurnstileGate } from "~/components/security/useTurnstileGate";
 
 interface SignupFormProps {
   initialData?:
@@ -32,13 +33,7 @@ export function SignupForm({
   >(signupAction, undefined);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [turnstileToken, setTurnstileToken] = useState("");
-  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
-  const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
-
-  const handleTurnstileVerify = useCallback((token: string) => {
-    setTurnstileToken(token);
-  }, []);
+  const turnstile = useTurnstileGate();
 
   if (state && !state.ok && state.code === "CONFIRMATION_REQUIRED") {
     return (
@@ -226,18 +221,27 @@ export function SignupForm({
         </Label>
       </div>
 
-      <input type="hidden" name="captchaToken" value={turnstileToken} />
+      <input type="hidden" name="captchaToken" value={turnstile.token} />
       <TurnstileWidget
-        onVerify={handleTurnstileVerify}
-        onExpire={() => setTurnstileToken("")}
+        onVerify={turnstile.onVerify}
+        onExpire={turnstile.onExpire}
+        onError={turnstile.onError}
       />
+      {turnstile.statusMessage && (
+        <p
+          aria-live="polite"
+          className="text-sm text-muted-foreground text-center"
+        >
+          {turnstile.statusMessage}
+        </p>
+      )}
 
       <Button
         type="submit"
         className="w-full"
         size="lg"
         loading={isPending}
-        disabled={isPending || (enforceCaptcha && !turnstileToken)}
+        disabled={isPending || turnstile.submitDisabled}
       >
         Create Account
       </Button>

--- a/src/components/security/TurnstileWidget.tsx
+++ b/src/components/security/TurnstileWidget.tsx
@@ -6,8 +6,15 @@ import { type JSX, useCallback } from "react";
 interface TurnstileWidgetProps {
   /** Called with the Turnstile token on successful verification */
   onVerify: (token: string) => void;
-  /** Called when the token expires or verification fails, clearing the token */
+  /** Called when the token expires (widget auto-refreshes a new one) */
   onExpire?: () => void;
+  /**
+   * Called when verification errors. Distinct from `onExpire`: an error is NOT
+   * a reason to clear a previously-good token — the widget auto-retries
+   * (`retry: "auto"`). Wiring this to a token-clearing handler is what caused
+   * the permanent lockout in PP-20yy, so keep it separate.
+   */
+  onError?: () => void;
   /** Optional CSS class name */
   className?: string;
 }
@@ -21,6 +28,7 @@ interface TurnstileWidgetProps {
 export function TurnstileWidget({
   onVerify,
   onExpire,
+  onError,
   className,
 }: TurnstileWidgetProps): JSX.Element | null {
   const siteKey = process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"];
@@ -36,6 +44,10 @@ export function TurnstileWidget({
     onExpire?.();
   }, [onExpire]);
 
+  const handleError = useCallback(() => {
+    onError?.();
+  }, [onError]);
+
   if (!siteKey) {
     return null;
   }
@@ -45,11 +57,14 @@ export function TurnstileWidget({
       siteKey={siteKey}
       onSuccess={handleVerify}
       onExpire={handleExpire}
-      onError={handleExpire}
+      onError={handleError}
       options={{
         size: "flexible",
         appearance: "interaction-only",
         refreshExpired: "auto",
+        // Auto-retry on transient widget/network failure instead of stranding
+        // the user on a single failed attempt (PP-20yy resilience).
+        retry: "auto",
       }}
       className={className}
     />

--- a/src/components/security/useTurnstileGate.test.tsx
+++ b/src/components/security/useTurnstileGate.test.tsx
@@ -70,6 +70,24 @@ describe("useTurnstileGate", () => {
     expect(result.current.submitDisabled).toBe(false);
   });
 
+  it("after a successful verify, a later expiry does not re-disable the button (one-way latch)", () => {
+    const { result } = renderHook(() => useTurnstileGate());
+
+    act(() => {
+      result.current.onVerify("tok-123");
+    });
+    expect(result.current.submitDisabled).toBe(false);
+
+    // Token expires minutes later: the freshest value is cleared, but the gate
+    // stays open so submit is never re-disabled (the bug Copilot flagged).
+    act(() => {
+      result.current.onExpire();
+    });
+    expect(result.current.token).toBe("");
+    expect(result.current.submitDisabled).toBe(false);
+    expect(result.current.statusMessage).toBeNull();
+  });
+
   it("once failed open, a later expiry does not re-disable the button (one-way latch)", () => {
     const { result } = renderHook(() => useTurnstileGate());
 

--- a/src/components/security/useTurnstileGate.test.tsx
+++ b/src/components/security/useTurnstileGate.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTurnstileGate } from "./useTurnstileGate";
+
+// Mock Sentry so the client fail-open breadcrumb doesn't need a transport.
+vi.mock("@sentry/nextjs", () => ({ addBreadcrumb: vi.fn() }));
+
+describe("useTurnstileGate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Force captcha enforcement on: requires a site key AND a non-test NODE_ENV.
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "test-site-key");
+    vi.stubEnv("NODE_ENV", "production");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("does not gate submit when captcha is not enforced (no site key)", () => {
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "");
+    const { result } = renderHook(() => useTurnstileGate());
+
+    expect(result.current.submitDisabled).toBe(false);
+    expect(result.current.statusMessage).toBeNull();
+  });
+
+  it("gates submit while waiting, then enables when a token arrives (resilience)", () => {
+    const { result } = renderHook(() => useTurnstileGate());
+
+    expect(result.current.submitDisabled).toBe(true);
+    expect(result.current.statusMessage).toBe("Verifying you're human…");
+
+    act(() => {
+      result.current.onVerify("tok-123");
+    });
+
+    expect(result.current.token).toBe("tok-123");
+    expect(result.current.submitDisabled).toBe(false);
+    expect(result.current.statusMessage).toBeNull();
+  });
+
+  it("FAILS OPEN: enables submit after the resilience window even with no token", () => {
+    const { result } = renderHook(() => useTurnstileGate());
+    expect(result.current.submitDisabled).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    // The dead-button bug: submit must never stay disabled forever.
+    expect(result.current.token).toBe("");
+    expect(result.current.submitDisabled).toBe(false);
+  });
+
+  it("dead button never happens: an error keeps a good token and never re-disables", () => {
+    const { result } = renderHook(() => useTurnstileGate());
+
+    act(() => {
+      result.current.onVerify("tok-123");
+    });
+    expect(result.current.submitDisabled).toBe(false);
+
+    // The original bug wired onError -> clear token, re-disabling submit.
+    act(() => {
+      result.current.onError();
+    });
+    expect(result.current.token).toBe("tok-123");
+    expect(result.current.submitDisabled).toBe(false);
+  });
+
+  it("once failed open, a later expiry does not re-disable the button (one-way latch)", () => {
+    const { result } = renderHook(() => useTurnstileGate());
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(result.current.submitDisabled).toBe(false);
+
+    act(() => {
+      result.current.onExpire();
+    });
+    expect(result.current.token).toBe("");
+    expect(result.current.submitDisabled).toBe(false);
+  });
+});

--- a/src/components/security/useTurnstileGate.ts
+++ b/src/components/security/useTurnstileGate.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * How long to wait for a Turnstile token before failing open and enabling
+ * submission anyway. Long enough for a healthy widget to solve an
+ * interaction-only challenge (typically < 1s) plus retries on a transient
+ * blip, short enough that a genuinely-stuck widget doesn't strand the user.
+ */
+const FAIL_OPEN_TIMEOUT_MS = 8000;
+
+export interface TurnstileGate {
+  /** Current token; wire into a hidden `captchaToken` input. May be "". */
+  token: string;
+  /**
+   * Whether the submit button should be disabled *for captcha reasons*.
+   * Callers OR this with their own `isPending`. Only ever true during the
+   * initial resilience window — once a token arrives OR the window elapses
+   * (fail-open latch), this is false forever, so the button never dies.
+   */
+  submitDisabled: boolean;
+  /** Optional user-facing status while waiting; null when nothing to show. */
+  statusMessage: string | null;
+  /** Pass to `TurnstileWidget.onVerify`. */
+  onVerify: (token: string) => void;
+  /** Pass to `TurnstileWidget.onError`. Does NOT clear the token (resilience). */
+  onError: () => void;
+  /** Pass to `TurnstileWidget.onExpire`. */
+  onExpire: () => void;
+}
+
+/**
+ * Shared Turnstile gating logic for the auth forms (login, signup,
+ * forgot-password, reset-password).
+ *
+ * ── Resilience first, then fail open (PP-20yy) ──────────────────────────────
+ * The previous per-form implementation hard-disabled submit until a token
+ * existed AND wired the widget's `onError` to a handler that *cleared* the
+ * token — so any transient Turnstile failure left the button permanently dead
+ * with no feedback. Tim chose (2026-07-10) availability over strict captcha
+ * enforcement here after repeated real-user lockouts.
+ *
+ * This hook:
+ *  1. Never clears the token on error (`onError` is a no-op for token state);
+ *     the widget auto-retries (`retry: "auto"`, `refreshExpired: "auto"`).
+ *  2. Runs a bounded resilience window: transient blips that recover within
+ *     {@link FAIL_OPEN_TIMEOUT_MS} enable submit *with* a real token.
+ *  3. Fails open as a last resort: once the window elapses with no token, a
+ *     one-way latch enables submit anyway and emits a Sentry breadcrumb.
+ *
+ * The server mirrors this via `verifyTurnstileFailOpen` — both sides must stay
+ * consistent (see that function's doc comment).
+ */
+export function useTurnstileGate(): TurnstileGate {
+  const hasTurnstile = Boolean(process.env["NEXT_PUBLIC_TURNSTILE_SITE_KEY"]);
+  const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
+
+  const [token, setToken] = useState("");
+  const [failedOpen, setFailedOpen] = useState(false);
+
+  // Fail-open latch: after a bounded window with no token, enable submit anyway.
+  // The latch is one-way — once open it never re-disables, so a later expiry or
+  // error can't resurrect the dead-button bug.
+  useEffect(() => {
+    if (!enforceCaptcha || token || failedOpen) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      setFailedOpen(true);
+      Sentry.addBreadcrumb({
+        category: "turnstile",
+        level: "warning",
+        message: "turnstile.client_fail_open",
+        data: { timeoutMs: FAIL_OPEN_TIMEOUT_MS },
+      });
+    }, FAIL_OPEN_TIMEOUT_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [enforceCaptcha, token, failedOpen]);
+
+  const onVerify = useCallback((next: string) => {
+    setToken(next);
+  }, []);
+
+  // Resilience: intentionally do NOT clear the token on error. The widget
+  // auto-retries; clearing here is exactly what caused the permanent lockout.
+  const onError = useCallback(() => {
+    /* no-op: keep any existing token, let the widget retry */
+  }, []);
+
+  const onExpire = useCallback(() => {
+    setToken("");
+  }, []);
+
+  const waiting = enforceCaptcha && !token && !failedOpen;
+
+  return {
+    token,
+    submitDisabled: waiting,
+    statusMessage: waiting ? "Verifying you're human…" : null,
+    onVerify,
+    onError,
+    onExpire,
+  };
+}

--- a/src/components/security/useTurnstileGate.ts
+++ b/src/components/security/useTurnstileGate.ts
@@ -17,8 +17,9 @@ export interface TurnstileGate {
   /**
    * Whether the submit button should be disabled *for captcha reasons*.
    * Callers OR this with their own `isPending`. Only ever true during the
-   * initial resilience window — once a token arrives OR the window elapses
-   * (fail-open latch), this is false forever, so the button never dies.
+   * initial resilience window: the gate is a one-way latch that opens the
+   * first time a token arrives OR the window elapses, and never re-closes — so
+   * a later token expiry can't re-disable the button.
    */
   submitDisabled: boolean;
   /** Optional user-facing status while waiting; null when nothing to show. */
@@ -46,9 +47,14 @@ export interface TurnstileGate {
  *  1. Never clears the token on error (`onError` is a no-op for token state);
  *     the widget auto-retries (`retry: "auto"`, `refreshExpired: "auto"`).
  *  2. Runs a bounded resilience window: transient blips that recover within
- *     {@link FAIL_OPEN_TIMEOUT_MS} enable submit *with* a real token.
- *  3. Fails open as a last resort: once the window elapses with no token, a
- *     one-way latch enables submit anyway and emits a Sentry breadcrumb.
+ *     {@link FAIL_OPEN_TIMEOUT_MS} open the gate *with* a real token.
+ *  3. Fails open as a last resort: if the window elapses before any token
+ *     arrives, the gate opens anyway and a Sentry breadcrumb is emitted.
+ *
+ * The gate is a one-way latch: it opens the first time a token arrives OR the
+ * window elapses, and never re-closes. That means a later token expiry (which
+ * clears `token` so the freshest value is sent) can't re-disable the button —
+ * closing the gap Copilot flagged where a post-verify expiry briefly re-gated.
  *
  * The server mirrors this via `verifyTurnstileFailOpen` — both sides must stay
  * consistent (see that function's doc comment).
@@ -58,17 +64,18 @@ export function useTurnstileGate(): TurnstileGate {
   const enforceCaptcha = hasTurnstile && process.env.NODE_ENV !== "test";
 
   const [token, setToken] = useState("");
-  const [failedOpen, setFailedOpen] = useState(false);
+  const [gateOpen, setGateOpen] = useState(false);
 
-  // Fail-open latch: after a bounded window with no token, enable submit anyway.
-  // The latch is one-way — once open it never re-disables, so a later expiry or
-  // error can't resurrect the dead-button bug.
+  // Fail-open path: if the gate is still closed after a bounded window (i.e. no
+  // token has arrived), open it anyway and record the client fail-open. Once
+  // the gate is open the effect short-circuits, so this only fires on a genuine
+  // no-token timeout — never after a successful verify.
   useEffect(() => {
-    if (!enforceCaptcha || token || failedOpen) {
+    if (!enforceCaptcha || gateOpen) {
       return;
     }
     const timer = setTimeout(() => {
-      setFailedOpen(true);
+      setGateOpen(true);
       Sentry.addBreadcrumb({
         category: "turnstile",
         level: "warning",
@@ -79,10 +86,14 @@ export function useTurnstileGate(): TurnstileGate {
     return () => {
       clearTimeout(timer);
     };
-  }, [enforceCaptcha, token, failedOpen]);
+  }, [enforceCaptcha, gateOpen]);
 
   const onVerify = useCallback((next: string) => {
     setToken(next);
+    // A real token permanently opens the gate — a subsequent expiry must not
+    // re-disable submit (the widget auto-refreshes a new token in the
+    // background, and the server fails open on the interim empty token).
+    setGateOpen(true);
   }, []);
 
   // Resilience: intentionally do NOT clear the token on error. The widget
@@ -95,7 +106,7 @@ export function useTurnstileGate(): TurnstileGate {
     setToken("");
   }, []);
 
-  const waiting = enforceCaptcha && !token && !failedOpen;
+  const waiting = enforceCaptcha && !gateOpen;
 
   return {
     token,

--- a/src/lib/security/turnstile.test.ts
+++ b/src/lib/security/turnstile.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { verifyTurnstileToken } from "./turnstile";
+import { verifyTurnstileToken, verifyTurnstileFailOpen } from "./turnstile";
+import * as Sentry from "@sentry/nextjs";
 
 // Mock server-only (no-op in test environment)
 vi.mock("server-only", () => ({}));
@@ -11,6 +12,11 @@ vi.mock("~/lib/logger", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+// Mock Sentry — assert fail-open observability without a real transport.
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
 }));
 
 describe("verifyTurnstileToken", () => {
@@ -141,5 +147,122 @@ describe("verifyTurnstileToken", () => {
     const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = callArgs[1].body as string;
     expect(body).not.toContain("remoteip");
+  });
+});
+
+describe("verifyTurnstileFailOpen", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+    vi.mocked(Sentry.captureMessage).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    process.env = originalEnv;
+  });
+
+  it("allows through a valid token (reason: verified) without a fail-open breadcrumb", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await verifyTurnstileFailOpen(
+      "valid-token",
+      "1.2.3.4",
+      "login"
+    );
+
+    expect(result).toEqual({ allowed: true, reason: "verified" });
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("FAILS OPEN on a missing token and records observability", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+
+    const result = await verifyTurnstileFailOpen("", "1.2.3.4", "login");
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("missing-token");
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "turnstile.fail_open",
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({
+          action: "login",
+          turnstileOutcome: "missing-token",
+        }),
+      })
+    );
+  });
+
+  it("FAILS OPEN when Cloudflare rejects the token as invalid", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: false,
+          "error-codes": ["invalid-input-response"],
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await verifyTurnstileFailOpen(
+      "bad-token",
+      undefined,
+      "signup"
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("invalid-token");
+    expect(Sentry.captureMessage).toHaveBeenCalledOnce();
+  });
+
+  it("FAILS OPEN when the verification request throws (network blip)", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "test-secret";
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await verifyTurnstileFailOpen(
+      "some-token",
+      undefined,
+      "reset-password"
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("unverifiable");
+    expect(Sentry.captureMessage).toHaveBeenCalledOnce();
+  });
+
+  it("FAILS OPEN when the secret key is missing in production", async () => {
+    delete process.env.TURNSTILE_SECRET_KEY;
+    vi.stubEnv("NODE_ENV", "production");
+
+    const result = await verifyTurnstileFailOpen(
+      "some-token",
+      undefined,
+      "forgot-password"
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("unverifiable");
+    expect(Sentry.captureMessage).toHaveBeenCalledOnce();
+  });
+
+  it("skips (reason: skipped) without a breadcrumb when no secret key in dev/test", async () => {
+    delete process.env.TURNSTILE_SECRET_KEY;
+    vi.stubEnv("NODE_ENV", "test");
+
+    const result = await verifyTurnstileFailOpen("", undefined, "login");
+
+    expect(result).toEqual({ allowed: true, reason: "skipped" });
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/security/turnstile.ts
+++ b/src/lib/security/turnstile.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import * as Sentry from "@sentry/nextjs";
+
 import { log } from "~/lib/logger";
 
 interface TurnstileVerifyResponse {
@@ -8,6 +10,26 @@ interface TurnstileVerifyResponse {
   challenge_ts?: string;
   hostname?: string;
 }
+
+/**
+ * Discriminated outcome of a server-side Turnstile verification attempt.
+ *
+ * Kept internal so the two public entry points can render it into their own
+ * shapes: {@link verifyTurnstileToken} collapses it to a strict boolean, while
+ * {@link verifyTurnstileFailOpen} keeps every submission flowing and only uses
+ * the outcome for observability.
+ */
+type TurnstileOutcome =
+  /** No secret configured in dev/test, or the Cloudflare test secret — skip. */
+  | { kind: "skipped" }
+  /** Token present and Cloudflare confirmed it. */
+  | { kind: "verified" }
+  /** Client sent no token (widget never produced one). */
+  | { kind: "missing-token" }
+  /** Cloudflare actively rejected the token. */
+  | { kind: "invalid-token"; errorCodes: string[] | undefined }
+  /** Could not reach a verdict (HTTP error, network error, missing prod key). */
+  | { kind: "unverifiable"; reason: string };
 
 /**
  * Cloudflare's well-known "always passes" test secret key.
@@ -20,40 +42,35 @@ interface TurnstileVerifyResponse {
 const TURNSTILE_TEST_SECRET = "1x0000000000000000000000000000000AA";
 
 /**
- * Verify a Cloudflare Turnstile token server-side.
- *
- * If TURNSTILE_SECRET_KEY is not configured, returns true to allow
- * graceful degradation in development / test environments.
- *
- * @param token - The cf-turnstile-response token from the client
- * @param ip    - Optional client IP for additional validation
- * @returns Whether the token is valid
+ * Core verification against Cloudflare's siteverify endpoint. Returns a
+ * discriminated outcome without deciding whether the caller should be allowed
+ * through — that policy lives in the public wrappers below.
  */
-export async function verifyTurnstileToken(
+async function runTurnstileVerification(
   token: string,
   ip?: string
-): Promise<boolean> {
+): Promise<TurnstileOutcome> {
   const secretKey = process.env["TURNSTILE_SECRET_KEY"];
 
   if (!secretKey) {
     if (process.env.NODE_ENV === "production") {
       log.error(
         { action: "turnstile" },
-        "TURNSTILE_SECRET_KEY not set in production — CAPTCHA verification will fail"
+        "TURNSTILE_SECRET_KEY not set in production — CAPTCHA verification cannot run"
       );
-      return false;
+      return { kind: "unverifiable", reason: "no-secret-key-prod" };
     }
     log.warn(
       { action: "turnstile" },
       "TURNSTILE_SECRET_KEY not set — skipping CAPTCHA verification"
     );
-    return true;
+    return { kind: "skipped" };
   }
 
   // Cloudflare test keys: skip verification entirely. The widget JS may
   // not complete in headless browsers (Playwright), producing no token.
   if (secretKey === TURNSTILE_TEST_SECRET) {
-    return true;
+    return { kind: "skipped" };
   }
 
   if (!token) {
@@ -64,7 +81,7 @@ export async function verifyTurnstileToken(
         ? "Empty Turnstile token — widget may not have loaded"
         : "Empty Turnstile token — NEXT_PUBLIC_TURNSTILE_SITE_KEY not set, widget did not render"
     );
-    return false;
+    return { kind: "missing-token" };
   }
 
   try {
@@ -91,7 +108,7 @@ export async function verifyTurnstileToken(
         { action: "turnstile", status: res.status },
         "Turnstile siteverify HTTP error"
       );
-      return false;
+      return { kind: "unverifiable", reason: `http-${String(res.status)}` };
     }
 
     const data = (await res.json()) as TurnstileVerifyResponse;
@@ -101,9 +118,10 @@ export async function verifyTurnstileToken(
         { action: "turnstile", errors: data["error-codes"] },
         "Turnstile verification failed"
       );
+      return { kind: "invalid-token", errorCodes: data["error-codes"] };
     }
 
-    return data.success;
+    return { kind: "verified" };
   } catch (error) {
     log.error(
       {
@@ -112,6 +130,110 @@ export async function verifyTurnstileToken(
       },
       "Turnstile verification request failed"
     );
-    return false;
+    return { kind: "unverifiable", reason: "fetch-error" };
   }
+}
+
+/**
+ * Verify a Cloudflare Turnstile token server-side (STRICT / fail-closed).
+ *
+ * If TURNSTILE_SECRET_KEY is not configured, returns true to allow
+ * graceful degradation in development / test environments.
+ *
+ * Used by surfaces where a hard captcha gate is still desired (e.g. anonymous
+ * public issue reports). Auth forms use {@link verifyTurnstileFailOpen} instead
+ * — see that function's doc comment for the availability tradeoff.
+ *
+ * @param token - The cf-turnstile-response token from the client
+ * @param ip    - Optional client IP for additional validation
+ * @returns Whether the token is valid
+ */
+export async function verifyTurnstileToken(
+  token: string,
+  ip?: string
+): Promise<boolean> {
+  const outcome = await runTurnstileVerification(token, ip);
+  return outcome.kind === "verified" || outcome.kind === "skipped";
+}
+
+/** Reason a fail-open submission was allowed without a confirmed token. */
+export type TurnstileFailOpenReason =
+  | "verified"
+  | "skipped"
+  | "missing-token"
+  | "invalid-token"
+  | "unverifiable";
+
+export interface TurnstileFailOpenResult {
+  /**
+   * Always true. This gate NEVER blocks a submission — see the doc comment.
+   * Exposed as a field (rather than a bare boolean) so callers read as
+   * `.allowed` and future policy changes stay source-compatible.
+   */
+  allowed: true;
+  /** Why the submission was allowed, for logging/branching by the caller. */
+  reason: TurnstileFailOpenReason;
+}
+
+/**
+ * Verify a Turnstile token but ALWAYS allow the submission through (FAIL OPEN).
+ *
+ * ── Intentional availability > strict-captcha tradeoff (PP-20yy) ────────────
+ * Cloudflare Turnstile is an external dependency that fails transiently in the
+ * real world (slow/blocked widget script, challenge timeout, network blip,
+ * ad-blocker/extension interference). When it does, a fail-CLOSED gate leaves a
+ * legitimate user unable to sign in / sign up / reset their password with no
+ * way forward. That has locked real users out repeatedly, so Tim chose
+ * (2026-07-10) to make the auth captcha gate resilient first and, as a last
+ * resort, fail OPEN: never block the request on a missing/unverifiable token.
+ *
+ * The client mirrors this (see `useTurnstileGate`): it retries the widget and
+ * only enables submission without a token after a bounded resilience window.
+ * Rate limiting (IP + account) remains the real abuse backstop — captcha here
+ * is best-effort deterrence, not a hard boundary. Do NOT "fix" this back to
+ * fail-closed without reverting the client gate AND re-enabling Supabase's
+ * built-in captcha protection; the two sides must stay consistent, and while
+ * Supabase captcha is on it would reject the very tokenless submissions this
+ * gate is meant to let through.
+ *
+ * Every fail-open path (token missing, rejected, or unverifiable) emits a
+ * structured log line AND a Sentry message so abuse is monitorable.
+ *
+ * @param token   - The cf-turnstile-response token from the client (may be "")
+ * @param ip      - Optional client IP for additional validation
+ * @param action  - Short identifier of the calling flow (for observability)
+ * @returns Always `{ allowed: true, reason }`.
+ */
+export async function verifyTurnstileFailOpen(
+  token: string,
+  ip: string | undefined,
+  action: string
+): Promise<TurnstileFailOpenResult> {
+  const outcome = await runTurnstileVerification(token, ip);
+
+  if (outcome.kind === "verified" || outcome.kind === "skipped") {
+    return { allowed: true, reason: outcome.kind };
+  }
+
+  // Fail-open path: the token was missing, rejected, or unverifiable, but we
+  // let the submission proceed anyway. Emit observability so this stays
+  // monitorable (spikes here may indicate abuse OR a Turnstile outage).
+  const detail =
+    outcome.kind === "unverifiable"
+      ? { reason: outcome.reason }
+      : outcome.kind === "invalid-token"
+        ? { errorCodes: outcome.errorCodes }
+        : {};
+
+  log.warn(
+    { action, event: "turnstile_fail_open", outcome: outcome.kind, ...detail },
+    "Turnstile fail-open: allowing submission without a verified token"
+  );
+  Sentry.captureMessage("turnstile.fail_open", {
+    level: "warning",
+    tags: { action, turnstileOutcome: outcome.kind },
+    extra: detail,
+  });
+
+  return { allowed: true, reason: outcome.kind };
 }


### PR DESCRIPTION
## Problem

A transient Cloudflare Turnstile hiccup (slow/blocked widget script, challenge timeout, network blip, ad-blocker/extension interference) could **silently disable the Sign In button** in production, with no error shown — repeatedly locking real users out. The submit was hard-disabled until a token existed, and the widget's `onError` was wired to a handler that *cleared* the token, so an error actively **re-disabled** the button forever. The pattern was duplicated across all 4 auth forms (login, signup, forgot-password, reset-password).

## Decision (Tim, 2026-07-10)

**Availability > strict captcha enforcement here.** Make it *resilient first*, then *fail open* as a last resort. This is an intentional tradeoff — rate limiting (IP + account) remains the real abuse backstop; captcha becomes best-effort deterrence. **Please do not revert this to fail-closed** without also reverting the client gate and re-enabling Supabase's built-in captcha (the two sides must stay consistent). The tradeoff is documented in code comments at both the client gate (`useTurnstileGate`) and the server verify (`verifyTurnstileFailOpen`).

## Changes

**Shared client hook `useTurnstileGate`** (replaces 4x duplicated per-form logic):
- Never clears the token on error; the widget auto-retries (`retry: "auto"`, `refreshExpired: "auto"`).
- Bounded **8s resilience window** so transient blips recover *with* a real token.
- **One-way fail-open latch**: after the window elapses with no token, submit is enabled anyway — the button can never stay dead, and a later expiry/error can't re-disable it.
- Visible `Verifying you're human…` status while waiting; Sentry breadcrumb when the client latch fires.

**Server `verifyTurnstileFailOpen`** (used by all 4 auth actions):
- **Never blocks**: missing / invalid / unverifiable token → allowed.
- Structured `log.warn` + `Sentry.captureMessage("turnstile.fail_open", …)` on every fail-open path, so abuse (or a Turnstile outage) is monitorable.
- The auth actions **no longer delegate captcha to Supabase's built-in protection** — they own verification via our fail-open seam. The strict `verifyTurnstileToken` is unchanged and still guards the anonymous public report form.

## ⚠️ Deploy coupling (action required before/at merge)

The auth actions no longer pass `captchaToken` to Supabase. **Supabase project-level captcha (Attack Protection) MUST be disabled** for this to work:
- Turnstile tokens are **single-use** — we consume the token in our own siteverify call, so Supabase can't also verify it.
- With Supabase captcha still **on**, Supabase would **reject the tokenless submissions** this gate is designed to let through → auth outage.

So: flip Supabase Auth → Attack Protection → CAPTCHA **off** as part of merging. Our fail-open seam becomes the sole captcha gate.

## Tests
- **RTL** (`useTurnstileGate.test.tsx`): dead-button-never-happens, fail-open-after-timeout, error-keeps-token (+ once-latched-stays-open), captcha-not-enforced passthrough.
- **Unit** (`turnstile.test.ts`): `verifyTurnstileFailOpen` fail-open on missing / invalid / network-error / no-prod-key, with Sentry observability asserted; strict `verifyTurnstileToken` behavior preserved.
- **Auth actions** (`actions-security.test.ts`): updated to the new seam; reset-password now asserts fail-open proceeds to `updateUser` instead of returning a CAPTCHA error.
- Turnstile mocked at its boundary (CORE-TEST-006); no calls to `challenges.cloudflare.com`.

## Verification
- `pnpm run check` — green (typecheck, lint, format, 1428 unit tests).
- `next build` — compiled + type-checked clean (page-data collection needs a DB, unrelated to this change).
- Local preflight integration/smoke not run: this worktree's Supabase env wasn't provisioned. CI runs the full integration + E2E suite.

Closes PP-20yy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)