### PR TITLE
docs: changelog week of July 7, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 135, "lastUpdated": "2026-06-21" }
+{ "totalEntries": 138, "lastUpdated": "2026-07-11" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,18 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## July 7, 2026
+
+### New Features
+
+- **Machine Settings** — Machine owners can now create named settings sets for their machines, covering software settings, DIP switch banks, rubber and post positions, and a baseline configuration; the preferred settings set also appears on the machine's activity timeline
+
+### Bug Fixes
+
+- Viewing the activity timeline on machines with older history no longer causes an error — leftover data from a removed feature has been cleaned up
+- Admins inviting new members now correctly check for duplicate email addresses across all existing members, not just the first 50
+
+---
+
 ## June 15, 2026
 
 ### New Features


### PR DESCRIPTION
Weekly user-facing changelog entry for the week of July 7, 2026.

**What's in this entry:**

New Features:
- Machine Settings tab — owner-defined settings sets with software settings, DIP switch banks, rubber/post positions, and baseline (#1388)

Bug Fixes:
- Machine timeline crash from orphaned `owner_notes_updated` events cleaned up (#1606)
- Admin invite flow now paginates `auth.users` to catch duplicate emails past the first 50 (#1634)

**Files changed:** `content/changelog.mdx`, `content/changelog-meta.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKKYuUumrZDT681j6DyBtd)_