### PR TITLE
feat(chores): weekly-chores nag — recurring bead + SessionStart hook + skill (PP-ld0o.3, PP-ld0o.4)

### DIFF
--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -64,8 +64,9 @@ When chores are done, **re-defer the bead one week out** so it goes dormant and 
 `<next Saturday>` = the next Saturday's date in `YYYY-MM-DD` (e.g. `bd defer --until=2026-07-18 PP-qehv`). Optionally leave a run summary comment first:
 
     bd comments add <chores-bead> "Chores done <date>: <one-line summary of what was reviewed / filed>."
-    bd update <chores-bead> --status open   # (defer sets status=deferred; the bead stays open-not-closed between cycles)
 
-Do **not** close the bead — it's a recurring holder. Deferring it (status `deferred`, future `defer_until`) is what makes it dormant. The nag stays silent until that date passes.
+Do **not** close the bead — it's a recurring holder. Deferring it (status `deferred`, future `defer_until`) is what makes it dormant; nothing else is needed — don't flip it back to `open`. The nag stays silent until that date passes.
+
+> **Note:** `bd defer --until=<date>` is interpreted as **UTC midnight** of that date. In US-Central that's the evening before, so a "next Saturday" re-arm actually becomes due Friday evening local — the nag's day-count boundary flips then, not at local Saturday midnight. Close enough for a weekly cadence; just don't expect the count to tick over exactly at local midnight.
 
 > Beads sync note: `bd` writes locally; the lead handles `bd dolt push`. Don't push beads from a chores session unless you're the lead.

--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pinpoint-chores
+description: Runbook for the weekly PinPoint "chores" session — the human-in-the-loop maintenance pass (Supabase CLI pin, TS-7 rollout, Dependabot, changelog, Sentry/Supabase advisors, cloud-routine beads). Use when Tim says "let's do chores", when the SessionStart chores-nag fires ("🧹 Weekly chores are N days overdue"), or when you want the chores checklist. After finishing, re-arm the nag with `bd defer`.
+---
+
+# pinpoint-chores
+
+> **Use when:** the SessionStart nag fires (`🧹 Weekly chores are N days overdue — say "let's do chores".`), Tim says "let's do chores" / "do the chores", or you want the weekly maintenance checklist. Triggers on "chores", "weekly chores", "chores nag".
+
+The weekly **chores** session is one focused, human-in-the-loop pass over the periodic maintenance that used to be scattered across the session-start briefing and various routines. Doing it here keeps the briefing slim (it drops to "status of open PRs") and gives version-drift / advisor / cloud-routine review a single home.
+
+This skill is the runbook. The checklist itself is duplicated on the recurring **Weekly Chores** bead (labeled `weekly-chore`) so both a human reading `bd show` and this skill stay in sync — keep them matched when items change.
+
+## How the nag works (context)
+
+- **State + due date** live on one recurring bead labeled `weekly-chore` (durable, DoltHub-synced across Tim's machines). Between cycles it sits **deferred** — `bd defer --until=<next Saturday>` — so it's dormant.
+- **The nudge** is a SessionStart hook, `.claude/hooks/session-start-chores-nag.sh`. It looks the bead up **by label** (never a hardcoded ID), reads its `defer_until`, and if that date has passed injects the one-line nag. It's silent while the bead is dormant.
+- **Reset** = re-defer the bead one week out. Because state is on the synced bead, doing chores on ANY machine clears the nag everywhere.
+
+Design record: **PP-ld0o.3** (Option C). Epic: **PP-ld0o**.
+
+## Running the chores
+
+Find the bead first (by label, so you have its ID for comments + the reset):
+
+    bd list --label weekly-chore --json
+
+Optionally move it to in-progress and log start:
+
+    bd update <chores-bead> --status in_progress
+
+Then work the checklist. For each item, note findings as a comment on the bead (`bd comments add <chores-bead> "..."`) and file follow-up beads for anything actionable — don't fix everything inline; chores is triage + quick wins.
+
+### Checklist
+
+1. **Stale Supabase CLI pin check** (PP-nlv6)
+   - Compare the pinned Supabase CLI version against the latest release. The pin lives in CI setup / config; a version-drift nudge belongs here, not in per-session briefing.
+   - If stale, file/refresh a bead to bump it (or bump it if trivial and verified).
+
+2. **TypeScript-7 rollout status**
+   - Read `docs/plans/2026-06-27-typescript-7-upgrade-plan.md` for the current phase.
+   - The pinned `tsgo` nightly (`@typescript/native-preview`) needs a bump to the **GA release** when TS 7.0 GA lands (~July 2026). Related bead: **PP-rl1l**.
+   - When bumping, re-validate 0-divergence parity vs `tsc 6`: `pnpm run typecheck:tsc6`.
+
+3. **Dependabot updates**
+   - Review open Dependabot PRs (`gh pr list --author "app/dependabot"`). Merge the safe ones via the normal PR workflow; file a bead for any that need real work.
+
+4. **Release-notes / changelog routine output**
+   - Review what the changelog/release-notes routine produced since last chores. Correct or supplement as needed.
+
+5. **Sentry + Supabase advisor checks**
+   - Run the Sentry error scan and the Supabase advisor checks that previously lived in the session-start briefing. Triage new issues into beads.
+
+6. **Review beads filed by the cloud routines**
+   - The scheduled cloud routines write findings straight into beads (security findings, flaky-test reports, etc.). Review everything filed since the last chores session and act on / prioritize / decline each.
+   - Handy: `bd list --json` filtered by recent `created_at`, or the labels the routines use.
+
+## Finish: re-arm the nag
+
+When chores are done, **re-defer the bead one week out** so it goes dormant and the nag clears everywhere:
+
+    bd defer --until=<next Saturday> <chores-bead>
+
+`<next Saturday>` = the next Saturday's date in `YYYY-MM-DD` (e.g. `bd defer --until=2026-07-18 PP-qehv`). Optionally leave a run summary comment first:
+
+    bd comments add <chores-bead> "Chores done <date>: <one-line summary of what was reviewed / filed>."
+    bd update <chores-bead> --status open   # (defer sets status=deferred; the bead stays open-not-closed between cycles)
+
+Do **not** close the bead — it's a recurring holder. Deferring it (status `deferred`, future `defer_until`) is what makes it dormant. The nag stays silent until that date passes.
+
+> Beads sync note: `bd` writes locally; the lead handles `bd dolt push`. Don't push beads from a chores session unless you're the lead.

--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -13,9 +13,12 @@ This skill is the runbook. The checklist itself is duplicated on the recurring *
 
 ## How the nag works (context)
 
-- **State + due date** live on one recurring bead labeled `weekly-chore` (durable, DoltHub-synced across Tim's machines). Between cycles it sits **deferred** — `bd defer --until=<next Saturday>` — so it's dormant.
-- **The nudge** is a SessionStart hook, `.claude/hooks/session-start-chores-nag.sh`. It looks the bead up **by label** (never a hardcoded ID), reads its `defer_until`, and if that date has passed injects the one-line nag. It's silent while the bead is dormant.
-- **Reset** = re-defer the bead one week out. Because state is on the synced bead, doing chores on ANY machine clears the nag everywhere.
+- **State + due date** live on one recurring bead labeled `weekly-chore` (durable, DoltHub-synced across Tim's machines).
+- **The nudge** is a SessionStart hook, `.claude/hooks/session-start-chores-nag.sh`. It looks the bead up **by label** (never a hardcoded ID) and reads its `defer_until` + `status`. The state machine it enforces:
+  - **Dormant** — `defer_until` in the **future** → no nag (between cycles, after the re-defer).
+  - **Due** — `defer_until` in the **past** AND status is **not** `in_progress` and **not** `closed` → **nag**.
+  - **Working** — status `in_progress` → no nag (you moved the bead there when you started this session; see below).
+- **Reset** = when you finish, re-defer the bead one week out (which also takes it out of `in_progress`). Because state is on the synced bead, doing chores on ANY machine clears the nag everywhere.
 
 Design record: **PP-ld0o.3** (Option C). Epic: **PP-ld0o**.
 
@@ -25,7 +28,7 @@ Find the bead first (by label, so you have its ID for comments + the reset):
 
     bd list --label weekly-chore --json
 
-Optionally move it to in-progress and log start:
+**Move it to in-progress** — this silences the nag while you work (a `due` bead only nags when it is NOT `in_progress`), and logs the start:
 
     bd update <chores-bead> --status in_progress
 

--- a/.claude/hooks/session-start-chores-nag.sh
+++ b/.claude/hooks/session-start-chores-nag.sh
@@ -88,8 +88,9 @@ for b in beads:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=datetime.timezone.utc)
     if now <= dt:
-        # Still dormant — chores not due yet.
-        break
+        # This bead is still dormant — keep scanning; another weekly-chore bead
+        # (e.g. a pre-sync duplicate) may be overdue and should still nag.
+        continue
     days = (now - dt).days  # floor: whole days past the defer date
     if days < 1:
         print('🧹 Weekly chores are due today — say \"let\'s do chores\".')

--- a/.claude/hooks/session-start-chores-nag.sh
+++ b/.claude/hooks/session-start-chores-nag.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# session-start-chores-nag.sh — SessionStart hook: nudge when the weekly chores
+# are overdue.
+#
+# The recurring "Weekly Chores" bead (labeled `weekly-chore`) is the durable,
+# beads-synced state + due-date holder. Between cycles it sits deferred (dormant)
+# via native `bd defer --until=<next Saturday>`. This hook looks it up BY LABEL
+# (never a hardcoded ID — the ID differs per machine/db and the bead may be
+# recreated), reads its `defer_until`, and if that date has passed injects ONE
+# line on stdout that Claude Code surfaces as session context:
+#
+#     🧹 Weekly chores are N days overdue — say "let's do chores".
+#
+# Design: PP-ld0o.3 (Option C — recurring bead + SessionStart nag). Doing chores
+# on ANY machine re-defers the bead and the nag clears everywhere (beads sync).
+# The runbook the chores session follows: .agents/skills/pinpoint-chores/SKILL.md.
+#
+# Why SessionStart (not UserPromptSubmit): the nag should match "when I start
+# talking to you", not fire on every message. Mirrors the huddle /
+# orphan-sweep SessionStart-nudge pattern (cheap, one line, fail-open).
+#
+# Guardrails:
+#   - Best-effort: every failure path exits 0 silently. This hook must NEVER
+#     block or fail a session start.
+#   - Skips subagent sessions (transcript path under /subagents/) — the nag is
+#     for Tim's interactive sessions, not tool-spawned agents.
+#   - Single fast `bd list` query, wrapped in a short timeout so a cold dolt
+#     server can't stall session start.
+
+set -u
+
+# bd unavailable → nothing to do.
+command -v bd >/dev/null 2>&1 || exit 0
+
+# Read stdin JSON (best-effort). Skip subagent sessions.
+INPUT=""
+if [[ ! -t 0 ]]; then
+  INPUT=$(cat)
+fi
+if [[ -n "$INPUT" ]]; then
+  TRANSCRIPT_PATH=$(
+    printf '%s' "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('transcript_path') or '')
+except Exception:
+    print('')
+" 2>/dev/null
+  ) || TRANSCRIPT_PATH=""
+  case "$TRANSCRIPT_PATH" in
+    */subagents/*) exit 0 ;;
+    *) ;;
+  esac
+fi
+
+# Look up the chores bead by its stable `weekly-chore` label. Short timeout so a
+# cold/hung dolt server can't stall session start; fail open on any error.
+if command -v timeout >/dev/null 2>&1; then
+  JSON=$(timeout 4 bd list --label weekly-chore --json 2>/dev/null) || exit 0
+elif command -v gtimeout >/dev/null 2>&1; then
+  JSON=$(gtimeout 4 bd list --label weekly-chore --json 2>/dev/null) || exit 0
+else
+  JSON=$(bd list --label weekly-chore --json 2>/dev/null) || exit 0
+fi
+[[ -n "$JSON" ]] || exit 0
+
+MSG=$(
+  printf '%s' "$JSON" | python3 -c "
+import sys, json, datetime
+
+try:
+    beads = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+now = datetime.datetime.now(datetime.timezone.utc)
+for b in beads:
+    if b.get('status') == 'closed':
+        continue
+    du = b.get('defer_until')
+    if not du:
+        # Not armed (freshly created, or actively being worked) — no nag.
+        continue
+    try:
+        dt = datetime.datetime.fromisoformat(du.replace('Z', '+00:00'))
+    except Exception:
+        continue
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    if now <= dt:
+        # Still dormant — chores not due yet.
+        break
+    days = (now - dt).days  # floor: whole days past the defer date
+    if days < 1:
+        print('🧹 Weekly chores are due today — say \"let\'s do chores\".')
+    else:
+        unit = 'day' if days == 1 else 'days'
+        print(f'🧹 Weekly chores are {days} {unit} overdue — say \"let\'s do chores\".')
+    break
+" 2>/dev/null
+) || exit 0
+
+[[ -n "$MSG" ]] && printf '%s\n' "$MSG"
+exit 0

--- a/.claude/hooks/session-start-chores-nag.sh
+++ b/.claude/hooks/session-start-chores-nag.sh
@@ -3,13 +3,21 @@
 # are overdue.
 #
 # The recurring "Weekly Chores" bead (labeled `weekly-chore`) is the durable,
-# beads-synced state + due-date holder. Between cycles it sits deferred (dormant)
-# via native `bd defer --until=<next Saturday>`. This hook looks it up BY LABEL
-# (never a hardcoded ID — the ID differs per machine/db and the bead may be
-# recreated), reads its `defer_until`, and if that date has passed injects ONE
-# line on stdout that Claude Code surfaces as session context:
+# beads-synced state + due-date holder. This hook looks it up BY LABEL (never a
+# hardcoded ID — the ID differs per machine/db and the bead may be recreated),
+# reads its `defer_until` + `status`, and injects ONE line on stdout that Claude
+# Code surfaces as session context:
 #
 #     🧹 Weekly chores are N days overdue — say "let's do chores".
+#
+# State machine (defer_until vs now, gated by status):
+#   - DORMANT  — defer_until in the FUTURE            → no nag (between cycles).
+#   - DUE      — defer_until in the PAST, status is
+#                NOT in_progress and NOT closed       → NAG.
+#   - WORKING  — status == in_progress                → no nag (chores under way;
+#                the operator moves the bead to in_progress at the start of a
+#                chores session, then re-defers to next Saturday when done).
+#   - (a bead with no defer_until — created before its first defer — is silent.)
 #
 # Design: PP-ld0o.3 (Option C — recurring bead + SessionStart nag). Doing chores
 # on ANY machine re-defers the bead and the nag clears everywhere (beads sync).
@@ -53,14 +61,23 @@ except Exception:
   esac
 fi
 
-# Look up the chores bead by its stable `weekly-chore` label. Short timeout so a
-# cold/hung dolt server can't stall session start; fail open on any error.
+# Look up the chores bead by its stable `weekly-chore` label. The call is ALWAYS
+# time-bounded so a cold/hung dolt server can't stall session start — using the
+# same timeout/gtimeout/perl-alarm fallback ladder as session-start-orphan-sweep.sh
+# (perl covers macOS boxes that ship neither coreutils `timeout` nor `gtimeout`).
+# Fail open on any error.
 if command -v timeout >/dev/null 2>&1; then
   JSON=$(timeout 4 bd list --label weekly-chore --json 2>/dev/null) || exit 0
 elif command -v gtimeout >/dev/null 2>&1; then
   JSON=$(gtimeout 4 bd list --label weekly-chore --json 2>/dev/null) || exit 0
 else
-  JSON=$(bd list --label weekly-chore --json 2>/dev/null) || exit 0
+  JSON=$(perl -e '
+    use strict;
+    $SIG{ALRM} = sub { kill 15, -$$; exit 0 };
+    alarm 4;
+    setpgrp 0, 0;
+    exec @ARGV
+  ' bd list --label weekly-chore --json 2>/dev/null) || exit 0
 fi
 [[ -n "$JSON" ]] || exit 0
 
@@ -75,11 +92,13 @@ except Exception:
 
 now = datetime.datetime.now(datetime.timezone.utc)
 for b in beads:
-    if b.get('status') == 'closed':
+    # WORKING or done: chores actively under way (in_progress) or the bead was
+    # closed — never nag in either state.
+    if b.get('status') in ('in_progress', 'closed'):
         continue
     du = b.get('defer_until')
     if not du:
-        # Not armed (freshly created, or actively being worked) — no nag.
+        # Not armed yet (created before its first defer) — no nag.
         continue
     try:
         dt = datetime.datetime.fromisoformat(du.replace('Z', '+00:00'))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -154,6 +154,11 @@
             "type": "command",
             "command": "node .claude/hooks/verify-guard-stack.cjs",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/session-start-chores-nag.sh",
+            "timeout": 5000
           }
         ]
       }

--- a/scripts/tests/test_chores_nag_hook.py
+++ b/scripts/tests/test_chores_nag_hook.py
@@ -153,10 +153,44 @@ def test_dormant_future_defer_is_silent(mock_bd: dict, tmp_path: Path) -> None:
 
 
 def test_no_defer_until_is_silent(mock_bd: dict, tmp_path: Path) -> None:
-    # Freshly created / actively being worked → not armed → no nag.
+    # A bead with no defer_until at all (created before its first `bd defer`) is
+    # not armed → no nag. Note this is about the MISSING field only — an
+    # in_progress bead still keeps its defer_until (see the in_progress test).
     bead = _chore_bead(status="open")
     bead.pop("defer_until")
     mock_bd["set_beads"]([bead])
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert out.strip() == ""
+
+
+def test_due_open_bead_nags(mock_bd: dict, tmp_path: Path) -> None:
+    # DUE + status open (not in_progress, not closed) → nag. Guards the corrected
+    # semantics: the nag keys on status, not just defer_until.
+    mock_bd["set_beads"](
+        [
+            _chore_bead(
+                status="open",
+                defer_until=_iso(_now() - datetime.timedelta(days=2, hours=2)),
+            )
+        ]
+    )
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert "2 days overdue" in out
+
+
+def test_due_in_progress_bead_is_silent(mock_bd: dict, tmp_path: Path) -> None:
+    # DUE (defer_until in the past) BUT status in_progress → chores actively
+    # under way → no nag, even though defer_until has passed.
+    mock_bd["set_beads"](
+        [
+            _chore_bead(
+                status="in_progress",
+                defer_until=_iso(_now() - datetime.timedelta(days=3)),
+            )
+        ]
+    )
     rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
     assert rc == 0, err
     assert out.strip() == ""

--- a/scripts/tests/test_chores_nag_hook.py
+++ b/scripts/tests/test_chores_nag_hook.py
@@ -1,0 +1,185 @@
+"""Unit tests for the SessionStart weekly-chores nag hook.
+
+The hook (`.claude/hooks/session-start-chores-nag.sh`) looks up the recurring
+"Weekly Chores" bead BY LABEL via `bd list --label weekly-chore --json`, reads
+its `defer_until`, and injects a one-line nudge when that date has passed.
+
+These tests mock `bd` with a fake executable on PATH (same technique as
+test_worktree_create_hook.py mocks git) so no real beads DB is touched.
+"""
+
+import datetime
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = (
+    Path(__file__).parent.parent.parent / ".claude/hooks/session-start-chores-nag.sh"
+)
+
+
+def _iso(dt: datetime.datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+@pytest.fixture
+def mock_bd(tmp_path: Path):
+    """Install a fake `bd` on PATH that prints a canned JSON array.
+
+    Returns a helper that writes the desired `bd list ... --json` payload.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    payload_file = tmp_path / "bd_payload.json"
+
+    bd_script = bin_dir / "bd"
+    # The hook only ever calls `bd list --label weekly-chore --json`; the fake
+    # ignores its args and echoes the payload file (or exits non-zero to
+    # simulate a bd failure when the payload file is absent).
+    bd_script.write_text(
+        f"""#!/usr/bin/env bash
+if [[ -f "{payload_file}" ]]; then
+  cat "{payload_file}"
+  exit 0
+fi
+exit 1
+"""
+    )
+    bd_script.chmod(0o755)
+
+    def set_beads(beads) -> None:
+        payload_file.write_text(json.dumps(beads))
+
+    return {"bin_dir": bin_dir, "set_beads": set_beads, "payload_file": payload_file}
+
+
+def run_hook(stdin_data: dict, mock_bd: dict, tmp_path: Path) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    env["HOME"] = str(fake_home)
+    env["XDG_CONFIG_HOME"] = str(fake_home / ".config")
+    # Fake bd wins over any real bd on PATH.
+    env["PATH"] = f"{mock_bd['bin_dir']}:{env['PATH']}"
+
+    process = subprocess.Popen(
+        ["bash", str(HOOK_PATH)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+    stdout, stderr = process.communicate(input=json.dumps(stdin_data))
+    return process.returncode, stdout, stderr
+
+
+def _chore_bead(**overrides) -> dict:
+    bead = {
+        "id": "PP-test",
+        "title": "Weekly Chores",
+        "status": "deferred",
+        "defer_until": _iso(_now() - datetime.timedelta(days=3)),
+    }
+    bead.update(overrides)
+    return bead
+
+
+STDIN = {"transcript_path": "/x/y/transcript.jsonl", "hook_event_name": "SessionStart"}
+
+
+def test_overdue_emits_nag(mock_bd: dict, tmp_path: Path) -> None:
+    # 3 days + a margin so floor lands firmly on 3 (not slop-sensitive).
+    mock_bd["set_beads"](
+        [_chore_bead(defer_until=_iso(_now() - datetime.timedelta(days=3, hours=2)))]
+    )
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert "🧹" in out
+    assert "3 days overdue" in out
+    assert 'say "let\'s do chores"' in out
+
+
+def test_overdue_one_day_is_singular(mock_bd: dict, tmp_path: Path) -> None:
+    # ~1 day + 5h overdue → floor 1 → singular "1 day".
+    mock_bd["set_beads"](
+        [_chore_bead(defer_until=_iso(_now() - datetime.timedelta(days=1, hours=5)))]
+    )
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert "1 day overdue" in out
+    assert "1 days" not in out
+
+
+def test_due_today_when_less_than_a_day_over(mock_bd: dict, tmp_path: Path) -> None:
+    # Passed the defer date but < 1 full day → "due today", not "0 days overdue".
+    mock_bd["set_beads"](
+        [_chore_bead(defer_until=_iso(_now() - datetime.timedelta(hours=6)))]
+    )
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert "due today" in out
+    assert "overdue" not in out
+
+
+def test_dormant_future_defer_is_silent(mock_bd: dict, tmp_path: Path) -> None:
+    mock_bd["set_beads"](
+        [_chore_bead(defer_until=_iso(_now() + datetime.timedelta(days=4)))]
+    )
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert out.strip() == ""
+
+
+def test_no_defer_until_is_silent(mock_bd: dict, tmp_path: Path) -> None:
+    # Freshly created / actively being worked → not armed → no nag.
+    bead = _chore_bead(status="open")
+    bead.pop("defer_until")
+    mock_bd["set_beads"]([bead])
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert out.strip() == ""
+
+
+def test_closed_bead_is_silent(mock_bd: dict, tmp_path: Path) -> None:
+    mock_bd["set_beads"]([_chore_bead(status="closed")])
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert out.strip() == ""
+
+
+def test_no_chore_bead_is_silent(mock_bd: dict, tmp_path: Path) -> None:
+    mock_bd["set_beads"]([])
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert out.strip() == ""
+
+
+def test_subagent_session_is_silent(mock_bd: dict, tmp_path: Path) -> None:
+    mock_bd["set_beads"]([_chore_bead()])  # overdue, but subagent → suppressed
+    stdin = {"transcript_path": "/x/subagents/z.jsonl"}
+    rc, out, err = run_hook(stdin, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert out.strip() == ""
+
+
+def test_bd_failure_fails_open(mock_bd: dict, tmp_path: Path) -> None:
+    # No payload file → fake bd exits non-zero → hook must fail open, exit 0, silent.
+    mock_bd["payload_file"].unlink(missing_ok=True)
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_malformed_json_fails_open(mock_bd: dict, tmp_path: Path) -> None:
+    mock_bd["payload_file"].write_text("not valid json")
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0
+    assert out.strip() == ""

--- a/scripts/tests/test_chores_nag_hook.py
+++ b/scripts/tests/test_chores_nag_hook.py
@@ -129,6 +129,20 @@ def test_due_today_when_less_than_a_day_over(mock_bd: dict, tmp_path: Path) -> N
     assert "overdue" not in out
 
 
+def test_dormant_first_does_not_suppress_overdue(mock_bd: dict, tmp_path: Path) -> None:
+    # A dormant (future-defer) bead ordered before an overdue one must NOT
+    # suppress the nag — the loop must scan past it (continue, not break).
+    mock_bd["set_beads"](
+        [
+            _chore_bead(defer_until=_iso(_now() + datetime.timedelta(days=4))),
+            _chore_bead(defer_until=_iso(_now() - datetime.timedelta(days=2, hours=2))),
+        ]
+    )
+    rc, out, err = run_hook(STDIN, mock_bd, tmp_path)
+    assert rc == 0, err
+    assert "2 days overdue" in out
+
+
 def test_dormant_future_defer_is_silent(mock_bd: dict, tmp_path: Path) -> None:
     mock_bd["set_beads"](
         [_chore_bead(defer_until=_iso(_now() + datetime.timedelta(days=4)))]


### PR DESCRIPTION
Consolidates scattered periodic maintenance into a single human-in-the-loop **weekly chores** session, surfaced by a **SessionStart nag** when it's overdue. Implements epic **PP-ld0o** children **PP-ld0o.4** (checklist + skill) and **PP-ld0o.3** (the nag) as one coupled PR.

## What's here

1. **`pinpoint-chores` skill** (`.agents/skills/pinpoint-chores/SKILL.md`) — the runbook the local chores session follows: the checklist (Supabase CLI pin PP-nlv6, TS-7 rollout status, Dependabot, changelog routine, Sentry/Supabase advisors, cloud-routine beads), how to run each item, and the final re-arm step (`bd defer --until=<next Saturday>`).

2. **Recurring "Weekly Chores" bead** (`PP-qehv`, label `weekly-chore`) — the nag's durable, DoltHub-synced state + checklist holder. Created and deferred to next Saturday (2026-07-18) so it starts dormant. *(Not pushed via `bd dolt push` — lead handles beads sync.)*

3. **SessionStart nag hook** (`.claude/hooks/session-start-chores-nag.sh`) — finds the bead **by the `weekly-chore` label** (never a hardcoded ID), reads its `defer_until`, and if past due injects one line: `🧹 Weekly chores are N days overdue — say "let's do chores".` (or "due today" when < 1 day over). Fail-open, skips subagent sessions, short `bd` timeout so a cold dolt server can't stall session start. Mirrors the huddle / orphan-sweep SessionStart-nudge pattern.

## Design

Per **PP-ld0o.3**'s recorded decision (Option C): recurring bead (synced source of truth) + SessionStart hook (message-time nag). Doing chores on any machine re-defers the bead and clears the nag everywhere.

## Safety / testing

- Appended only to the SessionStart hooks array in `.claude/settings.json`; the PreToolUse guard stack + permissions block are untouched and the guard-stack canary stays healthy.
- pytest coverage (`scripts/tests/test_chores_nag_hook.py`, 10 tests) via a mocked `bd` on PATH: overdue / singular / due-today / dormant / no-defer / closed / no-bead / subagent / bd-failure / malformed-json.
- `pnpm run check` green (the one flaky error was an unrelated jsdom/Radix teardown race in `MetadataDrawer.test.tsx`; clean on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DxTkgncy5iCsySTZC4cbh