### PR TITLE
fix(beads-server): correct runbook + templates from live cutover (PP-0fwz)

### DIFF
--- a/scripts/beads-server/SETUP.md
+++ b/scripts/beads-server/SETUP.md
@@ -79,9 +79,12 @@ as `claude-rc.service`).
 ### 2. Seed the data dir from DoltHub
 
 ```bash
-mkdir -p ~/.beads-server && cd ~/.beads-server
+mkdir -p ~/.beads-server/dolt && cd ~/.beads-server/dolt
 dolt clone https://doltremoteapi.dolthub.com/advacar/pinpoint-beads PP
 # → ~/.beads-server/dolt/PP with its `origin` remote already registered
+# Remove any stray `.dolt/` the clone leaves in the PARENT data dir — otherwise the
+# server exposes a phantom empty database named after the dir alongside `PP`.
+rm -rf ~/.beads-server/dolt/.dolt
 ```
 
 Point `data_dir` in `server.yaml` at `~/.beads-server/dolt` (the parent that
@@ -99,11 +102,26 @@ to a DB admin connection.)
 
 ```bash
 cd ~/.beads-server/dolt
-dolt sql-server --host 127.0.0.1 --port 3306 &
-dolt sql --host 127.0.0.1 --port 3306 --user root --query \
-  "CREATE USER 'beads'@'%' IDENTIFIED BY '<PASSWORD>'; GRANT ALL PRIVILEGES ON PP.* TO 'beads'@'%'; FLUSH PRIVILEGES;"
-# stop the throwaway localhost server (kill the backgrounded PID)
+# Boot with the SAME --privilege-file the hardened server will read, or the user
+# won't persist into it.
+dolt sql-server --host 127.0.0.1 --port 3306 \
+  --data-dir ~/.beads-server/dolt --privilege-file ~/.beads-server/privileges.db &
+sleep 5
+# dolt's connection flags are GLOBAL — they go BEFORE the `sql` subcommand (the form
+# `dolt sql --host …` errors with "unknown option host"). Passwordless root needs an
+# explicit `--password ""` (no TTY to prompt otherwise). `--no-tls` for the plaintext
+# first boot.
+dolt --host 127.0.0.1 --port 3306 --user root --password "" --no-tls sql -q \
+  "CREATE USER 'beads'@'%' IDENTIFIED BY '<PASSWORD>'; GRANT ALL PRIVILEGES ON *.* TO 'beads'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+kill %1   # stop the throwaway localhost server
 ```
+
+`beads` gets `ALL PRIVILEGES ON *.*` (not just `PP.*`): the bridge's `bd dolt
+pull`/`push` run `DOLT_PULL`/`DOLT_PUSH` which are denied to a `PP.*`-only user
+("command denied to user 'beads'@'%'"). It's the sole app user on a private,
+single-purpose server, so full privileges are appropriate. If you ever need to
+re-grant later, the hardened server binds only the Tailscale IP where root is denied
+— stop it and repeat this throwaway-localhost boot to reach root.
 
 Pick a strong `<PASSWORD>`; it goes ONLY into env (next steps), never into any
 committed file.
@@ -128,7 +146,9 @@ passwordless root. `privilege_file` persists the `beads` grant across restarts.
 
 ### 5. Repoint both machines to server mode
 
-Per machine, edit `.beads/metadata.json` (gitignored, per-machine):
+Per machine, edit `.beads/metadata.json` (gitignored, per-machine). Do **not** put
+`dolt_server_port` here — it's deprecated (bd warns "can cause cross-project data
+leakage"); the port lives in a separate file instead:
 
 ```json
 {
@@ -136,13 +156,19 @@ Per machine, edit `.beads/metadata.json` (gitignored, per-machine):
   "backend": "dolt",
   "dolt_mode": "server",
   "dolt_server_host": "100.87.228.116",
-  "dolt_server_port": 3306,
   "dolt_server_user": "beads",
   "dolt_database": "PP"
 }
 ```
 
-And in `.beads/config.yaml` set `dolt.auto-start: false` and pin
+```bash
+printf '3306\n' > .beads/dolt-server.port   # the port's new primary source
+```
+
+In `.beads/config.yaml` set `backup.enabled: false` — bd's server-side auto-backup
+is denied (it needs privileges the setup doesn't grant) and is redundant now that the
+bridge replicates to DoltHub; manual `bd export` still works for JSONL snapshots.
+Also set `dolt.auto-start: false` so bd never tries to spawn a local server, and pin
 `dolt.auto-commit: on` (bd's default is OFF; the bridge chain assumes committed
 working sets before it pulls — the server-side `server.yaml` also sets
 `autocommit: true`).

--- a/scripts/beads-server/SETUP.md
+++ b/scripts/beads-server/SETUP.md
@@ -106,6 +106,7 @@ cd ~/.beads-server/dolt
 # won't persist into it.
 dolt sql-server --host 127.0.0.1 --port 3306 \
   --data-dir ~/.beads-server/dolt --privilege-file ~/.beads-server/privileges.db &
+THROWAWAY_PID=$!
 sleep 5
 # dolt's connection flags are GLOBAL — they go BEFORE the `sql` subcommand (the form
 # `dolt sql --host …` errors with "unknown option host"). Passwordless root needs an
@@ -113,7 +114,7 @@ sleep 5
 # first boot.
 dolt --host 127.0.0.1 --port 3306 --user root --password "" --no-tls sql -q \
   "CREATE USER 'beads'@'%' IDENTIFIED BY '<PASSWORD>'; GRANT ALL PRIVILEGES ON *.* TO 'beads'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;"
-kill %1   # stop the throwaway localhost server
+kill "$THROWAWAY_PID"   # stop the throwaway localhost server (PID, not %1 — job control isn't reliable in scripts)
 ```
 
 `beads` gets `ALL PRIVILEGES ON *.*` (not just `PP.*`): the bridge's `bd dolt

--- a/scripts/beads-server/beads-dolthub-bridge.service
+++ b/scripts/beads-server/beads-dolthub-bridge.service
@@ -18,7 +18,12 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+# REQUIRED: run from the project so `bd` resolves .beads (the server config).
+# Without this the bridge runs from $HOME and every `bd dolt` call fails.
+WorkingDirectory=%h/Code/PinPoint
 Environment=PATH=/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
 # Secret lives here, mode 600, outside git. See SETUP.md.
 EnvironmentFile=%h/.beads-server/bridge.env
-ExecStart=/home/linuxbrew/.linuxbrew/bin/bash %h/.beads-server/beads-dolthub-bridge.sh
+# System bash (brew bash is not guaranteed installed); script is invoked via bash
+# so its +x bit is optional.
+ExecStart=/usr/bin/bash %h/.beads-server/beads-dolthub-bridge.sh

--- a/scripts/beads-server/dolt-sql-server.service
+++ b/scripts/beads-server/dolt-sql-server.service
@@ -19,8 +19,9 @@ Wants=network-online.target
 Type=simple
 Environment=PATH=/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
 # Absolute path to the seeded Dolt data dir (holds the `PP` database).
-WorkingDirectory=/home/tim/.beads-server/dolt
-ExecStart=/home/linuxbrew/.linuxbrew/bin/dolt sql-server --config /home/tim/.beads-server/server.yaml --skip-root-user-initialization
+# Edit <USER> to the real home (Tim's is /home/froeht).
+WorkingDirectory=/home/<USER>/.beads-server/dolt
+ExecStart=/home/linuxbrew/.linuxbrew/bin/dolt sql-server --config /home/<USER>/.beads-server/server.yaml --skip-root-user-initialization
 Restart=on-failure
 RestartSec=5
 

--- a/scripts/beads-server/server.yaml
+++ b/scripts/beads-server/server.yaml
@@ -1,10 +1,14 @@
 # Dolt SQL-server config for the shared PinPoint beads database.
 # Used on the Bazzite host: `dolt sql-server --config server.yaml`.
 #
-# This is a TEMPLATE. ${TAILSCALE_IP} defaults to Tim's Bazzite tailnet IP
-# (100.87.228.116) — Mac MagicDNS does not resolve *.ts.net, so both machines
-# connect by raw Tailscale IP. Edit data_dir / privilege_file to match the real
-# on-host paths from SETUP.md before first boot.
+# This is a TEMPLATE. `host` is the Bazzite Tailscale IP (100.87.228.116) — Mac
+# MagicDNS does not resolve *.ts.net, so both machines connect by raw Tailscale IP.
+# Edit data_dir / privilege_file to match the real on-host paths from SETUP.md
+# before first boot.
+#
+# IMPORTANT: do NOT reference an env var (dollar-sign + curly-brace syntax) anywhere
+# in this file, even in a comment — dolt interpolates such tokens across the whole
+# YAML and aborts the boot if any referenced var is unset.
 #
 # Password is NEVER in this file: the `beads` user is created once with a
 # GRANT + IDENTIFIED BY (SETUP.md step 4), and clients pass the secret via the
@@ -22,11 +26,12 @@ listener:
   write_timeout_millis: 28800000
 
 # Absolute path to the Dolt data directory that holds the seeded `PP` database
-# (created by `dolt clone … PP` in SETUP.md step 3). Adjust to the real path.
-data_dir: "/home/tim/.beads-server/dolt"
+# (created by `dolt clone … PP` in SETUP.md step 3). Edit <USER> to the real home
+# (Tim's is /home/froeht).
+data_dir: "/home/<USER>/.beads-server/dolt"
 
 # Persisted privileges/users table so the `beads` grant survives restarts.
-privilege_file: "/home/tim/.beads-server/privileges.db"
+privilege_file: "/home/<USER>/.beads-server/privileges.db"
 
 behavior:
   # Commit each write immediately. bd's default auto-commit is OFF; the DoltHub


### PR DESCRIPTION
## Context

The beads-server templates and runbook (`scripts/beads-server/`) merged in #1651 as part of PP-0fwz. Executing the actual Phase B cutover on 2026-07-12 (beads → shared Dolt sql-server on Bazzite) surfaced several bugs where the **committed versions did not work as-is**. This PR corrects them so the runbook is reproducible.

## Corrections (all discovered by hitting them during the real cutover)

**Templates**
- `server.yaml`: a literal `${...}` token in a header comment aborted the dolt boot — dolt interpolates env-var tokens across the *entire* YAML including comments, and fails if any is unset. Removed it and documented the hazard. Fixed `/home/tim` → `/home/<USER>` placeholders.
- `dolt-sql-server.service`: same `/home/tim` placeholder fix.
- `beads-dolthub-bridge.service`: **added `WorkingDirectory=%h/Code/PinPoint`** — without it the bridge runs from `$HOME`, where `bd` can't resolve `.beads` and every cycle fails. Switched interpreter to `/usr/bin/bash` (brew bash isn't guaranteed installed).

**SETUP.md**
- First boot must pass `--privilege-file` so the created user persists into the file the hardened server reads.
- dolt connection flags are **global** (before the `sql` subcommand); passwordless root needs explicit `--password ""` (no TTY) and `--no-tls`.
- Grant `ALL PRIVILEGES ON *.* WITH GRANT OPTION` — `PP.*` alone makes the bridge's `DOLT_PULL`/`DOLT_PUSH` fail "command denied".
- Remove the stray `.dolt/` the clone leaves in the data dir (phantom database).
- Use `.beads/dolt-server.port` instead of the deprecated `dolt_server_port` in metadata.json; set `backup.enabled: false`.

## Verification

The corrected steps are exactly what produced the now-live, verified setup: both machines on the shared server, `bd doctor --server` 6/6 clean, cross-machine round-trips instant, DoltHub bridge cycling successfully. `pnpm run check` green (2 unrelated `global-setup.test.ts` timeouts were load flakes — pass 12/12 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)