### PR TITLE
docs: consolidate 3 weekly cloud routines into one Weekly Review routine (PP-ld0o.6)

### DIFF
--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -48,15 +48,15 @@ Then work the checklist. For each item, note findings as a comment on the bead (
 3. **Dependabot updates**
    - Review open Dependabot PRs (`gh pr list --author "app/dependabot"`). Merge the safe ones via the normal PR workflow; file a bead for any that need real work.
 
-4. **Release-notes / changelog routine output**
-   - Review what the changelog/release-notes routine produced since last chores. Correct or supplement as needed.
+4. **Changelog PR from the Weekly Review routine**
+   - The consolidated Weekly Review cloud routine opens a changelog PR (`docs/changelog-<date>`) when user-facing PRs merged that week. Review and merge it via the normal PR workflow (or correct/supplement first).
 
 5. **Sentry + Supabase advisor checks**
    - Run the Sentry error scan and the Supabase advisor checks that previously lived in the session-start briefing. Triage new issues into beads.
 
-6. **Review beads filed by the cloud routines**
-   - The scheduled cloud routines write findings straight into beads (security findings, flaky-test reports, etc.). Review everything filed since the last chores session and act on / prioritize / decline each.
-   - Handy: `bd list --json` filtered by recent `created_at`, or the labels the routines use.
+6. **Review beads filed by the Weekly Review routine**
+   - The consolidated Weekly Review cloud routine files beads for its security findings (`security` label) and its flaky-test report (`flaky-test` label). Review everything filed since the last chores session and act on / prioritize / decline each.
+   - Handy: `bd list --label security` and `bd list --label flaky-test`, or `bd list --json` filtered by recent `created_at`.
 
 ## Finish: re-arm the nag
 

--- a/docs/runbooks/cloud-routines-beads-access.md
+++ b/docs/runbooks/cloud-routines-beads-access.md
@@ -182,5 +182,10 @@ handles that); use your DoltHub account email or any non-personal address.
 
 - **PP-3x7s** — the enabler this runbook documents.
 - **PP-nlv6** — a future weekly-chores checklist item (stale Supabase CLI pin).
-- Adoption target: the Weekly Security Review routine files beads for findings
-  (first routine to adopt this).
+- **Consolidated Weekly Review routine** (`trig_01Dp3rMq8LevE4P9gQ1mFSj4`, cron
+  `0 10 * * 6`, Beads env): the three former weekly routines (Security Review,
+  Changelog, Flaky Test Tracker) were merged into one session on 2026-07-12
+  (PP-ld0o.6). Output is "split by risk" — security findings and the flaky-test
+  report are filed as beads (`security` / `flaky-test` labels); the changelog
+  still opens a PR. The former standalone Changelog and Flaky routines are
+  disabled (not deleted).


### PR DESCRIPTION
## Summary

PinPoint's three weekly Claude cloud routines — **Weekly Security Review**, **Weekly Changelog**, and **Flaky Test Tracker** — were consolidated into a single **Weekly Review** routine on 2026-07-12 (PP-ld0o.6). This PR updates the two docs that still described the old separate routines.

The routine changes themselves were applied externally via the RemoteTrigger API (the Security Review trigger was repurposed into the "Weekly Review Agent"; the Changelog and Flaky triggers were disabled, not deleted). Only the docs live in this repo.

## Split-by-risk output model

The consolidated routine emits its findings in three parts:

- **Part A — security findings** → beads (`security` label)
- **Part B — changelog** → still opens a PR (`docs/changelog-<date>`)
- **Part C — flaky tests** → a bead (`flaky-test` label), no auto-fix PR

## Doc edits

- **`docs/runbooks/cloud-routines-beads-access.md`** — replaced the stale "Weekly Security Review adoption target" line in `## Related` with a record of the consolidated Weekly Review routine (trigger ID, cron `0 10 * * 6`, Beads env, split-by-risk output, and the note that the standalone Changelog/Flaky routines are disabled).
- **`.agents/skills/pinpoint-chores/SKILL.md`** — updated checklist item 4 (changelog PR from the Weekly Review routine) and item 6 (review the `security` / `flaky-test` beads it files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)