### PR TITLE
docs: changelog week of July 14, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 138, "lastUpdated": "2026-07-11" }
+{ "totalEntries": 140, "lastUpdated": "2026-07-12" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,17 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## July 14, 2026
+
+### New Features
+
+- **Redesigned Machine Info Tab** — The Info tab on each machine's detail page (the first thing you see when you scan a QR code) now shows the machine's current status, a peek at up to three known issues, a direct "Report a problem" link, and a Details card with the machine description and owner
+
+### Bug Fixes
+
+- Login, sign-up, forgot-password, and reset-password forms no longer get permanently stuck with a disabled button when the security verification widget loads slowly or encounters a network error
+
+---
+
 ## July 7, 2026
 
 ### New Features


### PR DESCRIPTION
Weekly changelog entry — two user-facing PRs missed by the July 7 run.

- **Redesigned Machine Info Tab** — PR #1575
- Auth forms no longer stuck disabled on widget error — PR #1641

---
_Generated by [Claude Code](https://claude.ai/code/session_018NJQCVb9uTHRz7xXAeNiEW)_