### PR TITLE
docs(huddle): post heads-up before dispatching rotation subagent

### DIFF
--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -88,7 +88,15 @@ When the `today_bead.date` in root notes doesn't match today's local date, hooks
 
 ### Rotation subagent dispatch
 
-Use this `Agent` call (adjust model as appropriate):
+**First, post a heads-up on the active daily bead**, then dispatch. Peer sessions poll that bead; a heads-up tells them a rotation is already underway so they don't fire their own subagent. (The rotation file-lock already makes a double-dispatch a safe no-op — this just saves peers a wasted subagent.) At this moment `today_bead.id` still points to the current, pre-rotation daily — that's the bead peers are polling, so it's the right place to post:
+
+```bash
+HUDDLE_DIR="$(dirname "$(git rev-parse --git-common-dir)")/.agents/huddle"
+TODAY_BEAD="$(bd show "$(jq -r '.root_bead_id' "$HUDDLE_DIR/config.json")" --json | jq -r '.[0].notes | fromjson | .today_bead.id')"
+bd comments add "$TODAY_BEAD" "Kicking off huddle rotation → <today's date>. —<YourName>"
+```
+
+Then use this `Agent` call (adjust model as appropriate):
 
 ```javascript
 Agent({

--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -93,7 +93,7 @@ When the `today_bead.date` in root notes doesn't match today's local date, hooks
 ```bash
 HUDDLE_DIR="$(dirname "$(git rev-parse --git-common-dir)")/.agents/huddle"
 TODAY_BEAD="$(bd show "$(jq -r '.root_bead_id' "$HUDDLE_DIR/config.json")" --json | jq -r '.[0].notes | fromjson | .today_bead.id')"
-bd comments add "$TODAY_BEAD" "Kicking off huddle rotation → <today's date>. —<YourName>"
+bd comments add "$TODAY_BEAD" "Kicking off huddle rotation → <today's date>. —<YourFullRegisteredName>"
 ```
 
 Then use this `Agent` call (adjust model as appropriate):


### PR DESCRIPTION
## What

Adds a pre-step to the huddle `### Rotation subagent dispatch` section: before dispatching the rotation subagent, the main agent first resolves the current daily bead ID and posts a heads-up comment on it.

## Why

Peer sessions poll the active daily bead. Posting a heads-up tells them a rotation is already underway so they skip firing their own rotation subagent. The rotation file-lock already makes a double-dispatch a safe no-op, but the comment saves peers a wasted subagent.

The bead-ID lookup reuses the exact snippet already documented later in the file under "How to post coordination updates", so the two stay consistent. At dispatch time `today_bead.id` still points to the current (pre-rotation) daily — the bead peers are actively polling — so it's the right place to post.

## Scope

Docs-only, single file (`.agents/skills/pinpoint-huddle/SKILL.md`). The Agent code block itself is untouched. `pnpm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)