### PR TITLE
feat(ops): GHA infra-flake log + weekly triage (PP-bq7y)

### DIFF
--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-chores
-description: Runbook for the weekly PinPoint "chores" session — the human-in-the-loop maintenance pass (Supabase CLI pin, TS-7 rollout, Dependabot, changelog, Sentry/Supabase advisors, PinballMap vendored-docs drift, cloud-routine beads). Use when Tim says "let's do chores", when the SessionStart chores-nag fires ("🧹 Weekly chores are N days overdue"), or when you want the chores checklist. After finishing, re-arm the nag with `bd defer`.
+description: Runbook for the weekly PinPoint "chores" session — the human-in-the-loop maintenance pass (Supabase CLI pin, TS-7 rollout, Dependabot, changelog, Sentry/Supabase advisors, PinballMap vendored-docs drift, GHA infra-flake triage, cloud-routine beads). Use when Tim says "let's do chores", when the SessionStart chores-nag fires ("🧹 Weekly chores are N days overdue"), or when you want the chores checklist. After finishing, re-arm the nag with `bd defer`.
 ---
 
 # pinpoint-chores
@@ -31,6 +31,8 @@ Find the bead first (by label, so you have its ID for comments + the reset):
 **Move it to in-progress** — this silences the nag while you work (a `due` bead only nags when it is NOT `in_progress`), and logs the start:
 
     bd update <chores-bead> --status in_progress
+
+**Delegate the context-heavy items to subagents.** The checklist keeps growing, and several items burn a lot of context (the GHA infra-flake triage, the Sentry / Supabase advisor sweeps, the Weekly-Review bead review). As lead, farm those out to subagents and keep just the synthesis — don't run everything inline. Give each subagent the item's runbook pointer and have it report back findings + proposed beads; you decide and file. Cheap, quick items (version-pin checks, the vendored-docs diff) can stay inline.
 
 Then work the checklist. For each item, note findings as a comment on the bead (`bd comments add <chores-bead> "..."`) and file follow-up beads for anything actionable — don't fix everything inline; chores is triage + quick wins.
 
@@ -63,6 +65,10 @@ Then work the checklist. For each item, note findings as a comment on the bead (
    - Fetch the live `https://pinballmap.com/llms.txt` and `https://pinballmap.com/robots.txt`, and diff each against the vendored copy in `docs/external/` (`pinballmap-llms.txt`, `pinballmap-robots.txt`). These must stay **byte-identical** to what PBM serves.
    - If either changed: refresh the vendored file verbatim from source, then re-review the conduct / rate-limit / attribution implications against `src/lib/pinballmap/`. File a bead if the change affects API conduct (not just a trivial wording tweak).
    - This weekly check is our **standing** drift guard — there is no automated drift GHA (the once-planned PP-o355.9 was closed in favor of this).
+
+8. **GHA infra-flake triage**
+   - Run the weekly triage procedure in `docs/runbooks/gha-flake-log.md`: read the recent weekly `gha-flake-week` sighting beads (current ISO week + prior 2) plus the permanent `gha-flake-log` ledger, pull new sightings past the ledger cursor, cluster by signature, rule out non-issues, spin genuine recurring infra issues into child beads, catch regressions against `fixed` rows, close aged-out weekly beads, then rewrite the ledger and advance the cursor.
+   - This is context-heavy — a good candidate to delegate to a subagent (see "Running the chores").
 
 ## Finish: re-arm the nag
 

--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -183,8 +183,9 @@ mcp__github__pull_request_read(method: "get_review_comments", owner, repo, pullN
 **Infrastructure failures** — first log the flake, then rerun (see `docs/runbooks/gha-flake-log.md`):
 
 ```bash
-bash scripts/workflow/log-gha-flake.sh <pr> <run-id> <class> "<symptom>" --rerun green
+bash scripts/workflow/log-gha-flake.sh <pr> <run-id> <class> "<symptom>"
 gh run rerun <run-id> --failed
+# (optionally re-run the helper with --rerun green|red once the rerun outcome is known)
 ```
 
 ### Label Ready PRs

--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -180,9 +180,10 @@ gh run view <run-id> --log-failed | tail -50
 mcp__github__pull_request_read(method: "get_review_comments", owner, repo, pullNumber, perPage: 100)
 ```
 
-**Infrastructure failures**:
+**Infrastructure failures** — first log the flake, then rerun (see `docs/runbooks/gha-flake-log.md`):
 
 ```bash
+bash scripts/workflow/log-gha-flake.sh <pr> <run-id> <class> "<symptom>" --rerun green
 gh run rerun <run-id> --failed
 ```
 

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -107,6 +107,8 @@ timeout_ms: 3600000
 
 Exit 0 = all passed, or stopped for a new Copilot review. Exit 1 = failure — read `tmp/gh-monitor/failure-<RUN_ID>.md`.
 
+If you judge the failure to be a GitHub Actions **infra** flake (network timeout, runner loss, download 5xx, Supabase container-start) rather than a real code/test failure, log it before rerunning: `bash scripts/workflow/log-gha-flake.sh <pr> <run-id> <class> "<symptom>"` (see `docs/runbooks/gha-flake-log.md`).
+
 ### 3.2 Check for review comments
 
 If the PR has review comments (from Tim or another agent), read them via MCP:
@@ -260,7 +262,8 @@ Prefer the Claude fallback (Phase 3.4 — run `/code-review` + `mark-claude-revi
 **`--bypass-merge-requirements`** — for CI/branch-protection issues:
 
 - A required check is failing for known-irrelevant reasons (infrastructure flake, unrelated job)
-  AND you've manually verified the change is safe
+  AND you've manually verified the change is safe. Log the flake first:
+  `bash scripts/workflow/log-gha-flake.sh <pr> <run-id> <class> "<symptom>"` (see `docs/runbooks/gha-flake-log.md`).
 - An emergency hotfix where waiting for CI is not acceptable
 - Combine with `--force` when both review-state and CI gates need to be skipped
 

--- a/docs/runbooks/gha-flake-log.md
+++ b/docs/runbooks/gha-flake-log.md
@@ -1,0 +1,253 @@
+# GHA infra-flake log + weekly triage
+
+## Overview
+
+Multiple sessions have been hitting GitHub Actions **infrastructure** flakes —
+runner losses, `pnpm install` network timeouts, action/browser download 5xx,
+Supabase container-start failures that exhaust the retry loop. Historically each
+session just reran and moved on; nothing was recorded, so we couldn't tell a
+one-off blip from a systemic problem worth a real fix.
+
+This runbook is the single source of truth for the durable **log** that agents
+append to when they classify a CI failure as infra, and the **weekly triage
+pass** (folded into the chores session) that correlates the raw sightings, rules
+out non-issues, spins genuine problems into their own beads, and keeps an
+annotated ledger of what's been dealt with, what's fixed, and what regressed.
+
+**Scope is distinct from `flaky-test` / `flaky`**, which cover _application test_
+flakiness (individual specs — see the Weekly Review routine's flaky-test report).
+This is **CI-platform / infra** flakiness — a different failure class with a
+different owner. If a spec is flaky because of its own logic, that's a
+`flaky-test`, not a `gha-flake`.
+
+## Hybrid three-part bead model
+
+Directly analogous to the **huddle** pattern — a permanent root that carries
+durable memory, plus rolling time-boxed beads that carry the high-churn raw
+stream (huddle: permanent monthly root + rolling daily beads; here: permanent
+ledger root + rolling weekly sighting beads). This keeps the durable memory
+bounded forever while the append-only raw stream is bounded by closing old
+weekly beads.
+
+Three bead roles:
+
+**1. Permanent LEDGER ROOT** = `PP-3w32` (label `gha-flake-log`, **never
+closes**), found **by label** (never a hardcoded id, mirroring how the chores
+nag finds `weekly-chore`):
+
+```bash
+bd list --label gha-flake-log --json | jq -r '.[0].id'
+```
+
+- Its **`notes`** hold the durable **signature ledger** — one row per flake
+  _signature_ (not per sighting), so it stays bounded forever. Single-writer:
+  only the weekly triage pass rewrites it (full replace). Format below.
+- Raw sightings do **not** go here. (Any comments already on `PP-3w32` are
+  historical pre-rotation backfill seed — leave them.)
+
+> **Do NOT create the ledger root with `--no-history`.** That makes an ephemeral
+> **wisp** (separate `dolt_ignored` table, not DoltHub-synced, TTL-compacted,
+> and invisible to `bd list --label`). The root must be a normal Dolt-versioned
+> bead. (An early `--no-history` wisp was discarded and replaced with `PP-3w32`
+> for exactly this reason.)
+
+**2. Rolling WEEKLY sighting beads** = one per ISO week, children of the root.
+
+- Title `GHA flakes <ISO-week>` where `<ISO-week>` = `date -u +%G-W%V` (e.g.
+  `GHA flakes 2026-W29`). **bd assigns its own `PP-xxxx` id — the year-week lives
+  in the TITLE, not the literal id** (you can't force the id).
+- Label `gha-flake-week`, type `task`, created
+  `--parent PP-3w32 --no-inherit-labels -l gha-flake-week`.
+- **Raw sightings are comments on the current week's bead** (append-only,
+  concurrency-safe — each `bd comments add` is an independent insert). The helper
+  find-or-creates this bead automatically.
+- Triage **closes** them once older than the ~3-week window (see below). Closing
+  whole weekly beads is the _only_ way to bound raw-sighting growth, because
+  comments are append-only (no delete).
+
+**3. Spun-out REAL-ISSUE beads** = created during triage for genuine recurring
+problems:
+
+```bash
+bd create "GHA flake: <signature>" -t bug \
+  --parent PP-3w32 --no-inherit-labels -l gha-flake,ops \
+  --deps discovered-from:PP-3w32 \
+  -d "<what recurs, links to run URLs, suspected cause>"
+```
+
+Note the label is **`gha-flake`** — distinct from the weekly beads' `gha-flake-week`.
+
+## Logging a sighting
+
+### When to log
+
+Log via the helper **only when YOU have judged the failure to be infra**, not a
+real code/test failure. The log is deliberately high-signal — there is **no
+auto-capture** of every CI failure. A red run you're confident is a network
+timeout, a runner loss, or a download 5xx belongs here; a genuine assertion
+failure or a real regression does not.
+
+### How to log
+
+```bash
+bash scripts/workflow/log-gha-flake.sh <pr#> <run-id> <class> "<symptom>" [--rerun green|red]
+```
+
+- `<pr#>` — the PR the failed run belongs to (bare number; `0` if none).
+- `<run-id>` — the run id (the number in the run URL).
+- `<class>` — one signature class from the taxonomy below.
+- `<symptom>` — one-line human description of what you saw.
+- `--rerun green|red` — the outcome if you reran. Omit if you haven't rerun yet
+  (records `rerun=n/a`). A rerun that goes **green with no code change** is the
+  strongest infra-flake signal — record it.
+
+The helper resolves the ledger root by label (self-healing, no hardcoded id),
+find-or-creates the current ISO-week sighting bead (creating it as a child of
+the root if this week's doesn't exist yet — concurrent creators converge on the
+oldest matching bead), constructs the run URL, best-effort derives the failing
+job + step via `gh run view` (degrades to `job=unknown step=unknown` if `gh` is
+unavailable or the run is gone), signs the comment, and appends it **to the
+week bead**.
+
+### Signature taxonomy
+
+Seeded from what `ci.yml` actually does (the real infra-heavy steps):
+
+| Class                         | Meaning                                                                                        |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `pnpm-install-network`        | `ETIMEDOUT` / `EAI_AGAIN` / `ECONNREFUSED` on `pnpm install`                                   |
+| `playwright-browser-download` | chromium/webkit binary download flake                                                          |
+| `supabase-start`              | Supabase container start failed **after** the 3-retry loop in `.github/actions/setup-supabase` |
+| `checkout-download`           | `actions/checkout` 5xx                                                                         |
+| `action-setup-download`       | `pnpm/action-setup` / `setup-node` / `setup-cli` download failure                              |
+| `registry-5xx`                | npm registry blips                                                                             |
+| `runner-lost`                 | runner died / job cancelled by GitHub infra                                                    |
+| `other`                       | unclassified — triage assigns a new class if a pattern emerges                                 |
+
+### Raw sighting schema
+
+One greppable, signed line per sighting (emitted by the helper):
+
+```
+class=<class> pr=#<n> run=<run-url> job=<job> step=<step> — <one-line symptom> [rerun=green|red|n/a] —<AgentName>
+```
+
+Signed `—<YourRegisteredName>` (em-dash), the same convention the huddle
+self-filter keys on. `<AgentName>` is derived from `$BEADS_ACTOR`, then git
+`user.name`, defaulting to `Claude`.
+
+## The signature ledger (permanent root notes)
+
+The durable memory. The weekly triage pass rewrites the ledger root's `notes`
+(single-writer, full replace) with a markdown table — **one row per flake
+signature** (not per sighting) — plus a `Triaged through:` cursor:
+
+```markdown
+## Triaged through: <ISO timestamp of last processed sighting>
+
+| Signature        | Class                       | First seen | Last seen  | Count | Status         | Fix/Bead | Notes                                   |
+| ---------------- | --------------------------- | ---------- | ---------- | ----- | -------------- | -------- | --------------------------------------- |
+| webkit-dl-503    | playwright-browser-download | 2026-07-08 | 2026-07-12 | 4     | promoted→PP-x  | PP-xxxx  | webkit 503 on download, recurring       |
+| supabase-3x-fail | supabase-start              | 2026-07-09 | 2026-07-09 | 1     | accepted-noise | —        | self-healed on rerun, single occurrence |
+```
+
+**Signature** is a short stable slug you assign to a cluster (finer-grained than
+`class`) so it can be tracked across weeks — this cross-week identity is what
+makes regression detection work.
+
+**Statuses:**
+
+- `investigating` — seen, not yet decided.
+- `accepted-noise` — known self-healing or a lone occurrence; no bead.
+- `promoted→PP-xxx` — spun out to a real-issue bead (record the id in **Fix/Bead**).
+- `fixed` — a fix merged and it hasn't recurred in ~2 weeks.
+- `regression` — a signature previously `fixed` reappeared in new sightings.
+
+The **`Triaged through:` cursor** is the timestamp of the last sighting the
+weekly pass processed. Next week's pass only considers sightings newer than it.
+
+## Weekly triage procedure (run from the chores session)
+
+Run this as the chores checklist's GHA infra-flake triage item. It is
+context-heavy — the chores lead should consider delegating it to a subagent and
+keeping only the synthesis.
+
+```bash
+root=$(bd list --label gha-flake-log --json | jq -r '.[0].id')   # PP-3w32
+bd show "$root"                                                   # current ledger + cursor
+```
+
+1. **Gather the window.** Consider the current ISO week plus the prior two. Find
+   those weekly beads and read their sightings:
+
+   ```bash
+   bd list --label gha-flake-week --status open --json     # open weekly beads
+   bd children "$root"                                      # cross-check via nesting
+   bd comments <week-bead> --json                           # sightings on each
+   ```
+
+2. **Read new sightings past the cursor.** Keep only sightings with a timestamp
+   newer than the ledger's `Triaged through:` cursor. (Ignore obvious test
+   sightings, e.g. `pr=#9999`.)
+
+3. **Cluster by signature.** Group the new sightings, matching them to existing
+   ledger rows where the signature already exists.
+
+4. **Rewrite the ledger (single-writer, full replace).** For each cluster,
+   add or update its row — refresh first-seen / last-seen / count. Rule out
+   non-issues as `accepted-noise` (known self-healing — a Supabase 3-retry that
+   eventually passed, a pnpm-audit registry error the job already swallows to
+   exit 0; a real code/test failure misfiled as infra; or a lone sighting with no
+   recurrence).
+
+5. **Regression check.** A new sighting whose signature matches a row currently
+   marked `fixed` → flip that row to `regression` and reopen (or replace) its fix
+   bead. This works across **any** time gap — catching a fixed-then-returned
+   flake weeks later is the whole point of the permanent ledger.
+
+   ```bash
+   bd reopen <fix-bead>      # or bd create a fresh real-issue bead if the old is stale
+   ```
+
+6. **Promote genuine new recurring issues.** If a cluster is material and has no
+   bead yet, spin out a real-issue bead (role #3 above) and set the row status to
+   `promoted→PP-xxx`.
+
+7. **Close aged-out weekly beads.** Once a weekly bead is older than the ~3-week
+   window and its sightings are folded into the ledger, **close it**:
+
+   ```bash
+   bd close <week-bead> --reason "folded into gha-flake-log ledger"
+   ```
+
+   This is what bounds raw-sighting growth — comments are append-only, so closing
+   whole weekly beads is the only lever. (Also merge/close any accidental
+   duplicate week bead a create-race produced.)
+
+8. **Advance the cursor.** Set `Triaged through:` to the timestamp of the newest
+   sighting you processed, and write the full ledger back:
+
+   ```bash
+   bd update "$root" --notes "$(cat ledger.md)"
+   ```
+
+## Verification
+
+- **Label lookup:** `bd list --label gha-flake-log --json` returns exactly the
+  one ledger root (`PP-3w32`).
+- **Helper:** `bash scripts/workflow/log-gha-flake.sh 9999 <recent-run-id> pnpm-install-network "test sighting" --rerun green`
+  find-or-creates this week's `GHA flakes <ISO-week>` bead and lands a
+  correctly-formatted signed comment on it; `bd comments <week-bead>` shows it.
+  Sightings are append-only (no delete), so use an obviously-fake `pr=#9999` for
+  tests — triage ignores it and the whole week bead is eventually closed.
+- **Skill wiring:** the orchestrator and pr-workflow skills point at the helper
+  at their log-time decision points; the chores checklist item #8 and the
+  `weekly-chore` bead body both carry the triage item.
+
+## Related
+
+- **Helper:** `scripts/workflow/log-gha-flake.sh`
+- **Chores runbook:** `.agents/skills/pinpoint-chores/SKILL.md` (weekly triage item)
+- **Log-time pointers:** `pinpoint-orchestrator` (Phase 4, infra failures),
+  `pinpoint-pr-workflow` (Phase 3.1 + Phase 4.3 escape hatch)
+- **`flaky-test` label** — the _application-test_ flakiness track (distinct owner).

--- a/scripts/workflow/log-gha-flake.sh
+++ b/scripts/workflow/log-gha-flake.sh
@@ -128,10 +128,17 @@ if [[ -z "$symptom" ]]; then
   echo "error: <symptom> must not be empty" >&2
   usage
 fi
+if [[ "$symptom" == *$'\n'* || "$symptom" == *$'\r'* ]]; then
+  echo "error: <symptom> must be a single line (no newlines) — it becomes one greppable log line" >&2
+  usage
+fi
 
 # --- Resolve the ledger root by label (self-healing, never hardcoded) --------
+# `|| true` so a failing `bd list` (DB unreachable, bd missing) yields an empty
+# result and falls through to the friendly error below, instead of `set -e`
+# killing the script silently mid-pipeline.
 log_bead=$(bd list --label "$LOG_LABEL" --json 2>/dev/null \
-  | jq -r '.[0].id // empty')
+  | jq -r '.[0].id // empty' 2>/dev/null || true)
 if [[ -z "$log_bead" ]]; then
   echo "error: no bead found with label '$LOG_LABEL' — is the beads DB reachable?" >&2
   echo "       (the permanent ledger root must exist; see docs/runbooks/gha-flake-log.md)" >&2
@@ -147,9 +154,12 @@ week_title="GHA flakes ${week}"
 # Return the OLDEST open bead labeled gha-flake-week whose title matches exactly.
 # Choosing the oldest is what makes concurrent creators converge on one bead.
 find_week_bead() {
+  # `|| true` for the same reason as the root lookup: a `bd list` failure must
+  # not `set -e`-abort; it should yield empty so the caller can create or error.
   bd list --label "$WEEK_LABEL" --status open --json 2>/dev/null \
     | jq -r --arg t "$week_title" \
-        '[.[] | select(.title == $t)] | sort_by(.created_at) | .[0].id // empty'
+        '[.[] | select(.title == $t)] | sort_by(.created_at) | .[0].id // empty' \
+        2>/dev/null || true
 }
 
 week_bead=$(find_week_bead)

--- a/scripts/workflow/log-gha-flake.sh
+++ b/scripts/workflow/log-gha-flake.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# log-gha-flake.sh — append one raw GHA infra-flake sighting to the current
+#                     ISO-week sighting bead.
+#
+# Records a GitHub Actions *infrastructure* flake (runner loss, pnpm-install
+# network timeout, action/browser download 5xx, Supabase container-start failure
+# after the 3-retry loop, etc.) as a signed comment on a rolling **weekly**
+# sighting bead. Hybrid bead model (see docs/runbooks/gha-flake-log.md):
+#
+#   - permanent LEDGER ROOT (label gha-flake-log) — durable per-signature ledger
+#     in its notes; the weekly chores triage pass curates it. Sightings do NOT
+#     go here.
+#   - rolling WEEKLY sighting beads (label gha-flake-week, one per ISO week,
+#     children of the root) — raw sightings are comments on the current week's
+#     bead. Triage closes them ~3 weeks after review to bound growth.
+#
+# This helper resolves the root by label, find-or-creates the current week's
+# child bead, and appends the sighting comment to it.
+#
+# Log via this helper only when YOU have judged the failure to be infra, not a
+# real code/test failure — the log is deliberately high-signal (no auto-capture).
+#
+# Usage:
+#   bash scripts/workflow/log-gha-flake.sh <pr#> <run-id> <class> "<symptom>" [--rerun green|red]
+#
+# Args:
+#   <pr#>      PR number the failed run belongs to (bare number, or 0 if none).
+#   <run-id>   GitHub Actions run id (the number in the run URL).
+#   <class>    Signature class — one of the taxonomy values (see usage()).
+#   <symptom>  One-line human description of what was observed.
+#   --rerun    Outcome of the rerun, if you reran: green (passed) or red (still failed).
+#              Omit if you haven't rerun yet; the sighting records rerun=n/a.
+#
+# The ledger root is resolved BY LABEL (`gha-flake-log`), self-healing — never a
+# hardcoded id. Failing job/step are best-effort derived via `gh run view`; the
+# script still logs with what it has if `gh` is unavailable or the run is gone.
+#
+# Invoked via `bash …` — no executable bit required (committed mode 644).
+
+REPO_SLUG="timothyfroehlich/PinPoint"
+LOG_LABEL="gha-flake-log"
+WEEK_LABEL="gha-flake-week"
+VALID_CLASSES=(
+  pnpm-install-network
+  playwright-browser-download
+  supabase-start
+  checkout-download
+  action-setup-download
+  registry-5xx
+  runner-lost
+  other
+)
+
+usage() {
+  {
+    echo "usage: bash scripts/workflow/log-gha-flake.sh <pr#> <run-id> <class> \"<symptom>\" [--rerun green|red]"
+    echo
+    echo "valid <class> values (the infra-flake taxonomy):"
+    printf '  %s\n' "${VALID_CLASSES[@]}"
+    echo
+    echo "See docs/runbooks/gha-flake-log.md for what each class means."
+  } >&2
+  exit 2
+}
+
+# --- Parse args -------------------------------------------------------------
+rerun="n/a"
+positionals=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rerun)
+      rerun="${2:-}"
+      if [[ "$rerun" != "green" && "$rerun" != "red" ]]; then
+        echo "error: --rerun takes 'green' or 'red' (got '${rerun:-<empty>}')" >&2
+        usage
+      fi
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      ;;
+    --*)
+      echo "error: unknown flag '$1'" >&2
+      usage
+      ;;
+    *)
+      positionals+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#positionals[@]} -ne 4 ]]; then
+  echo "error: expected 4 positional args, got ${#positionals[@]}" >&2
+  usage
+fi
+
+pr="${positionals[0]}"
+run_id="${positionals[1]}"
+class="${positionals[2]}"
+symptom="${positionals[3]}"
+
+if [[ ! "$pr" =~ ^[0-9]+$ ]]; then
+  echo "error: <pr#> must be a number (got '$pr'); use 0 if there is no PR" >&2
+  usage
+fi
+if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+  echo "error: <run-id> must be a number (got '$run_id')" >&2
+  usage
+fi
+
+# Validate class against the taxonomy.
+class_ok="false"
+for c in "${VALID_CLASSES[@]}"; do
+  if [[ "$class" == "$c" ]]; then
+    class_ok="true"
+    break
+  fi
+done
+if [[ "$class_ok" != "true" ]]; then
+  echo "error: unknown class '$class'" >&2
+  usage
+fi
+
+if [[ -z "$symptom" ]]; then
+  echo "error: <symptom> must not be empty" >&2
+  usage
+fi
+
+# --- Resolve the ledger root by label (self-healing, never hardcoded) --------
+log_bead=$(bd list --label "$LOG_LABEL" --json 2>/dev/null \
+  | jq -r '.[0].id // empty')
+if [[ -z "$log_bead" ]]; then
+  echo "error: no bead found with label '$LOG_LABEL' — is the beads DB reachable?" >&2
+  echo "       (the permanent ledger root must exist; see docs/runbooks/gha-flake-log.md)" >&2
+  exit 1
+fi
+
+# --- Find-or-create the current ISO-week sighting bead ----------------------
+# ISO year-week (e.g. 2026-W29). The year-week lives in the TITLE, not the id
+# (bd assigns its own PP-xxxx id).
+week=$(date -u +%G-W%V)
+week_title="GHA flakes ${week}"
+
+# Return the OLDEST open bead labeled gha-flake-week whose title matches exactly.
+# Choosing the oldest is what makes concurrent creators converge on one bead.
+find_week_bead() {
+  bd list --label "$WEEK_LABEL" --status open --json 2>/dev/null \
+    | jq -r --arg t "$week_title" \
+        '[.[] | select(.title == $t)] | sort_by(.created_at) | .[0].id // empty'
+}
+
+week_bead=$(find_week_bead)
+if [[ -z "$week_bead" ]]; then
+  # No bead for this week yet — create one as a child of the ledger root.
+  # Two agents may race here; after creating we re-query and take the oldest, so
+  # racers converge. Any accidental duplicate week bead is merged by triage.
+  bd create "$week_title" -t task \
+    --parent "$log_bead" --no-inherit-labels -l "$WEEK_LABEL" \
+    -d "Raw GHA infra-flake sightings for ISO week ${week}. Ledger root: ${log_bead}. Runbook: docs/runbooks/gha-flake-log.md" \
+    >/dev/null 2>&1 || true
+  week_bead=$(find_week_bead)
+fi
+
+if [[ -z "$week_bead" ]]; then
+  echo "error: could not find or create the weekly sighting bead '$week_title'" >&2
+  echo "       (is the beads DB reachable? see docs/runbooks/gha-flake-log.md)" >&2
+  exit 1
+fi
+
+# --- Construct run URL + best-effort job/step -------------------------------
+run_url="https://github.com/${REPO_SLUG}/actions/runs/${run_id}"
+
+job="unknown"
+step="unknown"
+if command -v gh >/dev/null 2>&1; then
+  # shellcheck disable=SC2016  # $f is a jq variable, deliberately not shell-expanded
+  job_step=$(gh run view "$run_id" --json jobs --jq \
+    '[.jobs[] | select(.conclusion=="failure")] as $f
+     | ($f[0].name // "unknown") + "\t"
+     + (([$f[0].steps[]? | select(.conclusion=="failure") | .name] | first) // "unknown")' \
+    2>/dev/null || true)
+  if [[ -n "$job_step" ]]; then
+    job="${job_step%%$'\t'*}"
+    step="${job_step#*$'\t'}"
+    [[ -z "$job" ]] && job="unknown"
+    [[ -z "$step" ]] && step="unknown"
+  fi
+fi
+
+# --- Derive signing AgentName ----------------------------------------------
+agent="${BEADS_ACTOR:-}"
+if [[ -z "$agent" ]]; then
+  agent=$(git config user.name 2>/dev/null || true)
+fi
+[[ -z "$agent" ]] && agent="Claude"
+
+# --- Append the signed raw sighting (schema must match the runbook) ---------
+comment="class=${class} pr=#${pr} run=${run_url} job=${job} step=${step} — ${symptom} [rerun=${rerun}] —${agent}"
+
+bd comments add "$week_bead" "$comment"
+echo "Logged infra-flake sighting to ${week_bead} (${week_title}): ${comment}"


### PR DESCRIPTION
## Summary

- Adds machinery for logging GitHub Actions **infrastructure** flakes (runner loss, pnpm-install network timeout, download 5xx, Supabase container-start) and triaging them weekly — deliberately distinct from the `flaky-test` application-flakiness track.
- **Hybrid three-part bead model** (analogous to the huddle's permanent-root + rolling-daily split): a permanent **ledger root** `PP-3w32` (label `gha-flake-log`, durable per-signature ledger in its notes), **rolling weekly sighting beads** (label `gha-flake-week`, one per ISO week, raw sightings as comments), and spun-out **real-issue beads** for genuine recurring problems.
- `scripts/workflow/log-gha-flake.sh` — helper that resolves the root by label (self-healing, no hardcoded id), find-or-creates the current ISO-week sighting bead (concurrency-safe converge-on-oldest), best-effort derives failing job/step via `gh`, and appends a signed, taxonomy-validated sighting comment to the week bead. Shellcheck-clean; committed mode 644 (run via `bash`).
- `docs/runbooks/gha-flake-log.md` — single source of truth: model, taxonomy, sighting + ledger schemas, and the full weekly triage procedure (window → cluster → rule-out → promote → regression-check → close aged-out weekly beads → advance cursor).
- Log-time pointers in `pinpoint-orchestrator` (Phase 4 infra failures) and `pinpoint-pr-workflow` (Phase 3.1 + Phase 4.3 escape hatch); new chores checklist item #8 + context-heavy-delegation guidance, mirrored onto the `weekly-chore` bead body.

## Test Plan

- [x] `pnpm run check` green (shellcheck on the helper + markdown/format).
- [x] Helper exercised with stubbed `bd`/`gh`: find-existing-week (converge on oldest), create-new-week, `gh`-unavailable graceful degradation, bad-class rejection, arg validation.
- [ ] Live smoke (optional, done by triage): `bash scripts/workflow/log-gha-flake.sh 9999 <recent-run-id> pnpm-install-network "test sighting" --rerun green` lands a comment on this week's `GHA flakes <ISO-week>` bead.

## Related Issues

Tracking bead: PP-bq7y (stays in-progress; lead closes on merge). Ledger root: PP-3w32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)