### PR TITLE
feat(report): searchable machine combobox on /report + shared picker

### DIFF
--- a/e2e/full/email-and-notifications.spec.ts
+++ b/e2e/full/email-and-notifications.spec.ts
@@ -7,7 +7,12 @@
 
 import { test, expect } from "@playwright/test";
 import { MailpitClient } from "../support/mailpit.js";
-import { ensureLoggedIn, updateIssueField } from "../support/actions.js";
+import {
+  ensureLoggedIn,
+  updateIssueField,
+  selectMachine,
+  machineSelectValue,
+} from "../support/actions.js";
 import {
   fillReportForm,
   submitFormAndWaitForRedirect,
@@ -73,16 +78,10 @@ test.describe("Notifications", () => {
     const publicPage = await publicContext.newPage();
 
     await publicPage.goto("/report");
-    // Wait for machine list to populate (check select exists)
-    await expect(publicPage.getByTestId("machine-select")).toBeVisible();
-    await publicPage
-      .getByTestId("machine-select")
-      .selectOption({ value: machine.id });
+    await selectMachine(publicPage, machine.id);
 
     // Verify selection stuck (mobile chrome stability)
-    await expect(publicPage.getByTestId("machine-select")).toHaveValue(
-      machine.id
-    );
+    await expect(machineSelectValue(publicPage)).toHaveValue(machine.id);
 
     const issueTitle = getTestIssueTitle("Public Report");
     await fillReportForm(publicPage, {
@@ -304,13 +303,11 @@ test.describe("Notifications", () => {
 
     // Use a seeded machine for convenience, or create one.
     // Since we are watching globally, any machine works.
-    await publicPage
-      .getByTestId("machine-select")
-      .selectOption({ value: seededMachines.medievalMadness.id });
+    await selectMachine(publicPage, seededMachines.medievalMadness.id);
 
     const issueTitle = getTestIssueTitle("Global Watcher Test");
     // Verify machine selection stuck
-    await expect(publicPage.getByTestId("machine-select")).toHaveValue(
+    await expect(machineSelectValue(publicPage)).toHaveValue(
       seededMachines.medievalMadness.id
     );
 
@@ -369,12 +366,8 @@ test.describe("Notifications", () => {
     const publicPage = await publicContext.newPage();
     await publicPage.goto("/report");
     // Select machine and verify state (Mobile Chrome hardening)
-    await publicPage
-      .getByTestId("machine-select")
-      .selectOption({ value: machine.id });
-    await expect(publicPage.getByTestId("machine-select")).toHaveValue(
-      machine.id
-    );
+    await selectMachine(publicPage, machine.id);
+    await expect(machineSelectValue(publicPage)).toHaveValue(machine.id);
     const issueTitle = getTestIssueTitle("Interaction Test");
     await fillReportForm(publicPage, {
       title: issueTitle,
@@ -435,16 +428,12 @@ test.describe("Notifications", () => {
     });
 
     await memberPage.goto("/report");
-    await memberPage
-      .getByTestId("machine-select")
-      .selectOption({ value: machine.id });
+    await selectMachine(memberPage, machine.id);
 
     const issueTitle = getTestIssueTitle("Email Test Issue");
     await fillReportForm(memberPage, { title: issueTitle });
 
-    await expect(memberPage.getByTestId("machine-select")).toHaveValue(
-      machine.id
-    );
+    await expect(machineSelectValue(memberPage)).toHaveValue(machine.id);
     await expect(memberPage.getByLabel("Issue Title *")).toHaveValue(
       issueTitle
     );

--- a/e2e/full/form-resets.spec.ts
+++ b/e2e/full/form-resets.spec.ts
@@ -18,6 +18,8 @@ import {
   loginAs,
   selectOption,
   assertSelectValue,
+  selectMachine,
+  machineSelectValue,
 } from "../support/actions.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { seededMachines, TEST_USERS } from "../support/constants.js";
@@ -65,7 +67,7 @@ test.describe("CREATE form resets", () => {
     const machineInitials = seededMachines.medievalMadness.initials;
 
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
 
     await fillReportForm(page, {
       title: `${RESET_PREFIX} Report Reset Test`,
@@ -85,7 +87,7 @@ test.describe("CREATE form resets", () => {
     await page.goto("/report");
 
     // Machine select shows placeholder option, not a previously chosen machine.
-    await expect(page.getByTestId("machine-select")).toHaveValue("");
+    await expect(machineSelectValue(page)).toHaveValue("");
 
     // Title cleared.
     await expect(page.getByLabel("Issue Title *")).toHaveValue("");
@@ -114,7 +116,7 @@ test.describe("CREATE form resets", () => {
     });
 
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
 
     // Picking a machine via the dropdown writes ?machine=… into the URL.
     // Verify before clicking Clear so the strip-on-clear assertion is meaningful.
@@ -142,7 +144,7 @@ test.describe("CREATE form resets", () => {
     ).not.toBeVisible();
 
     await expect(page.getByLabel("Issue Title *")).toHaveValue("");
-    await expect(page.getByTestId("machine-select")).toHaveValue("");
+    await expect(machineSelectValue(page)).toHaveValue("");
 
     // Severity select returned to default "Minor".
     await assertSelectValue(page.getByTestId("issue-severity-select"), "Minor");
@@ -200,7 +202,7 @@ test.describe("CREATE form resets", () => {
     // issue. afterEach cleans up all issues whose title starts with RESET_PREFIX
     // (which cascades their comments), so no timeline noise accumulates.
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     await fillReportForm(page, {
       title: `${RESET_PREFIX} Comment Form Reset Issue`,
       description: "Throwaway issue for AddCommentForm reset test.",

--- a/e2e/full/public-reporting-extended.spec.ts
+++ b/e2e/full/public-reporting-extended.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { loginAs } from "../support/actions.js";
+import { loginAs, selectMachine } from "../support/actions.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { TEST_USERS } from "../support/constants.js";
 import { fillReportForm } from "../support/page-helpers.js";
@@ -27,7 +27,7 @@ test.describe("Public Issue Reporting - Extended", () => {
     const email = `newuser-${timestamp}@example.com`;
 
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     // Wait for URL refresh (router.push) to prevent race conditions on Mobile Safari
     await expect(page).toHaveURL(/machine=/);
 
@@ -53,7 +53,7 @@ test.describe("Public Issue Reporting - Extended", () => {
     page,
   }) => {
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     // Wait for URL refresh (router.push) to prevent race conditions on Mobile Safari
     await expect(page).toHaveURL(/machine=/);
 
@@ -88,7 +88,7 @@ test.describe("Public Issue Reporting - Extended", () => {
     const email = `reporter-${timestamp}@example.com`;
 
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     // Wait for URL refresh (router.push) to prevent race conditions on Mobile Safari
     await expect(page).toHaveURL(/machine=/);
 
@@ -128,7 +128,7 @@ test.describe("Public Issue Reporting - Extended", () => {
 
     // 1. Submit anonymous issue
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     await expect(page).toHaveURL(/machine=/);
 
     await fillReportForm(page, {

--- a/e2e/full/report-stale-machine.spec.ts
+++ b/e2e/full/report-stale-machine.spec.ts
@@ -18,14 +18,16 @@
  * What this test verifies:
  *   - Seed localStorage with a clearly-stale UUID before navigation.
  *   - Load /report with no URL machine param.
- *   - Assert the machine select is empty (placeholder shown), not "first machine".
+ *   - Assert the machine picker is empty (placeholder shown), not "first machine".
  *   - Assert the title (from the same draft) DID restore — proving the draft
  *     wasn't wholesale discarded; only the bad machine was dropped.
- *   - Submit without re-selecting and confirm the form refuses (required attr).
+ *   - Confirm the form refuses submission with no machine (Submit is disabled —
+ *     the combobox submits a hidden input the browser can't `required`-validate,
+ *     so the button is gated on a selection instead).
  */
 
 import { test, expect } from "@playwright/test";
-import { ensureLoggedIn } from "../support/actions.js";
+import { ensureLoggedIn, machineSelectValue } from "../support/actions.js";
 import { TEST_USERS } from "../support/constants.js";
 
 const STALE_UUID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
@@ -69,17 +71,20 @@ test.describe("UnifiedReportForm — stale localStorage machineId (PP-lql)", () 
     const machineSelect = page.getByTestId("machine-select");
     await expect(machineSelect).toBeVisible();
 
-    // The dropdown is empty (placeholder) — NOT the first real machine.
-    await expect(machineSelect).toHaveValue("");
+    // The picker is empty (placeholder shown) — NOT the first real machine.
+    await expect(machineSelect).toContainText("Select a machine");
+    await expect(machineSelectValue(page)).toHaveValue("");
 
     // Other draft fields restored normally — only the invalid machine was dropped.
     await expect(page.getByLabel("Issue Title *")).toHaveValue(
       "PP-lql stale draft restoration"
     );
 
-    // Required attribute blocks submission until the user picks a machine.
-    await page.getByRole("button", { name: "Submit Issue Report" }).click();
-    await expect(page).toHaveURL(/\/report(\?.*)?$/, { timeout: 5000 });
-    await expect(machineSelect).toHaveValue("");
+    // With no machine selected, submission is blocked: the Submit button is
+    // disabled until the user picks a machine (replaces native `required`).
+    await expect(
+      page.getByRole("button", { name: "Submit Issue Report" })
+    ).toBeDisabled();
+    await expect(machineSelectValue(page)).toHaveValue("");
   });
 });

--- a/e2e/full/status-overhaul.spec.ts
+++ b/e2e/full/status-overhaul.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import {
   updateIssueField,
   visibleIssueFieldControl,
+  selectMachine,
 } from "../support/actions.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { seededMachines, TEST_USERS } from "../support/constants.js";
@@ -32,7 +33,7 @@ test.describe("Status Overhaul E2E", () => {
     // confirms the server component saw the auth cookie correctly.
     await expect(page.getByTestId("issue-priority-select")).toBeVisible();
 
-    await page.getByTestId("machine-select").selectOption(machine.id);
+    await selectMachine(page, machine.id);
     await fillReportForm(page, {
       title: "E2E Status Overhaul Test",
       severity: "unplayable",

--- a/e2e/smoke/image-upload.spec.ts
+++ b/e2e/smoke/image-upload.spec.ts
@@ -6,7 +6,11 @@ import {
   fillReportForm,
   submitFormAndWaitForRedirect,
 } from "../support/page-helpers.js";
-import { loginAs, assertNoA11yViolations } from "../support/actions.js";
+import {
+  loginAs,
+  assertNoA11yViolations,
+  selectMachine,
+} from "../support/actions.js";
 import { TEST_USERS } from "../support/constants.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -32,9 +36,8 @@ test.describe("Image Upload Reporting", () => {
 
     // 2. Go to Report
     await page.goto("/report");
-    const select = page.getByTestId("machine-select");
-    // Ensure we pick the same machine as the dashboard default or just pick the first one
-    await select.selectOption({ index: 1 });
+    // Just pick the first machine in the list
+    await selectMachine(page);
     await expect(page).toHaveURL(/machine=/);
 
     await assertNoA11yViolations(page);

--- a/e2e/smoke/public-reporting.spec.ts
+++ b/e2e/smoke/public-reporting.spec.ts
@@ -8,6 +8,8 @@ import { test, expect } from "@playwright/test";
 import {
   assertNoHorizontalOverflow,
   assertNoA11yViolations,
+  selectMachine,
+  machineSelectValue,
 } from "../support/actions.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { TEST_USERS } from "../support/constants.js";
@@ -32,9 +34,7 @@ test.describe("Public Issue Reporting", () => {
       })
     ).toBeVisible();
 
-    const select = page.getByTestId("machine-select");
-    await expect(select).toBeVisible();
-    await select.selectOption({ index: 1 });
+    await selectMachine(page);
     // Wait for URL refresh (router.push) to prevent race conditions on Mobile Safari
     await expect(page).toHaveURL(/machine=/);
 
@@ -75,7 +75,7 @@ test.describe("Public Issue Reporting", () => {
     page,
   }) => {
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     await expect(page).toHaveURL(/machine=/);
 
     const machineInitials = new URL(page.url()).searchParams.get("machine");
@@ -114,7 +114,7 @@ test.describe("Public Issue Reporting", () => {
     page,
   }) => {
     await page.goto("/report");
-    await page.getByTestId("machine-select").selectOption({ index: 1 });
+    await selectMachine(page);
     await expect(page).toHaveURL(/machine=/);
 
     const machineInitials = new URL(page.url()).searchParams.get("machine");
@@ -155,15 +155,15 @@ test.describe("Public Issue Reporting", () => {
   }) => {
     // Submit an issue first - select a machine (dropdown starts unselected)
     await page.goto("/report");
-    const select = page.getByTestId("machine-select");
+    const machineValue = machineSelectValue(page);
 
-    // Verify machine dropdown starts with no selection (empty value)
-    const initialMachineId = await select.inputValue();
+    // Verify machine picker starts with no selection (empty value)
+    const initialMachineId = await machineValue.inputValue();
     expect(initialMachineId).toBe(""); // Should be unselected by default
 
-    // Select a machine (use index 1 to select the first actual machine option)
-    await select.selectOption({ index: 1 });
-    const selectedMachineId = await select.inputValue();
+    // Select the first actual machine option
+    await selectMachine(page);
+    const selectedMachineId = await machineValue.inputValue();
     expect(selectedMachineId).toBeTruthy(); // Should have a valid selection now
     await expect(page).toHaveURL(/machine=/);
 
@@ -203,7 +203,7 @@ test.describe("Public Issue Reporting", () => {
 
     // Machine should be back to unselected state (empty), not the one we selected
     // This verifies draft wasn't restored - the form starts with no machine selected
-    const machineAfterReset = await select.inputValue();
+    const machineAfterReset = await machineValue.inputValue();
     expect(machineAfterReset).toBe(""); // Should be unselected again
     expect(machineAfterReset).not.toBe(selectedMachineId);
   });

--- a/e2e/smoke/report-form-clear.spec.ts
+++ b/e2e/smoke/report-form-clear.spec.ts
@@ -13,7 +13,7 @@ import {
   fillReportForm,
   submitFormAndWaitForRedirect,
 } from "../support/page-helpers.js";
-import { assertNoA11yViolations } from "../support/actions.js";
+import { assertNoA11yViolations, selectMachine } from "../support/actions.js";
 
 const TITLE_PREFIX = "E2E Form Clear";
 
@@ -37,9 +37,7 @@ test.describe("Report Form Clears After Submission", () => {
 
     await assertNoA11yViolations(page);
 
-    const select = page.getByTestId("machine-select");
-    await expect(select).toBeVisible();
-    await select.selectOption({ index: 1 });
+    await selectMachine(page);
     await expect(page).toHaveURL(/machine=/);
 
     const issueTitle = `${TITLE_PREFIX} ${Date.now()}`;

--- a/e2e/support/actions.ts
+++ b/e2e/support/actions.ts
@@ -275,6 +275,38 @@ export async function selectOption(
   await expect(option).toBeHidden({ timeout: 5000 });
 }
 
+/**
+ * Selects a machine from the report-form MachineCombobox (Popover + cmdk).
+ *
+ * The old machine picker was a native `<select>` driven by Playwright's
+ * `.selectOption()`; the combobox needs an open-then-click sequence. Pass a
+ * machine id to pick a specific machine, or omit `machineId` to pick the first
+ * one in the list (the equivalent of the old `.selectOption({ index: 1 })`,
+ * which just needed *a* machine selected).
+ */
+export async function selectMachine(
+  page: Page,
+  machineId?: string
+): Promise<void> {
+  const trigger = page.getByTestId("machine-select");
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+
+  const option = machineId
+    ? page.getByTestId(`machine-option-${machineId}`)
+    : page.locator('[data-testid^="machine-option-"]').first();
+  await expect(option).toBeVisible({ timeout: 5000 });
+  await option.click();
+
+  // Selecting closes the popover, so the option unmounts.
+  await expect(option).toBeHidden({ timeout: 5000 });
+}
+
+/** The hidden input carrying the report form's selected machine id. */
+export function machineSelectValue(page: Page): Locator {
+  return page.getByTestId("machine-select-input");
+}
+
 type IssueFieldName = "status" | "severity" | "priority" | "frequency";
 
 export function visibleIssueFieldControl(page: Page, field: IssueFieldName) {

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/reassign-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/reassign-machine-form.tsx
@@ -2,7 +2,6 @@
 
 import type React from "react";
 import { useActionState, useEffect, useState, startTransition } from "react";
-import { Check } from "lucide-react";
 import {
   reassignIssueMachineAction,
   type ReassignIssueMachineResult,
@@ -17,15 +16,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "~/components/ui/alert-dialog";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "~/components/ui/command";
-import { cn } from "~/lib/utils";
+import { MachinePickerList } from "~/components/machines/MachineCombobox";
 
 interface ReassignMachineCandidate {
   initials: string;
@@ -87,38 +78,19 @@ export function ReassignMachineForm({
           </AlertDialogDescription>
         </AlertDialogHeader>
 
-        <Command className="rounded-md border" data-testid="reassign-command">
-          <CommandInput placeholder="Search machines…" />
-          <CommandList>
-            <CommandEmpty>No matching machines.</CommandEmpty>
-            <CommandGroup>
-              {candidates.map((machine) => {
-                const selected = machine.initials === selectedInitials;
-                return (
-                  <CommandItem
-                    key={machine.initials}
-                    value={`${machine.name} ${machine.initials}`}
-                    onSelect={() => {
-                      setSelectedInitials(machine.initials);
-                    }}
-                    data-testid={`reassign-option-${machine.initials}`}
-                  >
-                    <Check
-                      className={cn(
-                        "mr-2 size-4",
-                        selected ? "opacity-100" : "opacity-0"
-                      )}
-                    />
-                    <span className="flex-1 truncate">{machine.name}</span>
-                    <span className="ml-2 font-mono text-xs text-muted-foreground">
-                      {machine.initials}
-                    </span>
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        <MachinePickerList
+          machines={candidates.map((machine) => ({
+            value: machine.initials,
+            name: machine.name,
+            initials: machine.initials,
+          }))}
+          selectedValue={selectedInitials}
+          onSelect={setSelectedInitials}
+          className="rounded-md border"
+          commandTestId="reassign-command"
+          optionTestId={(machine) => `reassign-option-${machine.initials}`}
+          emptyText="No matching machines."
+        />
 
         {state && !state.ok && (
           <p className="text-sm text-destructive">{state.message}</p>

--- a/src/app/(app)/report/unified-report-form.tsx
+++ b/src/app/(app)/report/unified-report-form.tsx
@@ -38,6 +38,7 @@ import { TurnstileWidget } from "~/components/security/TurnstileWidget";
 import { getLoginUrl } from "~/lib/login-url";
 import { RecentIssuesPanelClient } from "~/components/issues/RecentIssuesPanelClient";
 import { RichTextEditor } from "~/components/editor/RichTextEditorDynamic";
+import { MachineCombobox } from "~/components/machines/MachineCombobox";
 import { type ProseMirrorDoc } from "~/lib/tiptap/types";
 import {
   AlertDialog,
@@ -149,6 +150,34 @@ export function UnifiedReportForm({
   const selectedMachine = useMemo(
     () => machinesList.find((m) => m.id === selectedMachineId),
     [machinesList, selectedMachineId]
+  );
+
+  // The report form submits the machine's id (as `machineId`), so each option's
+  // combobox `value` is the machine id.
+  const machineOptions = useMemo(
+    () =>
+      machinesList.map((m) => ({
+        value: m.id,
+        name: m.name,
+        initials: m.initials,
+      })),
+    [machinesList]
+  );
+
+  // Mirrors the previous native <select> onChange: track the selection and
+  // silently sync ?machine=<initials> into the URL (no navigation) so a reload
+  // or a "Log in" round-trip lands back on the same machine.
+  const handleMachineChange = useCallback(
+    (newId: string) => {
+      setSelectedMachineId(newId);
+      const machine = machinesList.find((m) => m.id === newId);
+      if (machine) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("machine", machine.initials);
+        window.history.replaceState(null, "", `?${params.toString()}`);
+      }
+    },
+    [machinesList, searchParams]
   );
 
   // Reset form state before navigating away on success (defense in depth).
@@ -457,40 +486,16 @@ export function UnifiedReportForm({
               <Label htmlFor="machineId" className="text-foreground">
                 Machine *
               </Label>
-              <select
+              <MachineCombobox
                 id="machineId"
                 name="machineId"
-                autoComplete="off"
-                data-testid="machine-select"
-                aria-label="Select Machine"
-                required
+                machines={machineOptions}
                 value={selectedMachineId}
-                onChange={(e) => {
-                  const newId = e.target.value;
-                  setSelectedMachineId(newId);
-                  // Update URL silently without triggering navigation
-                  const machine = machinesList.find((m) => m.id === newId);
-                  if (machine) {
-                    const params = new URLSearchParams(searchParams.toString());
-                    params.set("machine", machine.initials);
-                    window.history.replaceState(
-                      null,
-                      "",
-                      `?${params.toString()}`
-                    );
-                  }
-                }}
-                className="w-full rounded-md border border-outline-variant bg-surface px-3 h-9 text-sm text-foreground focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-[color,background-color,border-color,box-shadow] duration-150"
-              >
-                <option value="" disabled>
-                  Select a machine...
-                </option>
-                {machinesList.map((machine) => (
-                  <option key={machine.id} value={machine.id}>
-                    {machine.name} ({machine.initials})
-                  </option>
-                ))}
-              </select>
+                onValueChange={handleMachineChange}
+                ariaLabel="Select Machine"
+                placeholder="Select a machine…"
+                triggerClassName="h-9"
+              />
             </div>
 
             {/* Mobile Recent Issues (Compact) - Visible only on small screens */}
@@ -799,7 +804,15 @@ export function UnifiedReportForm({
                 type="submit"
                 className="flex-1 bg-primary text-on-primary hover:bg-primary/90 h-10 text-sm font-semibold"
                 loading={isPending}
-                disabled={isPending || (enforceCaptcha && !turnstileToken)}
+                disabled={
+                  isPending ||
+                  // The combobox submits via a hidden input, which the browser
+                  // can't `required`-validate — gate the button instead so a
+                  // report can't be filed without a machine (replaces the native
+                  // <select required>).
+                  !selectedMachineId ||
+                  (enforceCaptcha && !turnstileToken)
+                }
               >
                 Submit Issue Report
               </Button>

--- a/src/components/machines/MachineCombobox.tsx
+++ b/src/components/machines/MachineCombobox.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+
+/**
+ * MachineCombobox — the single, shared searchable machine picker.
+ *
+ * ## Why this exists
+ * Every place that selects one machine from the org's roster should use the
+ * SAME control. With 100+ machines a flat native `<select>` (the old /report
+ * picker) is unusable on mobile — you scroll forever. This is a type-to-filter
+ * combobox instead: tap the trigger, the on-screen keyboard opens on the search
+ * input, type "God" to narrow to Godzilla, tap to lock it in.
+ *
+ * ## Primitives
+ * Popover + cmdk `Command` — the established PinPoint picker pattern
+ * (OwnerSelect / AssigneePicker / BaselineCombobox). No new dependency, no
+ * polyfill: cmdk is already installed and Radix Popover auto-focuses the search
+ * input when it opens, which is what surfaces the mobile keyboard.
+ *
+ * ## Composition
+ * - `MachinePickerList` is the filterable core (search input + option rows). It
+ *   is exported so contexts that already own their own chrome — e.g. the issue
+ *   reassign dialog — render the identical list without a redundant popover.
+ * - `MachineCombobox` wraps that list in a Popover with a trigger button, for
+ *   inline form use (the report form). An optional hidden `<input>` (via `name`)
+ *   keeps it compatible with native/progressive-enhancement form submission.
+ *
+ * Filtering matches on both the machine name and its initials, so "GZ" and
+ * "God" both find Godzilla.
+ */
+
+export interface MachineOption {
+  /**
+   * The value tracked/submitted when this machine is chosen. Callers pick the
+   * identifier that suits their form: the report form uses the machine `id`
+   * (submitted as `machineId`), the reassign dialog uses `initials`.
+   */
+  value: string;
+  name: string;
+  initials: string;
+}
+
+interface MachinePickerListProps {
+  machines: MachineOption[];
+  /** Currently selected value, or null when nothing is chosen. */
+  selectedValue: string | null;
+  onSelect: (value: string) => void;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  /** Extra classes for the `Command` wrapper (e.g. a border in a dialog). */
+  className?: string;
+  commandTestId?: string;
+  /** Builds the `data-testid` for each option row. */
+  optionTestId?: (machine: MachineOption) => string;
+}
+
+/**
+ * The searchable list of machines — the shared core of every machine picker.
+ *
+ * The filter input receives focus automatically because Radix Popover/Dialog
+ * focus their first focusable descendant on open (the `CommandInput` here) —
+ * which is what surfaces the on-screen keyboard on mobile the moment the picker
+ * opens. (Same reason `OwnerSelect`/`AssigneePicker` need no `autoFocus`.)
+ */
+export function MachinePickerList({
+  machines,
+  selectedValue,
+  onSelect,
+  searchPlaceholder = "Search machines…",
+  emptyText = "No machines found.",
+  className,
+  commandTestId,
+  optionTestId,
+}: MachinePickerListProps): React.JSX.Element {
+  return (
+    <Command
+      className={className}
+      {...(commandTestId ? { "data-testid": commandTestId } : {})}
+    >
+      <CommandInput placeholder={searchPlaceholder} />
+      <CommandList>
+        <CommandEmpty>{emptyText}</CommandEmpty>
+        <CommandGroup>
+          {machines.map((machine) => {
+            const isSelected = machine.value === selectedValue;
+            return (
+              <CommandItem
+                key={machine.value}
+                // cmdk filters against this value; include the initials so both
+                // "Godzilla" and "GZ" match. onSelect closes over machine.value
+                // rather than the (cmdk-lowercased) callback arg.
+                value={`${machine.name} ${machine.initials}`}
+                onSelect={() => onSelect(machine.value)}
+                aria-current={isSelected ? "true" : undefined}
+                {...(optionTestId
+                  ? { "data-testid": optionTestId(machine) }
+                  : {})}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 size-4 shrink-0",
+                    isSelected ? "opacity-100" : "opacity-0"
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="flex-1 truncate">{machine.name}</span>
+                <span className="ml-2 font-mono text-xs text-muted-foreground">
+                  {machine.initials}
+                </span>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+interface MachineComboboxProps {
+  machines: MachineOption[];
+  /** Selected value ("" when nothing is chosen). */
+  value: string;
+  onValueChange: (value: string) => void;
+  id?: string;
+  /** When set, renders a hidden `<input name={name}>` for native form submit. */
+  name?: string;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+  triggerTestId?: string;
+  valueInputTestId?: string;
+  triggerClassName?: string;
+}
+
+/**
+ * Inline, trigger-driven machine picker for forms. Renders `MachinePickerList`
+ * inside a Popover and (optionally) a hidden input carrying the chosen value.
+ */
+export function MachineCombobox({
+  machines,
+  value,
+  onValueChange,
+  id,
+  name,
+  placeholder = "Select a machine…",
+  searchPlaceholder = "Search machines…",
+  emptyText = "No machines found.",
+  disabled = false,
+  ariaLabel,
+  triggerTestId = "machine-select",
+  valueInputTestId = "machine-select-input",
+  triggerClassName,
+}: MachineComboboxProps): React.JSX.Element {
+  const [open, setOpen] = React.useState(false);
+
+  const selected = React.useMemo(
+    () => machines.find((m) => m.value === value) ?? null,
+    [machines, value]
+  );
+
+  return (
+    <>
+      {name !== undefined && (
+        <input
+          type="hidden"
+          name={name}
+          value={value}
+          data-testid={valueInputTestId}
+        />
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            id={id}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
+            disabled={disabled}
+            data-testid={triggerTestId}
+            className={cn(
+              "w-full justify-between border-outline-variant bg-surface font-normal text-foreground",
+              !selected && "text-muted-foreground",
+              triggerClassName
+            )}
+          >
+            <span className="truncate">
+              {selected
+                ? `${selected.name} (${selected.initials})`
+                : placeholder}
+            </span>
+            <ChevronsUpDown
+              className="ml-2 size-4 shrink-0 opacity-50"
+              aria-hidden="true"
+            />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-(--radix-popover-trigger-width) p-0"
+          align="start"
+        >
+          <MachinePickerList
+            machines={machines}
+            selectedValue={value === "" ? null : value}
+            onSelect={(next) => {
+              onValueChange(next);
+              setOpen(false);
+            }}
+            searchPlaceholder={searchPlaceholder}
+            emptyText={emptyText}
+            optionTestId={(machine) => `machine-option-${machine.value}`}
+          />
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+}


### PR DESCRIPTION
## What & why

The `/report` machine picker was a native `<select>` — a flat, unfilterable list. With APC's 100+ machines that's a lot of scrolling, especially on mobile. This replaces it with a **type-to-filter combobox**: tap the trigger, the on-screen keyboard opens on the search input, type `God` to narrow to Godzilla, tap to lock it in. Filtering matches on both the machine **name** and its **initials** (so `GZ` works too).

It also introduces one **shared** machine picker so every single-machine selection uses the same control, per the request.

## Approach / primitives

Built on the established **Popover + cmdk `Command`** pattern already used by `OwnerSelect` / `AssigneePicker` / `BaselineCombobox` — no new dependency, no polyfill. The keyboard-on-open behavior comes from Radix focusing the first focusable descendant (the search input) when the Popover/Dialog opens, which is the conventional "modern web" combobox approach here and satisfies the `jsx-a11y/no-autofocus` rule.

## Changes

- **New `src/components/machines/MachineCombobox.tsx`**
  - `MachineCombobox` — Popover-wrapped single-select for inline form use, with an optional hidden `<input>` for native form submission.
  - `MachinePickerList` — the filterable core, exported for contexts that own their chrome (the reassign dialog) so they render the *identical* list.
- **`unified-report-form.tsx`** — swaps the native `<select>` for `MachineCombobox`, preserving `selectedMachineId` state, the `?machine=` URL sync, the localStorage draft, and the stale-id reset guard. The browser can't `required`-validate a hidden input, so the **Submit button is gated on a machine being selected** — same "must pick a machine" guarantee as the old `<select required>`.
- **`reassign-machine-form.tsx`** — the issue-reassign dialog now renders the shared `MachinePickerList`; its `reassign-command` / `reassign-option-*` / `reassign-confirm` testids and dialog UX are unchanged.

## Scope note

Applied to both single-machine pickers (report form + reassign dialog). The machine **multi-select filters** (issue list, collections, timelines) are left as-is — they're multi-select and already have a search box. Happy to extend or narrow if you'd prefer.

## Tests

- New E2E helpers `selectMachine` / `machineSelectValue`; report specs migrated off Playwright's native `.selectOption()` / `.toHaveValue()` (which only work on `<select>`) to drive the combobox and read the hidden value input.
- The stale-machine regression spec now asserts a **disabled** Submit button instead of relying on the native `required` popup.
- Local gates green: `typecheck` (source/tests/e2e), `lint`, `format`, and the full unit suite (1471 passing). The full E2E suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F99Kmy86kNynuzxrBFv6Uk

---
_Generated by [Claude Code](https://claude.ai/code/session_01F99Kmy86kNynuzxrBFv6Uk)_