### PR TITLE
chore(deps): bump pnpm 10.2.0 → 11.7.0 for bulk advisory audit endpoint (PP-w0eq)

### DIFF
--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -38,9 +38,17 @@ Then work the checklist. For each item, note findings as a comment on the bead (
 
 ### Checklist
 
-1. **Stale Supabase CLI pin check** (PP-nlv6)
-   - Compare the pinned Supabase CLI version against the latest release. The pin lives in CI setup / config; a version-drift nudge belongs here, not in per-session briefing.
-   - If stale, file/refresh a bead to bump it (or bump it if trivial and verified).
+1. **Stale version-pin checks** (Supabase CLI — PP-nlv6; pnpm corepack pin — PP-w0eq)
+   - **Supabase CLI pin.** Compare the pinned Supabase CLI version against the latest release. The pin lives in CI setup / config; a version-drift nudge belongs here, not in per-session briefing. If stale, file/refresh a bead to bump it (or bump it if trivial and verified).
+   - **pnpm corepack pin.** The pnpm binary is pinned in the `packageManager` field of `package.json` (corepack). **Dependabot cannot bump this field** — it's an open, unimplemented feature request ([dependabot-core#4830](https://github.com/dependabot/dependabot-core/issues/4830)); Dependabot's pnpm support only updates deps _inside_ the lockfile, never the corepack pin. So this is the only watcher it has, and it silently rots without it (that's how we ended up 9 months behind on 10.2.0 until npm's audit-endpoint retirement forced the jump — PP-w0eq).
+     - **Apply a 30-day cooldown** (supply-chain soak — same rationale as the Dependabot npm cooldown): bump only to the newest stable pnpm ≥30 days old, never the just-released `latest`.
+     - Find the newest eligible version:
+
+       ```bash
+       npm view pnpm time --json | python3 -c "import json,sys,datetime as d; t=json.load(sys.stdin); c=d.datetime.now(d.UTC)-d.timedelta(days=30); r=[(v,ts) for v,ts in t.items() if '-' not in v and v.split('.')[0].isdigit()]; r.sort(key=lambda x:list(map(int,x[0].split('.')))); print(next(v for v,ts in reversed(r) if d.datetime.fromisoformat(ts.replace('Z','+00:00'))<=c))"
+       ```
+
+     - If it's newer than the current pin (mind major bumps — read the pnpm release notes/migration guide first), bump via `corepack use pnpm@<version>`, then verify no lockfile churn (`pnpm install --frozen-lockfile` → only `package.json` should change), `pnpm audit --audit-level=high` still resolves, and `pnpm run check` is green. PR it through the normal workflow; file a bead if a major bump needs real migration work.
 
 2. **TypeScript-7 rollout status**
    - Read `docs/plans/2026-06-27-typescript-7-upgrade-plan.md` for the current phase.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinpoint",
   "version": "0.2.0",
-  "packageManager": "pnpm@11.13.1",
+  "packageManager": "pnpm@11.7.0",
   "type": "module",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinpoint",
   "version": "0.2.0",
-  "packageManager": "pnpm@10.2.0",
+  "packageManager": "pnpm@11.13.1",
   "type": "module",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
@@ -194,30 +194,6 @@
     "vitest": "^4.1.4",
     "vitest-mock-extended": "^4.0.0",
     "webpack": "^5.106.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "esbuild": ">=0.28.1",
-      "minimatch": ">=10.2.3",
-      "rollup": ">=4.59.0",
-      "serialize-javascript": ">=7.0.3",
-      "flatted": ">=3.4.2",
-      "webpack": ">=5.105.4",
-      "brace-expansion": ">=5.0.6",
-      "yaml": ">=2.8.3",
-      "uuid": ">=14.0.0",
-      "postcss": ">=8.5.10",
-      "shell-quote": ">=1.8.4",
-      "ws": ">=8.21.0",
-      "vite": ">=8.0.16",
-      "undici": "^7.28.0",
-      "js-yaml": ">=4.2.0"
-    },
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "eslint-plugin-jsx-a11y>eslint": "10"
-      }
-    }
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,36 @@
+# pnpm 11 settings home. In pnpm 11 the `pnpm` field in package.json is no
+# longer read — `overrides` and `peerDependencyRules` moved here (see
+# https://pnpm.io/settings). Migrated from package.json during the pnpm 10→11
+# bump (PP-w0eq: pnpm 10.x hit the retired npm audit endpoint; only pnpm 11
+# uses the bulk advisory endpoint).
+
+# Dependency build/postinstall scripts. `false` = intentionally not run,
+# matching the pnpm 10 default here (main had no build allowlist, so these were
+# already skipped and the app/prod build relied on their prebuilt binaries).
+# In pnpm 11 they must be listed explicitly or `pnpm install` errors on
+# undecided build scripts.
+allowBuilds:
+  '@sentry/cli': false
+  esbuild: false
+  sharp: false
+
+overrides:
+  esbuild: '>=0.28.1'
+  minimatch: '>=10.2.3'
+  rollup: '>=4.59.0'
+  serialize-javascript: '>=7.0.3'
+  flatted: '>=3.4.2'
+  webpack: '>=5.105.4'
+  brace-expansion: '>=5.0.6'
+  yaml: '>=2.8.3'
+  uuid: '>=14.0.0'
+  postcss: '>=8.5.10'
+  shell-quote: '>=1.8.4'
+  ws: '>=8.21.0'
+  vite: '>=8.0.16'
+  undici: '^7.28.0'
+  js-yaml: '>=4.2.0'
+
+peerDependencyRules:
+  allowedVersions:
+    eslint-plugin-jsx-a11y>eslint: '10'


### PR DESCRIPTION
## Problem (PP-w0eq)

npm retired the legacy audit endpoint (`/-/npm/v1/security/audits[/quick]`), which now returns **HTTP 410**:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (…/-/npm/v1/security/audits) responded with 410:
{"error":"This endpoint is being retired. Use the bulk advisory endpoint instead…"}
```

This breaks Group B (security audit) of the `pinpoint-briefing` skill (`pnpm audit --audit-level=moderate`) and degrades the CI audit gate (`pnpm audit --audit-level=high`) — CI's `registry_errors` escape was silently treating the 410 as an infra flake and skipping the audit.

## Diagnosis

- Repo pins `pnpm@10.2.0` via `packageManager` (corepack) — set once in the pnpm migration (#704) and never bumped since, because **Dependabot cannot update the `packageManager` field** ([dependabot-core#4830](https://github.com/dependabot/dependabot-core/issues/4830)); its pnpm support only updates deps _inside_ the lockfile.
- **Every** pnpm 10.x — including the latest `10.34.5` — still targets the retired endpoint. Verified locally: both fail with 410.
- **pnpm 11** is the first line to query the bulk advisory endpoint (`/-/npm/v1/security/advisories/bulk`). There is no `.npmrc`/config knob to redirect the endpoint on v10, so a major bump is the only real fix.

## Fix

- Bump `packageManager` to **`pnpm@11.7.0`** — the newest stable pnpm that is **≥30 days old** (published 2026-06-15), applying the same supply-chain **cooldown** we use for Dependabot npm bumps (not the just-released `latest`, 11.13.1, which was 0 days old). Any pnpm 11 uses the bulk advisory endpoint, so this fully fixes the 410. CI's `pnpm/action-setup@v4` (no `version:` input) reads `packageManager`, so all workflows pick it up automatically — no workflow edits needed.
- pnpm 11 no longer reads the `pnpm` field in `package.json`; moved `overrides` and `peerDependencyRules` to their new home, **`pnpm-workspace.yaml`** (values unchanged).
- Added `allowBuilds` (all `false`) so pnpm 11 doesn't error on undecided build scripts. `main` had no build allowlist, so `@sentry/cli` / `esbuild` / `sharp` scripts were already skipped under pnpm 10 — this preserves that exact behavior (they use prebuilt binaries).
- **Prevent the recurrence:** added a pnpm-corepack-pin drift check (with the 30-day-cooldown recipe) to the weekly `pinpoint-chores` checklist, alongside the existing Supabase CLI pin check. Since Dependabot can't watch this pin, the weekly chore is now its only watcher.

`pnpm-lock.yaml` is **byte-identical** after regeneration (lockfileVersion stays `9.0`) — no dependency resolution changed; `pnpm install --frozen-lockfile` is clean.

## Proof the audit works again

```
$ pnpm --version
11.7.0

$ pnpm audit --audit-level=moderate
No known vulnerabilities found          # exit 0

$ pnpm audit --audit-level=high
No known vulnerabilities found          # exit 0
```

Real structured results — not a 410 / parse error. `pnpm run check` green (1471 tests).

Bead: PP-w0eq

🤖 Generated with [Claude Code](https://claude.com/claude-code)
