### PR TITLE
feat(pbm): shared foundation — pinballmap_state + store-and-heal lmx (PP-o355.16)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-pbm-foundation-PP-o355.16.md
+++ b/docs/superpowers/plans/2026-07-16-pbm-foundation-PP-o355.16.md
@@ -1,0 +1,449 @@
+# PinballMap Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the shared DB schema + snapshot read path that PP-o355.11 (inbound sync) and PP-o355.12 (list/unlist) both build on, as one PR, so those two then proceed in parallel adding zero schema.
+
+**Architecture:** A `pinballmap_state` singleton table (full proven shape ported from unmerged `b6eb7dca`, mirroring the `discord_integration_config` singleton pattern) plus net-new `machines` columns for the store-and-heal lmx model. One server module `state.ts` exposes `getPinballMapState()` + `syncLocationSnapshot()`: fetch our location through the client seam **outside any transaction**, then upsert the whole snapshot + health fields. The PBM client is pinned to the in-memory mock at its seam in tests.
+
+**Tech Stack:** Drizzle ORM + drizzle-kit (migration 0052), Postgres (Supabase/PGlite), Vitest integration (PGlite worker-scoped), TypeScript strictest.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-pbm-foundation-design.md`
+
+## Global Constraints
+
+- **Drizzle migrations only** (CORE-ARCH-009): `pnpm run db:generate` + `pnpm run db:migrate`. Never `drizzle-kit push`.
+- **Migration is fresh `0052`** — chain is at 0051. NEVER cherry-pick `b6eb7dca`'s `0046_purple_vision.sql`. Verify `drizzle/meta/_journal.json` chains 0051 → 0052.
+- **No side effects inside DB transactions** (CORE-ARCH-011): the `fetchLocation` call runs before/outside any `db.transaction`.
+- **Test what we own** (CORE-TEST-006): PBM client pinned to the mock at the seam; never reach `pinballmap.com`.
+- **Type safety** (CORE-TS-007): ts-strictest, no `any`/`!`/unsafe `as`. **Path aliases** (CORE-TS-008): always `~/`.
+- **Worker-scoped PGlite** (CORE-TEST-001): use `setupTestDb()` / `getTestDb()`; no per-test DB instances.
+- `pnpm run preflight` before pushing (this touches DB schema + a migration).
+- **No `force-db-reset.mjs` change** — it auto-discovers public tables since PP-wv4p (#1638).
+
+---
+
+### Task 1: Schema + Migration 0052
+
+**Files:**
+
+- Modify: `src/server/db/schema.ts` (add import; add `pinballmapState` table; add `machines` lmx column + 2 CHECKs + partial unique index)
+- Modify: `src/lib/types/database.ts` (export `PinballmapState`, `NewPinballmapState`)
+- Generate: `drizzle/0052_*.sql` + `drizzle/meta/0052_snapshot.json` + `_journal.json` (via `db:generate`)
+
+**Interfaces:**
+
+- Produces: `pinballmapState` table export (columns: `id`, `enabled`, `locationId`, `snapshotJson` typed `LocationSnapshot`, `lastSyncedAt`, `lastSyncStatus`, `lastSyncError`, `outboundEmail`, `outboundTokenVaultId`, `updatedAt`, `updatedBy`); `machines.pinballmapLmxId`; types `PinballmapState` / `NewPinballmapState`. Task 2 consumes all of these.
+
+- [ ] **Step 1: Import `LocationSnapshot` into schema.ts**
+
+Add to the type-imports block near the top of `src/server/db/schema.ts` (after the existing `~/lib/...` type imports, e.g. after line 25):
+
+```ts
+import type { LocationSnapshot } from "~/lib/pinballmap/types";
+```
+
+- [ ] **Step 2: Add the `pinballmapState` singleton table**
+
+Add after the `discordIntegrationConfig` table definition in `src/server/db/schema.ts` (it mirrors that pattern — id-singleton CHECK, enum health CHECK, vault UUID with no cross-schema FK):
+
+```ts
+/**
+ * PinballMap integration state (singleton).
+ *
+ * Exactly one row (id = 'singleton'), enforced by a CHECK constraint. Holds the
+ * whole last-fetched location snapshot (`snapshotJson`) plus sync health, so every
+ * downstream surface reads the stored snapshot rather than hitting PBM per request
+ * (PBM's "one call per hour" conduct, CORE-PBM-001). Outbound creds (email + vault
+ * token id) are written by the connect flow (PP-o355.12). Shared foundation for
+ * PP-o355.11 (cron sync) and PP-o355.12 (list/unlist) — PP-o355.16.
+ *
+ * `outboundTokenVaultId` references `vault.secrets.id` and `updatedBy` references
+ * `auth.users.id` — no FK (Drizzle cannot express cross-schema references).
+ */
+export const pinballmapState = pgTable(
+  "pinballmap_state",
+  {
+    id: text("id").primaryKey().default("singleton"),
+    enabled: boolean("enabled").notNull().default(false),
+    locationId: integer("location_id").notNull().default(26454),
+    snapshotJson: jsonb("snapshot_json").$type<LocationSnapshot>(),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    lastSyncStatus: text("last_sync_status", {
+      enum: ["unknown", "ok", "error"],
+    })
+      .notNull()
+      .default("unknown"),
+    lastSyncError: text("last_sync_error"),
+    outboundEmail: text("outbound_email"),
+    outboundTokenVaultId: uuid("outbound_token_vault_id"),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedBy: uuid("updated_by"),
+  },
+  (_t) => ({
+    singletonCheck: check("pinballmap_state_singleton", sql`id = 'singleton'`),
+    syncStatusCheck: check(
+      "pinballmap_state_sync_status_check",
+      sql`last_sync_status IN ('unknown', 'ok', 'error')`
+    ),
+  })
+);
+```
+
+- [ ] **Step 3: Add the `machines` lmx column + constraints**
+
+In the `machines` table (`src/server/db/schema.ts`), add the column after `pinballmapListed` (around line 182):
+
+```ts
+    // Durable captured PBM listing handle (the location_machine_xref id). We
+    // STORE AND HEAL this rather than re-resolving it per push (PP-o355.16 /
+    // .12). Nullable: only set once a machine is actually listed on PBM. An lmx
+    // implies both a catalog link and pinballmap_listed (CHECKs below).
+    pinballmapLmxId: integer("pinballmap_lmx_id"),
+```
+
+Then add to the table's constraint object `(t) => ({ ... })` (alongside the existing `pinballmapListedRequiresLinkCheck`):
+
+```ts
+    // An lmx handle presupposes a catalog link.
+    pinballmapLmxRequiresLinkCheck: check(
+      "machines_pinballmap_lmx_requires_link",
+      sql`NOT (pinballmap_lmx_id IS NOT NULL AND pinballmap_machine_id IS NULL)`
+    ),
+    // An lmx handle presupposes we consider the machine listed.
+    pinballmapLmxRequiresListedCheck: check(
+      "machines_pinballmap_lmx_requires_listed",
+      sql`NOT (pinballmap_lmx_id IS NOT NULL AND NOT pinballmap_listed)`
+    ),
+    // One PBM lister per catalog title at our location — duplicate cabinets of
+    // the same title share one PBM lmx (PbmApiAudit finding #1). Partial: only
+    // listed rows participate.
+    pinballmapListedUnique: uniqueIndex("machines_pinballmap_listed_unique")
+      .on(t.pinballmapMachineId)
+      .where(sql`pinballmap_listed`),
+```
+
+(`uniqueIndex`, `check`, `integer`, `boolean`, `text`, `jsonb`, `timestamp`, `uuid` are already imported in schema.ts.)
+
+- [ ] **Step 4: Export the row types**
+
+In `src/lib/types/database.ts`, alongside the existing `PinballmapCatalogEntry` exports (~line 67), add:
+
+```ts
+export type PinballmapState = InferSelectModel<typeof pinballmapState>;
+export type NewPinballmapState = InferInsertModel<typeof pinballmapState>;
+```
+
+Ensure `pinballmapState` is in the schema import at the top of that file (it re-imports table objects from `~/server/db/schema`; add `pinballmapState` to that import list).
+
+- [ ] **Step 5: Generate the migration**
+
+Run: `pnpm run db:generate`
+Expected: creates `drizzle/0052_<random>.sql` containing `CREATE TABLE "pinballmap_state"` (with both CHECKs), `ALTER TABLE "machines" ADD COLUMN "pinballmap_lmx_id"`, both machines CHECKs, and `CREATE UNIQUE INDEX "machines_pinballmap_listed_unique" ... WHERE "pinballmap_listed"`. Also updates `drizzle/meta/`.
+
+- [ ] **Step 6: Inspect the generated SQL**
+
+Run: `cat drizzle/0052_*.sql` and confirm: fresh 0052 (not a re-add of 0046), the partial index has the `WHERE "pinballmap_listed"` clause, and `_journal.json` chains 0051 → 0052. If drizzle emitted an unexpected `pgTable`/enum artifact, stop and fix the schema before proceeding.
+
+- [ ] **Step 7: Apply the migration locally**
+
+Run: `pnpm run db:migrate`
+Expected: applies cleanly, no error. (If local Supabase is down: `supabase start` from this worktree first.)
+
+- [ ] **Step 8: Verify no schema drift**
+
+Run: `pnpm run db:generate`
+Expected: "No schema changes, nothing to migrate" (or equivalent no-op). If it emits a new migration, the schema and generated SQL disagree — fix and delete the stray migration.
+
+- [ ] **Step 9: Typecheck**
+
+Run: `pnpm run typecheck`
+Expected: PASS (0 errors). Confirms `$type<LocationSnapshot>()` and the new type exports compile.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/server/db/schema.ts src/lib/types/database.ts drizzle/
+git commit -m "feat(pbm): migration 0052 — pinballmap_state singleton + store-and-heal lmx columns (PP-o355.16)"
+```
+
+---
+
+### Task 2: Shared read path (`state.ts`) + comment fix + integration test
+
+**Files:**
+
+- Create: `src/lib/pinballmap/state.ts`
+- Modify: `src/lib/pinballmap/types.ts:23-30` (rewrite the stale ephemeral-lmx `PbmLmx` comment)
+- Create: `src/test/integration/pinballmap-state.test.ts`
+
+**Interfaces:**
+
+- Consumes (from Task 1): `pinballmapState` table, `PinballmapState` type.
+- Produces: `getPinballMapState(): Promise<PinballmapState | null>`; `syncLocationSnapshot(opts?: { updatedBy?: string }): Promise<SyncResult>` where `SyncResult = { ok: true; machineCount: number; syncedAt: Date } | { ok: false; error: string }`. PP-o355.11 (cron) and PP-o355.12 (link/verify) consume these.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `src/test/integration/pinballmap-state.test.ts` (ported from `b6eb7dca`'s `pinballmap-sync.test.ts`, dropping the action/permission block and pointing at `state`; `state.ts` imports only db + client + config + types, so only those two mocks are needed):
+
+```ts
+/**
+ * Integration Test: PinballMap shared read path (PP-o355.16)
+ *
+ * Covers the foundation read path against PGlite:
+ *  - syncLocationSnapshot(): stores the whole snapshot on the singleton, sets
+ *    sync health (ok/error), upserts (one row), records the error path
+ *  - getPinballMapState(): reads the singleton
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import { pinballmapState } from "~/server/db/schema";
+
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+// Pin the PinballMap client to the in-memory mock at the seam (CORE-TEST-006),
+// so the sync can never reach pinballmap.com regardless of PINBALLMAP_MODE.
+vi.mock("~/lib/pinballmap/client", async () => {
+  const { getMockClient } = await import("~/lib/pinballmap/client-mock");
+  return { getPinballMapClient: () => getMockClient() };
+});
+
+describe("PinballMap shared read path (PGlite)", () => {
+  setupTestDb();
+
+  it("syncLocationSnapshot stores the snapshot and marks health ok", async () => {
+    const { syncLocationSnapshot, getPinballMapState } =
+      await import("~/lib/pinballmap/state");
+
+    const result = await syncLocationSnapshot();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.machineCount).toBeGreaterThan(0);
+
+    const state = await getPinballMapState();
+    expect(state).not.toBeNull();
+    expect(state?.lastSyncStatus).toBe("ok");
+    expect(state?.lastSyncError).toBeNull();
+    expect(state?.lastSyncedAt).toBeInstanceOf(Date);
+    // The whole LocationSnapshot is stored as JSON.
+    expect(state?.snapshotJson?.locationId).toBe(state?.locationId);
+    expect(state?.snapshotJson?.lmxes.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("is a singleton — a second sync updates the same row", async () => {
+    const db = await getTestDb();
+    const { syncLocationSnapshot } = await import("~/lib/pinballmap/state");
+
+    await syncLocationSnapshot();
+    await syncLocationSnapshot();
+
+    const rows = await db.select().from(pinballmapState);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.id).toBe("singleton");
+  });
+
+  it("records the error path without throwing when the fetch fails", async () => {
+    const { getMockClient } = await import("~/lib/pinballmap/client-mock");
+    const { syncLocationSnapshot, getPinballMapState } =
+      await import("~/lib/pinballmap/state");
+    const spy = vi
+      .spyOn(getMockClient(), "fetchLocation")
+      .mockRejectedValueOnce(new Error("PBM unreachable"));
+
+    const result = await syncLocationSnapshot();
+    expect(result).toEqual({ ok: false, error: "PBM unreachable" });
+
+    const state = await getPinballMapState();
+    expect(state?.lastSyncStatus).toBe("error");
+    expect(state?.lastSyncError).toBe("PBM unreachable");
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/test/integration/pinballmap-state.test.ts`
+Expected: FAIL — cannot resolve `~/lib/pinballmap/state` (module doesn't exist yet).
+
+- [ ] **Step 3: Create `state.ts`**
+
+Create `src/lib/pinballmap/state.ts` (ported from `b6eb7dca`'s `sync.ts`, module renamed and the `./status` re-exports dropped):
+
+```ts
+import "server-only";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { pinballmapState } from "~/server/db/schema";
+import { getPinballMapClient } from "./client";
+import { APC_LOCATION_ID } from "./config";
+import type { PinballmapState } from "~/lib/types/database";
+
+/**
+ * PinballMap location-snapshot read path (foundation — PP-o355.16).
+ *
+ * The integration keeps one `pinballmap_state` singleton row. A sync fetches our
+ * location's full JSON through the client seam and stores the WHOLE snapshot, so
+ * every downstream surface (status card, desync view, link/verify) reads the
+ * stored snapshot rather than hitting PBM per request — PBM's "one call per hour"
+ * conduct (CORE-PBM-001). The fetch is a side effect performed OUTSIDE any
+ * transaction (CORE-ARCH-011); we persist the result after it returns.
+ *
+ * PP-o355.11 schedules `syncLocationSnapshot` on a cron; PP-o355.12 reuses the
+ * persisted snapshot to resolve/verify lmx handles.
+ */
+
+const SINGLETON_ID = "singleton";
+
+/** Read the integration-state singleton (null when never initialized). */
+export async function getPinballMapState(): Promise<PinballmapState | null> {
+  const [row] = await db
+    .select()
+    .from(pinballmapState)
+    .where(eq(pinballmapState.id, SINGLETON_ID))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Outcome of a sync attempt. */
+export type SyncResult =
+  | { ok: true; machineCount: number; syncedAt: Date }
+  | { ok: false; error: string };
+
+/**
+ * Fetch the configured location's snapshot from PBM and store it whole, updating
+ * sync health. Never throws on a PBM/network failure: it records the error on the
+ * singleton and returns `{ ok: false }` so callers (cron, "Sync now") can surface
+ * it without a 500.
+ */
+export async function syncLocationSnapshot(opts?: {
+  updatedBy?: string;
+}): Promise<SyncResult> {
+  const state = await getPinballMapState();
+  const locationId = state?.locationId ?? APC_LOCATION_ID;
+  const syncedAt = new Date();
+
+  try {
+    const snapshot = await getPinballMapClient().fetchLocation(locationId);
+    await db
+      .insert(pinballmapState)
+      .values({
+        id: SINGLETON_ID,
+        locationId,
+        snapshotJson: snapshot,
+        lastSyncedAt: syncedAt,
+        lastSyncStatus: "ok",
+        lastSyncError: null,
+        updatedAt: syncedAt,
+        ...(opts?.updatedBy ? { updatedBy: opts.updatedBy } : {}),
+      })
+      .onConflictDoUpdate({
+        target: pinballmapState.id,
+        set: {
+          snapshotJson: snapshot,
+          lastSyncedAt: syncedAt,
+          lastSyncStatus: "ok",
+          lastSyncError: null,
+          updatedAt: syncedAt,
+          ...(opts?.updatedBy ? { updatedBy: opts.updatedBy } : {}),
+        },
+      });
+    return { ok: true, machineCount: snapshot.machineCount, syncedAt };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown sync error";
+    await db
+      .insert(pinballmapState)
+      .values({
+        id: SINGLETON_ID,
+        locationId,
+        lastSyncedAt: syncedAt,
+        lastSyncStatus: "error",
+        lastSyncError: message,
+        updatedAt: syncedAt,
+      })
+      .onConflictDoUpdate({
+        target: pinballmapState.id,
+        set: {
+          lastSyncedAt: syncedAt,
+          lastSyncStatus: "error",
+          lastSyncError: message,
+          updatedAt: syncedAt,
+        },
+      });
+    return { ok: false, error: message };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run src/test/integration/pinballmap-state.test.ts`
+Expected: PASS — all 3 cases green.
+
+- [ ] **Step 5: Fix the stale ephemeral-lmx comment**
+
+In `src/lib/pinballmap/types.ts`, replace the `PbmLmx` doc comment (lines 23-30) — the current text says the lmx "is ephemeral … resolved from the latest snapshot at action time and never cached," which contradicts the locked store-and-heal model. Replace with:
+
+```ts
+/**
+ * A location_machine_xref — "this machine at this location". The `id` (lmx id)
+ * is the durable listing handle: we capture it when a machine is listed and
+ * STORE it on `machines.pinballmap_lmx_id`, healing it from the latest snapshot
+ * when PBM re-mints one (removing + re-adding a machine changes the id). We do
+ * not re-resolve it per push — see the store-and-heal model (PP-o355.16 / .12).
+ *
+ * Note: PBM's location payload carries only `machineId` here, not the machine
+ * name — names come from the catalog mirror (bead B).
+ */
+```
+
+- [ ] **Step 6: Re-run the test + typecheck**
+
+Run: `pnpm exec vitest run src/test/integration/pinballmap-state.test.ts && pnpm run typecheck`
+Expected: test PASS, typecheck PASS (the comment change is doc-only; this confirms nothing regressed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/pinballmap/state.ts src/lib/pinballmap/types.ts src/test/integration/pinballmap-state.test.ts
+git commit -m "feat(pbm): shared snapshot read path + store-and-heal lmx comment fix (PP-o355.16)"
+```
+
+---
+
+### Task 3: Preflight + PR
+
+- [ ] **Step 1: Run preflight** (this touches DB schema + a migration — preflight is required, not just `check`)
+
+Run: `pnpm run preflight`
+Expected: check + build + integration all green. Fix anything red before proceeding.
+
+- [ ] **Step 2: Push and open the PR ready-for-review**
+
+```bash
+git push -u origin worktree-pbm-foundation-PP-o355.16
+```
+
+Then open the PR (title references PP-o355.16; body summarizes: migration 0052, state.ts read path, comment fix; notes it unblocks parallel .11 + .12). Follow `pinpoint-pr-workflow` for CI + Copilot review handling. Update the bead `--design` with the plan path + branch and `--notes` with the PR number.
+
+## Self-Review
+
+**Spec coverage:**
+
+- Migration 0052 (pinballmap_state full shape + machines lmx + 2 CHECKs + partial unique) → Task 1 ✓
+- `getPinballMapState()` + `syncLocationSnapshot()` (fetch outside txn, never throws, health fields) → Task 2 ✓
+- `PinballmapState` type export → Task 1 Step 4 ✓
+- `types.ts` ephemeral-lmx comment fix → Task 2 Step 5 ✓
+- Integration test (upsert + persist + error path, mock at seam) → Task 2 Steps 1-4 ✓
+- Fresh-0052 / never-reapply-0046 landmine → Global Constraints + Task 1 Steps 5-6 ✓
+- Partial-unique-on-existing-data risk → verified by `db:migrate` on local seed (Task 1 Step 7); low risk (listing default false, backfill is PP-h059)
+- Explicitly-out items (cron/status/action/UI/vault-write) → not present in any task ✓
+
+**Placeholder scan:** No TBD/TODO; all code blocks complete; all commands have expected output.
+
+**Type consistency:** `pinballmapState`, `PinballmapState`, `SyncResult { ok; machineCount; syncedAt } | { ok; error }`, `getPinballMapState`, `syncLocationSnapshot` — names/signatures match across Task 1 (produces) and Task 2 (consumes) and the test.

--- a/docs/superpowers/specs/2026-07-16-pbm-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-16-pbm-foundation-design.md
@@ -1,0 +1,136 @@
+# PinballMap Foundation — Shared Schema + Snapshot Read Path (PP-o355.16)
+
+**Date:** 2026-07-16
+**Bead:** PP-o355.16 (parent epic PP-o355)
+**Status:** Design approved (Tim + Claude, 2026-07-16)
+
+## Purpose
+
+PP-o355.11 (inbound snapshot sync, automatic/cron) and PP-o355.12 (outbound
+list/unlist) both build on the same DB schema and the same "fetch our location
+and persist the snapshot" read path. If each added its own migration they'd
+collide on the drizzle chain and on the `pinballmap_state` table shape. This
+bead **lands that shared foundation first, as its own PR**, so `.11` and `.12`
+then fork cleanly and proceed in parallel — each adding **zero** schema.
+
+A complete but **unmerged** reference implementation exists in commit `b6eb7dca`
+(the original PP-o355.3 backend). This bead ports the schema + shared read path
+from it and **drops** everything cron/status/action/UI (those go to `.11`/`.12`).
+It also adds **net-new** machine columns for the locked _store-and-heal_ lmx
+model that `b6eb7dca` did not have.
+
+## Scope
+
+### In
+
+1. **Migration 0052** — regenerated _fresh_ via `pnpm run db:generate` (chain is
+   at 0051). **Never** cherry-pick `b6eb7dca`'s `0046_purple_vision.sql`; on
+   `origin/main`, 0046 is an unrelated migration.
+
+   **a. `pinballmap_state` singleton table** — full proven `b6eb7dca` column set,
+   so `.11`/`.12` add no schema:
+
+   | Column                    | Type / constraint                                                                       |
+   | ------------------------- | --------------------------------------------------------------------------------------- |
+   | `id`                      | `text` PK, default `'singleton'`, CHECK `id = 'singleton'`                              |
+   | `enabled`                 | `boolean` NOT NULL default `false`                                                      |
+   | `location_id`             | `integer` NOT NULL default `26454` (APC)                                                |
+   | `snapshot_json`           | `jsonb` nullable, Drizzle `$type<LocationSnapshot>()`                                   |
+   | `last_synced_at`          | `timestamptz` nullable                                                                  |
+   | `last_sync_status`        | `text` NOT NULL default `'unknown'`, CHECK in `unknown\|ok\|error`                      |
+   | `last_sync_error`         | `text` nullable                                                                         |
+   | `outbound_email`          | `text` nullable                                                                         |
+   | `outbound_token_vault_id` | `uuid` nullable (references `vault.secrets.id`; **no FK** — Drizzle can't cross-schema) |
+   | `updated_at`              | `timestamptz` NOT NULL default `now()`                                                  |
+   | `updated_by`              | `uuid` nullable (references `auth.users.id`; no FK)                                     |
+
+   Mirrors the `discord_integration_config` singleton pattern already in
+   `schema.ts` (id-singleton CHECK, health-enum CHECK, vault UUID with no FK).
+
+   **b. `machines` net-new (store-and-heal lmx model):**
+
+   - `pinballmap_lmx_id` `integer` nullable — the durable captured PBM listing
+     handle (the `location_machine_xref` id). We **store and heal** it, not
+     re-resolve per push.
+   - CHECK `machines_pinballmap_lmx_requires_link`:
+     `NOT (pinballmap_lmx_id IS NOT NULL AND pinballmap_machine_id IS NULL)`
+     (an lmx implies a catalog link).
+   - CHECK `machines_pinballmap_lmx_requires_listed`:
+     `NOT (pinballmap_lmx_id IS NOT NULL AND NOT pinballmap_listed)`
+     (an lmx implies we consider it listed).
+   - Partial `UNIQUE(pinballmap_machine_id) WHERE pinballmap_listed` — one PBM
+     lister per catalog title at our location. Duplicate physical cabinets of
+     the same title share one PBM lmx (PbmApiAudit finding #1).
+
+2. **`src/lib/pinballmap/state.ts`** (new file — `state.ts`, not `sync.ts`, so
+   `.11`'s cron/scheduling layer gets a clean `sync.ts`):
+
+   - `getPinballMapState(): Promise<PinballmapState | null>` — read the singleton.
+   - `syncLocationSnapshot(opts?): Promise<SyncResult>` — the **single shared read
+     path**. Fetch `getPinballMapClient().fetchLocation(locationId)` **outside any
+     transaction** (CORE-ARCH-011), then upsert `snapshot_json` + `last_synced_at`
+     - `last_sync_status`/`last_sync_error`. Never throws on PBM/network failure:
+       records the error on the singleton and returns `{ ok: false, error }`.
+       Ported from `b6eb7dca`'s `sync.ts` **minus** the `status.ts` re-exports.
+
+3. **Type export** `PinballmapState` in `src/lib/types/database.ts`
+   (`InferSelectModel<typeof pinballmapState>`), matching the existing pattern.
+
+4. **Fix the stale comment** in `src/lib/pinballmap/types.ts:23-30`. The current
+   `PbmLmx` doc says the lmx id "is ephemeral … resolved from the latest snapshot
+   at action time and never cached." That directly contradicts the locked
+   store-and-heal model (we persist `pinballmap_lmx_id` and heal it). Rewrite it
+   to describe store-and-heal.
+
+5. **Integration test** — PGlite + direct call, PBM pinned to the mock client at
+   the seam (CORE-TEST-006): singleton upsert, snapshot persist with health
+   fields, and the error path (fetch throws → `last_sync_status = 'error'`,
+   `last_sync_error` set, no throw).
+
+### Explicitly out (→ other beads)
+
+- **PP-o355.11:** cron route `/api/cron/pinballmap-sync`, hourly schedule,
+  `status.ts` (`shouldBeListedOnPbm`, `derivePbmMachineStatus`), desync UI.
+- **PP-o355.12:** `pinballmap.sync` permission matrix entry, "Sync now" action,
+  vault token write, connect/link/list/unlist server actions, form UI.
+- **PP-h059:** backfilling existing machines' `pinballmap_lmx_id` from the
+  snapshot.
+
+## Architecture / data flow
+
+```
+getPinballMapClient()  ──fetchLocation(APC_LOCATION_ID)──►  LocationSnapshot
+        (seam; live or mock by env)                              │
+                                                                 ▼  (outside txn)
+                            syncLocationSnapshot()  ──upsert──►  pinballmap_state
+                                                                 (snapshot_json + health)
+```
+
+- The fetch is the only side effect and runs **before/outside** any DB
+  transaction — the upsert itself is a single statement, no wrapping txn needed.
+- `.11` will call `syncLocationSnapshot()` on a cron; `.12` reads the persisted
+  `snapshot_json` to resolve/verify lmx handles for link/unlist. Neither re-adds
+  schema.
+
+## Testing
+
+- **Layer:** integration (PGlite + direct action call) per CORE-TEST-005 — this
+  is server-action/query-correctness wiring, not a UI journey.
+- **Mock the SDK at its boundary** (CORE-TEST-006): inject the mock
+  `PinballMapClient`; never reach `pinballmap.com`.
+- Cases: (1) first sync inserts the singleton with `snapshot_json` + `ok` health;
+  (2) second sync updates it (upsert, not duplicate); (3) fetch throws → `error`
+  health recorded, `syncLocationSnapshot` returns `{ ok: false }` without
+  throwing. Schema CHECKs/partial-unique are exercised by the migration applying
+  - a targeted insert conflict assertion if cheap.
+
+## Risks / landmines
+
+- **Migration renumber landmine:** generate fresh `0052`; never reapply `0046`.
+  Verify `drizzle/meta/_journal.json` chains 0051 → 0052.
+- **Partial-unique on existing data:** if two current machines already share a
+  `pinballmap_machine_id` with `pinballmap_listed = true`, creating the unique
+  index fails. Listing is a newish flag (default false, backfill is PP-h059), so
+  risk is low — but the plan verifies against local seed before relying on it.
+- **`snapshot_json` typing:** `$type<LocationSnapshot>()` is a compile-time cast
+  only; the column is plain `jsonb`. The client is the source of the shape.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
     "timeline_events",
     "timeline_event_people",
     "pinballmap_catalog",
+    "pinballmap_state",
     "machine_settings_sets",
   ],
   schemaFilter: ["public"],

--- a/drizzle/0052_complex_dreaming_celestial.sql
+++ b/drizzle/0052_complex_dreaming_celestial.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "pinballmap_state" (
+	"id" text PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"location_id" integer DEFAULT 26454 NOT NULL,
+	"snapshot_json" jsonb,
+	"last_synced_at" timestamp with time zone,
+	"last_sync_status" text DEFAULT 'unknown' NOT NULL,
+	"last_sync_error" text,
+	"outbound_email" text,
+	"outbound_token_vault_id" uuid,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_by" uuid,
+	CONSTRAINT "pinballmap_state_singleton" CHECK (id = 'singleton'),
+	CONSTRAINT "pinballmap_state_sync_status_check" CHECK (last_sync_status IN ('unknown', 'ok', 'error'))
+);
+--> statement-breakpoint
+ALTER TABLE "machines" ADD COLUMN "pinballmap_lmx_id" integer;--> statement-breakpoint
+CREATE UNIQUE INDEX "machines_pinballmap_listed_unique" ON "machines" USING btree ("pinballmap_machine_id") WHERE pinballmap_listed;--> statement-breakpoint
+ALTER TABLE "machines" ADD CONSTRAINT "machines_pinballmap_lmx_requires_link" CHECK (NOT (pinballmap_lmx_id IS NOT NULL AND pinballmap_machine_id IS NULL));--> statement-breakpoint
+ALTER TABLE "machines" ADD CONSTRAINT "machines_pinballmap_lmx_requires_listed" CHECK (NOT (pinballmap_lmx_id IS NOT NULL AND NOT pinballmap_listed));

--- a/drizzle/meta/0052_snapshot.json
+++ b/drizzle/meta/0052_snapshot.json
@@ -1,0 +1,2352 @@
+{
+  "id": "1a82e65d-361c-48e5-b641-e4f445b82341",
+  "prevId": "5eebd47f-f504-4113-b405-0089eb55046b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_integration_config": {
+      "name": "discord_integration_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_link": {
+          "name": "invite_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_token_vault_id": {
+          "name": "bot_token_vault_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_health_status": {
+          "name": "bot_health_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_bot_check_at": {
+          "name": "last_bot_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "discord_integration_config_singleton": {
+          "name": "discord_integration_config_singleton",
+          "value": "id = 'singleton'"
+        },
+        "discord_integration_config_health_check": {
+          "name": "discord_integration_config_health_check",
+          "value": "bot_health_status IN ('unknown', 'healthy', 'degraded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invited_users": {
+      "name": "invited_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "first_name || ' ' || last_name",
+            "type": "stored"
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invite_sent_at": {
+          "name": "invite_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invited_users_email_unique": {
+          "name": "invited_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invited_users_role_check": {
+          "name": "invited_users_role_check",
+          "value": "role IN ('guest', 'member', 'technician', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_comments": {
+      "name": "issue_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_comments_issue_id_created_at": {
+          "name": "idx_issue_comments_issue_id_created_at",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_comments_author_id": {
+          "name": "idx_issue_comments_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_comments_idempotency_key": {
+          "name": "idx_issue_comments_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_comments\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_comments_issue_id_issues_id_fk": {
+          "name": "issue_comments_issue_id_issues_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_comments_author_id_user_profiles_id_fk": {
+          "name": "issue_comments_author_id_user_profiles_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_system_event_data": {
+          "name": "chk_system_event_data",
+          "value": "NOT \"issue_comments\".\"is_system\" OR \"issue_comments\".\"event_data\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_images": {
+      "name": "issue_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_image_url": {
+          "name": "full_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cropped_image_url": {
+          "name": "cropped_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_blob_pathname": {
+          "name": "full_blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cropped_blob_pathname": {
+          "name": "cropped_blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issue_images_issue_id": {
+          "name": "idx_issue_images_issue_id",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_uploaded_by": {
+          "name": "idx_issue_images_uploaded_by",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_deleted_at": {
+          "name": "idx_issue_images_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_comment_id": {
+          "name": "idx_issue_images_comment_id",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issue_images_deleted_by": {
+          "name": "idx_issue_images_deleted_by",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_images_issue_id_issues_id_fk": {
+          "name": "issue_images_issue_id_issues_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_images_comment_id_issue_comments_id_fk": {
+          "name": "issue_images_comment_id_issue_comments_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "issue_comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_images_uploaded_by_user_profiles_id_fk": {
+          "name": "issue_images_uploaded_by_user_profiles_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_images_deleted_by_user_profiles_id_fk": {
+          "name": "issue_images_deleted_by_user_profiles_id_fk",
+          "tableFrom": "issue_images",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_watchers": {
+      "name": "issue_watchers",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_issue_watchers_user_id": {
+          "name": "idx_issue_watchers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_watchers_issue_id_issues_id_fk": {
+          "name": "issue_watchers_issue_id_issues_id_fk",
+          "tableFrom": "issue_watchers",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_watchers_user_id_user_profiles_id_fk": {
+          "name": "issue_watchers_user_id_user_profiles_id_fk",
+          "tableFrom": "issue_watchers",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_watchers_issue_id_user_id_pk": {
+          "name": "issue_watchers_issue_id_user_id_pk",
+          "columns": ["issue_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_initials": {
+          "name": "machine_initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'minor'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'intermittent'"
+        },
+        "reported_by": {
+          "name": "reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_reported_by": {
+          "name": "invited_reported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_name": {
+          "name": "reporter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_email": {
+          "name": "reporter_email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_issues_idempotency_key": {
+          "name": "idx_issues_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issues\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_assigned_to": {
+          "name": "idx_issues_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_reported_by": {
+          "name": "idx_issues_reported_by",
+          "columns": [
+            {
+              "expression": "reported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_status": {
+          "name": "idx_issues_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_created_at": {
+          "name": "idx_issues_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_invited_reported_by": {
+          "name": "idx_issues_invited_reported_by",
+          "columns": [
+            {
+              "expression": "invited_reported_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_issues_severity": {
+          "name": "idx_issues_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_machine_initials_machines_initials_fk": {
+          "name": "issues_machine_initials_machines_initials_fk",
+          "tableFrom": "issues",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_initials"],
+          "columnsTo": ["initials"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issues_reported_by_user_profiles_id_fk": {
+          "name": "issues_reported_by_user_profiles_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["reported_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_invited_reported_by_invited_users_id_fk": {
+          "name": "issues_invited_reported_by_invited_users_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "invited_users",
+          "columnsFrom": ["invited_reported_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_assigned_to_user_profiles_id_fk": {
+          "name": "issues_assigned_to_user_profiles_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_issue_number": {
+          "name": "unique_issue_number",
+          "nullsNotDistinct": false,
+          "columns": ["machine_initials", "issue_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reporter_check": {
+          "name": "reporter_check",
+          "value": "(\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NOT NULL AND \"issues\".\"invited_reported_by\" IS NULL AND \"issues\".\"reporter_name\" IS NULL AND \"issues\".\"reporter_email\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NOT NULL AND \"issues\".\"reporter_name\" IS NULL AND \"issues\".\"reporter_email\" IS NULL) OR\n          (\"issues\".\"reported_by\" IS NULL AND \"issues\".\"invited_reported_by\" IS NULL AND (\"issues\".\"reporter_name\" IS NOT NULL OR \"issues\".\"reporter_email\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.machine_settings_sets": {
+      "name": "machine_settings_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_preferred": {
+          "name": "is_preferred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_machine_settings_sets_machine": {
+          "name": "idx_machine_settings_sets_machine",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_machine_settings_preferred": {
+          "name": "uniq_machine_settings_preferred",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"machine_settings_sets\".\"is_preferred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machine_settings_sets_created_by": {
+          "name": "idx_machine_settings_sets_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machine_settings_sets_updated_by": {
+          "name": "idx_machine_settings_sets_updated_by",
+          "columns": [
+            {
+              "expression": "updated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_settings_sets_machine_id_machines_id_fk": {
+          "name": "machine_settings_sets_machine_id_machines_id_fk",
+          "tableFrom": "machine_settings_sets",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_settings_sets_created_by_user_profiles_id_fk": {
+          "name": "machine_settings_sets_created_by_user_profiles_id_fk",
+          "tableFrom": "machine_settings_sets",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "machine_settings_sets_updated_by_user_profiles_id_fk": {
+          "name": "machine_settings_sets_updated_by_user_profiles_id_fk",
+          "tableFrom": "machine_settings_sets",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.machine_watchers": {
+      "name": "machine_watchers",
+      "schema": "",
+      "columns": {
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watch_mode": {
+          "name": "watch_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_machine_watchers_user_id": {
+          "name": "idx_machine_watchers_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_watchers_machine_id_machines_id_fk": {
+          "name": "machine_watchers_machine_id_machines_id_fk",
+          "tableFrom": "machine_watchers",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_watchers_user_id_user_profiles_id_fk": {
+          "name": "machine_watchers_user_id_user_profiles_id_fk",
+          "tableFrom": "machine_watchers",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "machine_watchers_machine_id_user_id_pk": {
+          "name": "machine_watchers_machine_id_user_id_pk",
+          "columns": ["machine_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_issue_number": {
+          "name": "next_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_owner_id": {
+          "name": "invited_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_requirements": {
+          "name": "owner_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_requests": {
+          "name": "settings_requests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_instructions": {
+          "name": "settings_instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_status": {
+          "name": "presence_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_the_floor'"
+        },
+        "pinballmap_machine_id": {
+          "name": "pinballmap_machine_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinballmap_excluded": {
+          "name": "pinballmap_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinballmap_excluded_reason": {
+          "name": "pinballmap_excluded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinballmap_listed": {
+          "name": "pinballmap_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinballmap_lmx_id": {
+          "name": "pinballmap_lmx_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opdb_id": {
+          "name": "opdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipdb_id": {
+          "name": "ipdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machines_pinballmap_listed_unique": {
+          "name": "machines_pinballmap_listed_unique",
+          "columns": [
+            {
+              "expression": "pinballmap_machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "pinballmap_listed",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machines_owner_id": {
+          "name": "idx_machines_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machines_invited_owner_id": {
+          "name": "idx_machines_invited_owner_id",
+          "columns": [
+            {
+              "expression": "invited_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_machines_name": {
+          "name": "idx_machines_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machines_owner_id_user_profiles_id_fk": {
+          "name": "machines_owner_id_user_profiles_id_fk",
+          "tableFrom": "machines",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "machines_invited_owner_id_invited_users_id_fk": {
+          "name": "machines_invited_owner_id_invited_users_id_fk",
+          "tableFrom": "machines",
+          "tableTo": "invited_users",
+          "columnsFrom": ["invited_owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machines_initials_unique": {
+          "name": "machines_initials_unique",
+          "nullsNotDistinct": false,
+          "columns": ["initials"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "initials_check": {
+          "name": "initials_check",
+          "value": "initials ~ '^[A-Z0-9]{2,6}$'"
+        },
+        "owner_check": {
+          "name": "owner_check",
+          "value": "(owner_id IS NULL OR invited_owner_id IS NULL)"
+        },
+        "machines_pinballmap_link_exclusive": {
+          "name": "machines_pinballmap_link_exclusive",
+          "value": "NOT (pinballmap_machine_id IS NOT NULL AND pinballmap_excluded)"
+        },
+        "machines_pinballmap_listed_requires_link": {
+          "name": "machines_pinballmap_listed_requires_link",
+          "value": "NOT (pinballmap_listed AND pinballmap_machine_id IS NULL)"
+        },
+        "machines_pinballmap_lmx_requires_link": {
+          "name": "machines_pinballmap_lmx_requires_link",
+          "value": "NOT (pinballmap_lmx_id IS NOT NULL AND pinballmap_machine_id IS NULL)"
+        },
+        "machines_pinballmap_lmx_requires_listed": {
+          "name": "machines_pinballmap_lmx_requires_listed",
+          "value": "NOT (pinballmap_lmx_id IS NOT NULL AND NOT pinballmap_listed)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "suppress_own_actions": {
+          "name": "suppress_own_actions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_assigned": {
+          "name": "email_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_assigned": {
+          "name": "in_app_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notify_on_status_change": {
+          "name": "email_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_notify_on_status_change": {
+          "name": "in_app_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_new_comment": {
+          "name": "email_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_notify_on_new_comment": {
+          "name": "in_app_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_notify_on_mentioned": {
+          "name": "email_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_mentioned": {
+          "name": "in_app_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notify_on_new_issue": {
+          "name": "email_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "in_app_notify_on_new_issue": {
+          "name": "in_app_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_watch_new_issues_global": {
+          "name": "email_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "in_app_watch_new_issues_global": {
+          "name": "in_app_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_enabled": {
+          "name": "discord_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_assigned": {
+          "name": "discord_notify_on_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_status_change": {
+          "name": "discord_notify_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_notify_on_new_comment": {
+          "name": "discord_notify_on_new_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_notify_on_mentioned": {
+          "name": "discord_notify_on_mentioned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_notify_on_new_issue": {
+          "name": "discord_notify_on_new_issue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "discord_watch_new_issues_global": {
+          "name": "discord_watch_new_issues_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_dm_blocked_at": {
+          "name": "discord_dm_blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_profiles_id_fk": {
+          "name": "notification_preferences_user_id_user_profiles_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_profiles_id_fk": {
+          "name": "notifications_user_id_user_profiles_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pinballmap_catalog": {
+      "name": "pinballmap_catalog",
+      "schema": "",
+      "columns": {
+        "pinballmap_machine_id": {
+          "name": "pinballmap_machine_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opdb_id": {
+          "name": "opdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipdb_id": {
+          "name": "ipdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_group_id": {
+          "name": "machine_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pinballmap_catalog_name": {
+          "name": "idx_pinballmap_catalog_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pinballmap_catalog_group": {
+          "name": "idx_pinballmap_catalog_group",
+          "columns": [
+            {
+              "expression": "machine_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.pinballmap_state": {
+      "name": "pinballmap_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 26454
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbound_email": {
+          "name": "outbound_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outbound_token_vault_id": {
+          "name": "outbound_token_vault_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pinballmap_state_singleton": {
+          "name": "pinballmap_state_singleton",
+          "value": "id = 'singleton'"
+        },
+        "pinballmap_state_sync_status_check": {
+          "name": "pinballmap_state_sync_status_check",
+          "value": "last_sync_status IN ('unknown', 'ok', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.timeline_event_people": {
+      "name": "timeline_event_people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_id": {
+          "name": "invited_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_timeline_event_people_event_id": {
+          "name": "idx_timeline_event_people_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_event_people_invited_id": {
+          "name": "idx_timeline_event_people_invited_id",
+          "columns": [
+            {
+              "expression": "invited_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_event_people_user_id": {
+          "name": "idx_timeline_event_people_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timeline_event_people_event_id_timeline_events_id_fk": {
+          "name": "timeline_event_people_event_id_timeline_events_id_fk",
+          "tableFrom": "timeline_event_people",
+          "tableTo": "timeline_events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_event_people_user_id_user_profiles_id_fk": {
+          "name": "timeline_event_people_user_id_user_profiles_id_fk",
+          "tableFrom": "timeline_event_people",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timeline_event_people_invited_id_invited_users_id_fk": {
+          "name": "timeline_event_people_invited_id_invited_users_id_fk",
+          "tableFrom": "timeline_event_people",
+          "tableTo": "invited_users",
+          "columnsFrom": ["invited_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "timeline_event_people_person_check": {
+          "name": "timeline_event_people_person_check",
+          "value": "(\"timeline_event_people\".\"user_id\" IS NULL OR \"timeline_event_people\".\"invited_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.timeline_events": {
+      "name": "timeline_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_timeline_events_machine_created": {
+          "name": "idx_timeline_events_machine_created",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_machine_tag": {
+          "name": "idx_timeline_events_machine_tag",
+          "columns": [
+            {
+              "expression": "machine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_author_id": {
+          "name": "idx_timeline_events_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_deleted_by": {
+          "name": "idx_timeline_events_deleted_by",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_timeline_events_idempotency_key": {
+          "name": "idx_timeline_events_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"timeline_events\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timeline_events_machine_id_machines_id_fk": {
+          "name": "timeline_events_machine_id_machines_id_fk",
+          "tableFrom": "timeline_events",
+          "tableTo": "machines",
+          "columnsFrom": ["machine_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_events_author_id_user_profiles_id_fk": {
+          "name": "timeline_events_author_id_user_profiles_id_fk",
+          "tableFrom": "timeline_events",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "timeline_events_deleted_by_user_profiles_id_fk": {
+          "name": "timeline_events_deleted_by_user_profiles_id_fk",
+          "tableFrom": "timeline_events",
+          "tableTo": "user_profiles",
+          "columnsFrom": ["deleted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "citext",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "first_name || ' ' || last_name",
+            "type": "stored"
+          }
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guest'"
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_email_unique": {
+          "name": "user_profiles_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_profiles_discord_user_id_unique": {
+          "name": "user_profiles_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["discord_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_profiles_role_check": {
+          "name": "user_profiles_role_check",
+          "value": "role IN ('guest', 'member', 'technician', 'admin')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1783910845299,
       "tag": "0051_numerous_millenium_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1784214065832,
+      "tag": "0052_complex_dreaming_celestial",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/pinballmap/state.ts
+++ b/src/lib/pinballmap/state.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { pinballmapState } from "~/server/db/schema";
+import { getPinballMapClient } from "./client";
+import { APC_LOCATION_ID } from "./config";
+import type { PinballmapState } from "~/lib/types/database";
+
+/**
+ * PinballMap location-snapshot read path (foundation — PP-o355.16).
+ *
+ * The integration keeps one `pinballmap_state` singleton row. A sync fetches our
+ * location's full JSON through the client seam and stores the WHOLE snapshot, so
+ * every downstream surface (status card, desync view, link/verify) reads the
+ * stored snapshot rather than hitting PBM per request — PBM's "one call per hour"
+ * conduct (CORE-PBM-001). The fetch is a side effect performed OUTSIDE any
+ * transaction (CORE-ARCH-011); we persist the result after it returns.
+ *
+ * PP-o355.11 schedules `syncLocationSnapshot` on a cron; PP-o355.12 reuses the
+ * persisted snapshot to resolve/verify lmx handles.
+ */
+
+const SINGLETON_ID = "singleton";
+
+/** Read the integration-state singleton (null when never initialized). */
+export async function getPinballMapState(): Promise<PinballmapState | null> {
+  const [row] = await db
+    .select()
+    .from(pinballmapState)
+    .where(eq(pinballmapState.id, SINGLETON_ID))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Outcome of a sync attempt. */
+export type SyncResult =
+  | { ok: true; machineCount: number; syncedAt: Date }
+  | { ok: false; error: string };
+
+/**
+ * Fetch the configured location's snapshot from PBM and store it whole, updating
+ * sync health. Never throws on a PBM/network failure: it records the error on the
+ * singleton and returns `{ ok: false }` so callers (cron, "Sync now") can surface
+ * it without a 500.
+ */
+export async function syncLocationSnapshot(opts?: {
+  updatedBy?: string;
+}): Promise<SyncResult> {
+  const state = await getPinballMapState();
+  const locationId = state?.locationId ?? APC_LOCATION_ID;
+  const syncedAt = new Date();
+
+  try {
+    const snapshot = await getPinballMapClient().fetchLocation(locationId);
+    await db
+      .insert(pinballmapState)
+      .values({
+        id: SINGLETON_ID,
+        locationId,
+        snapshotJson: snapshot,
+        lastSyncedAt: syncedAt,
+        lastSyncStatus: "ok",
+        lastSyncError: null,
+        updatedAt: syncedAt,
+        ...(opts?.updatedBy ? { updatedBy: opts.updatedBy } : {}),
+      })
+      .onConflictDoUpdate({
+        target: pinballmapState.id,
+        set: {
+          snapshotJson: snapshot,
+          lastSyncedAt: syncedAt,
+          lastSyncStatus: "ok",
+          lastSyncError: null,
+          updatedAt: syncedAt,
+          ...(opts?.updatedBy ? { updatedBy: opts.updatedBy } : {}),
+        },
+      });
+    return { ok: true, machineCount: snapshot.machineCount, syncedAt };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown sync error";
+    await db
+      .insert(pinballmapState)
+      .values({
+        id: SINGLETON_ID,
+        locationId,
+        lastSyncedAt: syncedAt,
+        lastSyncStatus: "error",
+        lastSyncError: message,
+        updatedAt: syncedAt,
+      })
+      .onConflictDoUpdate({
+        target: pinballmapState.id,
+        set: {
+          lastSyncedAt: syncedAt,
+          lastSyncStatus: "error",
+          lastSyncError: message,
+          updatedAt: syncedAt,
+        },
+      });
+    return { ok: false, error: message };
+  }
+}

--- a/src/lib/pinballmap/state.ts
+++ b/src/lib/pinballmap/state.ts
@@ -4,7 +4,7 @@ import { db } from "~/server/db";
 import { pinballmapState } from "~/server/db/schema";
 import { getPinballMapClient } from "./client";
 import { APC_LOCATION_ID } from "./config";
-import type { PinballmapState } from "~/lib/types/database";
+import type { NewPinballmapState, PinballmapState } from "~/lib/types/database";
 
 /**
  * PinballMap location-snapshot read path (foundation — PP-o355.16).
@@ -38,10 +38,33 @@ export type SyncResult =
   | { ok: false; error: string };
 
 /**
+ * Upsert the singleton, writing the given health fields. `id` is fixed and the
+ * differing fields (snapshot, health, actor) are passed by the caller, so the ok
+ * and error paths can't drift. The `set` reuses the same fields, so a key omitted
+ * by the caller (e.g. `snapshotJson`/`lastSyncedAt` on the error path) is left
+ * untouched on an existing row rather than clobbered.
+ */
+async function upsertState(
+  fields: Omit<NewPinballmapState, "id"> & { locationId: number }
+): Promise<void> {
+  await db
+    .insert(pinballmapState)
+    .values({ id: SINGLETON_ID, ...fields })
+    .onConflictDoUpdate({ target: pinballmapState.id, set: fields });
+}
+
+/**
  * Fetch the configured location's snapshot from PBM and store it whole, updating
  * sync health. Never throws on a PBM/network failure: it records the error on the
  * singleton and returns `{ ok: false }` so callers (cron, "Sync now") can surface
  * it without a 500.
+ *
+ * Does NOT gate on `state.enabled` — this is the pure read-path mechanism and the
+ * caller owns the "should we sync at all" decision (the PP-o355.11 cron checks
+ * `enabled`/connection before calling; CORE-PBM-001). `lastSyncedAt` means "last
+ * SUCCESSFUL sync" and is only written on the ok path, so downstream freshness
+ * math (`now - lastSyncedAt`, PP-o355.11 status card) isn't fooled by a failed
+ * attempt over a stale snapshot — read `lastSyncStatus` for attempt outcome.
  */
 export async function syncLocationSnapshot(opts?: {
   updatedBy?: string;
@@ -49,54 +72,31 @@ export async function syncLocationSnapshot(opts?: {
   const state = await getPinballMapState();
   const locationId = state?.locationId ?? APC_LOCATION_ID;
   const syncedAt = new Date();
+  const actor = opts?.updatedBy ? { updatedBy: opts.updatedBy } : {};
 
   try {
     const snapshot = await getPinballMapClient().fetchLocation(locationId);
-    await db
-      .insert(pinballmapState)
-      .values({
-        id: SINGLETON_ID,
-        locationId,
-        snapshotJson: snapshot,
-        lastSyncedAt: syncedAt,
-        lastSyncStatus: "ok",
-        lastSyncError: null,
-        updatedAt: syncedAt,
-        ...(opts?.updatedBy ? { updatedBy: opts.updatedBy } : {}),
-      })
-      .onConflictDoUpdate({
-        target: pinballmapState.id,
-        set: {
-          snapshotJson: snapshot,
-          lastSyncedAt: syncedAt,
-          lastSyncStatus: "ok",
-          lastSyncError: null,
-          updatedAt: syncedAt,
-          ...(opts?.updatedBy ? { updatedBy: opts.updatedBy } : {}),
-        },
-      });
+    await upsertState({
+      locationId,
+      snapshotJson: snapshot,
+      lastSyncedAt: syncedAt,
+      lastSyncStatus: "ok",
+      lastSyncError: null,
+      updatedAt: syncedAt,
+      ...actor,
+    });
     return { ok: true, machineCount: snapshot.machineCount, syncedAt };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown sync error";
-    await db
-      .insert(pinballmapState)
-      .values({
-        id: SINGLETON_ID,
-        locationId,
-        lastSyncedAt: syncedAt,
-        lastSyncStatus: "error",
-        lastSyncError: message,
-        updatedAt: syncedAt,
-      })
-      .onConflictDoUpdate({
-        target: pinballmapState.id,
-        set: {
-          lastSyncedAt: syncedAt,
-          lastSyncStatus: "error",
-          lastSyncError: message,
-          updatedAt: syncedAt,
-        },
-      });
+    // Note: no `lastSyncedAt` here — a failed attempt must not advance the
+    // last-successful-sync clock. `updatedAt` still records that we wrote.
+    await upsertState({
+      locationId,
+      lastSyncStatus: "error",
+      lastSyncError: message,
+      updatedAt: syncedAt,
+      ...actor,
+    });
     return { ok: false, error: message };
   }
 }

--- a/src/lib/pinballmap/types.ts
+++ b/src/lib/pinballmap/types.ts
@@ -22,8 +22,10 @@ export interface PbmCondition {
 
 /**
  * A location_machine_xref — "this machine at this location". The `id` (lmx id)
- * is ephemeral: removing and re-adding a machine mints a new one, so it is
- * resolved from the latest snapshot at action time and never cached.
+ * is the durable listing handle: we capture it when a machine is listed and
+ * STORE it on `machines.pinballmap_lmx_id`, healing it from the latest snapshot
+ * when PBM re-mints one (removing + re-adding a machine changes the id). We do
+ * not re-resolve it per push — see the store-and-heal model (PP-o355.16 / .12).
  *
  * Note: PBM's location payload carries only `machineId` here, not the machine
  * name — names come from the catalog mirror (bead B).

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -17,6 +17,7 @@ import type {
   issueWatchers,
   issueImages,
   pinballmapCatalog,
+  pinballmapState,
 } from "~/server/db/schema";
 
 // Enum types for type safety (import/define before using in Issue type)
@@ -68,3 +69,7 @@ export type PinballmapCatalogEntry = InferSelectModel<typeof pinballmapCatalog>;
 export type NewPinballmapCatalogEntry = InferInsertModel<
   typeof pinballmapCatalog
 >;
+
+// PinballMap integration state singleton (PP-o355.16)
+export type PinballmapState = InferSelectModel<typeof pinballmapState>;
+export type NewPinballmapState = InferInsertModel<typeof pinballmapState>;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -23,6 +23,7 @@ import { type MachineTimelineEventData } from "~/lib/timeline/machine-event-type
 import { type TimelineEventSourceType } from "~/lib/timeline/machine-events";
 import { type TimelineTag } from "~/lib/timeline/machine-tags";
 import { type SettingsSection } from "~/lib/machines/settings-types";
+import type { LocationSnapshot } from "~/lib/pinballmap/types";
 
 /**
  * ⚠️ IMPORTANT: When adding new tables to this schema file,
@@ -180,6 +181,11 @@ export const machines = pgTable(
     // the CHECK below. Reconciling this against PBM's actual snapshot is a later
     // feature (inbound sync); pushing the change to PBM is bead E (outbound).
     pinballmapListed: boolean("pinballmap_listed").notNull().default(false),
+    // Durable captured PBM listing handle (the location_machine_xref id). We
+    // STORE AND HEAL this rather than re-resolving it per push (PP-o355.16 /
+    // .12). Nullable: only set once a machine is actually listed on PBM. An lmx
+    // implies both a catalog link and pinballmap_listed (CHECKs below).
+    pinballmapLmxId: integer("pinballmap_lmx_id"),
     manufacturer: text("manufacturer"),
     year: integer("year"),
     opdbId: text("opdb_id"),
@@ -202,6 +208,22 @@ export const machines = pgTable(
       "machines_pinballmap_listed_requires_link",
       sql`NOT (pinballmap_listed AND pinballmap_machine_id IS NULL)`
     ),
+    // An lmx handle presupposes a catalog link.
+    pinballmapLmxRequiresLinkCheck: check(
+      "machines_pinballmap_lmx_requires_link",
+      sql`NOT (pinballmap_lmx_id IS NOT NULL AND pinballmap_machine_id IS NULL)`
+    ),
+    // An lmx handle presupposes we consider the machine listed.
+    pinballmapLmxRequiresListedCheck: check(
+      "machines_pinballmap_lmx_requires_listed",
+      sql`NOT (pinballmap_lmx_id IS NOT NULL AND NOT pinballmap_listed)`
+    ),
+    // One PBM lister per catalog title at our location — duplicate cabinets of
+    // the same title share one PBM lmx (PbmApiAudit finding #1). Partial: only
+    // listed rows participate.
+    pinballmapListedUnique: uniqueIndex("machines_pinballmap_listed_unique")
+      .on(t.pinballmapMachineId)
+      .where(sql`pinballmap_listed`),
     ownerIdIdx: index("idx_machines_owner_id").on(t.ownerId),
     invitedOwnerIdIdx: index("idx_machines_invited_owner_id").on(
       t.invitedOwnerId
@@ -1003,6 +1025,49 @@ export const discordIntegrationConfig = pgTable(
     healthStatusCheck: check(
       "discord_integration_config_health_check",
       sql`bot_health_status IN ('unknown', 'healthy', 'degraded')`
+    ),
+  })
+);
+
+/**
+ * PinballMap integration state (singleton).
+ *
+ * Exactly one row (id = 'singleton'), enforced by a CHECK constraint. Holds the
+ * whole last-fetched location snapshot (`snapshotJson`) plus sync health, so every
+ * downstream surface reads the stored snapshot rather than hitting PBM per request
+ * (PBM's "one call per hour" conduct, CORE-PBM-001). Outbound creds (email + vault
+ * token id) are written by the connect flow (PP-o355.12). Shared foundation for
+ * PP-o355.11 (cron sync) and PP-o355.12 (list/unlist) — PP-o355.16.
+ *
+ * `outboundTokenVaultId` references `vault.secrets.id` and `updatedBy` references
+ * `auth.users.id` — no FK (Drizzle cannot express cross-schema references).
+ */
+export const pinballmapState = pgTable(
+  "pinballmap_state",
+  {
+    id: text("id").primaryKey().default("singleton"),
+    enabled: boolean("enabled").notNull().default(false),
+    locationId: integer("location_id").notNull().default(26454),
+    snapshotJson: jsonb("snapshot_json").$type<LocationSnapshot>(),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    lastSyncStatus: text("last_sync_status", {
+      enum: ["unknown", "ok", "error"],
+    })
+      .notNull()
+      .default("unknown"),
+    lastSyncError: text("last_sync_error"),
+    outboundEmail: text("outbound_email"),
+    outboundTokenVaultId: uuid("outbound_token_vault_id"),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedBy: uuid("updated_by"),
+  },
+  (_t) => ({
+    singletonCheck: check("pinballmap_state_singleton", sql`id = 'singleton'`),
+    syncStatusCheck: check(
+      "pinballmap_state_sync_status_check",
+      sql`last_sync_status IN ('unknown', 'ok', 'error')`
     ),
   })
 );

--- a/src/test/integration/pinballmap-state.test.ts
+++ b/src/test/integration/pinballmap-state.test.ts
@@ -72,4 +72,34 @@ describe("PinballMap shared read path (PGlite)", () => {
     expect(state?.lastSyncError).toBe("PBM unreachable");
     spy.mockRestore();
   });
+
+  it("a failed sync after a success preserves lastSyncedAt and the snapshot", async () => {
+    const { getMockClient } = await import("~/lib/pinballmap/client-mock");
+    const { syncLocationSnapshot, getPinballMapState } =
+      await import("~/lib/pinballmap/state");
+
+    // Establish a good sync, then fail the next fetch.
+    await syncLocationSnapshot();
+    const afterOk = await getPinballMapState();
+    expect(afterOk?.lastSyncStatus).toBe("ok");
+
+    const spy = vi
+      .spyOn(getMockClient(), "fetchLocation")
+      .mockRejectedValueOnce(new Error("PBM down"));
+    await syncLocationSnapshot();
+
+    const afterErr = await getPinballMapState();
+    // lastSyncedAt = "last SUCCESSFUL sync" — unchanged by the failed attempt.
+    expect(afterErr?.lastSyncedAt?.getTime()).toBe(
+      afterOk?.lastSyncedAt?.getTime()
+    );
+    // The stale-but-good snapshot is kept, not clobbered.
+    expect(afterErr?.snapshotJson?.locationId).toBe(
+      afterOk?.snapshotJson?.locationId
+    );
+    // Health reflects the failure.
+    expect(afterErr?.lastSyncStatus).toBe("error");
+    expect(afterErr?.lastSyncError).toBe("PBM down");
+    spy.mockRestore();
+  });
 });

--- a/src/test/integration/pinballmap-state.test.ts
+++ b/src/test/integration/pinballmap-state.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Integration Test: PinballMap shared read path (PP-o355.16)
+ *
+ * Covers the foundation read path against PGlite:
+ *  - syncLocationSnapshot(): stores the whole snapshot on the singleton, sets
+ *    sync health (ok/error), upserts (one row), records the error path
+ *  - getPinballMapState(): reads the singleton
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import { pinballmapState } from "~/server/db/schema";
+
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+// Pin the PinballMap client to the in-memory mock at the seam (CORE-TEST-006),
+// so the sync can never reach pinballmap.com regardless of PINBALLMAP_MODE.
+vi.mock("~/lib/pinballmap/client", async () => {
+  const { getMockClient } = await import("~/lib/pinballmap/client-mock");
+  return { getPinballMapClient: () => getMockClient() };
+});
+
+describe("PinballMap shared read path (PGlite)", () => {
+  setupTestDb();
+
+  it("syncLocationSnapshot stores the snapshot and marks health ok", async () => {
+    const { syncLocationSnapshot, getPinballMapState } =
+      await import("~/lib/pinballmap/state");
+
+    const result = await syncLocationSnapshot();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.machineCount).toBeGreaterThan(0);
+
+    const state = await getPinballMapState();
+    expect(state).not.toBeNull();
+    expect(state?.lastSyncStatus).toBe("ok");
+    expect(state?.lastSyncError).toBeNull();
+    expect(state?.lastSyncedAt).toBeInstanceOf(Date);
+    // The whole LocationSnapshot is stored as JSON.
+    expect(state?.snapshotJson?.locationId).toBe(state?.locationId);
+    expect(state?.snapshotJson?.lmxes.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("is a singleton — a second sync updates the same row", async () => {
+    const db = await getTestDb();
+    const { syncLocationSnapshot } = await import("~/lib/pinballmap/state");
+
+    await syncLocationSnapshot();
+    await syncLocationSnapshot();
+
+    const rows = await db.select().from(pinballmapState);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.id).toBe("singleton");
+  });
+
+  it("records the error path without throwing when the fetch fails", async () => {
+    const { getMockClient } = await import("~/lib/pinballmap/client-mock");
+    const { syncLocationSnapshot, getPinballMapState } =
+      await import("~/lib/pinballmap/state");
+    const spy = vi
+      .spyOn(getMockClient(), "fetchLocation")
+      .mockRejectedValueOnce(new Error("PBM unreachable"));
+
+    const result = await syncLocationSnapshot();
+    expect(result).toEqual({ ok: false, error: "PBM unreachable" });
+
+    const state = await getPinballMapState();
+    expect(state?.lastSyncStatus).toBe("error");
+    expect(state?.lastSyncError).toBe("PBM unreachable");
+    spy.mockRestore();
+  });
+});

--- a/src/test/unit/components/machines/MachineDetailHeader.test.tsx
+++ b/src/test/unit/components/machines/MachineDetailHeader.test.tsx
@@ -30,6 +30,7 @@ function makeMachine(
     pinballmapExcluded: false,
     pinballmapExcludedReason: null,
     pinballmapListed: false,
+    pinballmapLmxId: null,
     opdbId: null,
     ipdbId: null,
     issues: [],


### PR DESCRIPTION
## What

Shared DB + read-path foundation both **PP-o355.11** (inbound cron sync) and **PP-o355.12** (outbound list/unlist) build on. Landing it first, as its own PR, lets those two proceed **in parallel adding zero schema** — no migration collision.

Ports the `pinballmap_state` singleton + `syncLocationSnapshot` from the unmerged reference commit `b6eb7dca`, **drops** all cron/status/action/UI, and **adds** net-new store-and-heal lmx columns that `b6eb7dca` didn't have.

## Changes

- **Migration 0052** (fresh — chain was at 0051; never re-applies `b6eb7dca`'s 0046):
  - `pinballmap_state` singleton table (id-singleton CHECK, `snapshot_json` jsonb typed `LocationSnapshot`, sync health `unknown|ok|error` CHECK, outbound creds refs, mirrors the `discord_integration_config` pattern).
  - `machines.pinballmap_lmx_id` (nullable) — the durable captured PBM listing handle.
  - Two machines CHECKs: lmx ⇒ catalog link; lmx ⇒ `pinballmap_listed`.
  - Partial `UNIQUE(pinballmap_machine_id) WHERE pinballmap_listed` — one PBM lister per catalog title (PbmApiAudit finding #1).
- **`src/lib/pinballmap/state.ts`** — `getPinballMapState()` + `syncLocationSnapshot()`. Fetch runs **outside any transaction** (CORE-ARCH-011); never throws on PBM failure (records health, returns `{ ok: false }`).
- **Type export** `PinballmapState` / `NewPinballmapState`.
- **Comment fix** in `types.ts` — the stale "ephemeral lmx, never cache" `PbmLmx` doc contradicted the locked store-and-heal model; rewritten.
- **Integration test** (PGlite) — upsert + persist + error path, PBM pinned to the mock at the seam (CORE-TEST-006).

## Explicitly out (→ other beads)

- **PP-o355.11:** cron route, hourly schedule, `status.ts` derivation, desync UI.
- **PP-o355.12:** `pinballmap.sync` permission, "Sync now" action, vault token write, connect/link/list/unlist actions, form UI.
- **PP-h059:** backfilling existing machines' lmx from the snapshot.

## Testing

- `pnpm run preflight:unlocked` — typecheck, lint, unit, build, and **both integration suites (PGlite + Supabase) green**.
- Local E2E `smoke` hit the known fresh-worktree degraded-auth-stack issue (`auth.setup` can't log in — documented 2026-07-13, not a code regression; this PR touches no auth/middleware/UI). CI runs the authoritative E2E.

Spec: `docs/superpowers/specs/2026-07-16-pbm-foundation-design.md`
Plan: `docs/superpowers/plans/2026-07-16-pbm-foundation-PP-o355.16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)