### PR TITLE
fix(issues): filter chips to own row on mobile + real overflow detector

### DIFF
--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -449,9 +449,9 @@ trigger: always_on
 **CORE-RESP-004:** Overflow testing required
 
 - **Severity:** High
-- **Why:** Horizontal overflow is invisible to Playwright visibility assertions but breaks the user experience
-- **Do:** Add route to `e2e/smoke/responsive-overflow.spec.ts` when creating a new page
-- **Don't:** Ship a new page without overflow coverage at both mobile and desktop viewports
+- **Why:** Horizontal overflow is invisible to Playwright visibility assertions but breaks the user experience. It is also invisible to a naive `document.scrollWidth` check, because the app shell clips overflow at `<body>` (`overflow-x: hidden` in `globals.css`) — so `assertNoHorizontalOverflow` walks the DOM for content a non-scrollable ancestor clips off-screen instead. Overflow bugs live in the **loaded, filled state** (long names, many chips/badges, active filters), not the empty default a page lands on — an empty-state visit passes while the real state is broken.
+- **Do:** Add every new top-level route to `e2e/smoke/responsive-overflow.spec.ts`, and exercise it in its **loaded state** — pre-apply filters/params so lists, chip rows, and badges actually render (see the `filterHeavyQuery` variants). Both mobile (375px) and desktop viewports run via the project matrix.
+- **Don't:** Ship a new page without overflow coverage, or cover it only in its empty state. Don't "fix" an overflow by adding `overflow-x: hidden` to hide the symptom — that clips content off-screen where the user can't reach it.
 
 ---
 

--- a/e2e/smoke/responsive-overflow.spec.ts
+++ b/e2e/smoke/responsive-overflow.spec.ts
@@ -23,9 +23,28 @@ import { getProfileIdByEmail } from "../support/supabase-admin.js";
 const machineInitials = seededMachines.addamsFamily.initials;
 const issueNum = seededIssue("TAF").num;
 
+// Filter-heavy query for surfaces that render <IssueFilters>. Overflow bugs
+// live in the loaded, many-chips state — not the empty default — so exercise a
+// route variant where a wide set of active-filter chips is rendered. This is
+// what surfaces content bleeding off the viewport (see PP collections chip
+// overflow: chips previously overlaid the search input and spilled off-screen
+// on narrow viewports once several filters were active).
+// Deliberately heavy: partial selections from each status group (so they render
+// as individual chips rather than collapsing to a single group chip) plus every
+// severity, priority, and frequency value. This produces ~19 chips — enough that
+// a non-wrapping chip row would overrun a 375px viewport, which is exactly the
+// regression this guards against.
+const filterHeavyQuery =
+  `?status=new,in_progress,need_parts,need_help,fixed,wont_fix,wai,no_repro` +
+  `&severity=cosmetic,minor,major,unplayable` +
+  `&priority=low,medium,high` +
+  `&frequency=intermittent,frequent,constant` +
+  `&machine=${machineInitials}`;
+
 const authenticatedRoutes = [
   "/dashboard",
   "/issues",
+  `/issues${filterHeavyQuery}`,
   "/m",
   `/m/${machineInitials}`,
   `/m/${machineInitials}/settings`,
@@ -69,6 +88,16 @@ test.describe("Responsive: no horizontal overflow", () => {
           await assertNoA11yViolations(page);
         });
       }
+
+      // Loaded state: the collection Issues tab with a wide set of active
+      // filters renders the full chip row — the surface where the chip overflow
+      // was originally reported.
+      test(`/c/owner/[member]/issues (filters active)`, async ({ page }) => {
+        await page.goto(`${collectionBase}/issues${filterHeavyQuery}`);
+        await page.waitForLoadState("load");
+        await assertNoHorizontalOverflow(page);
+        await assertNoA11yViolations(page);
+      });
     });
   });
 

--- a/e2e/support/actions.ts
+++ b/e2e/support/actions.ts
@@ -355,15 +355,118 @@ export async function updateIssueField(
  * the overflow amount and viewport width.
  */
 export async function assertNoHorizontalOverflow(page: Page): Promise<void> {
-  const result = await page.evaluate(() => ({
-    scrollWidth: document.documentElement.scrollWidth,
-    clientWidth: document.documentElement.clientWidth,
-  }));
+  const result = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const viewportWidth = doc.clientWidth;
+
+    // How far past a viewport edge an element must extend before we treat it as
+    // a layout break rather than acceptable graceful clipping. Components that
+    // deliberately clip a few px of trailing content (e.g. a right-pinned
+    // timestamp in a density-managed row that already truncates its main text)
+    // are working as designed; a chip row or card spilling tens/hundreds of px
+    // off-screen is not. 32px ≈ more than a stray sub-pixel or a clipped
+    // character — a whole word/control has been pushed out of view.
+    const OVERFLOW_LIMIT = 32;
+
+    const overflowsViewport = (rect: DOMRect): boolean =>
+      rect.left < -OVERFLOW_LIMIT ||
+      rect.right > viewportWidth + OVERFLOW_LIMIT;
+
+    // Classify how an ancestor constrains horizontal overflow:
+    //   "scroll" — user can scroll to reveal it (not a visual break)
+    //   "clip"   — content is clipped and unreachable (a real break)
+    //   "visible" — no constraint
+    const clipKindX = (el: Element): "scroll" | "clip" | "visible" => {
+      const ox = getComputedStyle(el).overflowX;
+      if (ox === "auto" || ox === "scroll") return "scroll";
+      if (ox === "hidden" || ox === "clip") return "clip";
+      return "visible";
+    };
+
+    // Nearest ancestor that constrains this element horizontally. Why this
+    // matters: PinPoint's app shell sets `overflow-x: hidden` on <html>/<body>
+    // (globals.css) plus an `overflow-hidden` content wrapper (layout.tsx), so
+    // any horizontal overrun is silently CLIPPED rather than widening the
+    // document. That defeats a plain `document.scrollWidth <= clientWidth`
+    // check — it can never fail. Here we instead detect content that a
+    // NON-scrollable ancestor clips off-screen (hidden from the user), while
+    // treating real scroll containers (carousels, tab strips) as fine.
+    const nearestClipperX = (el: Element): "scroll" | "clip" | "none" => {
+      let node = el.parentElement;
+      while (node) {
+        const k = clipKindX(node);
+        if (k !== "visible") return k;
+        node = node.parentElement;
+      }
+      return "none";
+    };
+
+    const describe = (el: Element, rect: DOMRect): string => {
+      const tag = el.tagName.toLowerCase();
+      const id = el.id ? `#${el.id}` : "";
+      const testid = el.getAttribute("data-testid");
+      const tid = testid ? `[data-testid="${testid}"]` : "";
+      const cls =
+        typeof el.className === "string" && el.className.trim()
+          ? "." + el.className.trim().split(/\s+/).slice(0, 3).join(".")
+          : "";
+      const side =
+        rect.left < 0
+          ? `left edge (left=${Math.round(rect.left)}px)`
+          : `right edge (right=${Math.round(rect.right)}px > ${viewportWidth}px)`;
+      return `${tag}${id}${tid}${cls} — clipped past the ${side}`;
+    };
+
+    const offenders: string[] = [];
+    for (const el of Array.from(document.body.querySelectorAll("*"))) {
+      if (
+        typeof el.checkVisibility === "function" &&
+        !el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true })
+      ) {
+        continue;
+      }
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+      if (!overflowsViewport(rect)) continue;
+
+      // Report only the boundary element — the one whose parent stays within
+      // the viewport — so we surface the source of the overrun instead of every
+      // descendant dragged off-screen with it.
+      const parent = el.parentElement;
+      if (parent && overflowsViewport(parent.getBoundingClientRect())) continue;
+
+      // Reachable by scrolling => not a visual break.
+      if (nearestClipperX(el) === "scroll") continue;
+
+      offenders.push(describe(el, rect));
+      if (offenders.length >= 10) break;
+    }
+
+    return {
+      scrollWidth: doc.scrollWidth,
+      clientWidth: viewportWidth,
+      offenders,
+    };
+  });
+
+  // Kept as a cheap belt-and-suspenders for any surface rendered outside the
+  // overflow-hidden app shell. Note: under the shell this can never fail (the
+  // shell clips the document), which is exactly why the element walk below
+  // exists.
   expect(
     result.scrollWidth,
     `Horizontal overflow detected: content is ${result.scrollWidth}px wide ` +
       `but viewport is only ${result.clientWidth}px (${result.scrollWidth - result.clientWidth}px overflow)`
   ).toBeLessThanOrEqual(result.clientWidth);
+
+  expect(
+    result.offenders,
+    `Visible element(s) are clipped off-screen by a non-scrollable ancestor — ` +
+      `content the user cannot see or reach. This is the mobile-overflow class ` +
+      `that document.scrollWidth misses because the app shell clips overflow at ` +
+      `<body>. Offenders (boundary element of each overrun):\n` +
+      result.offenders.map((o) => `  • ${o}`).join("\n")
+  ).toEqual([]);
 }
 
 /**

--- a/src/components/issues/IssueFilters.tsx
+++ b/src/components/issues/IssueFilters.tsx
@@ -60,11 +60,12 @@ import {
  *   `~/lib/issues/filter-utils`.
  * - Search input is debounced at 300ms before pushing to URL params
  *
- * ## Mobile Notes
- * Desktop uses this component directly. Mobile will use a separate chip-based
- * filter bar that imports the shared utilities from `~/lib/issues/filter-utils`
- * for badge grouping and filter state management; those utilities are not
- * consumed by this component today.
+ * ## Active-filter chips
+ * Selected filters render as removable chips on their own wrapping row below
+ * the search input (`flex-wrap`), at every viewport. Each chip's remove (✕)
+ * button is always visible so it works on touch, where there is no hover.
+ * (Chips were previously overlaid on the right edge of the search input, which
+ * spilled off-screen on narrow viewports once several filters were active.)
  */
 interface MachineOption {
   initials: string;
@@ -105,7 +106,6 @@ export function IssueFilters({
   const [search, setSearch] = React.useState(filters.q ?? "");
   const [expanded, setExpanded] = React.useState(false);
 
-  const searchBarRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const machineOptions = React.useMemo(
@@ -470,68 +470,34 @@ export function IssueFilters({
           }}
         >
           <div
-            ref={searchBarRef}
             className={cn(
-              "flex items-center gap-2 px-3 h-11 bg-background border rounded-md transition-colors duration-150 shadow-sm ring-offset-background flex-1 relative focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+              "flex items-center gap-2 px-3 h-11 bg-background border rounded-md transition-colors duration-150 shadow-sm ring-offset-background flex-1 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
               isSearching && "opacity-70 grayscale-[0.3]"
             )}
           >
             <Search className="h-4 w-4 text-muted-foreground shrink-0" />
-            <div className="flex-1 min-w-0 relative h-full flex items-center">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <input
-                    ref={inputRef}
-                    placeholder="Search issues..."
-                    data-testid="issue-search"
-                    className="flex-1 bg-transparent border-0 text-sm focus:outline-none placeholder:text-muted-foreground relative z-10 w-full"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                  />
-                </TooltipTrigger>
-                <TooltipContent
-                  side="bottom"
-                  align="start"
-                  className="max-w-[300px] p-3"
-                >
-                  <p className="text-xs leading-relaxed text-muted-foreground">
-                    Search across titles, descriptions, IDs (e.g., AFM-101),
-                    machine names, assignees, reporters, and comments.
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-
-              <div
-                data-testid="filter-bar"
-                className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1.5 z-20 pointer-events-none"
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <input
+                  ref={inputRef}
+                  placeholder="Search issues..."
+                  data-testid="issue-search"
+                  className="flex-1 min-w-0 w-full bg-transparent border-0 text-sm focus:outline-none placeholder:text-muted-foreground"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                align="start"
+                className="max-w-[300px] p-3"
               >
-                {visibleBadges.map((badge) => (
-                  <Badge
-                    key={badge.id}
-                    data-testid="filter-badge"
-                    className={cn(
-                      "flex items-center gap-1 px-2 py-0.5 whitespace-nowrap rounded-sm text-[10px] font-medium leading-none h-6 bg-secondary/50 border-secondary/30 text-foreground group/badge max-w-[120px] pointer-events-auto",
-                      badge.iconColor
-                    )}
-                  >
-                    {badge.icon && (
-                      <badge.icon
-                        className={cn("h-3 w-3 shrink-0", badge.iconColor)}
-                      />
-                    )}
-                    <span className="truncate">{badge.label}</span>
-                    <button
-                      type="button"
-                      className="opacity-0 group-hover/badge:opacity-100 p-0.5 hover:bg-secondary rounded-full transition-opacity duration-150 ml-0.5"
-                      onClick={() => badge.clear()}
-                      aria-label={`Clear ${badge.label}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </Badge>
-                ))}
-              </div>
-            </div>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Search across titles, descriptions, IDs (e.g., AFM-101),
+                  machine names, assignees, reporters, and comments.
+                </p>
+              </TooltipContent>
+            </Tooltip>
           </div>
 
           {(badgeList.length > 0 || search) && (
@@ -567,6 +533,38 @@ export function IssueFilters({
             </Button>
           )}
         </form>
+
+        {visibleBadges.length > 0 && (
+          <div
+            data-testid="filter-bar"
+            className="mt-2 flex flex-wrap items-center gap-1.5"
+          >
+            {visibleBadges.map((badge) => (
+              <Badge
+                key={badge.id}
+                data-testid="filter-badge"
+                className="flex items-center gap-1 px-2 py-0.5 rounded-sm text-xs font-medium leading-none h-7 bg-secondary/50 border-secondary/30 text-foreground max-w-[200px]"
+              >
+                {/* Accent color lives on the icon only — tinting the label text
+                    fails WCAG contrast on the secondary chip background. */}
+                {badge.icon && (
+                  <badge.icon
+                    className={cn("h-3 w-3 shrink-0", badge.iconColor)}
+                  />
+                )}
+                <span className="truncate">{badge.label}</span>
+                <button
+                  type="button"
+                  className="shrink-0 -mr-1 ml-0.5 p-0.5 rounded-full hover:bg-secondary transition-colors"
+                  onClick={() => badge.clear()}
+                  aria-label={`Clear ${badge.label}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="p-3">


### PR DESCRIPTION
## Summary

- **Bug fix:** active-filter chips were absolutely positioned over the search input and spilled off-screen on narrow viewports. Moved onto their own `flex-wrap` row below the input at all viewports, with an always-visible remove (✕) button (was hover-only → unusable on touch). Reported by Tim on a collection issues page.
- **Latent a11y fix:** chip labels used the severity/priority accent color as text over the chip background (WCAG contrast fail, e.g. light-purple "High"). Accent now lives on the icon only; label is neutral `text-foreground`. Surfaced by rendering active chips through axe for the first time.
- **Overflow detector rewritten:** the old `document.scrollWidth` check was vacuous — the app shell clips at `<body>` (`overflow-x:hidden`), so the document can never exceed the viewport. It now walks the DOM for visible content a non-scrollable ancestor clips off-screen (32px threshold). Added filters-active route variants to `responsive-overflow.spec.ts` (empty-state routes never rendered chips) and strengthened **CORE-RESP-004** to require loaded-state coverage.

## Test Plan

- [ ] CI green (full E2E suite — this is the clean run the local box couldn't produce under memory pressure)
- [ ] `responsive-overflow.spec.ts` exercises the filters-active state and passes
- [ ] Chips render below the search input, wrap, and the ✕ is tappable on mobile widths

## Related Issues

PP-e6ky. Follow-up filed: PP-bu9e (pre-existing timeline timestamp clip).