### PR TITLE
fix(report): resolve 5 code-review findings on tabbed report (PP-2m17)

### DIFF
--- a/src/app/(app)/report/(tabbed)/layout.tsx
+++ b/src/app/(app)/report/(tabbed)/layout.tsx
@@ -1,13 +1,14 @@
 import type React from "react";
-import { asc, eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "~/server/db";
-import { machines, userProfiles } from "~/server/db/schema";
+import { userProfiles } from "~/server/db/schema";
 import { createClient } from "~/lib/supabase/server";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 import { PageContainer } from "~/components/layout/PageContainer";
 import { PageHeader } from "~/components/layout/PageHeader";
 import { ReportDraftProvider } from "../report-draft-store";
 import { ReportTabs } from "../report-tabs";
+import { getReportMachines, getReportAssignees } from "../report-data";
 
 // Avoid SSG hitting Supabase during builds that run parallel to db resets, and
 // keep the report Server Actions bounded so a slow submit fails fast (PP-2053.1).
@@ -27,10 +28,7 @@ export default async function ReportLayout({
 }: {
   children: React.ReactNode;
 }): Promise<React.JSX.Element> {
-  const machinesListPromise = db.query.machines.findMany({
-    orderBy: asc(machines.name),
-    columns: { id: true, name: true, initials: true },
-  });
+  const machinesListPromise = getReportMachines();
 
   const supabase = await createClient();
   const {
@@ -48,18 +46,10 @@ export default async function ReportLayout({
   const accessLevel = getAccessLevel(userProfile?.role);
   const canQuick = checkPermission("issues.report.quick", accessLevel);
 
-  // Superset of both former per-page assignee queries: technician+ can be a
-  // grid assignee, admin/member are the single-form assignees. Fetched only for
-  // signed-in staff; anonymous reporters never see the assignee control.
-  let assignees: { id: string; name: string | null }[] = [];
-  if (accessLevel === "admin" || accessLevel === "member") {
-    assignees = await db.query.userProfiles.findMany({
-      where: (profile) =>
-        sql`${profile.role} = 'admin' OR ${profile.role} = 'member' OR ${profile.role} = 'technician'`,
-      columns: { id: true, name: true },
-      orderBy: asc(userProfiles.name),
-    });
-  }
+  // Assignees for whoever can assign (matrix-gated — includes technicians, who
+  // the old hand-rolled admin/member check dropped). Deduped with page.tsx's
+  // call via React cache(); anonymous reporters get [] and no assignee control.
+  const assignees = await getReportAssignees(accessLevel);
 
   const machinesList = await machinesListPromise;
   const machineOptions = machinesList.map((m) => ({

--- a/src/app/(app)/report/(tabbed)/page.tsx
+++ b/src/app/(app)/report/(tabbed)/page.tsx
@@ -1,12 +1,13 @@
 import type React from "react";
-import { asc, eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "~/server/db";
-import { machines, userProfiles } from "~/server/db/schema";
+import { userProfiles } from "~/server/db/schema";
 import { resolveDefaultMachineId } from "../default-machine";
 import { UnifiedReportForm } from "../unified-report-form";
 import { createClient } from "~/lib/supabase/server";
 import { getAccessLevel } from "~/lib/permissions/helpers";
 import { getRecentIssuesAction, type RecentIssueData } from "../actions";
+import { getReportMachines, getReportAssignees } from "../report-data";
 
 // Avoid SSG hitting Supabase during builds that run parallel to db resets
 export const dynamic = "force-dynamic";
@@ -28,10 +29,10 @@ export default async function PublicReportPage({
     source?: string;
   }>;
 }): Promise<React.JSX.Element> {
-  const machinesListPromise = db.query.machines.findMany({
-    orderBy: asc(machines.name),
-    columns: { id: true, name: true, initials: true },
-  });
+  // Machines + assignees come from the shared request-deduped loaders (also
+  // called by the layout), so /report doesn't fetch them twice. Assignees are
+  // matrix-gated inside the loader (technicians included). (PP-2m17 #1/#3)
+  const machinesListPromise = getReportMachines();
 
   // Auth context for the form
   const supabase = await createClient();
@@ -40,7 +41,6 @@ export default async function PublicReportPage({
   } = await supabase.auth.getUser();
 
   let userProfile;
-  let assignees: { id: string; name: string | null }[] = [];
   if (user) {
     userProfile = await db.query.userProfiles.findFirst({
       where: eq(userProfiles.id, user.id),
@@ -49,17 +49,9 @@ export default async function PublicReportPage({
   }
 
   const accessLevel = getAccessLevel(userProfile?.role);
+  const assignees = await getReportAssignees(accessLevel);
 
-  if (accessLevel === "admin" || accessLevel === "member") {
-    assignees = await db.query.userProfiles.findMany({
-      where: (profile) =>
-        sql`${profile.role} = 'admin' OR ${profile.role} = 'member'`,
-      columns: { id: true, name: true },
-      orderBy: asc(userProfiles.name),
-    });
-  }
-
-  const [machinesList] = await Promise.all([machinesListPromise]);
+  const machinesList = await machinesListPromise;
 
   const params = await searchParams;
   const errorMessage = params.error

--- a/src/app/(app)/report/report-data.ts
+++ b/src/app/(app)/report/report-data.ts
@@ -1,0 +1,49 @@
+import "server-only";
+import { cache } from "react";
+import { asc, sql } from "drizzle-orm";
+import { db } from "~/server/db";
+import { machines, userProfiles } from "~/server/db/schema";
+import { checkPermission } from "~/lib/permissions/helpers";
+import type { AccessLevel } from "~/lib/permissions/matrix";
+
+/**
+ * Shared, request-deduped data loaders for the tabbed report page (PP-idrb).
+ *
+ * `report/(tabbed)/layout.tsx` (which hydrates the ReportDraftProvider) and
+ * `report/(tabbed)/page.tsx` (the Single form, which also needs machines
+ * server-side to resolve `?machine=` + prefetch recent issues) both need this
+ * data. Wrapping the queries in React `cache()` collapses the layout's call and
+ * the page's call for the same request into a single DB round-trip each, so
+ * `/report` no longer fetches machines + assignees twice (PP-2m17 #3).
+ */
+
+/** All machines, id/name/initials, ordered by name. */
+export const getReportMachines = cache(async () =>
+  db.query.machines.findMany({
+    orderBy: asc(machines.name),
+    columns: { id: true, name: true, initials: true },
+  })
+);
+
+/**
+ * Assignable users for the report forms, or `[]` when the viewer can't assign.
+ *
+ * Gated on the `issues.report.assignee` matrix permission rather than a
+ * hand-rolled role list — the previous `accessLevel === "admin" || "member"`
+ * check silently excluded technicians, who DO hold that permission, so a
+ * technician saw an empty assignee dropdown (PP-2m17 #1, CORE-ARCH-008). The
+ * assignable pool itself is every admin/member/technician.
+ */
+export const getReportAssignees = cache(
+  async (
+    accessLevel: AccessLevel
+  ): Promise<{ id: string; name: string | null }[]> => {
+    if (!checkPermission("issues.report.assignee", accessLevel)) return [];
+    return db.query.userProfiles.findMany({
+      where: (profile) =>
+        sql`${profile.role} = 'admin' OR ${profile.role} = 'member' OR ${profile.role} = 'technician'`,
+      columns: { id: true, name: true },
+      orderBy: asc(userProfiles.name),
+    });
+  }
+);

--- a/src/app/(app)/report/report-tabs.test.tsx
+++ b/src/app/(app)/report/report-tabs.test.tsx
@@ -105,6 +105,9 @@ describe("ReportTabs", () => {
   });
 
   it("disables Single with 2+ content rows and reveals the reason on tap", async () => {
+    // The lock is seen while ON the grid (that's where you build 2+ rows); the
+    // Single tab is the non-active one being blocked.
+    vi.mocked(usePathname).mockReturnValue("/report/quick");
     seedContentRows(2);
     renderTabs(true);
 
@@ -121,5 +124,17 @@ describe("ReportTabs", () => {
         /you're logging several issues — remove the extras to go back to a single report\./i
       )
     ).toBeInTheDocument();
+  });
+
+  it("keeps Single as the active tab (not a greyed lock) when it's the current route", () => {
+    // Reaching /report directly with a multi-row draft: the tab reflects the
+    // current route rather than rendering as a disabled lock (PP-2m17 #5).
+    vi.mocked(usePathname).mockReturnValue("/report");
+    seedContentRows(2);
+    renderTabs(true);
+
+    const single = screen.getByRole("link", { name: /single issue/i });
+    expect(single).toHaveAttribute("aria-current", "page");
+    expect(single).not.toHaveAttribute("aria-disabled");
   });
 });

--- a/src/app/(app)/report/report-tabs.tsx
+++ b/src/app/(app)/report/report-tabs.tsx
@@ -84,9 +84,12 @@ export function ReportTabs({
             const isActive = pathname === href;
             const testIdAttr = `report-tab-${testId}`;
 
-            if (href === SINGLE_HREF && singleLocked) {
+            if (href === SINGLE_HREF && singleLocked && !isActive) {
               // Disabled via aria-disabled (not the `disabled` attribute) so the
-              // control stays focusable/tappable to reveal the reason.
+              // control stays focusable/tappable to reveal the reason. Only when
+              // Single ISN'T the current route: if the user reached /report
+              // directly with a multi-row draft, the tab still shows its active
+              // state rather than a greyed lock (PP-2m17 #5).
               return (
                 <button
                   key={href}

--- a/src/app/(app)/report/success/clear-draft.tsx
+++ b/src/app/(app)/report/success/clear-draft.tsx
@@ -1,20 +1,44 @@
 "use client";
 
 import { useEffect } from "react";
-import { REPORT_DRAFT_KEY, LEGACY_DRAFT_KEY } from "../report-draft-schema";
+import {
+  parseDraft,
+  serializeDraft,
+  emptySingle,
+  DRAFT_VERSION,
+  REPORT_DRAFT_KEY,
+  LEGACY_DRAFT_KEY,
+} from "../report-draft-schema";
 
 /**
- * Client component that clears the report draft from localStorage. Mounted on
- * the success page to clear the draft after a successful submission.
+ * Clears the just-submitted single issue from the persisted report draft.
+ * Mounted on the success page because the server action redirects (to
+ * /report/success) before the form's own cleanup effect can run.
  *
- * This is needed because the server action redirects (to /report/success) before
- * the client-side cleanup effect in the form component can run. Clears both the
- * current unified key and the legacy single-form key.
+ * The Single form submits entry #1, so this removes entry #1 (and the reporter
+ * identity) — but PRESERVES any extra unsubmitted grid rows so a batch in
+ * progress survives a single submit (PP-2m17 #2). Only when entry #1 was the
+ * whole draft is the key removed outright. The legacy key is always retired.
  */
 export function ClearReportDraft(): null {
   useEffect(() => {
-    window.localStorage.removeItem(REPORT_DRAFT_KEY);
     window.localStorage.removeItem(LEGACY_DRAFT_KEY);
+
+    const draft = parseDraft(window.localStorage.getItem(REPORT_DRAFT_KEY));
+    if (!draft || draft.entries.length <= 1) {
+      window.localStorage.removeItem(REPORT_DRAFT_KEY);
+      return;
+    }
+
+    // Drop the submitted entry #1; keep the remaining rows, reset identity.
+    window.localStorage.setItem(
+      REPORT_DRAFT_KEY,
+      serializeDraft({
+        version: DRAFT_VERSION,
+        entries: draft.entries.slice(1),
+        single: emptySingle(),
+      })
+    );
   }, []);
 
   return null;

--- a/src/app/(app)/report/unified-report-form.tsx
+++ b/src/app/(app)/report/unified-report-form.tsx
@@ -31,9 +31,10 @@ import { TurnstileWidget } from "~/components/security/TurnstileWidget";
 import { getLoginUrl } from "~/lib/login-url";
 import { RecentIssuesPanelClient } from "~/components/issues/RecentIssuesPanelClient";
 import { RichTextEditor } from "~/components/editor/RichTextEditorDynamic";
+import { docIsEmpty } from "~/lib/tiptap/types";
 import { MachineCombobox } from "~/components/machines/MachineCombobox";
 import { useReportDraft } from "./report-draft-store";
-import { defaultEntry } from "./report-draft-schema";
+import { defaultEntry, emptySingle } from "./report-draft-schema";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -107,8 +108,15 @@ export function UnifiedReportForm({
   // The shared draft is the single source of truth for the synced entry-#1
   // fields + the reporter identity/photos. Persistence + hydration + legacy
   // migration all live in the provider now — the form owns none of it.
-  const { entries, single, patchEntry, patchSingle, clearAll, hydrated } =
-    useReportDraft();
+  const {
+    entries,
+    single,
+    patchEntry,
+    patchSingle,
+    resetEntryZero,
+    clearAll,
+    hydrated,
+  } = useReportDraft();
   const entry = entries[0] ?? FALLBACK_ENTRY;
 
   // CAPTCHA is only required for anonymous reporters. Logged-in users skip it
@@ -181,12 +189,21 @@ export function UnifiedReportForm({
   );
 
   // Reset the single view back to a fresh report: blank entry #1 (fresh
-  // idempotency key), empty reporter identity/photos, cleared draft storage,
-  // remounted rich editor + CAPTCHA. Shared by the success effect and the Clear
-  // dialog. Machine is preserved when it came from the URL (?machine=), matching
-  // the prior behavior — the user came here to report on that specific machine.
+  // idempotency key), empty reporter identity/photos, remounted rich editor +
+  // CAPTCHA. Shared by the success effect and the Clear dialog. Machine is
+  // preserved when it came from the URL (?machine=), matching prior behavior.
+  //
+  // When entry #1 is the whole draft, clear everything (storage included). When
+  // extra unsubmitted grid rows exist, reset ONLY entry #1 + identity so the
+  // batch in progress survives — the Single form owns entry #1, not the whole
+  // batch (PP-2m17 #2).
   const resetSingleForm = useCallback(() => {
-    clearAll();
+    if (entries.length <= 1) {
+      clearAll();
+    } else {
+      resetEntryZero();
+      patchSingle(emptySingle());
+    }
     if (defaultMachineId) patchEntry(0, { machineId: defaultMachineId });
     // Native form reset — clears the honeypot and any browser autofill that
     // bypassed controlled inputs.
@@ -210,7 +227,14 @@ export function UnifiedReportForm({
     setTurnstileToken("");
     setEditorResetKey((k) => k + 1);
     setTurnstileWidgetKey((k) => k + 1);
-  }, [clearAll, patchEntry, defaultMachineId]);
+  }, [
+    entries.length,
+    clearAll,
+    resetEntryZero,
+    patchSingle,
+    patchEntry,
+    defaultMachineId,
+  ]);
 
   // Reset form state before navigating away on success (defense in depth): if
   // navigation fails the user sees an empty form, not stale values, and a
@@ -403,8 +427,13 @@ export function UnifiedReportForm({
               <input
                 type="hidden"
                 name="description"
+                // Route an empty editor (e.g. typed-then-cleared) to "" so the
+                // server stores null — matches the grid's docIsEmpty handling so
+                // a junk empty-paragraph doc is never persisted (spec §4, PP-2m17 #4).
                 value={
-                  entry.description ? JSON.stringify(entry.description) : ""
+                  entry.description && !docIsEmpty(entry.description)
+                    ? JSON.stringify(entry.description)
+                    : ""
                 }
               />
             </div>


### PR DESCRIPTION
Follow-up to #1685 (PP-idrb). A high-effort review of the merged tabbed-report feature surfaced five findings; this fixes all of them.

## Findings & fixes

**#1 — Technicians lost the assignee dropdown (regression).** `report/(tabbed)/layout.tsx` gated the assignee fetch on a hand-rolled `accessLevel === "admin" || "member"`, silently excluding technicians — who hold `issues.report.quick` and could assign before the tabbed refactor. Now gated on the **`issues.report.assignee` matrix permission** (CORE-ARCH-008), so it can't drift from the role model again. Fixes both the grid and the single form.

**#3 — machines + assignees fetched twice per `/report`.** The layout and the single `page.tsx` each fetched both independently. Extracted shared **React `cache()`-wrapped loaders** (`report-data.ts`); both call them, so it's one DB round-trip each per request. #1 and #3 share this fix — the matrix gate lives in the loader.

**#2 — Single-form submit destroyed unsubmitted grid rows.** `resetSingleForm` called `clearAll()`, wiping the whole draft. Now: when extra rows exist, it resets **only entry #1** (+ reporter identity) and the success page's `clear-draft` pops **only entry #1** from the persisted draft; when entry #1 is the whole draft it still clears everything.

**#4 — Single form persisted a junk empty description doc.** Type-then-clear left a non-null empty-paragraph doc where the grid normalizes to `null`. Now routed through `docIsEmpty` → `""` → `null` (spec §4 parity).

**#5 — Locked Single tab greyed even when active.** Reaching `/report` directly with a multi-row draft rendered the current tab as a disabled lock. Now it only greys when it **isn't** the active route.

## Testing
- `pnpm run check` green (1548 unit tests)
- E2E (chromium): `public-reporting`, `report-form-clear`, `quick-report` (smoke), `report-tabbed` (full) — all pass
- New RTL: locked-tab-while-active renders active (not greyed); updated the lock test to the realistic on-grid path

🤖 Generated with [Claude Code](https://claude.com/claude-code)