### PR TITLE
feat(hooks,workflow): human-gated merges + UI screenshot workflow (PP-wi85)

### DIFF
--- a/.agents/skills/pinpoint-agy-execute/SKILL.md
+++ b/.agents/skills/pinpoint-agy-execute/SKILL.md
@@ -248,7 +248,7 @@ Verification: <commands run + outcome>
 Do not merge — Tim reviews and merges.'
 ```
 
-**Do not merge.** The `block-direct-merge.cjs` hook refuses `mcp__github__merge_pull_request` and `gh pr merge` — do not attempt either.
+**Do not merge — by any path, including `merge-pr.sh`.** Merging is human-only (PP-wi85). Note that the `block-direct-merge.cjs` PreToolUse hook is Claude-Code-specific and does not fire inside Antigravity — the enforcement you're actually bound by here is this instruction plus `merge-pr.sh`'s own `--human` flag requirement (it refuses to execute a merge without `--human`, which only Tim should ever pass). Never run `gh pr merge`, `mcp__github__merge_pull_request`, or `scripts/workflow/merge-pr.sh` yourself, with or without `--human`.
 
 ---
 
@@ -257,7 +257,7 @@ Do not merge — Tim reviews and merges.'
 These apply throughout every step. No exceptions without explicit Tim approval.
 
 - **Never `--no-verify`** on any git command.
-- **Never `gh pr merge` or `mcp__github__merge_pull_request`** — Tim merges.
+- **Never `gh pr merge`, `mcp__github__merge_pull_request`, or `scripts/workflow/merge-pr.sh` (with or without `--human`)** — Tim merges.
 - **Sync via merge, never rebase:** `git fetch origin && git merge origin/main`. Rebase rewrites SHAs, forces push, breaks guardrails.
 - **`bd show <id>` and `bd ready` are the source of truth for scope.** If reality diverges from the bead, stop and update the bead first.
 - **If sandboxed / cannot run `chmod`:** ask Tim to run `chmod +x <path>` and `git update-index --chmod=+x <path>` manually (per `~/.claude/CLAUDE.md`).

--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -32,11 +32,14 @@ Coordinate multiple subagents working in parallel across isolated git worktrees.
 # Review thread inspection + reply → use MCP via pinpoint-pr-workflow skill Phase 3
 # (mcp__github__pull_request_read / add_reply_to_pull_request_comment / pull_request_review_write)
 
-# Readiness label + merge: pinpoint-pr-workflow skill Phases 3.4 + 4
+# Readiness label + merge handoff: pinpoint-pr-workflow skill Phases 3.4-3.6 + 4
 # Apply label via mcp__github__issue_write or `gh pr edit --add-label`
-bash scripts/workflow/merge-pr.sh <PR>                   # Composite gate-then-merge enforcer; 5 gates incl. `reviewed` (--dry-run)
-bash scripts/workflow/merge-pr.sh <PR> --dry-run         # Preview gate evaluation without merging
+# merge-pr.sh is human-only (PP-wi85) — blocked for agents via ANY invocation shape,
+# including --dry-run. The lead does NOT run it, even to preview gates. Once the PR
+# is ready (label applied, screenshots posted if UI-touching), hand Tim:
+#   ! scripts/workflow/merge-pr.sh <PR> --human
 bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"  # Post SHA-pinned Claude-review marker (satisfies the `reviewed` gate when Copilot skips)
+node scripts/workflow/pr-screenshots.mjs <PR>                 # UI-touching PRs: desktop+mobile screenshots, sticky PR comment
 
 # Worktree health — covers manually created ../pinpoint-worktrees/* ONLY;
 # agent-created .claude/worktrees/* are handled by the WorktreeRemove hook and not scanned here
@@ -200,13 +203,13 @@ Or fallback: `gh pr edit <PR> --add-label ready-for-review`.
 
 ### Ensure every PR is reviewed (lead backstop)
 
-The subagent self-reviews its own diff (Phase 3 template), but that can be skipped or Copilot can silently miss the head commit — so the lead re-checks at the merge boundary. Before applying `ready-for-review` or handing a PR to `merge-pr.sh`, confirm the head commit is covered by **either** a Copilot review **or** a SHA-pinned Claude marker (`<!-- pinpoint-claude-review: <head_sha> -->`). If neither covers head:
+The subagent self-reviews its own diff (Phase 3 template), but that can be skipped or Copilot can silently miss the head commit — so the lead re-checks at the handoff boundary. Before applying `ready-for-review` or handing a PR to Tim for `merge-pr.sh --human`, confirm the head commit is covered by **either** a Copilot review **or** a SHA-pinned Claude marker (`<!-- pinpoint-claude-review: <head_sha> -->`). If neither covers head:
 
 1. Run `/code-review` on the PR diff — the model-invocable **local** review. (`ultra` is the cloud multi-agent review; it is user-triggered and billed, so the agent cannot launch it.)
 2. Address serious findings (fix → have the subagent push → re-review; a fix re-arms the gate). Decline the rest.
 3. `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` to post the marker.
 
-The `reviewed` gate in `merge-pr.sh` is the hard enforcement — it FAILs the merge if the head commit has no Copilot or Claude review once the 600s Copilot window has elapsed. Running the fallback is how you satisfy it; `--force`-bypassing it defeats the guarantee.
+The `reviewed` gate in `merge-pr.sh` is the hard enforcement — it FAILs the merge if the head commit has no Copilot or Claude review once the 600s Copilot window has elapsed. Running the fallback before handoff is how the lead satisfies it; telling Tim to `--force`-bypass it defeats the guarantee.
 
 ---
 

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-pr-workflow
-description: Full PR lifecycle for PinPoint — commit, push, CI monitoring, Copilot + human review handling (via MCP), readiness labeling, gate-enforced merge. Use when committing changes, opening PRs, watching CI, addressing review comments, or merging.
+description: Full PR lifecycle for PinPoint — commit, push, CI monitoring, Copilot + human review handling (via MCP), UI screenshots, readiness labeling, human-only gate-enforced merge handoff. Use when committing changes, opening PRs, watching CI, addressing review comments, posting screenshots, or handing a PR to Tim to merge.
 ---
 
 # PinPoint PR Workflow
@@ -12,7 +12,7 @@ End-to-end pipeline from "I have changes" to "merged in main". Replaces the depr
 - Uncommitted changes in tree → **Phase 1: Commit**
 - Local commits, no PR yet → **Phase 2: PR**
 - PR open, CI not yet green-and-clean → **Phase 3: Review**
-- `ready-for-review` label applied → **Phase 4: Merge**
+- `ready-for-review` label applied → **Phase 4: Merge** (human-only handoff — see below)
 
 ---
 
@@ -186,9 +186,21 @@ If head is newer than the latest Copilot review:
 
 `merge-pr.sh` enforces this at merge time via the `reviewed` gate (PASSes on a Copilot review OR a SHA-matched Claude marker; WAITs inside the 600s window; FAILs after it with no review of either kind). Unlike the older `currency` gate — which WARN-proceeds on a stale/absent Copilot review — `reviewed` blocks the merge, so the Claude fallback is the way past it, not a bypass. Don't tell Tim a PR is "ready" or "done" while head is still unreviewed — making a review happen is part of finishing the PR, not an optional extra.
 
-### 3.5 Apply `ready-for-review` label
+### 3.5 Post UI screenshots (UI-touching PRs only)
 
-Once CI green + zero unresolved review threads (including Copilot) + Copilot reviewed head commit + no merge conflict:
+If the diff touches `src/app/**`, `src/components/**`, any `.css`, or design tokens, screenshots must be posted before the PR can be called ready — Tim reviews UI by eye, not by reading a diff. The commit-time `ui-screenshot-reminder.cjs` PostToolUse hook nudges on the first `git commit` that touches a UI glob; don't ignore it.
+
+```
+node scripts/workflow/pr-screenshots.mjs <PR>
+```
+
+Shoots the manifest in `scripts/workflow/ui-screenshot-manifest.json` (issues list, issue detail, report form, dashboard, a machine detail, collections — pass `--pages a,b,c` to shoot a subset) at desktop (1440×900) and mobile (390×844) viewports, pushes the PNGs to the orphan `pr-screenshots` branch, and posts/updates one sticky PR comment (marker `<!-- pr-screenshots -->`) with a desktop|mobile table per page. Re-run after any UI-affecting push — it updates the same sticky comment in place, tagged with the new head SHA.
+
+Requires the local dev server (`pnpm run dev`) and Supabase (`supabase start`) running. First run (or a stale/missing login session) regenerates `e2e/.auth/*.json` via the `auth-setup` Playwright project, which resets + reseeds the local dev DB — same as running E2E tests locally, not a new risk.
+
+### 3.6 Apply `ready-for-review` label
+
+Once CI green + zero unresolved review threads (including Copilot) + Copilot reviewed head commit + no merge conflict + screenshots posted (if UI-touching, per 3.5):
 
 1. Read current labels via `pull_request_read(method: "get")` and extract `.labels[]`.
 2. Build new labels array: existing labels + `"ready-for-review"`.
@@ -206,23 +218,34 @@ labels: [<existing>, "ready-for-review"]
 
 NOTE: PR labels are added via the issues endpoint. `labels` parameter is full-replacement, so read current labels first to avoid clobbering.
 
-The label is a hint to Tim that the PR is ready. `merge-pr.sh` re-checks all gates at merge time regardless.
+The label is a hint to Tim that the PR is ready for **him** to merge — it does not authorize an agent to merge. `merge-pr.sh --human` re-checks all gates when Tim runs it.
 
 ---
 
-## Phase 4: Merge
+## Phase 4: Merge — human-only (PP-wi85)
 
-Direct `gh pr merge` and MCP `merge_pull_request` are blocked by hook. Use `merge-pr.sh`.
+**Merging is human-only, via ANY path.** Direct `gh pr merge`, MCP `merge_pull_request`, AND `scripts/workflow/merge-pr.sh` itself are ALL blocked for an agent by the `block-direct-merge.cjs` PreToolUse hook — including `merge-pr.sh --dry-run`. There is no agent-usable bypass; the old `.claude-merge-bypass` sentinel was removed entirely. If you want to sanity-check gate-relevant PR state without running the script, read it via MCP (`pull_request_read`) instead — you cannot invoke `merge-pr.sh` at all, not even to preview.
 
-### 4.1 Invoke
+### 4.1 Agent's terminal state: handoff, not merge
+
+Once 3.1–3.6 are satisfied (CI green, threads resolved, head commit reviewed, no conflict, screenshots posted if UI-touching), your job on this PR is done. Tell Tim it's ready and hand him the exact command to run himself:
 
 ```
-bash scripts/workflow/merge-pr.sh <PR>
+! scripts/workflow/merge-pr.sh <PR> --human
 ```
 
-Flags (stackable, order-independent):
+Never say "merged" or "I merged it" — only Tim runs the merge. Say "ready for you to merge" and give him the command. (A `!`-prefixed command in Claude Code is a human-typed shell passthrough — it does not generate a PreToolUse event, so it is the only channel this hook cannot see. That is by design: it is the human channel.)
 
-- `--dry-run` — preview only, no action.
+### 4.2 What `merge-pr.sh --human` does (reference — Tim runs this, not you)
+
+```
+scripts/workflow/merge-pr.sh <PR> --human [--dry-run] [--force] [--bypass-merge-requirements]
+```
+
+`--human` is required to actually merge; omitting it makes the script refuse with a `REFUSE:` message (defense-in-depth for harnesses without the Claude Code hook — Codex/Gemini/Antigravity). `--dry-run` doesn't require `--human` in the script itself, but that exemption only matters outside Claude Code — inside Claude Code the hook blocks the Bash call before the script even runs, dry-run or not.
+
+Other flags (stackable, order-independent):
+
 - `--force` — bypass `currency` + `threads` + `reviewed` (review-state) gates. Requires manual permission approval.
 - `--bypass-merge-requirements` — bypass `ci` gate AND pass `--admin` to `gh pr merge`,
   overriding GitHub branch-protection rules. Requires manual permission approval.
@@ -230,9 +253,9 @@ Flags (stackable, order-independent):
 Combine `--force --bypass-merge-requirements` to bypass `currency` + `threads` + `reviewed` + `ci` together.
 The `no_conflict` gate is NEVER bypassable — GitHub rejects conflicting merges regardless of `--admin`.
 
-`merge-pr.sh` evaluates **5 gates**: `ci`, `currency`, `threads`, `reviewed`, `no_conflict`. The `reviewed` gate is the hard backstop that no head commit merges unreviewed — prefer running the Claude fallback (Phase 3.4) to satisfy it over `--force`-bypassing it.
+`merge-pr.sh` evaluates **5 gates**: `ci`, `currency`, `threads`, `reviewed`, `no_conflict`. The `reviewed` gate is the hard backstop that no head commit merges unreviewed — prefer running the Claude fallback (Phase 3.4) to satisfy it before handoff, rather than telling Tim to `--force` past it.
 
-### 4.2 Interpret output
+### 4.3 Interpret output (for reading over Tim's shoulder / diagnosing a FAIL he reports)
 
 Script emits structured status tokens:
 
@@ -245,46 +268,39 @@ Script emits structured status tokens:
 | `WARN: <gate>: <state>`  | Permitted to proceed with notice                       | Continue, but be informed             |
 | `SKIP: <gate>: <reason>` | Gate doesn't apply                                     | Continue                              |
 
-On any FAIL: script removes `ready-for-review` label if present (the label's contract is "click-merge-without-thinking"; if a gate fails at merge time, that contract is broken). Exit 1.
+On any FAIL: script removes `ready-for-review` label if present (the label's contract is "click-merge-without-thinking"; if a gate fails at merge time, that contract is broken). Exit 1. If Tim reports a FAIL, fix the underlying issue and push — then re-hand him the same `--human` command.
 
 On all PASS: script captures head SHA, calls `gh pr merge <PR> --squash --match-head-commit=<sha>`. TOCTOU-safe — if a new commit lands between gate check and merge, GitHub rejects the merge (`--match-head-commit` mismatch). Branch deletion is handled by the repo's auto-delete-branches setting, not by the merge command — passing `--delete-branch` from a worktree fails local cleanup because main is held by the root checkout.
 
-### 4.3 Escape hatches
+### 4.4 Escape hatches (Tim decides; you can inform, not invoke)
 
 **`--force`** — for Copilot/review-state issues (bypasses `currency` + `threads` + `reviewed`):
 
-- API failure on the `threads`, `currency`, or `reviewed` gate where you've manually verified the underlying state is fine
-- Copilot has silently-skipped a merge-from-main commit AND you've reviewed the diff manually
-- You're aware the `threads` / `currency` / `reviewed` gates would fail and you're explicitly accepting
+- API failure on the `threads`, `currency`, or `reviewed` gate where the underlying state has been manually verified fine
+- Copilot has silently-skipped a merge-from-main commit and the diff was reviewed manually
+- The `threads` / `currency` / `reviewed` gates are known to fail and that's being explicitly accepted
 
-Prefer the Claude fallback (Phase 3.4 — run `/code-review` + `mark-claude-review.sh`) over `--force` for a `reviewed`-gate failure: the fallback makes the guarantee true rather than skipping it.
+Prefer the Claude fallback (Phase 3.4 — run `/code-review` + `mark-claude-review.sh`) over asking Tim to `--force` a `reviewed`-gate failure: the fallback makes the guarantee true rather than skipping it, and you can do it before handoff.
 
 **`--bypass-merge-requirements`** — for CI/branch-protection issues:
 
 - A required check is failing for known-irrelevant reasons (infrastructure flake, unrelated job)
-  AND you've manually verified the change is safe. Log the flake first:
+  AND the change has been manually verified safe. Log the flake first:
   `bash scripts/workflow/log-gha-flake.sh <pr> <run-id> <class> "<symptom>"` (see `docs/runbooks/gha-flake-log.md`).
 - An emergency hotfix where waiting for CI is not acceptable
 - Combine with `--force` when both review-state and CI gates need to be skipped
 
-Do NOT bypass when:
+Do NOT suggest bypassing when:
 
 - Merge conflict exists (`no_conflict` gate is never bypassable; conflicts can't be ignored)
-- You haven't manually verified the underlying state. Both flags require manual permission approval
+- The underlying state hasn't been manually verified. Both flags require manual permission approval
   in the chat — treat the approval prompt as a "are you sure?" checkpoint.
 
-### 4.4 Bypass the hook (emergency only)
+### 4.5 If `merge-pr.sh` itself is broken
 
-If you absolutely need to bypass the hook (e.g., merge-pr.sh itself is broken and you have a hotfix to ship):
+There is no hook bypass — that channel was removed entirely (PP-wi85). If a hotfix genuinely can't wait for the script to be fixed, that's Tim's call, made in his own shell (`gh pr merge <PR> --squash` run by him directly, or a fixed `--human` run). Document why in the merge commit or a follow-up comment. An agent should not look for a workaround here — flag the breakage and let Tim decide.
 
-```bash
-touch .claude-merge-bypass
-gh pr merge <PR> --squash
-```
-
-The sentinel is single-use — deleted on the next merge attempt. Document in commit message WHY you bypassed.
-
-### 4.5 Dependabot PRs: rebase before merging back-to-back
+### 4.6 Dependabot PRs: rebase before merging back-to-back
 
 When two or more Dependabot PRs that both touch `pnpm-lock.yaml` (or any lockfile) are open simultaneously, merging them in succession without rebasing the second-and-later PRs can silently break the lockfile.
 
@@ -292,7 +308,7 @@ When two or more Dependabot PRs that both touch `pnpm-lock.yaml` (or any lockfil
 
 **Why `rebase-strategy: auto` in `.github/dependabot.yml` doesn't save you:** "auto" means Dependabot rebases when _the dependency version_ is out of date, not when _the lockfile region_ has shifted under it. Two independent Dependabot PRs against the same main can both stay "current" by Dependabot's definition while their lockfile diffs collide on merge.
 
-**Rule:** when merging the first of two or more Dependabot PRs that both touch a lockfile, comment `@dependabot rebase` on each remaining Dependabot PR before merging it. Dependabot regenerates the lockfile against post-first-merge main and the duplicate is deduped automatically. Wait for the rebased CI to pass before invoking `merge-pr.sh` on the second PR.
+**Rule:** when merging the first of two or more Dependabot PRs that both touch a lockfile, comment `@dependabot rebase` on each remaining Dependabot PR before merging it. Dependabot regenerates the lockfile against post-first-merge main and the duplicate is deduped automatically. Wait for the rebased CI to pass before handing Tim the `--human` command for the second PR.
 
 **Casework:** 2026-05-19 — PRs #1379 and #1381 each added `brace-expansion@5.0.6:` to `packages:` independently. Both merged within ~1 minute. Main's `Setup Dependencies` broke until a manual dedup of `pnpm-lock.yaml` was bundled into PR #1383 alongside that PR's primary E2E locator fix.
 
@@ -305,7 +321,7 @@ pr_branch=$(gh pr view <second_pr> --json headRefName --jq .headRefName)
 gh api "repos/{owner}/{repo}/compare/main...$pr_branch" --jq '.behind_by'
 ```
 
-If `behind_by > 0`, comment `@dependabot rebase` on the PR and wait for the rebased CI to pass before invoking `merge-pr.sh`. Do not use `gh pr view --json baseRefOid` for this — `baseRefOid` is the base branch's current SHA at query time, so it always equals `origin/main` and cannot detect a stale PR head.
+If `behind_by > 0`, comment `@dependabot rebase` on the PR and wait for the rebased CI to pass before handing Tim the `--human` command. Do not use `gh pr view --json baseRefOid` for this — `baseRefOid` is the base branch's current SHA at query time, so it always equals `origin/main` and cannot detect a stale PR head.
 
 ---
 

--- a/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
+++ b/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
@@ -69,7 +69,7 @@ Everything above happens **in a worktree** — the root checkout is read-only (A
 
 Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally". **In PinPoint that menu does not apply.** There is exactly one finish path:
 
-- **Never merge locally, never push/merge to `main`.** Ship through a PR: push the branch, open it **ready-for-review**, let **CI** run the full suite, then merge **only** via `scripts/workflow/merge-pr.sh <PR>` (never `gh pr merge` / MCP merge). Full pipeline: `pinpoint-pr-workflow` + landing-the-plane (AGENTS.md §9).
+- **Never merge locally, never push/merge to `main`, and never merge the PR yourself by any path.** Ship through a PR: push the branch, open it **ready-for-review**, let **CI** run the full suite, post UI screenshots if UI-touching, then hand Tim the exact command to run himself: `! scripts/workflow/merge-pr.sh <PR> --human` (never `gh pr merge` / MCP merge / running `merge-pr.sh` yourself — all three are blocked for agents, PP-wi85). Full pipeline: `pinpoint-pr-workflow` + landing-the-plane (AGENTS.md §9).
 - **Tests:** use PinPoint's tiered commands (`pnpm run check` floor; `pnpm run preflight` for migrations/auth/server-actions/middleware/schema; `pnpm run smoke` for UI) — **not** `npm test` / `pytest`. Don't run the full E2E suite locally; CI owns it.
 - **Worktree cleanup is destructive → wait for explicit confirmation** (AGENTS.md §9 "Landing the plane", step 6). When confirmed, cleanup goes through the `WorktreeRemove` hook / `scripts/worktree_cleanup.py` (dealloc slot + Docker volumes) — **never raw `git worktree remove`/`rm -rf`**, which leaks the slot manifest and volumes.
 - **"Discard" is not a routine option.** Abandoning work is a deliberate, confirmed action, not a menu pick.
@@ -79,17 +79,17 @@ Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally".
 
 ## 4. Quick reference
 
-| Superpowers step         | PinPoint override                                                      |
-| :----------------------- | :--------------------------------------------------------------------- |
-| Spec written             | + create bead with `--spec-id` + `--acceptance` (§2)                   |
-| Plan written             | record path + branch in `--design` (§1)                                |
-| Worktree create          | `EnterWorktree` / `Agent(isolation:"worktree")`, from main worktree    |
-| SDD dispatch             | clear the scale gate (count + cost, Tim's yes) first                   |
-| Code review              | CI Gate + `/code-review`; replies via MCP, signed with your agent name |
-| Finish: "merge locally"  | ❌ prohibited → PR + `merge-pr.sh` + landing-the-plane                 |
-| Finish: tests            | tiered `pnpm run check`/`preflight`/`smoke`, not `npm test`            |
-| Finish: worktree cleanup | `WorktreeRemove` hook / `worktree_cleanup.py`, on confirmation         |
-| Close bead               | only after merge                                                       |
+| Superpowers step         | PinPoint override                                                                 |
+| :----------------------- | :-------------------------------------------------------------------------------- |
+| Spec written             | + create bead with `--spec-id` + `--acceptance` (§2)                              |
+| Plan written             | record path + branch in `--design` (§1)                                           |
+| Worktree create          | `EnterWorktree` / `Agent(isolation:"worktree")`, from main worktree               |
+| SDD dispatch             | clear the scale gate (count + cost, Tim's yes) first                              |
+| Code review              | CI Gate + `/code-review`; replies via MCP, signed with your agent name            |
+| Finish: "merge locally"  | ❌ prohibited → PR + human-only `merge-pr.sh --human` handoff + landing-the-plane |
+| Finish: tests            | tiered `pnpm run check`/`preflight`/`smoke`, not `npm test`                       |
+| Finish: worktree cleanup | `WorktreeRemove` hook / `worktree_cleanup.py`, on confirmation                    |
+| Close bead               | only after merge                                                                  |
 
 ## Red flags — stop if you catch yourself
 

--- a/.claude/hooks/block-bad-shell-patterns.cjs
+++ b/.claude/hooks/block-bad-shell-patterns.cjs
@@ -6,9 +6,9 @@
  * 1. Manual CI polling loops → use ./scripts/workflow/pr-watch.py
  * 2. Ad-hoc curl health checks → use `pnpm run dev:status`
  *
- * Note: `gh pr merge` is gated by the "ask" tier in settings.json, not by this
- * hook. That keeps the confirmation interactive (and overridable) instead of a
- * hard deny that can't be authorized in-conversation.
+ * Note: `gh pr merge` (and `scripts/workflow/merge-pr.sh`, and MCP
+ * merge_pull_request) is hard-blocked by block-direct-merge.cjs, not by this
+ * hook — merging is human-only with no agent-usable bypass (PP-wi85).
  */
 
 const rules = [

--- a/.claude/hooks/block-direct-merge.cjs
+++ b/.claude/hooks/block-direct-merge.cjs
@@ -58,12 +58,14 @@ process.stdin.on("end", () => {
     }
 
     // scripts/workflow/merge-pr.sh — detect at a command-start position, tolerating
-    // `bash`/`sh` wrappers, `env [VAR=val...]` prefixes, and a relative/absolute path
-    // prefix ahead of the basename. Quote-stripped `stripped` reuses the same
-    // false-positive protection as the gh checks above (docs/echo mentions don't match).
+    // `bash`/`sh` wrappers, leading `VAR=val` assignments (bare or after `env`),
+    // and a relative/absolute path prefix ahead of the basename. Quote-stripped
+    // `stripped` reuses the same false-positive protection as the gh checks above
+    // (docs/echo mentions don't match).
     const mergeScript = new RegExp(
       cmdStart.source +
-        "(?:env\\s+(?:[A-Za-z_][A-Za-z0-9_]*=\\S+\\s+)*)?" + // optional env VAR=val... prefix
+        "(?:env\\s+)?" + // optional `env` wrapper
+        "(?:[A-Za-z_][A-Za-z0-9_]*=\\S+\\s+)*" + // optional leading VAR=val assignments (bare or after env)
         "(?:(?:bash|sh)\\s+)?" + // optional interpreter wrapper
         "(?:\\S*/)?" + // optional path prefix (relative or absolute)
         "merge-pr\\.sh\\b"

--- a/.claude/hooks/block-direct-merge.cjs
+++ b/.claude/hooks/block-direct-merge.cjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 // .claude/hooks/block-direct-merge.cjs
-// PreToolUse hook: blocks direct PR merge calls.
-// Bypass: presence of .claude-merge-bypass file in repo root (single-use, deleted on fire).
-
-const fs = require("node:fs");
-const path = require("node:path");
+// PreToolUse hook: blocks ALL agent-initiated PR merges. There is no agent-usable
+// bypass — merging is human-only (PP-wi85). The only merge channel left is a human
+// typing a `!`-prefixed command in Claude Code, which does not generate a
+// PreToolUse event and so is never seen by this hook.
+//
+// Blocks three shapes:
+//   1. `gh pr merge` (direct CLI merge)
+//   2. `gh api .../pulls/N/merge` with a write method (REST merge)
+//   3. `scripts/workflow/merge-pr.sh` (the gate-enforced merge script itself —
+//      gate-enforcement is not a substitute for human sign-off)
+//   4. mcp__github__merge_pull_request (MCP merge)
 
 let input = "";
 process.stdin.on("data", (c) => (input += c));
@@ -21,18 +27,20 @@ process.stdin.on("end", () => {
   const toolInput = payload.tool_input || {};
 
   let isMergeAttempt = false;
+  let isMergeScriptAttempt = false;
   let detail = "";
 
   if (tool === "Bash") {
     const cmd = String(toolInput.command || "");
-    // Prefix gate: skip all regex work when nothing gh-related is present, and
+    // Strip quoted content so mentions in `echo`/`rg`/docs/heredocs don't false-positive.
+    const stripped = cmd
+      .replace(/'[^']*'/g, "''")
+      .replace(/"(?:\\.|[^"\\])*"/g, '""');
+    const cmdStart = /(?:^|;|&&|\|\||\||&|\n|\$\(|<\(|\(|`)\s*/;
+
+    // Prefix gate: skip gh-related regex work when nothing gh-related is present, and
     // pass any --help invocation symmetrically (`gh pr merge --help`, `gh api --help`).
     if (cmd.includes("gh") && !/--help\b/.test(cmd)) {
-      // Strip quoted content so mentions in `echo`/`rg`/docs/heredocs don't false-positive.
-      const stripped = cmd
-        .replace(/'[^']*'/g, "''")
-        .replace(/"(?:\\.|[^"\\])*"/g, '""');
-      const cmdStart = /(?:^|;|&&|\|\||\||&|\n|\$\(|<\(|\(|`)\s*/;
       const ghMerge = new RegExp(cmdStart.source + "gh\\s+pr\\s+merge\\b");
       if (ghMerge.test(stripped)) {
         isMergeAttempt = true;
@@ -48,30 +56,46 @@ process.stdin.on("end", () => {
         detail = "gh api PUT .../merge";
       }
     }
+
+    // scripts/workflow/merge-pr.sh — detect at a command-start position, tolerating
+    // `bash`/`sh` wrappers, `env [VAR=val...]` prefixes, and a relative/absolute path
+    // prefix ahead of the basename. Quote-stripped `stripped` reuses the same
+    // false-positive protection as the gh checks above (docs/echo mentions don't match).
+    const mergeScript = new RegExp(
+      cmdStart.source +
+        "(?:env\\s+(?:[A-Za-z_][A-Za-z0-9_]*=\\S+\\s+)*)?" + // optional env VAR=val... prefix
+        "(?:(?:bash|sh)\\s+)?" + // optional interpreter wrapper
+        "(?:\\S*/)?" + // optional path prefix (relative or absolute)
+        "merge-pr\\.sh\\b"
+    );
+    if (mergeScript.test(stripped)) {
+      isMergeScriptAttempt = true;
+      detail = "scripts/workflow/merge-pr.sh";
+    }
   } else if (tool === "mcp__github__merge_pull_request") {
     isMergeAttempt = true;
     detail = "MCP merge_pull_request";
+  }
+
+  if (isMergeScriptAttempt) {
+    console.error(
+      "Merge is human-only. You cannot run merge-pr.sh. Finish the PR (CI green, reviews " +
+        "resolved, screenshots posted if UI), then hand Tim the exact command to run himself: " +
+        "! scripts/workflow/merge-pr.sh <PR> --human"
+    );
+    process.exit(2);
   }
 
   if (!isMergeAttempt) {
     process.exit(0);
   }
 
-  // Check for bypass sentinel.
-  const cwd = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  const sentinel = path.join(cwd, ".claude-merge-bypass");
-  if (fs.existsSync(sentinel)) {
-    // Allow this merge; consume the sentinel.
-    try {
-      fs.unlinkSync(sentinel);
-    } catch {}
-    process.exit(0);
-  }
-
-  // Block.
+  // Block. No bypass sentinel — merging has no agent-usable escape hatch under
+  // the hard gate (PP-wi85). If merge-pr.sh itself is broken and a hotfix must
+  // ship, that is a human decision made in a human-run shell, not a hook bypass.
   console.error(
-    `Direct merge blocked: ${detail}. Use scripts/workflow/merge-pr.sh <PR> to enforce gate re-checks. ` +
-      `Override with: touch .claude-merge-bypass (single-use sentinel, auto-deleted on hook fire).`
+    `Direct merge blocked: ${detail}. Merging is human-only — hand Tim the exact command to ` +
+      "run himself: ! scripts/workflow/merge-pr.sh <PR> --human"
   );
   process.exit(2);
 });

--- a/.claude/hooks/ui-screenshot-reminder.cjs
+++ b/.claude/hooks/ui-screenshot-reminder.cjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// .claude/hooks/ui-screenshot-reminder.cjs
+// PostToolUse hook (Bash): non-blocking reminder to post UI screenshots.
+//
+// Fires on `git commit`. If the branch's cumulative diff vs origin/main touches
+// a UI glob, prints one reminder line to stderr. Always exits 0 — this is a
+// nudge, not a gate. No network calls beyond the already-local `git diff`
+// (which reads git's local knowledge of origin/main — it does not fetch).
+//
+// PP-wi85: UI-touching PRs must have desktop+mobile screenshots posted before
+// handoff to Tim (see AGENTS.md §9, pinpoint-pr-workflow skill Phase 2/3).
+
+const { execFileSync } = require("node:child_process");
+
+let input = "";
+process.stdin.on("data", (c) => (input += c));
+process.stdin.on("end", () => {
+  let payload;
+  try {
+    payload = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  const tool = payload.tool_name || "";
+  if (tool !== "Bash") {
+    process.exit(0);
+  }
+
+  const cmd = String((payload.tool_input && payload.tool_input.command) || "");
+  // Same cmdStart-position + quote-stripping approach as the other Bash-command
+  // hooks, so a docs/echo mention of "git commit" doesn't false-positive.
+  const stripped = cmd
+    .replace(/'[^']*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""');
+  const cmdStart = /(?:^|;|&&|\|\||\||&|\n|\$\(|<\(|\(|`)\s*/;
+  const gitCommit = new RegExp(cmdStart.source + "git\\s+commit\\b");
+  if (!gitCommit.test(stripped)) {
+    process.exit(0);
+  }
+
+  // Determine cwd for the git call — prefer the payload's cwd (worktree-aware).
+  const cwd = payload.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  let changedFiles = [];
+  try {
+    const out = execFileSync(
+      "git",
+      ["diff", "--name-only", "origin/main...HEAD"],
+      // stdio: explicitly pipe stderr too — execFileSync's default inherits
+      // stderr to the parent, which would leak git's error text onto this
+      // hook's own stderr and break the "fail open silently" contract below.
+      { cwd, encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] }
+    );
+    changedFiles = out.split("\n").filter(Boolean);
+  } catch {
+    // origin/main unreachable/unknown, not a git repo at cwd, or the diff
+    // otherwise failed — this is a nudge, not a gate. Fail open silently.
+    process.exit(0);
+  }
+
+  const UI_GLOBS = [
+    /^src\/app\/.*\.tsx$/,
+    /^src\/app\/.*\.css$/,
+    /^src\/components\//,
+    /\.css$/,
+    /(^|\/)tailwind[^/]*$/i,
+    /(^|\/)design-tokens?[^/]*$/i,
+  ];
+
+  const touchesUi = changedFiles.some((f) =>
+    UI_GLOBS.some((re) => re.test(f))
+  );
+
+  if (!touchesUi) {
+    process.exit(0);
+  }
+
+  process.stderr.write(
+    "🖼  UI-touching change — before handing this PR to Tim, post screenshots: " +
+      "scripts/workflow/pr-screenshots.mjs <PR> (desktop+mobile).\n"
+  );
+  process.exit(0);
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,6 +74,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/ui-screenshot-reminder.cjs",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
         "matcher": "Bash|mcp__github__create_pull_request",
         "hooks": [
           {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 3. **Don't kill processes you didn't start** — see §4 Process safety.
 4. **Sync with merge, never rebase** — see §5 Branches.
 5. **Root checkout is read-only.** It stays on `main`. All work — including planning docs — happens in a worktree. Dispatch a subagent or switch into an existing worktree. Tool-specific dispatch mechanics live in `CLAUDE.md` and `.agents/rules/AGY.md`. (PP-46z, PP-bg45.)
-6. **Never `--no-verify`**, never `gh pr merge`, never wildcard tool permissions — without explicit user approval each time.
+6. **Never `--no-verify`**, never wildcard tool permissions — without explicit user approval each time. **Merging is human-only, via ANY path** — never `gh pr merge`, never MCP `merge_pull_request`, and never `scripts/workflow/merge-pr.sh` (even though it enforces the merge gates, running it is still an agent merge). An agent's terminal state on a PR is: ready-for-review, CI green, reviews resolved, screenshots posted if UI-touching, then hand Tim the exact command to run himself: `! scripts/workflow/merge-pr.sh <PR> --human`. (PP-wi85.)
 7. **Beads: `team-maintainer` policy** (not the conservative default).
 
 ## 3. Agent Skills
@@ -233,11 +233,12 @@ Actionable, "what" and "how" only. Skills carry the deep dives.
 Work isn't done at "git push" — it's done when the change is **merged, deployed clean, and cleaned up**. The full pipeline (commit → PR → CI → merge) lives in the `pinpoint-pr-workflow` skill; the load-bearing rules are repeated here in case that skill isn't loaded.
 
 1. **Before you push:** `pnpm run check` is the floor (types, lint, format, unit). Run `pnpm run preflight` for non-trivial changes — migrations, security/auth, server actions, middleware, DB schema. Don't run the full E2E suite locally; CI owns it.
-2. **Push and open the PR ready-for-review** (draft only while iterating — see "Working style"). Sync with main by **merge, never rebase**; `git status` must show "up to date with origin". "Ready" is not just "pushed": wait for Copilot to review the current head commit and resolve/decline its threads before you call the PR ready or done — `merge-pr.sh` re-enforces this (`currency` + `threads` gates) at merge time. See `pinpoint-pr-workflow` Phase 3.
+2. **Push and open the PR ready-for-review** (draft only while iterating — see "Working style"). Sync with main by **merge, never rebase**; `git status` must show "up to date with origin". "Ready" is not just "pushed": wait for Copilot to review the current head commit and resolve/decline its threads before you call the PR ready or done — `merge-pr.sh` re-enforces this (`currency` + `threads` gates) at merge time. See `pinpoint-pr-workflow` Phase 3. **UI-touching PRs additionally need screenshots posted** (see step 4) before they can be called ready.
 3. **Lean on CI for the full E2E suite** — don't run `e2e:full` locally; CI owns it once the PR is up. Do run **selected specs locally** while writing them or iterating on a feature they touch (`pnpm exec playwright test <spec> --project=chromium`).
-4. **Merge via `scripts/workflow/merge-pr.sh <PR>`** — never `gh pr merge` or MCP merge directly. (Bead close timing follows beads' defaults; there's no fixed at-merge rule.)
-5. **After merge, watch the deployment.** Don't walk away at merge — watch the production deploy land and confirm no build, migration, or runtime errors. A merge that breaks prod isn't done.
-6. **Cleanup — non-destructive now, destructive on confirmation.** Close the bead, file genuine follow-up beads, and hand off freely. For destructive cleanup (removing worktrees, deleting branches/volumes), wait for explicit confirmation.
-7. **Hand off** for the next session, and post to the huddle daily bead if other sessions need to know what landed.
+4. **UI-touching PRs: post screenshots before handoff.** `node scripts/workflow/pr-screenshots.mjs <PR>` shoots the manifest pages at desktop+mobile viewports and posts a sticky PR comment so Tim can eyeball them before merging. The commit-time `ui-screenshot-reminder.cjs` hook nudges when a commit touches a UI glob — don't ignore it.
+5. **Merging is human-only, via ANY path — including `merge-pr.sh`.** An agent never runs `merge-pr.sh` itself, even to enforce the gates; that hook is blocked (PP-wi85). The agent's terminal state on a PR is: ready-for-review, CI green, reviews resolved, screenshots posted if UI-touching, then hand Tim the exact command to run himself: `! scripts/workflow/merge-pr.sh <PR> --human`. (Bead close timing follows beads' defaults; there's no fixed at-merge rule.)
+6. **After Tim merges, watch the deployment.** Don't consider the work done at handoff — after Tim runs the merge, watch the production deploy land and confirm no build, migration, or runtime errors. A merge that breaks prod isn't done. If you're not present when Tim merges, this step is his to do or to ask you to pick back up.
+7. **Cleanup — non-destructive now, destructive on confirmation.** Close the bead, file genuine follow-up beads, and hand off freely. For destructive cleanup (removing worktrees, deleting branches/volumes), wait for explicit confirmation.
+8. **Hand off** for the next session, and post to the huddle daily bead if other sessions need to know what landed.
 
-Never say "ready to push when you are" — you push.
+Never say "ready to push when you are" — you push. Never say a PR is "merged" or that you merged it — only Tim runs the merge; say "ready for Tim to merge" and give him the command.

--- a/docs/superpowers/specs/2026-07-17-human-gated-merges-ui-screenshots-design.md
+++ b/docs/superpowers/specs/2026-07-17-human-gated-merges-ui-screenshots-design.md
@@ -1,0 +1,232 @@
+# Human-Gated Merges + UI Screenshots (PP-wi85)
+
+**Date:** 2026-07-17
+**Bead:** PP-wi85
+**Status:** Design approved (Tim + Claude, 2026-07-17); implemented in this PR.
+
+## Purpose
+
+`.claude/hooks/block-direct-merge.cjs` already blocked `gh pr merge`, `gh api
+.../merge`, and MCP `mcp__github__merge_pull_request` — but it deliberately
+steered agents to `scripts/workflow/merge-pr.sh`, which merges once its 5
+gates (`ci`/`reviewed`/`currency`/`threads`/`no_conflict`) pass, with **no
+human-approval gate**. That is exactly how recent Claude sessions auto-merged
+features without Tim's explicit approval: passing the gates was treated as
+equivalent to Tim's sign-off, which it never was.
+
+Tim (solo dev) wants two things:
+
+1. **No merges by ANY path unless he explicitly runs the merge himself.**
+2. **UI-touching PRs get desktop+mobile screenshots auto-posted to the PR**
+   so he can eyeball them before merging — code review doesn't substitute for
+   looking at the rendered UI.
+
+## Scope
+
+### 1. Hard merge gate — `.claude/hooks/block-direct-merge.cjs`
+
+Extended to additionally block an agent Bash call invoking
+`scripts/workflow/merge-pr.sh`, detected at a command-start position
+(mirroring the existing `cmdStart` regex used for the `gh pr merge` check):
+after `^`, `;`, `&&`, `||`, `|`, `&`, newline, `$(`, `<(`, `(`, backtick — and
+additionally tolerating `bash`/`sh` interpreter wrappers, an `env
+[VAR=val...]` prefix, and a relative/absolute path prefix ahead of the
+`merge-pr.sh` basename. The existing quote-stripping (single- and
+double-quoted spans replaced with empty quotes before matching) is reused
+unchanged, so `echo`/`rg`/docs mentions of "merge-pr.sh" don't false-positive.
+
+Block message for this case:
+
+> Merge is human-only. You cannot run merge-pr.sh. Finish the PR (CI green,
+> reviews resolved, screenshots posted if UI), then hand Tim the exact command
+> to run himself: `! scripts/workflow/merge-pr.sh <PR> --human`
+
+Exit code 2 (deny), matching the existing `gh pr merge` / MCP-merge block
+behavior.
+
+**The `.claude-merge-bypass` sentinel file mechanism was removed entirely.**
+Under a hard gate there is no agent-usable bypass — the hook no longer reads
+any filesystem state at all. The only merge channel is a human typing a
+`!`-prefixed command in Claude Code: that is a shell passthrough which does
+**not** generate a `PreToolUse` event, so it is never intercepted. This is the
+one open feasibility item in this design — see "Open feasibility item" below.
+Malformed JSON payloads on stdin still fail open (exit 0), unchanged.
+
+Test coverage: `src/test/unit/hooks/block-direct-merge.test.ts` (new),
+mirroring the subprocess-invocation pattern already used by
+`verify-guard-stack.test.ts` (spawn `node` on the hook, JSON on stdin, assert
+exit code + stderr). Cases added: `bash scripts/workflow/merge-pr.sh 123` →
+blocked; `./scripts/workflow/merge-pr.sh 123` → blocked; bare `merge-pr.sh
+123` → blocked; absolute-path invocation → blocked; `sh merge-pr.sh` →
+blocked; chained after another command (`&&`) → blocked; a quoted mention
+(`echo "run merge-pr.sh"`, `rg "merge-pr.sh" docs/`) → **not** blocked; an
+unrelated `gh pr view` → **not** blocked; a stray `.claude-merge-bypass`-shaped
+command → still blocked (proves there's nothing left for a sentinel to flip).
+
+### 2. Defense-in-depth guard in `scripts/workflow/merge-pr.sh`
+
+The Claude Code hook only fires inside Claude Code. Other harnesses that run
+in this repo (Codex, Gemini, Antigravity) don't wire it. `merge-pr.sh` now
+requires a `--human` flag to actually execute a merge:
+
+```
+scripts/workflow/merge-pr.sh <PR> --human [--dry-run] [--force] [--bypass-merge-requirements]
+```
+
+Omitting `--human` (when not `--dry-run`) fails fast, before any GitHub API
+call, with a `REFUSE:` message naming the canonical command. `--dry-run` is
+exempt from the `--human` requirement — it takes no action, so previewing
+gate status is harmless. This exemption only matters **outside** Claude Code:
+inside Claude Code, the hook in §1 blocks the Bash call before the script
+runs at all, `--dry-run` included, so a Claude Code agent can never invoke
+`merge-pr.sh` in any form.
+
+`--human` is a same-tool guard against non-interactive/scripted invocation —
+it cannot verify a human is actually typing the command, and doesn't try to.
+It stops accidental/scripted calls; it is not a security boundary on its own.
+
+All documented invocations were updated to the canonical `<PR> --human` form:
+`AGENTS.md`, `pinpoint-pr-workflow` SKILL.md, `pinpoint-orchestrator`
+SKILL.md, `pinpoint-superpowers-bridge` SKILL.md, `pinpoint-agy-execute`
+SKILL.md, `scripts/workflow/AGENTS.md`, and the script's own usage/help text.
+
+### 3. Commit-time screenshot reminder — `.claude/hooks/ui-screenshot-reminder.cjs`
+
+New PostToolUse hook (pattern copied from the existing
+`preflight-reminder.sh`). Fires on a Bash `git commit` (detected via the same
+cmdStart + quote-stripping approach as the merge-blocking hooks). Diffs
+`origin/main...HEAD` (three-dot / merge-base diff, so it reflects the whole
+branch's cumulative changes, not just the latest commit) and, if any changed
+file matches a UI glob (`src/app/**/*.tsx`, `src/app/**/*.css`,
+`src/components/**`, any `*.css`, `tailwind*`, `design-token*`), prints one
+line to stderr:
+
+> 🖼 UI-touching change — before handing this PR to Tim, post screenshots:
+> scripts/workflow/pr-screenshots.mjs <PR> (desktop+mobile).
+
+Always exits 0 (non-blocking nudge, not a gate) and fails open silently if
+`origin/main` is unreachable or the cwd isn't a git repo. Registered in
+`.claude/settings.json` under `PostToolUse` (matcher `Bash`), immediately
+after the `preflight-reminder.sh` entry. No network calls beyond the local
+`git diff` (reads git's already-fetched knowledge of `origin/main`; does not
+fetch).
+
+Test coverage: `src/test/unit/hooks/ui-screenshot-reminder.test.ts` (new) —
+builds a scratch git repo per test with a fake `origin/main` ref (via
+`git update-ref refs/remotes/origin/main <sha>`, no real remote needed) so
+the diff resolves deterministically; asserts the reminder fires for
+`src/components/**`, `src/app/**/*.tsx`, and `*.css` changes, stays silent for
+non-UI changes and non-commit commands, and fails open when `origin/main`
+doesn't exist.
+
+### 4. Screenshot workflow — `scripts/workflow/pr-screenshots.mjs`
+
+Node ESM script:
+
+```
+node scripts/workflow/pr-screenshots.mjs <PR> [--pages a,b,c] [--force-auth]
+```
+
+- **Viewports:** desktop `1440×900`, mobile `390×844`. Two PNGs per manifest
+  page.
+- **Page manifest:** `scripts/workflow/ui-screenshot-manifest.json`, an id →
+  `{ label, route, authRole, seedNeeds }` map. Seeded with six core pages:
+  issues list (`/issues`), issue detail (`/m/AFM/i/1`), report form
+  (`/report`), dashboard (`/dashboard`), a machine detail (`/m/TAF`), and
+  collections (`/c/collections`). `--pages` filters to a subset; default is
+  every manifest page.
+- **Auth:** reuses the existing E2E harness — `e2e/support/auth-state.ts`'s
+  `STORAGE_STATE` role→path convention (`e2e/.auth/{admin,member,technician}.json`)
+  is duplicated as a small local constant (documented hardening follow-up:
+  import the shared TS constant instead once there's a clean way to do so
+  from a plain `.mjs` script without pulling in `tsx`). If storage state is
+  missing (or `--force-auth` is passed), the script shells out to `pnpm exec
+playwright test --project=auth-setup`, which — via `e2e/global-setup.ts` —
+  resets and reseeds the **local** dev DB. This is the same reset the E2E
+  suite already does locally; it is never run against production, and
+  `baseURL` is always `http://localhost:<PORT>` (CORE-SEC-008), resolved via
+  `@next/env`'s `loadEnvConfig` the same way `playwright.config.ts` does
+  (worktree-aware `PORT`).
+- **Capture:** launches one `chromium` instance via `@playwright/test`'s
+  exported `chromium.launch()` (not the test runner), opens one
+  `BrowserContext` per (role, viewport) pair reused across pages in that
+  pair, navigates with `waitUntil: "networkidle"`, screenshots to a temp dir.
+- **Hosting:** pushes PNGs to a dedicated **orphan branch `pr-screenshots`**
+  (created if missing) at path `pr-<N>/<shortsha>/<viewport>-<pagelabel>.png`.
+  Done entirely inside a throwaway temp directory with its **own fresh `git
+init`** — deliberately **not** `git worktree add` against the main repo —
+  so it never touches the working tree and never trips the repo's Husky
+  post-checkout hook (which would otherwise allocate a worktree port slot for
+  a directory that exists only to hold PNGs for a few seconds). The repo is
+  public, so `https://raw.githubusercontent.com/<owner>/<repo>/pr-screenshots/<path>`
+  renders inline in PR comments without auth.
+- **Comment:** posts or updates ONE sticky PR comment (found by marker
+  `<!-- pr-screenshots -->`, mirroring `mark-claude-review.sh`'s sticky-marker
+  pattern including the `--paginate` + `jq -s add` slurp-and-flatten so a
+  marker on page 2+ of a busy PR isn't missed) — a section per page with a
+  desktop|mobile markdown image table, headed by the capture's head SHA.
+
+Hardening follow-ups deliberately deferred (best-effort per Tim's framing of
+this as a hooks/tooling change, not a polished feature):
+
+- No retry/backoff on flaky navigation — single attempt per page.
+- Session staleness is handled only via the manual `--force-auth` escape
+  hatch, not detected automatically (an expired JWT would just screenshot a
+  login page).
+- The `pr-screenshots` branch has no pruning/TTL, unlike the preview-
+  deployment reaper (`pinpoint-preview-deployments`) — it will grow
+  unbounded. A follow-up bead should add an hourly/weekly reaper mirroring
+  that pattern once the branch's actual growth rate is known.
+- PR-number/local-HEAD mismatch is a warning, not a hard failure (covers the
+  common case of forgetting to push before shooting screenshots).
+
+### 5. Docs + skill updates
+
+- `AGENTS.md` §2.2 rule 6 and §9 "Landing the plane": merge is explicitly
+  human-only via ANY path including `merge-pr.sh`; the agent's terminal state
+  on a PR is "ready-for-review + CI green + reviews resolved + screenshots
+  posted if UI-touching + hand Tim `! scripts/workflow/merge-pr.sh <PR>
+--human`." Added an explicit UI-screenshot step and vocabulary guidance
+  ("ready for Tim to merge", never "merged").
+- `pinpoint-pr-workflow` SKILL.md: new §3.5 "Post UI screenshots" (before the
+  ready-for-review label step, now §3.6); Phase 4 rewritten around the
+  human-only handoff — what the agent does (§4.1: hand off, don't merge),
+  what `merge-pr.sh --human` does for reference (§4.2-4.4, reframed as "Tim
+  runs this"), and what to do if the script itself is broken (§4.5: flag it,
+  don't work around it).
+- `pinpoint-orchestrator`, `pinpoint-superpowers-bridge`, and
+  `pinpoint-agy-execute` SKILL.md files updated to the same human-only
+  framing. `pinpoint-agy-execute` additionally corrects a pre-existing
+  inaccuracy: Antigravity doesn't have the Claude-Code-specific PreToolUse
+  hook, so its actual enforcement there is the explicit "do not merge"
+  instruction plus `merge-pr.sh`'s own `--human` requirement.
+- `scripts/workflow/AGENTS.md`: merge-pr.sh marked human-only in the scripts
+  table and the "Key Design Decisions" section; added `pr-screenshots.mjs`
+  and `ui-screenshot-manifest.json` to the scripts table.
+- `.claude/hooks/block-bad-shell-patterns.cjs`: fixed a stale header comment
+  that pre-dated this change and claimed `gh pr merge` was only "ask"-gated,
+  not hard-blocked — it was already hard-blocked by `block-direct-merge.cjs`
+  before this PR; the comment was simply wrong.
+
+## Open feasibility item
+
+The `!`-bypass assumption — that a human-typed `!`-prefixed command in Claude
+Code does not generate a `PreToolUse` event, and so is invisible to
+`block-direct-merge.cjs` — is the load-bearing mechanism for this whole
+design. It could not be independently verified from inside the implementing
+subagent (no way to simulate a human keystroke in this environment). If it
+turns out `!` commands **do** fire `PreToolUse` in some Claude Code version,
+the practical effect is simply that Tim would also need to run the merge
+command outside Claude Code (a separate terminal) — the agent-side guarantee
+(no agent can merge, by any path) holds either way, since it doesn't depend
+on this assumption at all.
+
+## Non-goals / explicitly out of scope
+
+- No attempt to detect or block a human running `gh pr merge` directly in a
+  separate terminal — that's not a Claude Code tool call and was never in
+  scope for a PreToolUse hook.
+- No screenshot diffing / visual-regression tooling — this posts current
+  screenshots for human review, it does not compare against a baseline.
+- No automatic pruning of the `pr-screenshots` branch (see hardening
+  follow-ups above).

--- a/scripts/workflow/AGENTS.md
+++ b/scripts/workflow/AGENTS.md
@@ -1,10 +1,12 @@
 # PR Workflow Scripts
 
-Bash scripts for managing GitHub PR lifecycle: CI monitoring, readiness labeling, and gate-enforced merge.
+Bash/Node scripts for managing GitHub PR lifecycle: CI monitoring, UI screenshots, readiness labeling, and human-only gate-enforced merge.
 
 ## Architecture
 
 Scripts are designed for the **PinPoint orchestrator workflow** where multiple subagents work in parallel worktrees. The orchestrator (or a human) uses these from the main repo to monitor and manage PRs created by agents.
+
+**Merging is human-only (PP-wi85).** `merge-pr.sh` is blocked for agents by the `block-direct-merge.cjs` PreToolUse hook, in ANY invocation shape (including `--dry-run`) — there is no agent bypass. Agents run every other script in this directory freely, including `pr-screenshots.mjs` and `mark-claude-review.sh`; only `merge-pr.sh` itself is off-limits. Tim runs it directly (`scripts/workflow/merge-pr.sh <PR> --human`) once an agent hands the PR off as ready.
 
 ## Scripts
 
@@ -15,13 +17,20 @@ Scripts are designed for the **PinPoint orchestrator workflow** where multiple s
 | `pr-dashboard.sh [PR...]` | Status table: CI checks, merge state, draft state. All open PRs if no args.                                                                 |
 | `pr-watch.py <PR>`        | Stream CI run events. One timestamped line per event. Use with the Claude Code Monitor tool. Writes failure artifacts to `tmp/gh-monitor/`. |
 
+### UI Screenshots
+
+| Script                                                   | Purpose                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pr-screenshots.mjs <PR> [--pages a,b,c] [--force-auth]` | Shoots the pages in `ui-screenshot-manifest.json` at desktop (1440×900) + mobile (390×844), pushes PNGs to the orphan `pr-screenshots` branch, posts/updates one sticky PR comment (marker `<!-- pr-screenshots -->`). Agent-runnable — not a merge action. |
+| `ui-screenshot-manifest.json`                            | Page manifest: id → `{ label, route, authRole, seedNeeds }`. Edit to add/remove shot targets.                                                                                                                                                               |
+
 ### Readiness and Merge
 
-| Script                                 | Purpose                                                                                                                                                                             |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `merge-pr.sh <PR>`                     | Re-evaluates all 5 gates (`ci`, `currency`, `threads`, `reviewed`, `no_conflict`) and squash-merges if all pass. Removes ready-for-review label on failure. `--dry-run` to preview. |
-| `mark-claude-review.sh <PR> [summary]` | Posts/updates a sticky SHA-pinned Claude-review marker comment (`<!-- pinpoint-claude-review: <head_sha> -->`) that satisfies the `reviewed` gate when Copilot skips.               |
-| `_pr-gates.sh`                         | Shared bash helper sourced by merge-pr.sh. Defines the gate functions.                                                                                                              |
+| Script                                 | Purpose                                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `merge-pr.sh <PR> --human`             | **Human-only — blocked for agents.** Re-evaluates all 5 gates (`ci`, `currency`, `threads`, `reviewed`, `no_conflict`) and squash-merges if all pass. Removes ready-for-review label on failure. `--human` is required to actually merge (defense-in-depth for non-Claude-Code harnesses); `--dry-run` doesn't need it but agents can't run the script at all inside Claude Code, dry-run included. |
+| `mark-claude-review.sh <PR> [summary]` | Posts/updates a sticky SHA-pinned Claude-review marker comment (`<!-- pinpoint-claude-review: <head_sha> -->`) that satisfies the `reviewed` gate when Copilot skips.                                                                                                                                                                                                                               |
+| `_pr-gates.sh`                         | Shared bash helper sourced by merge-pr.sh. Defines the gate functions.                                                                                                                                                                                                                                                                                                                              |
 
 ### Gates (evaluated by `merge-pr.sh`, defined in `_pr-gates.sh`)
 
@@ -50,14 +59,15 @@ The agent reads these tokens from script stdout to decide next steps. Scripts ne
 
 The pinpoint-pr-workflow skill defaults to MCP tools for per-operation reads and writes. Scripts handle composite enforcement.
 
-| Operation                                      | Use MCP                                        | Use Script                                    |
-| ---------------------------------------------- | ---------------------------------------------- | --------------------------------------------- |
-| Read PR metadata, reviews, threads, check_runs | `pull_request_read(method: ...)`               | —                                             |
-| Apply/remove PR label                          | `issue_write(method: "update", labels: [...])` | —                                             |
-| Get failed CI logs                             | `get_job_logs(failed_only, tail_lines)`        | —                                             |
-| Stream CI runs in real time                    | —                                              | `pr-watch.py`                                 |
-| Merge a PR                                     | —                                              | `merge-pr.sh` (direct merges blocked by hook) |
-| Composite gate evaluation                      | —                                              | `merge-pr.sh` (sources `_pr-gates.sh`)        |
+| Operation                                      | Use MCP                                        | Use Script                                                                                                   |
+| ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Read PR metadata, reviews, threads, check_runs | `pull_request_read(method: ...)`               | —                                                                                                            |
+| Apply/remove PR label                          | `issue_write(method: "update", labels: [...])` | —                                                                                                            |
+| Get failed CI logs                             | `get_job_logs(failed_only, tail_lines)`        | —                                                                                                            |
+| Stream CI runs in real time                    | —                                              | `pr-watch.py`                                                                                                |
+| Merge a PR                                     | —                                              | `merge-pr.sh --human` (human-only — blocked for agents via ANY invocation shape)                             |
+| Composite gate evaluation                      | —                                              | `merge-pr.sh` (sources `_pr-gates.sh`) — Tim runs it; an agent cannot invoke it at all, not even `--dry-run` |
+| Post UI screenshots                            | —                                              | `pr-screenshots.mjs` (agent-runnable)                                                                        |
 
 MCP field-naming gotcha: responses use snake_case (`is_resolved`, `submitted_at`, `head.sha`). GraphQL we previously used was camelCase.
 
@@ -65,7 +75,7 @@ MCP field-naming gotcha: responses use snake_case (`is_resolved`, `submitted_at`
 
 - **MCP first for reads and per-op writes**: typed tool calls beat shell-escaped gh CLI for the agent's use cases. Scripts wrap composite enforcement that can't be a single API call.
 - **Mechanical script output**: scripts emit status (FAIL, WAIT, BLOCK, PASS), never prescriptive advice. The skill documents what to do per token.
-- **Direct merge blocked**: `gh pr merge` and MCP `merge_pull_request` are blocked by the `.claude/hooks/block-direct-merge.cjs` PreToolUse hook. Use `merge-pr.sh` to enforce gate re-checks. Bypass via `.claude-merge-bypass` sentinel file (single-use, deleted on hook fire).
+- **Merge is human-only (PP-wi85)**: `gh pr merge`, MCP `merge_pull_request`, AND `scripts/workflow/merge-pr.sh` itself (any flags, including `--dry-run`) are all blocked for an agent by the `.claude/hooks/block-direct-merge.cjs` PreToolUse hook. There is no agent-usable bypass — the old `.claude-merge-bypass` sentinel was removed entirely. `merge-pr.sh` also refuses to execute a merge without `--human` at the script level, as defense-in-depth for harnesses that don't wire the Claude Code hook.
 - **Fail closed on API errors**: gates that can't determine state exit non-zero.
 
 ## Dependencies

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -6,8 +6,11 @@
 # Usage: merge-pr.sh <PR> --human [--dry-run] [--force] [--bypass-merge-requirements]
 #   --human                       REQUIRED to actually merge. Merging is human-authorized
 #                                 only (PP-wi85) — this script refuses to execute a merge
-#                                 without it. Not required for --dry-run (gate preview is
-#                                 safe to run without a human present).
+#                                 without it. Not required for --dry-run: a human or CI
+#                                 process previewing gate status without merging is fine.
+#                                 This is NOT an agent-preview allowance — inside Claude
+#                                 Code, block-direct-merge.cjs blocks an agent from
+#                                 invoking this script at all, --dry-run included.
 #   --dry-run                     Print would-do summary, take no action. Does not require --human.
 #   --force                       Bypass currency + threads + reviewed gates.
 #   --bypass-merge-requirements   Bypass ci gate AND pass --admin to gh pr merge
@@ -53,10 +56,14 @@ if [ -z "$PR" ] || ! [[ "$PR" =~ ^[0-9]+$ ]]; then
 fi
 
 # Merges are human-authorized only (PP-wi85). --dry-run is exempt — it takes no
-# action, so an agent previewing gate status before handing off to Tim is fine.
+# action, so a human or CI process previewing gate status without merging is
+# fine. This is NOT an agent-preview allowance: inside Claude Code, the
+# block-direct-merge.cjs PreToolUse hook blocks an agent from invoking this
+# script at all, --dry-run included — an agent should read PR state via MCP
+# (pull_request_read) instead of ever reaching this line.
 if [ "$DRY_RUN" != "true" ] && [ "$HUMAN" != "true" ]; then
   echo "REFUSE: merges are human-authorized only. Canonical command: scripts/workflow/merge-pr.sh $PR --human" >&2
-  echo "        (add --dry-run instead to preview gate status without merging)" >&2
+  echo "        (forgot --human? add it to merge. --dry-run previews gate status without merging.)" >&2
   exit 1
 fi
 

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -3,18 +3,31 @@
 # Re-evaluates all 5 PR gates at merge time (TOCTOU safety vs label-time gates),
 # squash-merges with --match-head-commit if all pass, removes ready-for-review label on failure.
 #
-# Usage: merge-pr.sh <PR> [--dry-run] [--force] [--bypass-merge-requirements]
-#   --dry-run                     Print would-do summary, take no action.
+# Usage: merge-pr.sh <PR> --human [--dry-run] [--force] [--bypass-merge-requirements]
+#   --human                       REQUIRED to actually merge. Merging is human-authorized
+#                                 only (PP-wi85) — this script refuses to execute a merge
+#                                 without it. Not required for --dry-run (gate preview is
+#                                 safe to run without a human present).
+#   --dry-run                     Print would-do summary, take no action. Does not require --human.
 #   --force                       Bypass currency + threads + reviewed gates.
 #   --bypass-merge-requirements   Bypass ci gate AND pass --admin to gh pr merge
 #                                 (overrides GitHub branch-protection rules).
 #                                 Combine with --force to bypass currency + threads + reviewed + ci together.
+#
+# Canonical human-run command: scripts/workflow/merge-pr.sh <PR> --human
 #
 # no_conflict gate is NEVER bypassable — GitHub rejects conflicting merges regardless of --admin.
 # Authorship gate has no bypass; this script operates only on PRs you authored OR PRs authored
 # by trusted Dependabot bot identities (app/dependabot, dependabot[bot], dependabot).
 # Both --force and --bypass-merge-requirements require manual permission approval
 # (settings.json permissions.ask).
+#
+# Defense-in-depth note (PP-wi85): the --human flag is a same-tool guard against
+# non-interactive/scripted invocation — it does not (and cannot) verify a human is
+# actually typing the command. It stops accidental/scripted calls; the real
+# enforcement boundary is that Claude Code's block-direct-merge.cjs PreToolUse hook
+# refuses to let an agent invoke this script at all (any flags), in ANY harness that
+# wires the hook. Cross-tool (Codex/Gemini/Antigravity) coverage is best-effort only.
 
 set -euo pipefail
 
@@ -22,18 +35,28 @@ PR=""
 DRY_RUN=false
 FORCE=false
 BYPASS_REQS=false
+HUMAN=false
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run)                   DRY_RUN=true ;;
     --force)                     FORCE=true ;;
     --bypass-merge-requirements) BYPASS_REQS=true ;;
+    --human)                     HUMAN=true ;;
     *) if [ -z "$PR" ]; then PR="$arg"; else echo "Error: unexpected argument $arg" >&2; exit 1; fi ;;
   esac
 done
 
 if [ -z "$PR" ] || ! [[ "$PR" =~ ^[0-9]+$ ]]; then
-  echo "Usage: $0 <PR> [--dry-run] [--force] [--bypass-merge-requirements]" >&2
+  echo "Usage: $0 <PR> --human [--dry-run] [--force] [--bypass-merge-requirements]" >&2
+  exit 1
+fi
+
+# Merges are human-authorized only (PP-wi85). --dry-run is exempt — it takes no
+# action, so an agent previewing gate status before handing off to Tim is fine.
+if [ "$DRY_RUN" != "true" ] && [ "$HUMAN" != "true" ]; then
+  echo "REFUSE: merges are human-authorized only. Canonical command: scripts/workflow/merge-pr.sh $PR --human" >&2
+  echo "        (add --dry-run instead to preview gate status without merging)" >&2
   exit 1
 fi
 
@@ -145,9 +168,11 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 # --- Execute merge ---
-# The block-direct-merge PreToolUse hook fires on top-level Claude Bash invocations only.
-# This `gh pr merge` runs as a subprocess of the script, so the hook does not see it —
-# no sentinel needed. (A leftover sentinel would silently bypass the next user-level merge.)
+# Reaching this line already required passing the --human gate above. The
+# block-direct-merge PreToolUse hook (Claude Code) additionally refuses to let
+# an agent invoke this script at all — see the header comment. This `gh pr
+# merge` runs as a subprocess of the script either way, so the hook does not
+# see it directly; --human is the guard for that layer.
 gh pr merge "$PR" "${MERGE_ARGS[@]}"
 echo "MERGED: PR #$PR"
 

--- a/scripts/workflow/pr-screenshots.mjs
+++ b/scripts/workflow/pr-screenshots.mjs
@@ -8,11 +8,11 @@
 // URLs render inline in the PR comment), and posts/updates one sticky PR comment.
 //
 // Usage:
-//   node scripts/workflow/pr-screenshots.mjs <PR> [--pages a,b,c] [--force-auth]
+//   node scripts/workflow/pr-screenshots.mjs <PR> [--pages=a,b,c] [--force-auth]
 //
 //   <PR>          Required. GitHub PR number — used for the screenshot storage
 //                 path and the sticky comment target.
-//   --pages       Optional comma-separated list of manifest page ids to shoot.
+//   --pages=a,b,c Optional comma-separated list of manifest page ids to shoot.
 //                 Default: every page in ui-screenshot-manifest.json.
 //   --force-auth  Regenerate e2e/.auth/*.json storage state even if present
 //                 (use when a previous session looks stale/expired).

--- a/scripts/workflow/pr-screenshots.mjs
+++ b/scripts/workflow/pr-screenshots.mjs
@@ -42,7 +42,14 @@
 import { chromium } from "@playwright/test";
 import nextEnv from "@next/env";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,7 +59,10 @@ const { loadEnvConfig } = nextEnv;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..", "..");
 
-const MANIFEST_PATH = join(REPO_ROOT, "scripts/workflow/ui-screenshot-manifest.json");
+const MANIFEST_PATH = join(
+  REPO_ROOT,
+  "scripts/workflow/ui-screenshot-manifest.json"
+);
 const STORAGE_STATE = {
   admin: join(REPO_ROOT, "e2e/.auth/admin.json"),
   member: join(REPO_ROOT, "e2e/.auth/member.json"),
@@ -77,7 +87,10 @@ function parseArgs(argv) {
       forceAuth = true;
     } else if (arg.startsWith("--pages")) {
       const value = arg.includes("=") ? arg.split("=")[1] : "";
-      pagesFilter = value.split(",").map((s) => s.trim()).filter(Boolean);
+      pagesFilter = value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
     } else if (!arg.startsWith("--") && pr === undefined) {
       pr = arg;
     } else {
@@ -197,7 +210,13 @@ async function captureScreenshots(baseUrl, pages, workDir) {
           const fileName = `${vpName}-${page.id}.png`;
           const outPath = join(workDir, fileName);
           await pw.screenshot({ path: outPath });
-          captured.push({ id: page.id, label: page.label, vpName, fileName, outPath });
+          captured.push({
+            id: page.id,
+            label: page.label,
+            vpName,
+            fileName,
+            outPath,
+          });
         } catch (error) {
           console.error(
             `⚠️  Failed to capture ${vpName}/${page.id}: ${error instanceof Error ? error.message : error}`
@@ -239,15 +258,23 @@ function publishScreenshots(pr, shortSha, captured) {
 
   try {
     git(["init", "-q", "-b", SCREENSHOTS_BRANCH], { cwd: tmpDir });
-    git(["config", "user.email", "pinpoint-bot@users.noreply.github.com"], { cwd: tmpDir });
+    git(["config", "user.email", "pinpoint-bot@users.noreply.github.com"], {
+      cwd: tmpDir,
+    });
     git(["config", "user.name", "PinPoint Screenshot Bot"], { cwd: tmpDir });
     git(["remote", "add", "origin", remoteUrl], { cwd: tmpDir });
 
     try {
-      git(["fetch", "-q", "--depth", "1", "origin", SCREENSHOTS_BRANCH], { cwd: tmpDir });
-      git(["checkout", "-q", "-B", SCREENSHOTS_BRANCH, "FETCH_HEAD"], { cwd: tmpDir });
+      git(["fetch", "-q", "--depth", "1", "origin", SCREENSHOTS_BRANCH], {
+        cwd: tmpDir,
+      });
+      git(["checkout", "-q", "-B", SCREENSHOTS_BRANCH, "FETCH_HEAD"], {
+        cwd: tmpDir,
+      });
     } catch {
-      console.log(`ℹ️  Remote branch "${SCREENSHOTS_BRANCH}" doesn't exist yet — creating it.`);
+      console.log(
+        `ℹ️  Remote branch "${SCREENSHOTS_BRANCH}" doesn't exist yet — creating it.`
+      );
     }
 
     const destDir = join(tmpDir, `pr-${pr}`, shortSha);
@@ -260,8 +287,12 @@ function publishScreenshots(pr, shortSha, captured) {
     }
 
     git(["add", "-A"], { cwd: tmpDir });
-    git(["commit", "-q", "-m", `screenshots: PR #${pr} @ ${shortSha}`], { cwd: tmpDir });
-    git(["push", "-q", "origin", `HEAD:${SCREENSHOTS_BRANCH}`], { cwd: tmpDir });
+    git(["commit", "-q", "-m", `screenshots: PR #${pr} @ ${shortSha}`], {
+      cwd: tmpDir,
+    });
+    git(["push", "-q", "origin", `HEAD:${SCREENSHOTS_BRANCH}`], {
+      cwd: tmpDir,
+    });
 
     return remotePaths;
   } finally {
@@ -272,7 +303,8 @@ function publishScreenshots(pr, shortSha, captured) {
 function buildCommentBody(repoSlug, pr, shortSha, captured) {
   const byPage = new Map();
   for (const shot of captured) {
-    if (!byPage.has(shot.id)) byPage.set(shot.id, { label: shot.label, desktop: null, mobile: null });
+    if (!byPage.has(shot.id))
+      byPage.set(shot.id, { label: shot.label, desktop: null, mobile: null });
     byPage.get(shot.id)[shot.vpName] = shot.fileName;
   }
 
@@ -312,12 +344,17 @@ function postOrUpdateStickyComment(repoSlug, pr, body) {
     ["api", "--paginate", `repos/${repoSlug}/issues/${pr}/comments`],
     { encoding: "utf8" }
   );
-  const flattened = execFileSync("jq", ["-s", "add"], { input: raw, encoding: "utf8" });
+  const flattened = execFileSync("jq", ["-s", "add"], {
+    input: raw,
+    encoding: "utf8",
+  });
   const list = JSON.parse(flattened);
   const stickyComment = list.find((c) => c.body?.startsWith(COMMENT_MARKER));
 
   if (stickyComment) {
-    console.log(`✏️  Updating sticky screenshot comment (id=${stickyComment.id})`);
+    console.log(
+      `✏️  Updating sticky screenshot comment (id=${stickyComment.id})`
+    );
     return ghJson([
       "api",
       "--method",
@@ -357,14 +394,19 @@ async function main() {
       ["pr", "view", pr, "--json", "headRefOid", "--jq", ".headRefOid"],
       { cwd: REPO_ROOT, encoding: "utf8" }
     ).trim();
-    if (!prHead.startsWith(shortSha) && !shortSha.startsWith(prHead.slice(0, shortSha.length))) {
+    if (
+      !prHead.startsWith(shortSha) &&
+      !shortSha.startsWith(prHead.slice(0, shortSha.length))
+    ) {
       console.warn(
         `⚠️  Local HEAD (${shortSha}) doesn't match PR #${pr}'s remote head (${prHead.slice(0, 7)}). ` +
           "Screenshots will be taken of local HEAD, not the PR's pushed head — push first if they should match."
       );
     }
   } catch {
-    console.warn(`⚠️  Could not verify PR #${pr}'s head via gh — continuing anyway.`);
+    console.warn(
+      `⚠️  Could not verify PR #${pr}'s head via gh — continuing anyway.`
+    );
   }
 
   const baseUrl = resolveBaseUrl();
@@ -383,11 +425,15 @@ async function main() {
   try {
     captured = await captureScreenshots(baseUrl, pages, workDir);
     if (captured.length === 0) {
-      throw new Error("No screenshots captured — every page failed. See errors above.");
+      throw new Error(
+        "No screenshots captured — every page failed. See errors above."
+      );
     }
 
     const remotePaths = publishScreenshots(pr, shortSha, captured);
-    console.log(`✅ Pushed ${remotePaths.length} screenshot(s) to ${SCREENSHOTS_BRANCH}`);
+    console.log(
+      `✅ Pushed ${remotePaths.length} screenshot(s) to ${SCREENSHOTS_BRANCH}`
+    );
 
     const repoSlug = execFileSync(
       "gh",

--- a/scripts/workflow/pr-screenshots.mjs
+++ b/scripts/workflow/pr-screenshots.mjs
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+// scripts/workflow/pr-screenshots.mjs — desktop+mobile screenshots for a PR.
+//
+// PP-wi85: UI-touching PRs must have screenshots posted before handoff to Tim
+// so he can eyeball them before running the (human-only) merge. This script
+// shoots a manifest of key pages at two viewports, pushes the PNGs to a
+// dedicated orphan `pr-screenshots` branch (repo is public, so raw.githubusercontent.com
+// URLs render inline in the PR comment), and posts/updates one sticky PR comment.
+//
+// Usage:
+//   node scripts/workflow/pr-screenshots.mjs <PR> [--pages a,b,c] [--force-auth]
+//
+//   <PR>          Required. GitHub PR number — used for the screenshot storage
+//                 path and the sticky comment target.
+//   --pages       Optional comma-separated list of manifest page ids to shoot.
+//                 Default: every page in ui-screenshot-manifest.json.
+//   --force-auth  Regenerate e2e/.auth/*.json storage state even if present
+//                 (use when a previous session looks stale/expired).
+//
+// Preconditions (best-effort, not auto-provisioned by this script):
+//   - Local dev server running at http://localhost:<PORT> (`pnpm run dev`).
+//     PORT is read from .env.local the same way playwright.config.ts does —
+//     worktree-aware, always localhost (CORE-SEC-008).
+//   - Local Supabase running (`supabase start`).
+//   - `gh` CLI authenticated.
+//
+// First run (or any run with missing/stale storage state) invokes
+// `pnpm exec playwright test --project=auth-setup`, which — via
+// e2e/global-setup.ts — resets and reseeds the local dev database. This is
+// the same reset the E2E suite already does locally; it is NOT run against
+// production. Subsequent runs reuse the saved storage state and do not reset
+// the DB, unless it's missing or --force-auth is passed.
+//
+// Hardening follow-ups (deferred — see PR description / spec doc):
+//   - No retry/backoff on flaky navigation (single attempt per page).
+//   - Session staleness is only handled via the manual --force-auth escape
+//     hatch, not detected automatically.
+//   - The pr-screenshots branch has no pruning/TTL (unlike the preview-deployment
+//     reaper) — it will grow unbounded over time.
+//   - PR-number/branch mismatch is a warning, not a hard failure.
+
+import { chromium } from "@playwright/test";
+import nextEnv from "@next/env";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { loadEnvConfig } = nextEnv;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..");
+
+const MANIFEST_PATH = join(REPO_ROOT, "scripts/workflow/ui-screenshot-manifest.json");
+const STORAGE_STATE = {
+  admin: join(REPO_ROOT, "e2e/.auth/admin.json"),
+  member: join(REPO_ROOT, "e2e/.auth/member.json"),
+  technician: join(REPO_ROOT, "e2e/.auth/technician.json"),
+};
+
+const VIEWPORTS = {
+  desktop: { width: 1440, height: 900 },
+  mobile: { width: 390, height: 844 },
+};
+
+const SCREENSHOTS_BRANCH = "pr-screenshots";
+const COMMENT_MARKER = "<!-- pr-screenshots -->";
+
+function parseArgs(argv) {
+  let pr;
+  let pagesFilter;
+  let forceAuth = false;
+
+  for (const arg of argv) {
+    if (arg === "--force-auth") {
+      forceAuth = true;
+    } else if (arg.startsWith("--pages")) {
+      const value = arg.includes("=") ? arg.split("=")[1] : "";
+      pagesFilter = value.split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (!arg.startsWith("--") && pr === undefined) {
+      pr = arg;
+    } else {
+      throw new Error(`Unrecognized argument: ${arg}`);
+    }
+  }
+
+  if (!pr || !/^\d+$/.test(pr)) {
+    throw new Error(
+      "Usage: node scripts/workflow/pr-screenshots.mjs <PR> [--pages=a,b,c] [--force-auth]"
+    );
+  }
+
+  return { pr, pagesFilter, forceAuth };
+}
+
+function loadManifest(pagesFilter) {
+  const raw = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const entries = Object.entries(raw).filter(([id]) => !id.startsWith("_"));
+  const selected = pagesFilter
+    ? entries.filter(([id]) => pagesFilter.includes(id))
+    : entries;
+
+  if (selected.length === 0) {
+    throw new Error(
+      pagesFilter
+        ? `No manifest pages matched --pages=${pagesFilter.join(",")}`
+        : "ui-screenshot-manifest.json has no pages defined"
+    );
+  }
+
+  for (const [id, page] of selected) {
+    if (!STORAGE_STATE[page.authRole]) {
+      throw new Error(
+        `Manifest page "${id}" has unknown authRole "${page.authRole}" (expected one of ${Object.keys(STORAGE_STATE).join(", ")})`
+      );
+    }
+  }
+
+  return selected.map(([id, page]) => ({ id, ...page }));
+}
+
+function resolveBaseUrl() {
+  loadEnvConfig(REPO_ROOT, true);
+  const port = Number(process.env.PORT ?? "3000");
+  return `http://localhost:${port}`;
+}
+
+async function checkServerReachable(baseUrl) {
+  try {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function ensureAuthStorageState(rolesNeeded, forceAuth) {
+  const missing = forceAuth
+    ? rolesNeeded
+    : rolesNeeded.filter((role) => !existsSync(STORAGE_STATE[role]));
+
+  if (missing.length === 0) {
+    console.log(`✅ Auth storage state present for: ${rolesNeeded.join(", ")}`);
+    return;
+  }
+
+  console.log(
+    `🔐 Auth storage state missing/stale for: ${missing.join(", ")}. ` +
+      "Regenerating via `pnpm exec playwright test --project=auth-setup` " +
+      "(this resets + reseeds the local dev DB — same as running E2E tests locally)."
+  );
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "playwright", "test", "--project=auth-setup"],
+    { cwd: REPO_ROOT, stdio: "inherit", env: process.env }
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      "auth-setup failed — see output above. Ensure the dev server + Supabase " +
+        "can start locally (pnpm run dev / supabase start)."
+    );
+  }
+}
+
+async function captureScreenshots(baseUrl, pages, workDir) {
+  const rolesNeeded = [...new Set(pages.map((p) => p.authRole))];
+  const browser = await chromium.launch();
+  /** @type {Map<string, import("@playwright/test").BrowserContext>} */
+  const contexts = new Map();
+  const captured = [];
+
+  try {
+    for (const role of rolesNeeded) {
+      for (const [vpName, vp] of Object.entries(VIEWPORTS)) {
+        const ctx = await browser.newContext({
+          storageState: STORAGE_STATE[role],
+          viewport: vp,
+          baseURL: baseUrl,
+        });
+        contexts.set(`${role}:${vpName}`, ctx);
+      }
+    }
+
+    for (const page of pages) {
+      for (const vpName of Object.keys(VIEWPORTS)) {
+        const ctx = contexts.get(`${page.authRole}:${vpName}`);
+        const pw = await ctx.newPage();
+        console.log(`📸 ${vpName} — ${page.label} (${page.route})`);
+        try {
+          await pw.goto(page.route, {
+            waitUntil: "networkidle",
+            timeout: 15000,
+          });
+          const fileName = `${vpName}-${page.id}.png`;
+          const outPath = join(workDir, fileName);
+          await pw.screenshot({ path: outPath });
+          captured.push({ id: page.id, label: page.label, vpName, fileName, outPath });
+        } catch (error) {
+          console.error(
+            `⚠️  Failed to capture ${vpName}/${page.id}: ${error instanceof Error ? error.message : error}`
+          );
+        } finally {
+          await pw.close();
+        }
+      }
+    }
+  } finally {
+    for (const ctx of contexts.values()) {
+      await ctx.close();
+    }
+    await browser.close();
+  }
+
+  return captured;
+}
+
+function git(args, opts = {}) {
+  return execFileSync("git", args, { encoding: "utf8", ...opts }).trim();
+}
+
+function ghJson(args) {
+  return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }));
+}
+
+/**
+ * Push captured PNGs to the orphan `pr-screenshots` branch under
+ * pr-<N>/<shortsha>/<file>. Runs entirely inside a throwaway temp dir with
+ * its own fresh `git init` (NOT `git worktree add` against the main repo) so
+ * it never touches the working tree and never trips the repo's Husky
+ * post-checkout hook (which would otherwise allocate a worktree port slot
+ * for a directory that only exists to hold PNGs for a few seconds).
+ */
+function publishScreenshots(pr, shortSha, captured) {
+  const remoteUrl = git(["remote", "get-url", "origin"], { cwd: REPO_ROOT });
+  const tmpDir = mkdtempSync(join(tmpdir(), "pr-screenshots-"));
+
+  try {
+    git(["init", "-q", "-b", SCREENSHOTS_BRANCH], { cwd: tmpDir });
+    git(["config", "user.email", "pinpoint-bot@users.noreply.github.com"], { cwd: tmpDir });
+    git(["config", "user.name", "PinPoint Screenshot Bot"], { cwd: tmpDir });
+    git(["remote", "add", "origin", remoteUrl], { cwd: tmpDir });
+
+    try {
+      git(["fetch", "-q", "--depth", "1", "origin", SCREENSHOTS_BRANCH], { cwd: tmpDir });
+      git(["checkout", "-q", "-B", SCREENSHOTS_BRANCH, "FETCH_HEAD"], { cwd: tmpDir });
+    } catch {
+      console.log(`ℹ️  Remote branch "${SCREENSHOTS_BRANCH}" doesn't exist yet — creating it.`);
+    }
+
+    const destDir = join(tmpDir, `pr-${pr}`, shortSha);
+    mkdirSync(destDir, { recursive: true });
+    const remotePaths = [];
+    for (const shot of captured) {
+      const dest = join(destDir, shot.fileName);
+      writeFileSync(dest, readFileSync(shot.outPath));
+      remotePaths.push(`pr-${pr}/${shortSha}/${shot.fileName}`);
+    }
+
+    git(["add", "-A"], { cwd: tmpDir });
+    git(["commit", "-q", "-m", `screenshots: PR #${pr} @ ${shortSha}`], { cwd: tmpDir });
+    git(["push", "-q", "origin", `HEAD:${SCREENSHOTS_BRANCH}`], { cwd: tmpDir });
+
+    return remotePaths;
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function buildCommentBody(repoSlug, pr, shortSha, captured) {
+  const byPage = new Map();
+  for (const shot of captured) {
+    if (!byPage.has(shot.id)) byPage.set(shot.id, { label: shot.label, desktop: null, mobile: null });
+    byPage.get(shot.id)[shot.vpName] = shot.fileName;
+  }
+
+  const rawBase = `https://raw.githubusercontent.com/${repoSlug}/${SCREENSHOTS_BRANCH}/pr-${pr}/${shortSha}`;
+
+  const sections = [...byPage.values()].map(({ label, desktop, mobile }) => {
+    const desktopCell = desktop
+      ? `![desktop](${rawBase}/${desktop})`
+      : "_capture failed_";
+    const mobileCell = mobile
+      ? `![mobile](${rawBase}/${mobile})`
+      : "_capture failed_";
+    return [
+      `### ${label}`,
+      "",
+      "| Desktop (1440×900) | Mobile (390×844) |",
+      "| --- | --- |",
+      `| ${desktopCell} | ${mobileCell} |`,
+      "",
+    ].join("\n");
+  });
+
+  return [
+    COMMENT_MARKER,
+    `## UI Screenshots — head \`${shortSha}\``,
+    "",
+    ...sections,
+  ].join("\n");
+}
+
+function postOrUpdateStickyComment(repoSlug, pr, body) {
+  // `--paginate` concatenates one JSON array per page back-to-back, which isn't
+  // valid single-document JSON — slurp+flatten via jq (same approach as
+  // mark-claude-review.sh) so a marker comment on page 2+ of a busy PR isn't missed.
+  const raw = execFileSync(
+    "gh",
+    ["api", "--paginate", `repos/${repoSlug}/issues/${pr}/comments`],
+    { encoding: "utf8" }
+  );
+  const flattened = execFileSync("jq", ["-s", "add"], { input: raw, encoding: "utf8" });
+  const list = JSON.parse(flattened);
+  const stickyComment = list.find((c) => c.body?.startsWith(COMMENT_MARKER));
+
+  if (stickyComment) {
+    console.log(`✏️  Updating sticky screenshot comment (id=${stickyComment.id})`);
+    return ghJson([
+      "api",
+      "--method",
+      "PATCH",
+      `repos/${repoSlug}/issues/comments/${stickyComment.id}`,
+      "-f",
+      `body=${body}`,
+      "--jq",
+      ".html_url",
+    ]);
+  }
+
+  console.log("📝 Posting new sticky screenshot comment");
+  return ghJson([
+    "api",
+    "--method",
+    "POST",
+    `repos/${repoSlug}/issues/${pr}/comments`,
+    "-f",
+    `body=${body}`,
+    "--jq",
+    ".html_url",
+  ]);
+}
+
+async function main() {
+  const { pr, pagesFilter, forceAuth } = parseArgs(process.argv.slice(2));
+  const pages = loadManifest(pagesFilter);
+
+  const shortSha = git(["rev-parse", "--short", "HEAD"], { cwd: REPO_ROOT });
+
+  // Best-effort sanity check — warn, don't fail, if local HEAD doesn't match
+  // the PR's head on GitHub (e.g. forgot to push, or wrong branch checked out).
+  try {
+    const prHead = execFileSync(
+      "gh",
+      ["pr", "view", pr, "--json", "headRefOid", "--jq", ".headRefOid"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    ).trim();
+    if (!prHead.startsWith(shortSha) && !shortSha.startsWith(prHead.slice(0, shortSha.length))) {
+      console.warn(
+        `⚠️  Local HEAD (${shortSha}) doesn't match PR #${pr}'s remote head (${prHead.slice(0, 7)}). ` +
+          "Screenshots will be taken of local HEAD, not the PR's pushed head — push first if they should match."
+      );
+    }
+  } catch {
+    console.warn(`⚠️  Could not verify PR #${pr}'s head via gh — continuing anyway.`);
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const healthy = await checkServerReachable(baseUrl);
+  if (!healthy) {
+    throw new Error(
+      `Dev server not reachable at ${baseUrl}/api/health. Start it first: pnpm run dev`
+    );
+  }
+
+  const rolesNeeded = [...new Set(pages.map((p) => p.authRole))];
+  ensureAuthStorageState(rolesNeeded, forceAuth);
+
+  const workDir = mkdtempSync(join(tmpdir(), "pr-screenshots-capture-"));
+  let captured;
+  try {
+    captured = await captureScreenshots(baseUrl, pages, workDir);
+    if (captured.length === 0) {
+      throw new Error("No screenshots captured — every page failed. See errors above.");
+    }
+
+    const remotePaths = publishScreenshots(pr, shortSha, captured);
+    console.log(`✅ Pushed ${remotePaths.length} screenshot(s) to ${SCREENSHOTS_BRANCH}`);
+
+    const repoSlug = execFileSync(
+      "gh",
+      ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    ).trim();
+
+    const body = buildCommentBody(repoSlug, pr, shortSha, captured);
+    const commentUrl = postOrUpdateStickyComment(repoSlug, pr, body);
+    console.log(`✅ Sticky comment: ${commentUrl}`);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`❌ ${error instanceof Error ? error.message : error}`);
+  process.exit(1);
+});

--- a/scripts/workflow/ui-screenshot-manifest.json
+++ b/scripts/workflow/ui-screenshot-manifest.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Page manifest for scripts/workflow/pr-screenshots.mjs. Keys are the page id (used in filenames + --pages filter). authRole must be one of admin/member/technician (matches e2e/support/auth-state.ts STORAGE_STATE roles). seedNeeds documents which local-seed fixture the route depends on so a broken screenshot points at the right cause.",
+  "issues-list": {
+    "label": "Issues List",
+    "route": "/issues",
+    "authRole": "member",
+    "seedNeeds": "default seed (src/test/data/issues.json)"
+  },
+  "issue-detail": {
+    "label": "Issue Detail (Attack from Mars #1)",
+    "route": "/m/AFM/i/1",
+    "authRole": "member",
+    "seedNeeds": "seeded machine AFM (attackFromMars) + issue #1 from src/test/data/issues.json"
+  },
+  "report": {
+    "label": "Report an Issue",
+    "route": "/report",
+    "authRole": "member",
+    "seedNeeds": "default seed (machine picker options)"
+  },
+  "dashboard": {
+    "label": "Dashboard",
+    "route": "/dashboard",
+    "authRole": "member",
+    "seedNeeds": "default seed"
+  },
+  "machine-detail": {
+    "label": "Machine Detail (Addams Family)",
+    "route": "/m/TAF",
+    "authRole": "member",
+    "seedNeeds": "seeded machine TAF (addamsFamily) from src/test/data/machines.json"
+  },
+  "collections": {
+    "label": "Collections",
+    "route": "/c/collections",
+    "authRole": "member",
+    "seedNeeds": "default seed"
+  }
+}

--- a/src/test/unit/hooks/block-direct-merge.test.ts
+++ b/src/test/unit/hooks/block-direct-merge.test.ts
@@ -1,0 +1,196 @@
+// Unit tests for .claude/hooks/block-direct-merge.cjs — the PreToolUse hook
+// that blocks ALL agent-initiated PR merges (PP-wi85). Merging is human-only:
+// there is no agent-usable bypass. The only merge channel is a human typing a
+// `!`-prefixed command in Claude Code, which never generates a PreToolUse
+// event and so is outside this hook's reach entirely.
+//
+// Exercises the hook as a subprocess (spawnSync node hookPath, JSON on stdin)
+// — matches the pattern used by verify-guard-stack.test.ts.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const hookPath = path.resolve(
+  process.cwd(),
+  ".claude/hooks/block-direct-merge.cjs"
+);
+
+function runHook(payload: unknown): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync("node", [hookPath], {
+    input: JSON.stringify(payload),
+    encoding: "utf8",
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function bashPayload(command: string): unknown {
+  return { tool_name: "Bash", tool_input: { command } };
+}
+
+describe("block-direct-merge.cjs — gh merge paths", () => {
+  it("blocks `gh pr merge <PR>`", () => {
+    const { status, stderr } = runHook(bashPayload("gh pr merge 123"));
+    expect(status).toBe(2);
+    expect(stderr).toContain("Direct merge blocked: gh pr merge");
+    expect(stderr).toContain("! scripts/workflow/merge-pr.sh <PR> --human");
+  });
+
+  it("blocks `gh pr merge` chained after another command", () => {
+    const { status, stderr } = runHook(
+      bashPayload("git status && gh pr merge 123 --squash")
+    );
+    expect(status).toBe(2);
+    expect(stderr).toContain("Direct merge blocked: gh pr merge");
+  });
+
+  it("blocks `gh api PUT .../pulls/N/merge`", () => {
+    const { status, stderr } = runHook(
+      bashPayload("gh api -X PUT repos/o/r/pulls/123/merge")
+    );
+    expect(status).toBe(2);
+    expect(stderr).toContain("gh api PUT .../merge");
+  });
+
+  it("does not block gh api GET on a pulls/N/merge path (no write method)", () => {
+    const { status } = runHook(bashPayload("gh api repos/o/r/pulls/123/merge"));
+    expect(status).toBe(0);
+  });
+
+  it("passes through `gh pr merge --help`", () => {
+    const { status } = runHook(bashPayload("gh pr merge --help"));
+    expect(status).toBe(0);
+  });
+
+  it("does not block an unrelated gh command", () => {
+    const { status } = runHook(bashPayload("gh pr view 123"));
+    expect(status).toBe(0);
+  });
+});
+
+describe("block-direct-merge.cjs — MCP merge", () => {
+  it("blocks mcp__github__merge_pull_request regardless of tool_input", () => {
+    const { status, stderr } = runHook({
+      tool_name: "mcp__github__merge_pull_request",
+      tool_input: { owner: "o", repo: "r", pullNumber: 123 },
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("MCP merge_pull_request");
+  });
+});
+
+describe("block-direct-merge.cjs — merge-pr.sh (PP-wi85 hard gate)", () => {
+  it("blocks a bare `merge-pr.sh <PR>` invocation", () => {
+    const { status, stderr } = runHook(bashPayload("merge-pr.sh 123"));
+    expect(status).toBe(2);
+    expect(stderr).toContain(
+      "Merge is human-only. You cannot run merge-pr.sh."
+    );
+  });
+
+  it("blocks `bash scripts/workflow/merge-pr.sh <PR>`", () => {
+    const { status, stderr } = runHook(
+      bashPayload("bash scripts/workflow/merge-pr.sh 123")
+    );
+    expect(status).toBe(2);
+    expect(stderr).toContain("Merge is human-only.");
+  });
+
+  it("blocks `./scripts/workflow/merge-pr.sh <PR>`", () => {
+    const { status, stderr } = runHook(
+      bashPayload("./scripts/workflow/merge-pr.sh 123")
+    );
+    expect(status).toBe(2);
+    expect(stderr).toContain("Merge is human-only.");
+  });
+
+  it("blocks an absolute-path invocation", () => {
+    const { status } = runHook(
+      bashPayload(
+        "/Users/tim/PinPoint/scripts/workflow/merge-pr.sh 123 --human"
+      )
+    );
+    expect(status).toBe(2);
+  });
+
+  it("blocks `sh scripts/workflow/merge-pr.sh <PR>`", () => {
+    const { status } = runHook(
+      bashPayload("sh scripts/workflow/merge-pr.sh 123")
+    );
+    expect(status).toBe(2);
+  });
+
+  it("blocks chained after another command", () => {
+    const { status } = runHook(
+      bashPayload("pnpm run check && scripts/workflow/merge-pr.sh 123 --human")
+    );
+    expect(status).toBe(2);
+  });
+
+  it("does NOT block a quoted mention (echo)", () => {
+    const { status } = runHook(
+      bashPayload('echo "run merge-pr.sh when ready"')
+    );
+    expect(status).toBe(0);
+  });
+
+  it("does NOT block a quoted mention (rg/docs search)", () => {
+    const { status } = runHook(
+      bashPayload('rg "merge-pr.sh" docs/superpowers/specs/')
+    );
+    expect(status).toBe(0);
+  });
+
+  it("does NOT block an unrelated command", () => {
+    const { status } = runHook(bashPayload("gh pr view 123"));
+    expect(status).toBe(0);
+  });
+
+  it("does NOT block dry-run mention text inside a single-quoted string", () => {
+    const { status } = runHook(
+      bashPayload(
+        "echo 'canonical command: scripts/workflow/merge-pr.sh <PR> --human'"
+      )
+    );
+    expect(status).toBe(0);
+  });
+});
+
+describe("block-direct-merge.cjs — no bypass sentinel", () => {
+  it("still blocks merge-pr.sh even with a stray .claude-merge-bypass-shaped arg", () => {
+    // PP-wi85 removed the bypass sentinel entirely — the hook no longer reads
+    // any filesystem state, so there is nothing for a sentinel file to flip.
+    const { status } = runHook(
+      bashPayload(
+        "touch .claude-merge-bypass && scripts/workflow/merge-pr.sh 123"
+      )
+    );
+    expect(status).toBe(2);
+  });
+});
+
+describe("block-direct-merge.cjs — fail-open contract", () => {
+  it("malformed JSON on stdin → exit 0", () => {
+    const result = spawnSync("node", [hookPath], {
+      input: "{not json",
+      encoding: "utf8",
+    });
+    expect(result.status ?? 1).toBe(0);
+  });
+
+  it("non-Bash, non-merge tool → exit 0", () => {
+    const { status } = runHook({
+      tool_name: "Read",
+      tool_input: { file_path: "/tmp/x" },
+    });
+    expect(status).toBe(0);
+  });
+});

--- a/src/test/unit/hooks/block-direct-merge.test.ts
+++ b/src/test/unit/hooks/block-direct-merge.test.ts
@@ -135,6 +135,23 @@ describe("block-direct-merge.cjs — merge-pr.sh (PP-wi85 hard gate)", () => {
     expect(status).toBe(2);
   });
 
+  it("blocks a bare leading VAR=val assignment (no env wrapper)", () => {
+    // Regression: the original regex only tolerated `env VAR=val ...`, so a
+    // bare shell assignment like `DUMMY=1 scripts/workflow/merge-pr.sh ...`
+    // slipped through the hard gate entirely.
+    const { status } = runHook(
+      bashPayload("DUMMY=1 scripts/workflow/merge-pr.sh 123 --human")
+    );
+    expect(status).toBe(2);
+  });
+
+  it("blocks `env VAR=val bash scripts/workflow/merge-pr.sh <PR>`", () => {
+    const { status } = runHook(
+      bashPayload("env FOO=bar bash scripts/workflow/merge-pr.sh 123")
+    );
+    expect(status).toBe(2);
+  });
+
   it("does NOT block a quoted mention (echo)", () => {
     const { status } = runHook(
       bashPayload('echo "run merge-pr.sh when ready"')

--- a/src/test/unit/hooks/ui-screenshot-reminder.test.ts
+++ b/src/test/unit/hooks/ui-screenshot-reminder.test.ts
@@ -1,0 +1,146 @@
+// Unit tests for .claude/hooks/ui-screenshot-reminder.cjs — the PostToolUse
+// (Bash) hook that nudges toward posting screenshots after a UI-touching
+// `git commit` (PP-wi85). Non-blocking: always exits 0.
+//
+// Builds a scratch git repo per test with a fake `origin/main` ref (via
+// `update-ref`, no real remote needed) so `git diff --name-only
+// origin/main...HEAD` resolves deterministically.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const hookPath = path.resolve(
+  process.cwd(),
+  ".claude/hooks/ui-screenshot-reminder.cjs"
+);
+
+const tmpDirs: string[] = [];
+
+function makeRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-screenshot-hook-"));
+  tmpDirs.push(dir);
+  const git = (...args: string[]): string =>
+    execFileSync("git", args, { cwd: dir, encoding: "utf8" });
+
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+
+  fs.writeFileSync(path.join(dir, "README.md"), "base\n");
+  git("add", "README.md");
+  git("commit", "-q", "-m", "base");
+  const baseSha = git("rev-parse", "HEAD").trim();
+  git("update-ref", "refs/remotes/origin/main", baseSha);
+
+  git("checkout", "-q", "-b", "feature");
+  return dir;
+}
+
+function commitFile(dir: string, relPath: string, contents = "x\n"): void {
+  const full = path.join(dir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, contents);
+  execFileSync("git", ["add", relPath], { cwd: dir });
+  execFileSync("git", ["commit", "-q", "-m", `add ${relPath}`], { cwd: dir });
+}
+
+function runHook(
+  cwd: string,
+  command = "git commit -m 'test'"
+): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync("node", [hookPath], {
+    input: JSON.stringify({
+      tool_name: "Bash",
+      tool_input: { command },
+      cwd,
+    }),
+    encoding: "utf8",
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const d = tmpDirs.pop();
+    if (d) fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("ui-screenshot-reminder.cjs", () => {
+  it("reminds when a commit touches src/components", () => {
+    const dir = makeRepo();
+    commitFile(dir, "src/components/Foo.tsx", "export const Foo = 1;\n");
+    const { status, stderr } = runHook(dir);
+    expect(status).toBe(0);
+    expect(stderr).toContain("UI-touching change");
+    expect(stderr).toContain("pr-screenshots.mjs");
+  });
+
+  it("reminds when a commit touches a src/app tsx page", () => {
+    const dir = makeRepo();
+    commitFile(
+      dir,
+      "src/app/dashboard/page.tsx",
+      "export default function P(){}\n"
+    );
+    const { status, stderr } = runHook(dir);
+    expect(status).toBe(0);
+    expect(stderr).toContain("UI-touching change");
+  });
+
+  it("reminds when a commit touches a css file", () => {
+    const dir = makeRepo();
+    commitFile(dir, "src/app/globals.css", "body{}\n");
+    const { status, stderr } = runHook(dir);
+    expect(status).toBe(0);
+    expect(stderr).toContain("UI-touching change");
+  });
+
+  it("stays silent for a non-UI commit", () => {
+    const dir = makeRepo();
+    commitFile(dir, "scripts/workflow/foo.sh", "#!/usr/bin/env bash\n");
+    const { status, stderr } = runHook(dir);
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+  });
+
+  it("stays silent for a non-commit Bash command", () => {
+    const dir = makeRepo();
+    commitFile(dir, "src/components/Foo.tsx", "export const Foo = 1;\n");
+    const { status, stderr } = runHook(dir, "git status");
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+  });
+
+  it("fails open when origin/main is unavailable", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-screenshot-hook-"));
+    tmpDirs.push(dir);
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+    execFileSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: dir,
+    });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    fs.writeFileSync(path.join(dir, "README.md"), "base\n");
+    execFileSync("git", ["add", "README.md"], { cwd: dir });
+    execFileSync("git", ["commit", "-q", "-m", "base"], { cwd: dir });
+    // No origin/main ref created — the hook must not throw/exit non-zero.
+    const { status, stderr } = runHook(dir);
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+  });
+
+  it("stays silent for malformed JSON on stdin", () => {
+    const result = spawnSync("node", [hookPath], {
+      input: "{not json",
+      encoding: "utf8",
+    });
+    expect(result.status ?? 1).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Root cause (per Tim): `block-direct-merge.cjs` already blocked `gh pr merge` / MCP `merge_pull_request`, but it deliberately steered agents to `scripts/workflow/merge-pr.sh` — which merges once its 5 gates pass, with **no human-approval gate**. That's how recent sessions auto-merged without explicit sign-off. This PR closes that gap and adds a UI-screenshot workflow so Tim can eyeball UI changes before merging.

1. **Hard merge gate** (`.claude/hooks/block-direct-merge.cjs`) — now also blocks an agent Bash call invoking `scripts/workflow/merge-pr.sh` (any wrapper/path/flag form), alongside the existing `gh pr merge` / `gh api .../merge` / MCP merge blocks. The `.claude-merge-bypass` sentinel is **removed entirely** — there is no agent-usable bypass left. Tests: `src/test/unit/hooks/block-direct-merge.test.ts`.
2. **Defense-in-depth in `merge-pr.sh`** — new required `--human` flag to actually execute a merge (fails fast with a clear message otherwise). `--dry-run` is exempt. This covers harnesses without the Claude Code hook (Codex/Gemini/Antigravity). Canonical command: `scripts/workflow/merge-pr.sh <PR> --human`.
3. **Commit-time screenshot reminder** — new PostToolUse hook `.claude/hooks/ui-screenshot-reminder.cjs` (pattern copied from `preflight-reminder.sh`): fires on `git commit`, diffs `origin/main...HEAD`, and nudges (non-blocking, stderr only) when the branch touches a UI glob. Tests: `src/test/unit/hooks/ui-screenshot-reminder.test.ts`.
4. **Screenshot workflow** — `scripts/workflow/pr-screenshots.mjs <PR> [--pages a,b,c] [--force-auth]`: shoots the manifest in `ui-screenshot-manifest.json` (issues list, issue detail, report form, dashboard, a machine detail, collections) at desktop (1440×900) + mobile (390×844), reusing the e2e auth-setup storage-state convention, pushes PNGs to an orphan `pr-screenshots` branch (via a throwaway temp git repo, not `git worktree add`), and posts/updates one sticky PR comment.
5. **Docs + skills** — `AGENTS.md`, `scripts/workflow/AGENTS.md`, and the `pinpoint-pr-workflow` / `pinpoint-orchestrator` / `pinpoint-superpowers-bridge` / `pinpoint-agy-execute` skills all updated: merge is human-only via ANY path; agent's terminal state is "ready + screenshots posted if UI + hand Tim the `--human` command."
6. **Design spec**: `docs/superpowers/specs/2026-07-17-human-gated-merges-ui-screenshots-design.md`.

## Open feasibility item

The load-bearing assumption for §1 is that a human-typed `!`-prefixed command in Claude Code does **not** generate a `PreToolUse` event, so it's invisible to the hook. This could not be independently verified from inside the implementing subagent. If it turns out `!` commands *do* fire `PreToolUse` in some version, the fallback is simply that Tim runs the merge in a separate terminal — the agent-side guarantee (no agent can merge, by any path) holds either way, since it doesn't depend on this assumption.

## Hardening follow-ups (deferred, best-effort per Tim's framing)

- No retry/backoff on flaky screenshot navigation.
- Session staleness in `pr-screenshots.mjs` only handled via manual `--force-auth`, not auto-detected.
- The `pr-screenshots` orphan branch has no pruning/TTL (unlike the preview-deployment reaper) — will grow unbounded; a follow-up bead should add a reaper once growth rate is known.
- `pr-screenshots.mjs` duplicates the `STORAGE_STATE` role→path convention from `e2e/support/auth-state.ts` as a local constant (plain `.mjs` can't cleanly import the `.ts` file without `tsx`).

## Test plan

- [x] `pnpm run check` green (types, lint, format, unit incl. `check:pytest`) — 1578 unit tests pass, including 27 new hook tests.
- [x] New hook tests cover: `merge-pr.sh` blocked in bare/`bash`/`./`/absolute-path/chained forms; quoted mentions NOT blocked; `.claude-merge-bypass`-shaped command still blocked; screenshot reminder fires for `src/components`/`src/app/**/*.tsx`/`*.css` changes, silent otherwise, fails open when `origin/main` is unavailable.
- [x] `shellcheck` clean on `merge-pr.sh`.
- [ ] `pr-screenshots.mjs` not exercised end-to-end in this PR (requires a running dev server + Supabase + a real PR) — best-effort per scope; will dry-run it against this PR once open.

**Tim: to merge, run** `! scripts/workflow/merge-pr.sh <PR> --human`

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>