### PR TITLE
fix(scripts): mark-migration-applied pooler safety — prepare:false + prod-fallback guard (PP-93tv)

### DIFF
--- a/scripts/mark-migration-applied.ts
+++ b/scripts/mark-migration-applied.ts
@@ -39,8 +39,26 @@ if (!migrationNumber) {
   process.exit(1);
 }
 
-const connectionString =
-  process.env["POSTGRES_URL_NON_POOLING"] ?? process.env["POSTGRES_URL"];
+// Resolve the connection endpoint. This script writes to
+// drizzle.__drizzle_migrations, so it must connect the way the migrator does:
+// prefer POSTGRES_URL_NON_POOLING (the IPv4 SESSION pooler, :5432) and, in
+// production, REFUSE to silently fall back to POSTGRES_URL (the :6543
+// TRANSACTION pooler) — it does not support prepared statements (the PP-d8l8
+// silent-COMMIT-loss hazard) and is the wrong endpoint for a migration write.
+// Mirrors scripts/migrate-production.ts. See AGENTS.md §7.
+const isVercelProduction = process.env["VERCEL_ENV"] === "production";
+const nonPooling = process.env["POSTGRES_URL_NON_POOLING"];
+
+if (isVercelProduction && !nonPooling) {
+  console.error(
+    "❌ POSTGRES_URL_NON_POOLING is required in production but is unset.\n" +
+      "   Refusing to fall back to the :6543 transaction pooler (POSTGRES_URL)."
+  );
+  process.exit(1);
+}
+
+// Outside Vercel production (local / ad-hoc), POSTGRES_URL is a fine fallback.
+const connectionString = nonPooling ?? process.env["POSTGRES_URL"];
 
 if (!connectionString) {
   console.error(
@@ -49,7 +67,11 @@ if (!connectionString) {
   process.exit(1);
 }
 
-const sql = postgres(connectionString, { max: 1 });
+// `prepare: false`: REQUIRED if this ever connects over the `:6543` transaction
+// pooler (which rejects prepared statements — the PP-d8l8 hazard) and harmless
+// on the session pooler. Mirrors scripts/migrate-production.ts and
+// scripts/lib/pg-client.mjs (the canonical PP-d8l8 setting).
+const sql = postgres(connectionString, { max: 1, prepare: false });
 // db not needed for this script, only sql client
 
 async function main() {


### PR DESCRIPTION
## What & why

`scripts/mark-migration-applied.ts` is a manual recovery script that **writes to `drizzle.__drizzle_migrations`**, but it built its porsager client with no `prepare: false` and resolved its connection string as `POSTGRES_URL_NON_POOLING ?? POSTGRES_URL`. Its documented invocation (AGENTS.md §7, and the recovery instructions printed by `migrate-production.ts` itself) is:

```
POSTGRES_URL=<prod_url> tsx scripts/mark-migration-applied.ts <n>
```

That connects over the `:6543` Supavisor **transaction pooler**, which does not support prepared statements — the exact configuration behind incident **PP-d8l8** (silent `COMMIT` loss). A silent loss here corrupts migration state.

## Fix

Mirror the known-good `scripts/migrate-production.ts`:

1. **Production-fallback guard** — when `VERCEL_ENV === "production"` and `POSTGRES_URL_NON_POOLING` is unset, refuse to silently fall back to the `:6543` pooler; fail loudly.
2. **`prepare: false`** on the `postgres()` client, so a transaction-pooler connection can never use prepared statements.

I did **not** route through `scripts/lib/pg-client.mjs::createScriptClient()` on purpose: that helper deliberately prefers `POSTGRES_URL` (`:6543`, IPv4-reachable from CI) over `POSTGRES_URL_NON_POOLING`, which is the correct priority for general one-shot scripts but the **wrong** one for a migration-table write — the migration family (`migrate-production.ts`) prefers the `:5432` session pooler for DDL. Matching `migrate-production.ts` keeps the two migration scripts consistent.

## Testing

- `pnpm run check` green (types, lint, format, 1580 unit tests, Python hook tests).
- The script cannot be exercised without a live pooler + DB; correctness is by construction — the new guard and `prepare: false` are copied from the audited-correct `migrate-production.ts`.

Found by the 2026-07-17 non-negotiables audit (bead PP-93tv). 🤖 Generated with [Claude Code](https://claude.com/claude-code)