### PR TITLE
fix(issues,logging): comment actions via permission matrix + email log redaction (PP-pgya)

### DIFF
--- a/src/app/(app)/issues/actions.ts
+++ b/src/app/(app)/issues/actions.ts
@@ -632,6 +632,15 @@ export async function addCommentAction(
     return err("UNAUTHORIZED", "Unauthorized");
   }
 
+  const userProfile = await db.query.userProfiles.findFirst({
+    where: eq(userProfiles.id, user.id),
+    columns: { role: true },
+  });
+  const accessLevel = getAccessLevel(userProfile?.role);
+  if (!checkPermission("comments.add", accessLevel)) {
+    return err("UNAUTHORIZED", "You do not have permission to add comments");
+  }
+
   const validation = addCommentSchema.safeParse({
     issueId: toOptionalString(formData.get("issueId")),
     comment: toOptionalString(formData.get("comment")),
@@ -781,7 +790,17 @@ export async function editCommentAction(
       return err("UNAUTHORIZED", "System comments cannot be edited");
     }
 
-    if (existingComment.authorId !== user.id) {
+    const userProfile = await db.query.userProfiles.findFirst({
+      where: eq(userProfiles.id, user.id),
+      columns: { role: true },
+    });
+    const accessLevel = getAccessLevel(userProfile?.role);
+    if (
+      !checkPermission("comments.edit", accessLevel, {
+        userId: user.id,
+        reporterId: existingComment.authorId,
+      })
+    ) {
       return err("UNAUTHORIZED", "You can only edit your own comments");
     }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -66,6 +66,9 @@ function createLogger(): pino.Logger {
 
   const baseConfig: pino.LoggerOptions = {
     level: LOG_LEVEL,
+    // Redact reporter PII (email) from log output. Covers both top-level and
+    // one-level-nested occurrences; uses Pino's default "[Redacted]" censor.
+    redact: ["reporterEmail", "*.reporterEmail", "email", "*.email"],
     formatters: {
       level: (label: string) => {
         return { level: label };

--- a/src/test/unit/issue-actions.test.ts
+++ b/src/test/unit/issue-actions.test.ts
@@ -43,8 +43,9 @@ vi.mock("~/lib/supabase/server", () => ({
 
 // Mock DB to satisfy the import: the actions module imports ~/server/db,
 // which throws on a missing POSTGRES_URL in unit tests, so the mock is required
-// just to load the module. The three KEEP-unit blocks below never exercise a
-// real query — the revalidation path after addIssueComment is the only consumer.
+// just to load the module. The only queries these blocks reach are the
+// userProfiles role lookup (for the comments.add permission gate) and the
+// revalidation path after addIssueComment — both mocked below.
 vi.mock("~/server/db", () => ({
   db: {
     insert: vi.fn(),
@@ -85,6 +86,7 @@ vi.mock("~/services/issues", () => ({
 
 import { createClient } from "~/lib/supabase/server";
 import { addIssueComment } from "~/services/issues";
+import { db } from "~/server/db";
 
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
@@ -105,6 +107,12 @@ describe("addCommentAction", () => {
 
     // Setup service mock
     vi.mocked(addIssueComment).mockResolvedValue(undefined as any);
+
+    // addCommentAction now routes through checkPermission("comments.add"),
+    // which needs the caller's role — mock an authenticated member by default.
+    vi.mocked(db.query.userProfiles.findFirst).mockResolvedValue({
+      role: "member",
+    } as any);
   });
 
   it("should return an error if not authenticated", async () => {


### PR DESCRIPTION
## What & why

Two audit findings, both hardening against drift rather than fixing a live gap.

**CORE-ARCH-008 — comment actions bypassed the permission matrix.** `addCommentAction` gated only on `!user`, and `editCommentAction` hand-rolled `authorId !== user.id`. Both are behaviorally identical to the matrix *today*, but they re-derive it instead of calling through `checkPermission`, so a future matrix change wouldn't propagate and the auto-generated `/help/permissions` page could silently lie. Now both call `checkPermission` (`comments.add`; `comments.edit` with `{ userId, reporterId }`), copying the sibling `deleteCommentAction` pattern exactly.

- `comments.add` = `true` for every authenticated role → no new rejections.
- `comments.edit` = `"own"` for all roles → reduces to `userId === authorId`, exactly the old check.

**CORE-SEC-007 adjacent — reporter email logged in plaintext.** `report/actions.ts` logs `reporterEmail`, and the Pino logger had no `redact` config, so PII landed in the Vercel log sink. Added `redact: ["reporterEmail", "*.reporterEmail", "email", "*.email"]` (default `[Redacted]` censor), scoped to the email PII fields only.

## Testing
- `pnpm run check` green (1580 unit tests + lint/types/format).
- `src/test/integration/issue-comment-actions.test.ts` — 9/9.
- One unit test's DB mock updated to return a role for the new `userProfiles` lookup (test-harness only; the unauthenticated case still short-circuits before it).

From the 2026-07-17 non-negotiables audit (bead PP-pgya). 🤖 Generated with [Claude Code](https://claude.com/claude-code)