### PR TITLE
fix(a11y,forms): motion-reduce, keyboard-operable controls, required indicator (PP-y798)

### DIFF
--- a/src/app/(app)/admin/integrations/discord/discord-config-form.tsx
+++ b/src/app/(app)/admin/integrations/discord/discord-config-form.tsx
@@ -222,7 +222,7 @@ export function DiscordConfigForm({
           >
             {validatingToken ? (
               <>
-                <Loader2 className="mr-1.5 size-3 animate-spin" />
+                <Loader2 className="mr-1.5 size-3 animate-spin motion-reduce:animate-none" />
                 Validating...
               </>
             ) : (
@@ -275,7 +275,7 @@ export function DiscordConfigForm({
             >
               {validatingServer ? (
                 <>
-                  <Loader2 className="mr-1.5 size-3 animate-spin" />
+                  <Loader2 className="mr-1.5 size-3 animate-spin motion-reduce:animate-none" />
                   Validating...
                 </>
               ) : (
@@ -432,8 +432,11 @@ function ValidationStatus({
   if (status.kind === "validating") {
     return (
       <p className="text-xs text-muted-foreground flex items-center gap-1">
-        <Loader2 className="size-3 animate-spin" aria-hidden /> Checking with
-        Discord…
+        <Loader2
+          className="size-3 animate-spin motion-reduce:animate-none"
+          aria-hidden
+        />{" "}
+        Checking with Discord…
       </p>
     );
   }
@@ -491,7 +494,7 @@ function SaveResetFooter({
       >
         {isPending ? (
           <>
-            <Loader2 className="mr-2 size-4 animate-spin" />
+            <Loader2 className="mr-2 size-4 animate-spin motion-reduce:animate-none" />
             Saving...
           </>
         ) : showSaved ? (

--- a/src/app/(app)/m/[initials]/i/[issueNumber]/editable-issue-title.tsx
+++ b/src/app/(app)/m/[initials]/i/[issueNumber]/editable-issue-title.tsx
@@ -150,7 +150,7 @@ export function EditableIssueTitle({
           disabled={isPending}
         />
         {isPending && (
-          <Loader2 className="size-5 animate-spin text-muted-foreground shrink-0" />
+          <Loader2 className="size-5 animate-spin motion-reduce:animate-none text-muted-foreground shrink-0" />
         )}
       </form>
     );

--- a/src/app/(app)/report/unified-report-form.tsx
+++ b/src/app/(app)/report/unified-report-form.tsx
@@ -406,6 +406,7 @@ export function UnifiedReportForm({
                 name="title"
                 required
                 maxLength={60}
+                enterKeyHint="next"
                 placeholder="e.g., Left flipper not responding"
                 value={entry.title}
                 onChange={(e) => patchEntry(0, { title: e.target.value })}
@@ -577,6 +578,7 @@ export function UnifiedReportForm({
                         id="firstName"
                         name="firstName"
                         autoComplete="given-name"
+                        enterKeyHint="next"
                         value={single.firstName}
                         onChange={(e) =>
                           patchSingle({ firstName: e.target.value })
@@ -595,6 +597,7 @@ export function UnifiedReportForm({
                         id="lastName"
                         name="lastName"
                         autoComplete="family-name"
+                        enterKeyHint="next"
                         value={single.lastName}
                         onChange={(e) =>
                           patchSingle({ lastName: e.target.value })
@@ -612,6 +615,7 @@ export function UnifiedReportForm({
                       name="email"
                       type="email"
                       autoComplete="email"
+                      enterKeyHint="send"
                       value={single.email}
                       onChange={(e) => patchSingle({ email: e.target.value })}
                       className="h-8 border-outline-variant bg-surface text-sm text-foreground"

--- a/src/app/(auth)/signup/signup-form.tsx
+++ b/src/app/(auth)/signup/signup-form.tsx
@@ -135,7 +135,7 @@ export function SignupForm({
           id="email"
           name="email"
           type="email"
-          autoComplete="email"
+          autoComplete="username"
           required
           enterKeyHint="next"
           className="bg-surface-variant"

--- a/src/components/collections/CollectionFields.tsx
+++ b/src/components/collections/CollectionFields.tsx
@@ -43,7 +43,13 @@ export function CollectionFields({
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor={nameId}>Name</Label>
+        <Label htmlFor={nameId}>
+          Name
+          <span aria-hidden="true" className="text-destructive">
+            {" "}
+            *
+          </span>
+        </Label>
         <Input
           id={nameId}
           value={name}

--- a/src/components/collections/CreateCollectionDialog.test.tsx
+++ b/src/components/collections/CreateCollectionDialog.test.tsx
@@ -39,7 +39,7 @@ describe("CreateCollectionDialog", () => {
     render(<CreateCollectionDialog allMachines={allMachines} />);
 
     await userEvent.click(screen.getByTestId("create-collection-trigger"));
-    await userEvent.type(screen.getByLabelText("Name"), "Tournament Bank");
+    await userEvent.type(screen.getByLabelText(/name/i), "Tournament Bank");
     await userEvent.click(screen.getByTestId("create-collection-submit"));
 
     await waitFor(() =>
@@ -57,7 +57,7 @@ describe("CreateCollectionDialog", () => {
     await userEvent.click(screen.getByTestId("create-collection-trigger"));
     expect(screen.getByTestId("create-collection-submit")).toBeDisabled();
 
-    await userEvent.type(screen.getByLabelText("Name"), "X");
+    await userEvent.type(screen.getByLabelText(/name/i), "X");
     expect(screen.getByTestId("create-collection-submit")).toBeEnabled();
   });
 
@@ -66,7 +66,7 @@ describe("CreateCollectionDialog", () => {
     render(<CreateCollectionDialog allMachines={allMachines} />);
 
     await userEvent.click(screen.getByTestId("create-collection-trigger"));
-    await userEvent.type(screen.getByLabelText("Name"), "Nope");
+    await userEvent.type(screen.getByLabelText(/name/i), "Nope");
     await userEvent.click(screen.getByTestId("create-collection-submit"));
 
     expect(await screen.findByText("Forbidden")).toBeInTheDocument();

--- a/src/components/images/ImageUploadButton.tsx
+++ b/src/components/images/ImageUploadButton.tsx
@@ -96,7 +96,7 @@ export function ImageUploadButton({
           onClick={() => fileInputRef.current?.click()}
         >
           {isUploading ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
           ) : (
             <ImageIcon className="h-4 w-4" />
           )}
@@ -121,7 +121,7 @@ export function ImageUploadButton({
           }}
         >
           {isUploading ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
           ) : (
             <Camera className="h-4 w-4" />
           )}

--- a/src/components/issues/AssigneePicker.tsx
+++ b/src/components/issues/AssigneePicker.tsx
@@ -126,7 +126,7 @@ export function AssigneePicker({
           <div className="flex items-center gap-2">
             {isPending ? (
               <>
-                <Loader2 className="size-6 animate-spin p-1 text-muted-foreground" />
+                <Loader2 className="size-6 animate-spin motion-reduce:animate-none p-1 text-muted-foreground" />
                 <span className="font-medium text-muted-foreground">
                   Updating...
                 </span>
@@ -146,7 +146,7 @@ export function AssigneePicker({
           </div>
           {isPending ? (
             <Loader2
-              className="size-4 animate-spin opacity-50"
+              className="size-4 animate-spin motion-reduce:animate-none opacity-50"
               aria-hidden="true"
               data-testid="assignee-picker-loader"
             />

--- a/src/components/issues/ExportButton.tsx
+++ b/src/components/issues/ExportButton.tsx
@@ -74,7 +74,7 @@ export function ExportButton({
           data-testid="export-csv-button"
         >
           {isExporting ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" />
           ) : (
             <Download className="h-3.5 w-3.5" />
           )}

--- a/src/components/issues/IssueFilters.tsx
+++ b/src/components/issues/IssueFilters.tsx
@@ -480,6 +480,7 @@ export function IssueFilters({
               <TooltipTrigger asChild>
                 <input
                   ref={inputRef}
+                  name="q"
                   placeholder="Search issues..."
                   data-testid="issue-search"
                   className="flex-1 min-w-0 w-full bg-transparent border-0 text-sm focus:outline-none placeholder:text-muted-foreground"

--- a/src/components/issues/IssueList.tsx
+++ b/src/components/issues/IssueList.tsx
@@ -174,23 +174,24 @@ export function IssueList({
       scope="col"
       aria-sort={getSortAriaSort(column)}
       className={cn(
-        "px-4 py-3 text-sm font-semibold text-muted-foreground group cursor-pointer hover:text-foreground transition-colors duration-150 sticky top-0 bg-muted/30 z-10",
+        "px-4 py-3 text-sm font-semibold text-muted-foreground sticky top-0 bg-muted/30 z-10",
         align === "right" && "text-right",
         align === "center" && "text-center",
         className
       )}
-      onClick={() => handleSort(column)}
     >
-      <div
+      <button
+        type="button"
+        onClick={() => handleSort(column)}
         className={cn(
-          "flex items-center",
+          "group flex w-full items-center cursor-pointer hover:text-foreground transition-colors duration-150",
           align === "right" && "justify-end",
           align === "center" && "justify-center"
         )}
       >
         {label}
         {renderSortIcon(column)}
-      </div>
+      </button>
     </th>
   );
 

--- a/src/components/issues/cells/IssueAssigneeCell.tsx
+++ b/src/components/issues/cells/IssueAssigneeCell.tsx
@@ -52,7 +52,7 @@ export function IssueAssigneeCell({
           >
             {isUpdating ? (
               <div className="flex items-center gap-2">
-                <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0 text-muted-foreground" />
+                <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none shrink-0 text-muted-foreground" />
                 <span>{issue.assignedToUser?.name ?? "Unassigned"}</span>
               </div>
             ) : (

--- a/src/components/issues/cells/IssueEditableCell.tsx
+++ b/src/components/issues/cells/IssueEditableCell.tsx
@@ -70,7 +70,7 @@ export function IssueEditableCell({
             )}
           >
             {isUpdating ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0 text-muted-foreground" />
+              <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none shrink-0 text-muted-foreground" />
             ) : (
               <config.icon
                 className={cn("h-3.5 w-3.5 shrink-0", config.iconColor)}

--- a/src/components/machines/WatchMachineButton.tsx
+++ b/src/components/machines/WatchMachineButton.tsx
@@ -74,7 +74,7 @@ export function WatchMachineButton({
   };
 
   const icon = isPending ? (
-    <Loader2 className="mr-1.5 size-4 animate-spin" />
+    <Loader2 className="mr-1.5 size-4 animate-spin motion-reduce:animate-none" />
   ) : isWatching ? (
     <BellRing className="mr-1.5 size-4" />
   ) : (

--- a/src/components/save-cancel-buttons.tsx
+++ b/src/components/save-cancel-buttons.tsx
@@ -47,7 +47,7 @@ export function SaveCancelButtons({
       >
         {isPending ? (
           <>
-            <Loader2 className="mr-2 size-4 animate-spin" />
+            <Loader2 className="mr-2 size-4 animate-spin motion-reduce:animate-none" />
             Saving...
           </>
         ) : showSaved ? (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -67,7 +67,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
         disabled={!!props.disabled || loading}
       >
-        {loading && <Loader2 className="mr-2 size-4 animate-spin" />}
+        {loading && (
+          <Loader2 className="mr-2 size-4 animate-spin motion-reduce:animate-none" />
+        )}
         {props.children}
       </button>
     );

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -110,6 +110,7 @@ export function MultiSelect({
   "data-testid": testId,
 }: MultiSelectProps): React.JSX.Element {
   const [open, setOpen] = React.useState(false);
+  const groupHeadingId = React.useId();
 
   const selectedCount = value.length;
 
@@ -220,16 +221,7 @@ export function MultiSelect({
                     key={group.label}
                     heading={
                       <div
-                        role="button"
-                        tabIndex={0}
-                        className="flex items-center gap-2 py-1 cursor-pointer select-none hover:bg-accent/50 -mx-2 px-2 rounded-sm transition-colors duration-150 group/header"
-                        onClick={toggleGroup}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            if (e.key === " ") e.preventDefault();
-                            toggleGroup();
-                          }
-                        }}
+                        className="flex items-center gap-2 py-1 select-none hover:bg-accent/50 -mx-2 px-2 rounded-sm transition-colors duration-150 group/header"
                         data-testid={
                           testId
                             ? `${testId}-group-${group.label.toLowerCase().replace(/\s+/g, "-")}`
@@ -237,6 +229,7 @@ export function MultiSelect({
                         }
                       >
                         <Checkbox
+                          id={`${groupHeadingId}-${group.label.toLowerCase().replace(/\s+/g, "-")}`}
                           checked={
                             isAllSelected
                               ? true
@@ -246,11 +239,13 @@ export function MultiSelect({
                           }
                           className="h-3.5 w-3.5"
                           onCheckedChange={toggleGroup}
-                          onClick={(e) => e.stopPropagation()}
                         />
-                        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground group-hover/header:text-foreground transition-colors duration-150">
+                        <label
+                          htmlFor={`${groupHeadingId}-${group.label.toLowerCase().replace(/\s+/g, "-")}`}
+                          className="flex-1 cursor-pointer text-xs font-semibold uppercase tracking-wider text-muted-foreground group-hover/header:text-foreground transition-colors duration-150"
+                        >
                           {group.label}
-                        </span>
+                        </label>
                       </div>
                     }
                   >

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -191,6 +191,10 @@ export function MultiSelect({
             <CommandEmpty>No results found.</CommandEmpty>
             {sortedGroups ? (
               sortedGroups.map((group) => {
+                const groupSlug = group.label
+                  .toLowerCase()
+                  .replace(/\s+/g, "-");
+                const groupCheckboxId = `${groupHeadingId}-${groupSlug}`;
                 const groupOptionValues = group.options.map((opt) => opt.value);
                 const groupSelectedCount = group.options.filter((opt) =>
                   value.includes(opt.value)
@@ -223,13 +227,11 @@ export function MultiSelect({
                       <div
                         className="flex items-center gap-2 py-1 select-none hover:bg-accent/50 -mx-2 px-2 rounded-sm transition-colors duration-150 group/header"
                         data-testid={
-                          testId
-                            ? `${testId}-group-${group.label.toLowerCase().replace(/\s+/g, "-")}`
-                            : undefined
+                          testId ? `${testId}-group-${groupSlug}` : undefined
                         }
                       >
                         <Checkbox
-                          id={`${groupHeadingId}-${group.label.toLowerCase().replace(/\s+/g, "-")}`}
+                          id={groupCheckboxId}
                           checked={
                             isAllSelected
                               ? true
@@ -241,7 +243,7 @@ export function MultiSelect({
                           onCheckedChange={toggleGroup}
                         />
                         <label
-                          htmlFor={`${groupHeadingId}-${group.label.toLowerCase().replace(/\s+/g, "-")}`}
+                          htmlFor={groupCheckboxId}
                           className="flex-1 cursor-pointer text-xs font-semibold uppercase tracking-wider text-muted-foreground group-hover/header:text-foreground transition-colors duration-150"
                         >
                           {group.label}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -8,7 +8,10 @@ function Skeleton({
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn(
+        "bg-accent animate-pulse motion-reduce:animate-none rounded-md",
+        className
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## What & why

Audit-confirmed accessibility + form-correctness fixes (CORE-A11Y-002/003/004, CORE-FORM-005). `pnpm run check` green (1580 unit tests + lint/types/format).

- **CORE-A11Y-002 — motion-reduce.** Paired every `animate-spin`/`animate-pulse` in `src/` with `motion-reduce:animate-none`. Fixing the shared `Button` spinner and `Skeleton` primitives covers most instances transitively; ~12 standalone sites swept too (`rg`-verified: zero bare occurrences remain in non-test `src/`).
- **CORE-A11Y-004 — real controls.** `multi-select`'s group-select-all header was a `<div role="button" tabIndex onKeyDown>`. Replaced with the native Radix `Checkbox` as the keyboard-operable control + an associated `<label>`. (A wrapping `<button>` would nest inside the Checkbox's own `<button>` — invalid HTML — so this is the correct fix; behavior and appearance preserved, `useId`-based id keeps `htmlFor` collision-safe.)
- **CORE-A11Y-003 — keyboard-sortable headers.** `IssueList`'s sortable `<th>` had `onClick` directly on it (mouse-only). Moved the trigger into a nested `<button type="button">` (matching the already-correct `CollectionOverviewTable`); `scope`/`aria-sort` stay on the `<th>`, layout unchanged.
- **CORE-FORM-005 — required indicator.** Added the existing inline `*` indicator to `CollectionFields`' `Name` label.
- **Progressive enhancement.** `IssueFilters` search input gets `name="q"` so a no-JS submit degrades to `?q=…`; `unified-report-form`'s sequential fields get `enterKeyHint`.

## Testing
- `pnpm run check` green.
- One test's label query loosened (`getByLabelText("Name")` → `/name/i`) to match the new required-indicator markup.

## Notes / not in scope
- `InviteUserDialog` progressive-enhancement refactor → separate PR.
- A custom ESLint rule enforcing the `motion-reduce` pairing, and a shared `RequiredLabel` helper → deferred follow-ups.
- A pre-existing `returnValue` deprecation hint in `discord-config-form.tsx` (deliberate legacy `beforeunload` code) surfaced because the file was touched; left as-is.

From the 2026-07-17 non-negotiables audit (bead PP-y798). 🤖 Generated with [Claude Code](https://claude.com/claude-code)