### PR TITLE
fix(users): InviteUserDialog progressive enhancement via useActionState (PP-eqhs)

### DIFF
--- a/e2e/full/invite-signup.spec.ts
+++ b/e2e/full/invite-signup.spec.ts
@@ -74,12 +74,10 @@ test.describe("User Invitation & Signup Flow", () => {
     await page.getByRole("textbox", { name: "Email" }).fill(userEmail);
 
     // Ensure "Send invitation email" is checked
-    const inviteSwitch = page.getByRole("switch", {
+    const inviteCheckbox = page.getByRole("checkbox", {
       name: /Send invitation email/i,
     });
-    if ((await inviteSwitch.getAttribute("aria-checked")) === "false") {
-      await inviteSwitch.click();
-    }
+    await inviteCheckbox.check();
 
     await page
       .getByRole("button", { name: /Invite User/i, includeHidden: false })
@@ -142,12 +140,10 @@ test.describe("User Invitation & Signup Flow", () => {
     await page.getByLabel(/Last Name/i).fill("Transfer");
     await page.getByRole("textbox", { name: "Email" }).fill(userEmail);
 
-    const inviteSwitch = page.getByRole("switch", {
+    const inviteCheckbox = page.getByRole("checkbox", {
       name: /Send invitation email/i,
     });
-    if ((await inviteSwitch.getAttribute("aria-checked")) === "false") {
-      await inviteSwitch.click();
-    }
+    await inviteCheckbox.check();
 
     await page
       .getByRole("button", { name: /Invite User/i, includeHidden: false })

--- a/e2e/full/machine-with-invite.spec.ts
+++ b/e2e/full/machine-with-invite.spec.ts
@@ -55,13 +55,10 @@ test.describe("Machine with Inline Invite (Smoke)", () => {
     await page.getByRole("textbox", { name: "Email" }).fill(userEmail);
 
     // Ensure "Send invitation email" is unchecked for smoke test to avoid Mailpit dep if it's slow
-    // (Though it's usually fine, we can toggle it to test the switch too)
-    const inviteSwitch = page.getByRole("switch", {
+    const inviteCheckbox = page.getByRole("checkbox", {
       name: /Send invitation email/i,
     });
-    if ((await inviteSwitch.getAttribute("aria-checked")) === "true") {
-      await inviteSwitch.click();
-    }
+    await inviteCheckbox.uncheck();
 
     await page
       .getByRole("button", { name: /Invite User/i, includeHidden: false })

--- a/src/app/(app)/admin/users/actions.ts
+++ b/src/app/(app)/admin/users/actions.ts
@@ -16,6 +16,7 @@ import { requireSiteUrl } from "~/lib/url";
 import { inviteUserSchema, updateUserRoleSchema } from "./schema";
 import { log } from "~/lib/logger";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { type Result, ok, err } from "~/lib/result";
 
 interface AdminListUsersParams {
   page?: number;
@@ -253,16 +254,33 @@ export async function updateUserRole(
   }
 }
 
+/**
+ * Result of {@link inviteUser}. On success it carries the new invited-user id
+ * plus the submitted name so the client can build a display row without a
+ * round-trip. Errors are returned (not thrown) so the form can surface them via
+ * `useActionState` — the progressive-enhancement pattern (CORE-ARCH-002/007).
+ */
+export type InviteUserResult = Result<
+  { userId: string; firstName: string; lastName: string },
+  | "VALIDATION"
+  | "FORBIDDEN"
+  | "EMAIL_TAKEN"
+  | "ALREADY_INVITED"
+  | "EMAIL_FAILED"
+  | "SERVER"
+>;
+
 export async function inviteUser(
+  _prevState: InviteUserResult | undefined,
   formData: FormData
-): Promise<{ ok: boolean; userId: string }> {
+): Promise<InviteUserResult> {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
-    throw new Error("Unauthorized");
+    return err("FORBIDDEN", "You must be signed in to invite users.");
   }
 
   try {
@@ -274,18 +292,29 @@ export async function inviteUser(
 
     const accessLevel = getAccessLevel(currentUserProfile?.role);
     if (!checkPermission("admin.users.invite", accessLevel)) {
-      throw new Error("Forbidden: You do not have permission to invite users");
+      return err("FORBIDDEN", "You do not have permission to invite users.");
     }
 
-    const rawData = {
+    const parsed = inviteUserSchema.safeParse({
       firstName: formData.get("firstName"),
       lastName: formData.get("lastName"),
       email: formData.get("email"),
       role: formData.get("role"),
       sendInvite: formData.get("sendInvite") === "true",
-    };
+    });
 
-    const validated = inviteUserSchema.parse(rawData);
+    if (!parsed.success) {
+      log.warn(
+        { action: "inviteUser", errors: parsed.error.issues },
+        "Invite validation failed"
+      );
+      return err(
+        "VALIDATION",
+        parsed.error.issues[0]?.message ?? "Invalid input"
+      );
+    }
+
+    const validated = parsed.data;
 
     // Check both auth.users and user_profiles — a user could exist in
     // auth.users without a profile row if the handle_new_user trigger failed.
@@ -298,7 +327,10 @@ export async function inviteUser(
     );
 
     if (existingAuthUser) {
-      throw new Error("A user with this email already exists and is active.");
+      return err(
+        "EMAIL_TAKEN",
+        "A user with this email already exists and is active."
+      );
     }
 
     const existingProfile = await db.query.userProfiles.findFirst({
@@ -306,7 +338,10 @@ export async function inviteUser(
     });
 
     if (existingProfile) {
-      throw new Error("A user with this email already exists and is active.");
+      return err(
+        "EMAIL_TAKEN",
+        "A user with this email already exists and is active."
+      );
     }
 
     const existingInvited = await db.query.invitedUsers.findFirst({
@@ -314,7 +349,7 @@ export async function inviteUser(
     });
 
     if (existingInvited) {
-      throw new Error("This user has already been invited.");
+      return err("ALREADY_INVITED", "This user has already been invited.");
     }
 
     // Create invited user
@@ -344,7 +379,9 @@ export async function inviteUser(
       });
 
       if (!emailResult.success) {
-        // Log the full error but don't expose it to the client
+        // Log the full error but don't expose it to the client. The invited
+        // row is intentionally left in place (creation succeeded before the
+        // email step) so the admin can resend without re-entering details.
         log.error(
           {
             action: "inviteUser",
@@ -353,7 +390,7 @@ export async function inviteUser(
           },
           "Failed to send invitation email"
         );
-        throw new Error("Failed to send invitation email");
+        return err("EMAIL_FAILED", "Failed to send invitation email");
       }
 
       await db
@@ -363,26 +400,12 @@ export async function inviteUser(
     }
 
     revalidatePath("/admin/users");
-    return { ok: true, userId: newInvited.id };
+    return ok({
+      userId: newInvited.id,
+      firstName: validated.firstName,
+      lastName: validated.lastName,
+    });
   } catch (error) {
-    // Allow known errors to propagate
-    if (
-      error instanceof Error &&
-      (error.message === "Unauthorized" ||
-        error.message.startsWith("Forbidden") ||
-        error.message ===
-          "A user with this email already exists and is active." ||
-        error.message === "This user has already been invited." ||
-        error.message === "Failed to send invitation email")
-    ) {
-      throw error;
-    }
-
-    // Validation errors from Zod (if they propagate as Error)
-    if (error instanceof Error && error.constructor.name === "ZodError") {
-      throw error;
-    }
-
     log.error(
       {
         action: "inviteUser",
@@ -391,9 +414,10 @@ export async function inviteUser(
       },
       "Invite user failed"
     );
-    throw new Error("An unexpected error occurred while inviting the user", {
-      cause: error,
-    });
+    return err(
+      "SERVER",
+      "An unexpected error occurred while inviting the user."
+    );
   }
 }
 

--- a/src/components/users/InviteUserDialog.tsx
+++ b/src/components/users/InviteUserDialog.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useTransition } from "react";
+import { useActionState, useEffect, useRef } from "react";
 import { toast } from "sonner";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import { type z } from "zod";
 import type { OwnerSelectUser } from "~/components/machines/OwnerSelect";
 
 import {
@@ -16,22 +13,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
 import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "~/components/ui/form";
-import { Switch } from "~/components/ui/switch";
-import { inviteUser } from "~/app/(app)/admin/users/actions";
-import { inviteUserSchema } from "~/app/(app)/admin/users/schema";
-
-type InviteUserFormValues = z.infer<typeof inviteUserSchema>;
+  inviteUser,
+  type InviteUserResult,
+} from "~/app/(app)/admin/users/actions";
 
 interface InviteUserDialogProps {
   open: boolean;
@@ -44,64 +33,6 @@ export function InviteUserDialog({
   onOpenChange,
   onSuccess,
 }: InviteUserDialogProps): React.JSX.Element {
-  const [isPending, startTransition] = useTransition();
-
-  const form = useForm<InviteUserFormValues>({
-    resolver: zodResolver(inviteUserSchema),
-    defaultValues: {
-      firstName: "",
-      lastName: "",
-      email: "",
-      role: "member",
-      sendInvite: true,
-    },
-  });
-
-  function onSubmit(values: InviteUserFormValues): void {
-    startTransition(async () => {
-      try {
-        // Create FormData to match server action signature
-        const formData = new FormData();
-        formData.append("firstName", values.firstName);
-        formData.append("lastName", values.lastName);
-        formData.append("email", values.email);
-        formData.append("role", values.role);
-        formData.append("sendInvite", String(values.sendInvite));
-
-        const result = await inviteUser(formData);
-        if (result.ok) {
-          toast.success("User invited successfully");
-          form.reset();
-          // Build minimal user object for the callback (CORE-SEC-006)
-          // Invited users are always created with member role (role field removed from UI)
-          const newUser: OwnerSelectUser = {
-            id: result.userId,
-            name: `${values.firstName} ${values.lastName}`,
-            lastName: values.lastName,
-            status: "invited",
-            machineCount: 0,
-            role: "member",
-          };
-          // Call onSuccess with both the ID and minimal OwnerSelectUser, then close dialog
-          // Note: router.refresh() removed - parent manages users state directly
-          onSuccess?.(result.userId, newUser);
-          onOpenChange(false);
-        }
-      } catch (error) {
-        toast.error(
-          error instanceof Error ? error.message : "Failed to invite user"
-        );
-      }
-    });
-  }
-
-  // Reset form when dialog closes
-  React.useEffect(() => {
-    if (!open) {
-      form.reset();
-    }
-  }, [open, form]);
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
@@ -112,91 +43,153 @@ export function InviteUserDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(onSubmit)}
-            className="space-y-4"
-            noValidate
-          >
-            <div className="grid grid-cols-2 gap-4">
-              <FormField
-                control={form.control}
-                name="firstName"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>First Name</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="lastName"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Last Name</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
-              control={form.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email</FormLabel>
-                  <FormControl>
-                    <Input type="email" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="sendInvite"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
-                  <div className="space-y-0.5">
-                    <FormLabel>Send Invitation Email</FormLabel>
-                    <FormDescription>
-                      User will receive an email to join.
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={!!field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <DialogFooter className="pt-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" loading={isPending}>
-                {isPending ? "Inviting..." : "Invite User"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
+        {/*
+         * The form (and its `useActionState`) lives in a child that mounts with
+         * the dialog content, so every open starts from a clean state instead of
+         * showing the previous attempt's error.
+         */}
+        <InviteUserForm
+          onOpenChange={onOpenChange}
+          {...(onSuccess ? { onSuccess } : {})}
+        />
       </DialogContent>
     </Dialog>
+  );
+}
+
+function InviteUserForm({
+  onOpenChange,
+  onSuccess,
+}: {
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: (userId: string, user: OwnerSelectUser) => void;
+}): React.JSX.Element {
+  const [state, formAction, isPending] = useActionState<
+    InviteUserResult | undefined,
+    FormData
+  >(inviteUser, undefined);
+
+  // Run success side effects once per resolved state (mirrors the create-machine
+  // form's handled-state guard so we don't re-fire on unrelated re-renders).
+  const handledStateRef = useRef<typeof state>(undefined);
+  useEffect(() => {
+    if (!state || state === handledStateRef.current || !state.ok) {
+      return;
+    }
+    handledStateRef.current = state;
+
+    toast.success("User invited successfully");
+
+    // Build a minimal display row for the caller (CORE-SEC-006). Invited users
+    // are always created with the member role.
+    const newUser: OwnerSelectUser = {
+      id: state.value.userId,
+      name: `${state.value.firstName} ${state.value.lastName}`,
+      lastName: state.value.lastName,
+      status: "invited",
+      machineCount: 0,
+      role: "member",
+    };
+    onSuccess?.(state.value.userId, newUser);
+    onOpenChange(false);
+  }, [state, onSuccess, onOpenChange]);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {state && !state.ok && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Invited users are always created as members; role isn't user-editable. */}
+      <input type="hidden" name="role" value="member" />
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="invite-firstName">
+            First Name{" "}
+            <span aria-hidden="true" className="text-destructive">
+              *
+            </span>
+          </Label>
+          <Input
+            id="invite-firstName"
+            name="firstName"
+            type="text"
+            autoComplete="given-name"
+            required
+            enterKeyHint="next"
+            maxLength={50}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="invite-lastName">
+            Last Name{" "}
+            <span aria-hidden="true" className="text-destructive">
+              *
+            </span>
+          </Label>
+          <Input
+            id="invite-lastName"
+            name="lastName"
+            type="text"
+            autoComplete="family-name"
+            required
+            enterKeyHint="next"
+            maxLength={50}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="invite-email">
+          Email{" "}
+          <span aria-hidden="true" className="text-destructive">
+            *
+          </span>
+        </Label>
+        <Input
+          id="invite-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          enterKeyHint="send"
+        />
+      </div>
+
+      <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+        <div className="space-y-0.5">
+          <Label htmlFor="invite-sendInvite">Send Invitation Email</Label>
+          <p className="text-sm text-muted-foreground">
+            User will receive an email to join.
+          </p>
+        </div>
+        {/* Native checkbox (value "true") so the form submits without JS and the
+            server reads `sendInvite === "true"`. */}
+        <input
+          id="invite-sendInvite"
+          name="sendInvite"
+          type="checkbox"
+          value="true"
+          defaultChecked
+          className="size-4 accent-primary"
+        />
+      </div>
+
+      <DialogFooter className="pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" loading={isPending}>
+          {isPending ? "Inviting..." : "Invite User"}
+        </Button>
+      </DialogFooter>
+    </form>
   );
 }

--- a/src/components/users/InviteUserDialog.tsx
+++ b/src/components/users/InviteUserDialog.tsx
@@ -156,13 +156,17 @@ function InviteUserForm({
           autoComplete="email"
           required
           enterKeyHint="send"
+          maxLength={254}
         />
       </div>
 
       <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
         <div className="space-y-0.5">
           <Label htmlFor="invite-sendInvite">Send Invitation Email</Label>
-          <p className="text-sm text-muted-foreground">
+          <p
+            id="invite-sendInvite-desc"
+            className="text-sm text-muted-foreground"
+          >
             User will receive an email to join.
           </p>
         </div>
@@ -174,6 +178,7 @@ function InviteUserForm({
           type="checkbox"
           value="true"
           defaultChecked
+          aria-describedby="invite-sendInvite-desc"
           className="size-4 accent-primary"
         />
       </div>

--- a/src/test/integration/admin/user-management.test.ts
+++ b/src/test/integration/admin/user-management.test.ts
@@ -160,9 +160,11 @@ describe("Admin User Management Integration", () => {
       formData.append("role", "member");
       formData.append("sendInvite", "true");
 
-      const result = await inviteUser(formData);
+      const result = await inviteUser(undefined, formData);
       expect(result.ok).toBe(true);
-      expect(result.userId).toBeDefined();
+      if (result.ok) {
+        expect(result.value.userId).toBeDefined();
+      }
 
       const ucUser = await (
         await getTestDb()
@@ -204,9 +206,11 @@ describe("Admin User Management Integration", () => {
       formData.append("email", "tech-invite@test.com");
       formData.append("role", "member");
 
-      const result = await inviteUser(formData);
+      const result = await inviteUser(undefined, formData);
       expect(result.ok).toBe(true);
-      expect(result.userId).toBeDefined();
+      if (result.ok) {
+        expect(result.value.userId).toBeDefined();
+      }
 
       const invited = await (
         await getTestDb()
@@ -226,9 +230,13 @@ describe("Admin User Management Integration", () => {
       formData.append("email", targetUser!.email); // targetUser already exists in beforeEach
       formData.append("role", "member");
 
-      await expect(inviteUser(formData)).rejects.toThrow(
-        "A user with this email already exists and is active."
-      );
+      const result = await inviteUser(undefined, formData);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe(
+          "A user with this email already exists and is active."
+        );
+      }
     });
 
     it("should reject invite when the email exists in auth.users beyond the first page (PP-a4st)", async () => {
@@ -266,9 +274,13 @@ describe("Admin User Management Integration", () => {
       formData.append("email", collisionEmail);
       formData.append("role", "member");
 
-      await expect(inviteUser(formData)).rejects.toThrow(
-        "A user with this email already exists and is active."
-      );
+      const result = await inviteUser(undefined, formData);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe(
+          "A user with this email already exists and is active."
+        );
+      }
 
       // And no invited row was created as a side effect.
       const leaked = await (
@@ -295,9 +307,11 @@ describe("Admin User Management Integration", () => {
       formData.append("email", email);
       formData.append("role", "member");
 
-      await expect(inviteUser(formData)).rejects.toThrow(
-        "This user has already been invited."
-      );
+      const result = await inviteUser(undefined, formData);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe("This user has already been invited.");
+      }
     });
 
     it("should throw error when email sending fails", async () => {
@@ -314,9 +328,11 @@ describe("Admin User Management Integration", () => {
       formData.append("role", "member");
       formData.append("sendInvite", "true");
 
-      await expect(inviteUser(formData)).rejects.toThrow(
-        "Failed to send invitation email"
-      );
+      const result = await inviteUser(undefined, formData);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe("Failed to send invitation email");
+      }
 
       // Verify user was still created (or should we rollback? Currently it's not in a transaction with email)
       // The current implementation inserts THEN sends email.


### PR DESCRIPTION
## What & why

**CORE-ARCH-002.** `InviteUserDialog` was the codebase's only `form.handleSubmit` call site: react-hook-form imperatively built `FormData` and called `inviteUser` inside `startTransition`, so the form did nothing without JS. Converted to the project-standard `<form action={formAction}>` + `useActionState` pattern (mirrors `signup-form.tsx`), dropping react-hook-form in favor of native validation + server-side Zod + server error display.

### `inviteUser` action: throw → `Result`

`useActionState` needs `(prevState, formData) => state`, so `inviteUser` now returns a `Result<{ userId, firstName, lastName }, Code>` discriminated union instead of throwing. **Behavior preserved** — the permission gating (`checkPermission("admin.users.invite", …)`, already matrix-based on `main`), `inviteUserSchema` validation, the dedup checks (auth.users + user_profiles + invitedUsers), and the deliberate "keep the invited row if the email send fails" behavior are all unchanged. Only the error-delivery contract changed. All callers updated (the dialog + the integration test; the other importers only render the dialog).

### Form correctness (CORE-FORM-001..006)

`type="email"`; `given-name`/`family-name`/`email` autocomplete tokens; visible required indicators (existing inline idiom); `enterKeyHint` on sequential fields. `sendInvite`/`role` are now native inputs so the form submits without JS.

## Testing
- `pnpm run check` green (types, lint, format, 1580 unit tests).
- `src/test/integration/admin/user-management.test.ts` updated to the new signature — 11/11.

## Honest scope note
The Radix `Dialog` container still needs JS to open (true of every modal in the app); what this fixes is the **form submission mechanism** — it now goes through the platform `action` path with real named inputs and server validation, instead of RHF's JS-only imperative submit. The form was extracted into a child mounted inside `DialogContent` so `useActionState` resets cleanly on each open.

From the 2026-07-17 non-negotiables audit (bead PP-eqhs). 🤖 Generated with [Claude Code](https://claude.com/claude-code)