### PR TITLE
refactor: extract getUserAccessLevel + maskEmail helpers (PP-ywcr, PP-bvd9)

### DIFF
--- a/src/app/(app)/admin/integrations/discord/actions.ts
+++ b/src/app/(app)/admin/integrations/discord/actions.ts
@@ -2,13 +2,14 @@
 
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
-import { discordIntegrationConfig, userProfiles } from "~/server/db/schema";
+import { discordIntegrationConfig } from "~/server/db/schema";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { saveDiscordConfigSchema, validateServerIdSchema } from "./schema";
 import { log } from "~/lib/logger";
 import { reportError } from "~/lib/observability/report-error";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { checkPermission } from "~/lib/permissions/helpers";
+import { getUserAccessLevel } from "~/lib/permissions/access";
 import { getDiscordTokenForAdmin } from "~/lib/discord/config";
 
 async function verifyIntegrationsAdmin(): Promise<{ userId: string }> {
@@ -18,11 +19,7 @@ async function verifyIntegrationsAdmin(): Promise<{ userId: string }> {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("Unauthorized");
 
-  const profile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-  const accessLevel = getAccessLevel(profile?.role);
+  const accessLevel = await getUserAccessLevel(user.id);
   if (!checkPermission("admin.integrations.manage", accessLevel)) {
     throw new Error(
       "Forbidden: You do not have permission to manage integrations"

--- a/src/app/(app)/issues/actions.ts
+++ b/src/app/(app)/issues/actions.ts
@@ -14,12 +14,7 @@ import { type z } from "zod";
 import { eq } from "drizzle-orm";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
-import {
-  issues,
-  userProfiles,
-  issueComments,
-  issueImages,
-} from "~/server/db/schema";
+import { issues, issueComments, issueImages } from "~/server/db/schema";
 import { log } from "~/lib/logger";
 import {
   reportError,
@@ -51,7 +46,8 @@ import {
   reassignIssueMachine,
 } from "~/services/issues";
 import { dispatchNotification } from "~/lib/notifications";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { checkPermission } from "~/lib/permissions/helpers";
+import { getUserAccessLevel } from "~/lib/permissions/access";
 import {
   type ProseMirrorDoc,
   docToPlainText,
@@ -182,12 +178,7 @@ export async function updateIssueStatusAction(
     }
 
     // Permission check
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,
@@ -285,12 +276,7 @@ export async function updateIssueSeverityAction(
     }
 
     // Permission check
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,
@@ -375,12 +361,7 @@ export async function updateIssueFrequencyAction(
     if (!currentIssue) return err("NOT_FOUND", "Issue not found");
 
     // Permission check
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,
@@ -473,12 +454,7 @@ export async function updateIssuePriorityAction(
     }
 
     // Permission check
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,
@@ -573,12 +549,7 @@ export async function assignIssueAction(
     }
 
     // Permission check
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,
@@ -632,11 +603,7 @@ export async function addCommentAction(
     return err("UNAUTHORIZED", "Unauthorized");
   }
 
-  const userProfile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-  const accessLevel = getAccessLevel(userProfile?.role);
+  const accessLevel = await getUserAccessLevel(user.id);
   if (!checkPermission("comments.add", accessLevel)) {
     return err("UNAUTHORIZED", "You do not have permission to add comments");
   }
@@ -790,11 +757,7 @@ export async function editCommentAction(
       return err("UNAUTHORIZED", "System comments cannot be edited");
     }
 
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     if (
       !checkPermission("comments.edit", accessLevel, {
         userId: user.id,
@@ -869,12 +832,7 @@ export async function deleteCommentAction(
       return err("UNAUTHORIZED", "System comments cannot be deleted");
     }
 
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const canDeleteOwn = checkPermission("comments.delete", accessLevel, {
       userId: user.id,
       reporterId: existingComment.authorId,
@@ -992,12 +950,7 @@ export async function updateIssueTitleAction(
     }
 
     // Permission check
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,
@@ -1082,12 +1035,7 @@ export async function reassignIssueMachineAction(
       return err("NOT_FOUND", "Issue not found");
     }
 
-    const userProfile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, user.id),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(userProfile?.role);
+    const accessLevel = await getUserAccessLevel(user.id);
     const ownershipCtx = {
       userId: user.id,
       reporterId: currentIssue.reportedBy,

--- a/src/app/(app)/report/(tabbed)/quick/actions.ts
+++ b/src/app/(app)/report/(tabbed)/quick/actions.ts
@@ -5,9 +5,10 @@ import { after } from "next/server";
 import { revalidatePath } from "next/cache";
 import { eq } from "drizzle-orm";
 import { db } from "~/server/db";
-import { machines, userProfiles } from "~/server/db/schema";
+import { machines } from "~/server/db/schema";
 import { createClient } from "~/lib/supabase/server";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { checkPermission } from "~/lib/permissions/helpers";
+import { getUserAccessLevel } from "~/lib/permissions/access";
 import { createIssue } from "~/services/issues";
 import { dispatchNotification } from "~/lib/notifications";
 import { reportError } from "~/lib/observability/report-error";
@@ -30,11 +31,7 @@ async function requireQuickReporter(): Promise<{ userId: string } | null> {
   } = await supabase.auth.getUser();
   if (!user) return null;
 
-  const profile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-  const accessLevel = getAccessLevel(profile?.role);
+  const accessLevel = await getUserAccessLevel(user.id);
   if (!checkPermission("issues.report.quick", accessLevel)) return null;
   return { userId: user.id };
 }

--- a/src/app/(app)/report/(tabbed)/quick/page.tsx
+++ b/src/app/(app)/report/(tabbed)/quick/page.tsx
@@ -1,10 +1,8 @@
 import type React from "react";
-import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
-import { db } from "~/server/db";
-import { userProfiles } from "~/server/db/schema";
 import { createClient } from "~/lib/supabase/server";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { checkPermission } from "~/lib/permissions/helpers";
+import { getUserAccessLevel } from "~/lib/permissions/access";
 import { getLoginUrl } from "~/lib/url";
 import { QuickReportGrid } from "./quick-report-grid";
 
@@ -19,11 +17,7 @@ export default async function QuickReportPage(): Promise<React.JSX.Element> {
 
   if (!user) redirect(getLoginUrl("/report/quick"));
 
-  const profile = await db.query.userProfiles.findFirst({
-    where: eq(userProfiles.id, user.id),
-    columns: { role: true },
-  });
-  const accessLevel = getAccessLevel(profile?.role);
+  const accessLevel = await getUserAccessLevel(user.id);
 
   if (!checkPermission("issues.report.quick", accessLevel)) {
     redirect("/report");

--- a/src/app/(app)/report/actions.ts
+++ b/src/app/(app)/report/actions.ts
@@ -47,7 +47,8 @@ import type {
   IssuePriority,
   IssueFrequency,
 } from "~/lib/types";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { checkPermission } from "~/lib/permissions/helpers";
+import { getUserAccessLevel } from "~/lib/permissions/access";
 
 const recentIssuesParamsSchema = z.object({
   machineInitials: z
@@ -226,12 +227,7 @@ export async function submitPublicIssueAction(
   if (reportedBy) {
     // Optimization: Check if we have the profile already?
     // We don't have it in scope if it came from `user.id`.
-    const profile = await db.query.userProfiles.findFirst({
-      where: eq(userProfiles.id, reportedBy),
-      columns: { role: true },
-    });
-
-    const accessLevel = getAccessLevel(profile?.role);
+    const accessLevel = await getUserAccessLevel(reportedBy);
     const canSetStatus = checkPermission("issues.report.status", accessLevel);
     const canSetPriority = checkPermission(
       "issues.report.priority",

--- a/src/app/(auth)/actions.ts
+++ b/src/app/(auth)/actions.ts
@@ -11,6 +11,7 @@ import {
   resetPasswordSchema,
 } from "./schemas";
 import { log } from "~/lib/logger";
+import { maskEmail } from "~/lib/logging/mask";
 import {
   serverActionError,
   reportError,
@@ -132,7 +133,7 @@ export async function loginAction(
     if (!accountLimit.success) {
       log.warn(
         {
-          email: email.substring(0, 3) + "***",
+          email: maskEmail(email),
           action: "login",
           resetIn: formatResetTime(accountLimit.reset),
         },
@@ -516,7 +517,7 @@ export async function forgotPasswordAction(
     if (!emailLimit.success) {
       log.warn(
         {
-          email: email.substring(0, 3) + "***",
+          email: maskEmail(email),
           action: "forgot-password",
           resetIn: formatResetTime(emailLimit.reset),
         },

--- a/src/lib/email/client.ts
+++ b/src/lib/email/client.ts
@@ -9,6 +9,7 @@ import {
   EMAIL_FROM,
 } from "./transport";
 import { log } from "~/lib/logger";
+import { maskEmail } from "~/lib/logging/mask";
 import { reportError } from "~/lib/observability/report-error";
 import { assertNotInTransaction } from "~/server/db/transaction-context";
 
@@ -75,11 +76,11 @@ export async function sendEmail({
   // transaction (the Doodle Bug, PP-2053).
   assertNotInTransaction("sendEmail");
 
-  log.info({ to, subject }, "[Email] Attempting to send email");
+  log.info({ to: maskEmail(to), subject }, "[Email] Attempting to send email");
 
   if (!transport) {
     log.warn(
-      { to, subject },
+      { to: maskEmail(to), subject },
       "[Email] No transport configured. Email not sent."
     );
     return { success: false, error: "No transport configured" };
@@ -94,7 +95,7 @@ export async function sendEmail({
     idempotencyKey,
   });
   if (result.success) {
-    log.info({ to, subject }, "[Email] Email sent successfully");
+    log.info({ to: maskEmail(to), subject }, "[Email] Email sent successfully");
   } else {
     reportError(result.error, { action: "sendEmail" });
   }

--- a/src/lib/logging/mask.ts
+++ b/src/lib/logging/mask.ts
@@ -1,0 +1,18 @@
+/**
+ * PII masking helpers for log output.
+ *
+ * Established precedent is call-site masking: mask the value where it is
+ * logged rather than relying on a global log redactor. Keeps recipient /
+ * account PII out of logs while retaining just enough of a prefix to
+ * correlate entries during debugging.
+ */
+
+/**
+ * Mask an email address for logging: keep the first (up to) three characters
+ * and replace the remainder with `***`.
+ *
+ * Handles short and empty strings gracefully — an empty string yields `"***"`.
+ */
+export function maskEmail(email: string): string {
+  return email.slice(0, 3) + "***";
+}

--- a/src/lib/permissions/access.ts
+++ b/src/lib/permissions/access.ts
@@ -1,0 +1,31 @@
+/**
+ * Server-only permission access helpers.
+ *
+ * These helpers touch the database, so they live apart from the pure,
+ * client-safe functions in `./helpers` (which are imported by client
+ * components). Keeping the `db` import out of `./helpers` prevents the
+ * server-only postgres client from leaking into the client bundle.
+ */
+
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { userProfiles } from "~/server/db/schema";
+import { type AccessLevel } from "./matrix";
+import { getAccessLevel } from "./helpers";
+
+/**
+ * Resolve a user's access level by looking up their profile role.
+ *
+ * Returns `"unauthenticated"` when the user has no profile/role (matching
+ * `getAccessLevel`'s handling of an undefined role).
+ */
+export async function getUserAccessLevel(userId: string): Promise<AccessLevel> {
+  const userProfile = await db.query.userProfiles.findFirst({
+    where: eq(userProfiles.id, userId),
+    columns: { role: true },
+  });
+
+  return getAccessLevel(userProfile?.role);
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -19,6 +19,7 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { headers } from "next/headers";
 import { log } from "~/lib/logger";
+import { maskEmail } from "~/lib/logging/mask";
 import { BLOB_CONFIG } from "~/lib/blob/config";
 
 /**
@@ -445,7 +446,7 @@ export async function checkLoginAccountLimit(
     log.error(
       {
         err: error instanceof Error ? error.message : "Unknown",
-        email: email.substring(0, 3) + "***",
+        email: maskEmail(email),
       },
       "Login account rate limit check failed"
     );
@@ -551,7 +552,7 @@ export async function checkForgotPasswordLimit(
     log.error(
       {
         err: error instanceof Error ? error.message : "Unknown",
-        email: email.substring(0, 3) + "***",
+        email: maskEmail(email),
       },
       "Forgot password rate limit check failed"
     );

--- a/src/server/actions/images.ts
+++ b/src/server/actions/images.ts
@@ -4,12 +4,7 @@ import { createClient } from "~/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { db } from "~/server/db";
-import {
-  issueImages,
-  issues,
-  issueComments,
-  userProfiles,
-} from "~/server/db/schema";
+import { issueImages, issues, issueComments } from "~/server/db/schema";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob/client";
 import { validateImageFile } from "~/lib/blob/validation";
 import { BLOB_CONFIG } from "~/lib/blob/config";
@@ -22,7 +17,8 @@ import {
 import { eq, count, and, isNull } from "drizzle-orm";
 import { log } from "~/lib/logger";
 import { reportError } from "~/lib/observability/report-error";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { checkPermission } from "~/lib/permissions/helpers";
+import { getUserAccessLevel } from "~/lib/permissions/access";
 
 const uploadSchema = z.object({
   issueId: z.string(), // Can be real UUID or 'new'
@@ -101,12 +97,7 @@ export async function uploadIssueImage(formData: FormData): Promise<
         return err("VALIDATION", "Issue not found");
       }
 
-      const userProfile = await db.query.userProfiles.findFirst({
-        where: eq(userProfiles.id, user.id),
-        columns: { role: true },
-      });
-
-      const accessLevel = getAccessLevel(userProfile?.role);
+      const accessLevel = await getUserAccessLevel(user.id);
       const ownershipCtx = {
         userId: user.id,
         reporterId: currentIssue.reportedBy,


### PR DESCRIPTION
## Summary

Removes real duplication (Rule-of-Three exceeded) by extracting two shared helpers, and resolves PP-bvd9 (recipient PII in send logs).

> Originally planned as a stack on #1690, but #1690 has since squash-merged into `main` (and its branch was deleted), so this PR targets `main` directly. The diff is clean — only the dedup changes below.

### 1. `getUserAccessLevel(userId)` — PP-ywcr

The `userProfiles` role lookup + `getAccessLevel(profile?.role)` pattern was duplicated ~15 times. Extracted into a single async helper and replaced every identical site:

- **10 sites** in `src/app/(app)/issues/actions.ts`
- **5 identical copies** elsewhere: `server/actions/images.ts`, `admin/integrations/discord/actions.ts`, `report/(tabbed)/quick/page.tsx`, `report/(tabbed)/quick/actions.ts`, `report/actions.ts`

Behavior is identical (same query, same `undefined → "unauthenticated"` handling). Now-unused `userProfiles` / `eq` / `getAccessLevel` imports were pruned per file.

**Placement note:** the helper lives in a new **server-only** `src/lib/permissions/access.ts` rather than in `helpers.ts` as the bead suggested. `helpers.ts` is imported by `"use client"` components (`user-menu-client.tsx`, `BottomTabBar.tsx`, the issue form leaves), so adding a `db` import there would pull the server-only postgres client into the client bundle. `access.ts` carries `import "server-only"` and re-uses the pure `getAccessLevel` from `helpers.ts`.

### 2. `maskEmail(email)` — PP-ywcr + resolves PP-bvd9

The masking expression `email.substring(0, 3) + "***"` was duplicated at 4 sites (`(auth)/actions.ts` ×2, `rate-limit.ts` ×2). Extracted into `src/lib/logging/mask.ts` (small focused module, matching the codebase convention of `dates.ts` / `url.ts`). Handles short/empty strings gracefully (`""` → `"***"`).

**PP-bvd9:** `src/lib/email/client.ts` logged the raw recipient address. Routed the three send-path log lines (`log.info` attempting/sent + the `log.warn` no-transport branch) through `maskEmail(to)`. This follows the established **call-site masking** precedent (not a global log redactor).

## Validation

`pnpm run check` green (types, lint, format, 1580 unit tests). Behavior-preserving throughout; no schema/migration changes.

## Step 4 survey — other genuine 3+ duplications (report only, NOT fixed here)

Flagged for Tim to prioritize separately (kept out of this PR to avoid over-scoping):

1. **Error-message ternary** — `error instanceof Error ? error.message : <fallback>` appears **~31 times** across ~15 non-test files (`lib/rate-limit.ts` ×6, `lib/blob/client.ts`, `lib/security/turnstile.ts`, `lib/auth/profile.ts`, `server/actions/images.ts`, `components/users/InviteUserDialog.tsx`, `lib/pinballmap/state.ts`, several `app/api/**` routes, …). Suggested helper: `errorMessage(error: unknown, fallback = "Unknown"): string`.

2. **Profile-role lookup + null-guard** — the `userProfiles.findFirst({ columns: { role: true } })` lookup followed by an `if (!profile) return …` guard (distinct from the identical copies deduped above, which have no guard) recurs in ~10 sites: `m/[initials]/(tabs)/timeline/actions.ts` ×3, `m/[initials]/(tabs)/settings/actions.ts`, `c/collections/actions.ts`, `m/pinballmap-actions.ts`, `admin/layout.tsx`, `help/admin/page.tsx`, `issues/watcher-actions.ts`, `lib/auth/context.ts`. Suggested helper: `getUserRole(userId): Promise<UserRole | null>` (returns `null` when no profile), complementing `getUserAccessLevel` for callers that need to distinguish "no profile".

3. **Auth boilerplate** — `const supabase = await createClient(); const { data: { user } } = await supabase.auth.getUser(); if (!user) return err(...)` recurs across **~69 server-action files**. Higher-value but higher-touch; a `requireUser()` helper returning the user or a uniform unauthorized `Result` would collapse it. Worth its own scoped pass given the size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
