### PR TITLE
docs: changelog week of July 14, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 140, "lastUpdated": "2026-07-12" }
+{ "totalEntries": 148, "lastUpdated": "2026-07-18" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -4,11 +4,19 @@
 
 ### New Features
 
+- **Machine Collections** — Members can now create a private collection of machines and view combined Overview, Issues, and Timeline for that whole set at once; share a view link with anyone — no sign-in required — for tournament scoreboards or event walk-throughs
+- **Service Tab** — Each machine's detail page now has a Service tab with an Open Issues card (toggleable to show all issues), service notes, and the owner-private configuration fields that used to live on the Info tab
+- **Unified Report Page** — "Report an Issue" and "Quick Report" are now one tabbed page at /report; the machine picker is shared between tabs so you don't have to re-select after switching views
+- **Quick-Report Grid** — Technicians and admins have a new Multiple tab for bulk issue entry: fill in a grid of machine + description rows and submit each one independently for fast floor-sweep reporting
+- **PinballMap Status on Info Tab** — Each machine's Info tab now shows a status card reflecting whether the machine is currently listed on PinballMap, recently added or removed, or out of sync; the status updates automatically every hour
+- **Searchable Machine Picker** — The report-an-issue machine picker is now a type-to-filter combobox; type a machine name or its initials (e.g. "GZ" for Godzilla) to narrow the list instantly, especially useful on large collections
 - **Redesigned Machine Info Tab** — The Info tab on each machine's detail page (the first thing you see when you scan a QR code) now shows the machine's current status, a peek at up to three known issues, a direct "Report a problem" link, and a Details card with the machine description and owner
 
 ### Bug Fixes
 
 - Login, sign-up, forgot-password, and reset-password forms no longer get permanently stuck with a disabled button when the security verification widget loads slowly or encounters a network error
+- Active filter chips on the Issues list no longer overlap the search bar or fall off-screen on phones; remove buttons are now always visible and tappable on touch screens
+- Animations throughout the app now pause when you have "reduce motion" turned on in your system settings; filter dropdowns and other controls are now fully keyboard-navigable
 
 ---
 


### PR DESCRIPTION
## Summary

Weekly changelog entry for the week of July 14, 2026.

- 7 new features: Machine Collections + view-link sharing (PR #1671, #1684), Service Tab (PR #1645), Unified Report Page (PR #1685), Quick-Report Grid (PR #1667), PinballMap status card (PR #1659, #1681), Searchable machine picker (PR #1670), Redesigned Machine Info Tab (PR #1575 — consolidated from prior catchup entry)
- 3 bug fixes: filter chips on mobile (PR #1680), motion-reduce/keyboard controls (PR #1691), auth forms stuck disabled (PR #1641 — consolidated from prior catchup entry)

Note: the prior "July 14, 2026" section (from PR #1660, a catchup for two older PRs) has been consolidated into this single section to avoid duplicate headings.

🤖 Generated by the Weekly Review scheduled routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4Rp8T2HzhZAHhNbndNo6W)_