### PR TITLE
fix(collections): validate setCollectionSharingAction inputs with Zod (PP-3iry)

### DIFF
--- a/src/app/(app)/c/collections/actions.ts
+++ b/src/app/(app)/c/collections/actions.ts
@@ -205,30 +205,43 @@ export async function updateCollectionAction(input: {
  * Returns the resulting token (null when disabled) so the Share dialog can
  * render the link without a re-fetch.
  */
+const setCollectionSharingSchema = z.object({
+  collectionId: z.uuid(),
+  enabled: z.boolean(),
+});
+
 export async function setCollectionSharingAction(input: {
   collectionId: string;
   enabled: boolean;
 }): Promise<ActionResult<{ viewToken: string | null }>> {
+  // Validate before any branching: `enabled` gates a security-sensitive
+  // choice (revoke vs. keep a live share link). Without z.boolean(), a
+  // stringified "false" would be truthy and silently take the *enable*
+  // branch — leaving a collection shareable after the owner revoked it.
+  const parsed = setCollectionSharingSchema.safeParse(input);
+  if (!parsed.success) return { success: false, error: "Invalid input" };
+  const { collectionId, enabled } = parsed.data;
+
   const actor = await resolveActor();
   if (!actor) return { success: false, error: "Not authenticated" };
-  const collection = await loadOwner(input.collectionId);
+  const collection = await loadOwner(collectionId);
   if (!collection) return { success: false, error: "Not found" };
   if (!canManageCollection(collection, { userId: actor.userId })) {
     return { success: false, error: "Forbidden" };
   }
 
-  if (!input.enabled) {
+  if (!enabled) {
     await db
       .update(collections)
       .set({ viewToken: null, updatedAt: new Date() })
-      .where(eq(collections.id, input.collectionId));
-    revalidatePath(`/c/${input.collectionId}`);
+      .where(eq(collections.id, collectionId));
+    revalidatePath(`/c/${collectionId}`);
     return { success: true, data: { viewToken: null } };
   }
 
   // Enable: reuse an existing token if present, else mint one.
   const existing = await db.query.collections.findFirst({
-    where: eq(collections.id, input.collectionId),
+    where: eq(collections.id, collectionId),
     columns: { viewToken: true },
   });
   const token = existing?.viewToken ?? generateViewToken();
@@ -236,9 +249,9 @@ export async function setCollectionSharingAction(input: {
     await db
       .update(collections)
       .set({ viewToken: token, updatedAt: new Date() })
-      .where(eq(collections.id, input.collectionId));
+      .where(eq(collections.id, collectionId));
   }
-  revalidatePath(`/c/${input.collectionId}`);
+  revalidatePath(`/c/${collectionId}`);
   return { success: true, data: { viewToken: token } };
 }
 

--- a/src/test/integration/collections-actions.test.ts
+++ b/src/test/integration/collections-actions.test.ts
@@ -400,6 +400,46 @@ describe("collection actions", () => {
     expect(await tokenOf(collection.id)).toBeNull();
   });
 
+  it("setCollectionSharingAction: rejects a stringified enabled without touching sharing", async () => {
+    const db = await getTestDb();
+    const owner = createTestUser({ role: "member" });
+    await db.insert(userProfiles).values(owner);
+    const [collection] = await db
+      .insert(collections)
+      .values({ name: "Bank", ownerId: owner.id })
+      .returning();
+
+    const { setCollectionSharingAction } =
+      await import("~/app/(app)/c/collections/actions");
+    signIn(owner.id);
+
+    // A form/RPC caller can smuggle the string "false" past the compile-time
+    // boolean type. Pre-fix, `!"false"` is falsy so the action took the ENABLE
+    // branch and minted a token — the opposite of the owner's intent. Zod's
+    // z.boolean() (no coercion) must reject it, leaving sharing untouched.
+    const result = await setCollectionSharingAction({
+      collectionId: collection.id,
+      enabled: "false",
+    } as unknown as { collectionId: string; enabled: boolean });
+    expect(result.success).toBe(false);
+    expect(await tokenOf(collection.id)).toBeNull();
+  });
+
+  it("setCollectionSharingAction: rejects a non-uuid collectionId", async () => {
+    const { setCollectionSharingAction } =
+      await import("~/app/(app)/c/collections/actions");
+    const owner = createTestUser({ role: "member" });
+    const db = await getTestDb();
+    await db.insert(userProfiles).values(owner);
+    signIn(owner.id);
+
+    const result = await setCollectionSharingAction({
+      collectionId: "not-a-uuid",
+      enabled: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("deleteCollectionAction: owner only", async () => {
     const db = await getTestDb();
     const owner = createTestUser({ role: "member" });


### PR DESCRIPTION
## What

Adds Zod validation to `setCollectionSharingAction` (`src/app/(app)/c/collections/actions.ts`), the one open finding from this week's security review (bead **PP-3iry**).

## Why

The action accepted `collectionId`/`enabled` without validation (**CORE-SEC-002**). `enabled` is only a *compile-time* boolean — a form or RPC caller can pass the string `"false"`, which is truthy, so `!enabled` was `false` and the action silently took the **enable** branch when the owner meant to **disable**. Net effect: a collection could stay publicly shareable after the owner revoked the link. Not an injection vector (Drizzle params those), but a real behavioral/security defect.

`collectionId` was already uuid-checked indirectly via `loadOwner`, but is now validated explicitly at entry too.

## How

- New `setCollectionSharingSchema = z.object({ collectionId: z.uuid(), enabled: z.boolean() })`, `safeParse`d at the top of the action before any branching — matching the pattern used by the neighboring `create`/`update` collection actions.
- `z.boolean()` does **not** coerce, so a stringified boolean is rejected (`{ success: false, error: "Invalid input" }`) rather than mis-branched.

## Tests

Two regression tests in `src/test/integration/collections-actions.test.ts`:
- stringified `"false"` is rejected and leaves sharing untouched (no token minted)
- a non-uuid `collectionId` is rejected

`pnpm run check` green (1580 unit); targeted integration suite 15/15.

Closes PP-3iry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)