### PR TITLE
fix(issues): dashboard badge grid clips off card right edge (PP-ytao)

### DIFF
--- a/src/components/issues/IssueBadgeGrid.tsx
+++ b/src/components/issues/IssueBadgeGrid.tsx
@@ -72,40 +72,42 @@ export function IssueBadgeGrid({
     );
   }
 
+  // A fixed 2-col grid (never a self-measuring `@container`): the badge column
+  // is an auto-width `shrink-0` flex item in IssueCard's/IssueRow's row layout,
+  // and `container-type: inline-size` would zero its intrinsic width, collapsing
+  // the box so the fixed-width pills overflow and get clipped (PP-ytao).
   return (
-    <div className={cn("@container", className)}>
-      <div
-        className="grid grid-cols-1 @sm:grid-cols-2 gap-2"
-        role="group"
-        aria-label="Issue metadata"
-      >
+    <div
+      className={cn("grid grid-cols-2 gap-2", className)}
+      role="group"
+      aria-label="Issue metadata"
+    >
+      <IssueBadge
+        type="status"
+        value={issue.status}
+        variant={variant}
+        size={size}
+      />
+      {showPriority && (
         <IssueBadge
-          type="status"
-          value={issue.status}
+          type="priority"
+          value={issue.priority}
           variant={variant}
           size={size}
         />
-        {showPriority && (
-          <IssueBadge
-            type="priority"
-            value={issue.priority}
-            variant={variant}
-            size={size}
-          />
-        )}
-        <IssueBadge
-          type="severity"
-          value={issue.severity}
-          variant={variant}
-          size={size}
-        />
-        <IssueBadge
-          type="frequency"
-          value={issue.frequency}
-          variant={variant}
-          size={size}
-        />
-      </div>
+      )}
+      <IssueBadge
+        type="severity"
+        value={issue.severity}
+        variant={variant}
+        size={size}
+      />
+      <IssueBadge
+        type="frequency"
+        value={issue.frequency}
+        variant={variant}
+        size={size}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

On the dashboard's "Recently Reported Issues" cards, the status/priority/severity/frequency badges were clipped off the right edge of each card once the viewport was wide enough for the badges to sit beside the text (side-by-side card layout).

## Root cause

`IssueBadgeGrid`'s normal variant wrapped its badges in an `@container` (`container-type: inline-size`). Inline-size containment sizes the element **as if it has no contents** on the inline axis. As the auto-width `shrink-0` badge column in `IssueCard`'s / `IssueRow`'s wide (row) layout, it had nothing to derive its width from and **collapsed to 0px** — the fixed `w-[120px]` badge pills then spilled past the card's right edge and were clipped by `Card`'s `overflow-hidden`. In the narrow (stacked) layout the wrapper stretched to full width, so it only broke once cards were wide enough to place badges on the right.

Confirmed by direct browser measurement: badge column `0px`, badges overflowing `+103px` past the card edge.

## Fix

Replace the self-collapsing `@container` + `@sm:grid-cols-2` with a fixed `grid grid-cols-2` (2×2). The four fixed-width pills always fit — in both the stacked (narrow) and side-by-side (wide) card layouts — so no container query is needed. This also fixes the same latent 0-width collapse in `IssueRow`, which renders the same variant inside a `shrink-0` flex wrapper.

## Verification

- Root cause + fix measured in a real browser (0px → 248px badge column; 103px overflow → none), at both 1440px and 1280px cards.
- Before/after screenshots captured locally (Firefox — see notes on `pr-screenshots` below).
- `pnpm run check` green (typecheck, lint, format, 1580 unit tests).

_Bead: PP-ytao_