### PR TITLE
fix(pinballmap): use canonical brand name 'Pinball Map' in user-facing copy (PP-op35)

### DIFF
--- a/src/app/(app)/m/[initials]/(tabs)/machine-pinballmap-card.test.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/machine-pinballmap-card.test.tsx
@@ -9,7 +9,7 @@ describe("MachinePinballmapCard", () => {
   it("renders a public link back to the PBM location (CORE-PBM-001)", () => {
     render(<MachinePinballmapCard locationUrl={LOCATION_URL} />);
     const link = screen.getByTestId("machine-pinballmap-link");
-    expect(link).toHaveTextContent(/view on pinballmap/i);
+    expect(link).toHaveTextContent(/view on pinball map/i);
     expect(link).toHaveAttribute("href", LOCATION_URL);
     expect(link).toHaveAttribute("target", "_blank");
     // noopener noreferrer to match the codebase convention for target="_blank".
@@ -32,7 +32,7 @@ describe("MachinePinballmapCard", () => {
       />
     );
     expect(screen.getByTestId("machine-pinballmap-desync")).toHaveTextContent(
-      /listed here but not showing on pinballmap/i
+      /listed here but not showing on pinball map/i
     );
   });
 
@@ -45,7 +45,7 @@ describe("MachinePinballmapCard", () => {
       />
     );
     expect(screen.getByTestId("machine-pinballmap-desync")).toHaveTextContent(
-      /on pinballmap but not marked listed here/i
+      /on pinball map but not marked listed here/i
     );
   });
 
@@ -58,7 +58,7 @@ describe("MachinePinballmapCard", () => {
       />
     );
     expect(screen.getByTestId("machine-pinballmap-desync")).toHaveTextContent(
-      /pinballmap link moved/i
+      /pinball map link moved/i
     );
   });
 

--- a/src/app/(app)/m/[initials]/(tabs)/machine-pinballmap-card.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/machine-pinballmap-card.tsx
@@ -23,9 +23,9 @@ import type { PbmMachineStatus } from "~/lib/pinballmap/status";
 
 /** Human-facing copy per desync reason. Reasons without an entry show no alert. */
 const DESYNC_COPY: Partial<Record<PbmMachineStatus["reason"], string>> = {
-  listed_locally_absent_on_pbm: "Listed here but not showing on PinballMap.",
-  on_pbm_not_listed_locally: "On PinballMap but not marked listed here.",
-  lmx_drifted: "PinballMap link moved — verify.",
+  listed_locally_absent_on_pbm: "Listed here but not showing on Pinball Map.",
+  on_pbm_not_listed_locally: "On Pinball Map but not marked listed here.",
+  lmx_drifted: "Pinball Map link moved — verify.",
 };
 
 export interface MachinePinballmapCardProps {
@@ -55,7 +55,7 @@ export function MachinePinballmapCard({
         <span className="text-secondary" aria-hidden="true">
           ◆
         </span>{" "}
-        PinballMap
+        Pinball Map
       </p>
 
       {desyncMessage ? (
@@ -76,7 +76,7 @@ export function MachinePinballmapCard({
         data-testid="machine-pinballmap-link"
         className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
       >
-        View on PinballMap
+        View on Pinball Map
         <ExternalLink className="size-3" aria-hidden="true" />
       </a>
     </div>

--- a/src/app/(app)/m/[initials]/update-machine-form.tsx
+++ b/src/app/(app)/m/[initials]/update-machine-form.tsx
@@ -457,13 +457,13 @@ export function EditMachineDialog({
                       htmlFor="edit-pinballmap-listed"
                       className="text-muted-foreground"
                     >
-                      List on PinballMap
+                      List on Pinball Map
                     </Label>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
                   Coming soon — PinPoint can&apos;t push listing changes to
-                  PinballMap.com yet.
+                  Pinball Map yet.
                 </TooltipContent>
               </Tooltip>
             )}

--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -189,14 +189,14 @@ async function resolvePbmLinkColumns(input: {
     return {
       ok: false,
       message:
-        "A machine can't be both linked to PinballMap and marked as not on it.",
+        "A machine can't be both linked to Pinball Map and marked as not on it.",
     };
   }
   if (validationError === "link_required") {
     return {
       ok: false,
       message:
-        "Select a PinballMap title or mark the machine as not on PinballMap.",
+        "Select a Pinball Map title or mark the machine as not on Pinball Map.",
     };
   }
 
@@ -230,7 +230,7 @@ async function resolvePbmLinkColumns(input: {
       return {
         ok: false,
         message:
-          "That PinballMap title is no longer in the catalog — search again.",
+          "That Pinball Map title is no longer in the catalog — search again.",
       };
     }
     return {
@@ -389,7 +389,7 @@ export async function createMachineAction(
   ) {
     return err(
       "UNAUTHORIZED",
-      "You do not have permission to link machines to PinballMap."
+      "You do not have permission to link machines to Pinball Map."
     );
   }
   const pbm = await resolvePbmLinkColumns(validation.data);
@@ -891,7 +891,7 @@ export async function updateMachineAction(
       ) {
         return err(
           "UNAUTHORIZED",
-          "You do not have permission to link this machine to PinballMap."
+          "You do not have permission to link this machine to Pinball Map."
         );
       }
       const pbm = await resolvePbmLinkColumns(validation.data);

--- a/src/app/(app)/m/new/create-machine-form.tsx
+++ b/src/app/(app)/m/new/create-machine-form.tsx
@@ -340,13 +340,13 @@ export function CreateMachineForm({
                 htmlFor="pinballmap-listed"
                 className="text-muted-foreground"
               >
-                List on PinballMap
+                List on Pinball Map
               </Label>
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            Coming soon — PinPoint can&apos;t push listing changes to
-            PinballMap.com yet.
+            Coming soon — PinPoint can&apos;t push listing changes to Pinball
+            Map yet.
           </TooltipContent>
         </Tooltip>
 

--- a/src/app/(app)/m/pinballmap-actions.ts
+++ b/src/app/(app)/m/pinballmap-actions.ts
@@ -154,7 +154,7 @@ export async function syncPinballMapNowAction(
   if (!checkPermission("machines.pinballmap.sync", accessLevel)) {
     return err(
       "UNAUTHORIZED",
-      "Only technicians and admins can trigger a PinballMap sync."
+      "Only technicians and admins can trigger a Pinball Map sync."
     );
   }
 
@@ -169,6 +169,6 @@ export async function syncPinballMapNowAction(
     return ok({ machineCount: result.machineCount, healed });
   } catch (error: unknown) {
     log.error({ err: error }, "Manual PinballMap sync failed");
-    return err("SERVER", "PinballMap sync failed. Please try again.");
+    return err("SERVER", "Pinball Map sync failed. Please try again.");
   }
 }

--- a/src/components/machines/MachineBackboxTranslite.tsx
+++ b/src/components/machines/MachineBackboxTranslite.tsx
@@ -46,7 +46,7 @@ export function MachineBackboxTranslite({
         className="object-cover object-center"
       />
       <figcaption className="absolute right-2 bottom-2 rounded bg-background/75 px-1.5 py-0.5 text-[8.5px] tracking-wide text-muted-foreground">
-        OPDB · PinballMap
+        OPDB · Pinball Map
       </figcaption>
     </figure>
   );

--- a/src/components/machines/PinballMapLinkField.tsx
+++ b/src/components/machines/PinballMapLinkField.tsx
@@ -227,7 +227,7 @@ export function PinballMapLinkField({
       >
         Model
         <span className="text-xs font-normal text-muted-foreground">
-          source: PinballMap
+          source: Pinball Map
         </span>
       </Label>
 
@@ -251,7 +251,7 @@ export function PinballMapLinkField({
               {family
                 ? `${family.name}${familyMeta ? ` · ${familyMeta}` : ""}`
                 : excluded
-                  ? "Not on PinballMap"
+                  ? "Not on Pinball Map"
                   : placeholderLabel}
             </span>
             <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
@@ -278,7 +278,7 @@ export function PinballMapLinkField({
                 </div>
               ) : query.trim().length === 0 ? (
                 <div className="px-3 py-4 text-xs text-muted-foreground">
-                  Type a title to search PinballMap.
+                  Type a title to search Pinball Map.
                 </div>
               ) : results.length > 0 ? (
                 <CommandGroup>
@@ -319,7 +319,7 @@ export function PinballMapLinkField({
                 // only appears once the catalog has actually come up empty.
                 <>
                   <p className="px-3 pt-3 pb-1 text-xs text-muted-foreground">
-                    No PinballMap match for “{query.trim()}”.
+                    No Pinball Map match for “{query.trim()}”.
                   </p>
                   <CommandGroup>
                     <CommandItem
@@ -329,10 +329,10 @@ export function PinballMapLinkField({
                     >
                       <div className="flex flex-col">
                         <span className="font-medium text-foreground">
-                          Not on PinballMap
+                          Not on Pinball Map
                         </span>
                         <span className="text-[10px] text-muted-foreground">
-                          PinballMap only maps standard pinball machines — pick
+                          Pinball Map only maps standard pinball machines — pick
                           this for novelty or non-pinball games it won&apos;t
                           list.
                         </span>
@@ -379,7 +379,7 @@ export function PinballMapLinkField({
             placeholder="e.g. novelty game, not real pinball"
             maxLength={200}
             disabled={disabled}
-            aria-label="Reason this machine is not on PinballMap"
+            aria-label="Reason this machine is not on Pinball Map"
           />
         ) : needsEdition ? (
           <Select

--- a/src/lib/permissions/matrix.ts
+++ b/src/lib/permissions/matrix.ts
@@ -393,9 +393,9 @@ export const PERMISSIONS_MATRIX: PermissionCategory[] = [
       },
       {
         id: "machines.pinballmap.link",
-        label: "Link machines to PinballMap",
+        label: "Link machines to Pinball Map",
         description:
-          "Set or change a machine's PinballMap catalog link, or mark it as not on PinballMap",
+          "Set or change a machine's Pinball Map catalog link, or mark it as not on Pinball Map",
         access: {
           unauthenticated: false,
           guest: false,
@@ -406,9 +406,9 @@ export const PERMISSIONS_MATRIX: PermissionCategory[] = [
       },
       {
         id: "machines.pinballmap.sync",
-        label: "Trigger a PinballMap sync",
+        label: "Trigger a Pinball Map sync",
         description:
-          "Manually refresh the stored PinballMap location snapshot ('Sync now'). The hourly cron does this automatically; this grants the on-demand action.",
+          "Manually refresh the stored Pinball Map location snapshot ('Sync now'). The hourly cron does this automatically; this grants the on-demand action.",
         access: {
           unauthenticated: false,
           guest: false,


### PR DESCRIPTION
## Summary
- PinballMap styles its brand as **'Pinball Map'** (two words) — confirmed from their `og:site_name`. PinPoint rendered it as one word ('PinballMap') across user-facing copy, which is incorrect brand attribution (CORE-PBM-001).
- Updates JSX display copy, tooltip text, ARIA labels, permission matrix labels/descriptions, and user-facing error/toast strings to 'Pinball Map'.
- Updates the matching test assertions in `machine-pinballmap-card.test.tsx` so they track the new copy.

**Out of scope (intentionally unchanged):** permission IDs (`machines.pinballmap.*`), code identifiers/component/function names (`PinballMapLinkField`, `PinballMapClient`), file/table/column names (`pinballmap-actions.ts`, `pinballmap_state`, `pinballmapListed`), and the `pinballmap.com` domain in links.

Closes PP-op35.

## Test plan
- [x] `pnpm run check` passes (types, lint, format, unit — 1580 Vitest tests, 108 Python tests)
- [x] Grepped in-scope display strings to confirm all read 'Pinball Map'
- [x] Confirmed no other test files assert on the changed strings