### PR TITLE
refactor(machines): extract machine mutation services (PP-u4ab.1)

### DIFF
--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -7,8 +7,14 @@
 
 "use server";
 
+import { after } from "next/server";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
+import {
+  createMachine,
+  updateMachinePresence,
+  type MachinePbmColumns,
+} from "~/services/machines";
 import {
   machines,
   machineWatchers,
@@ -40,7 +46,6 @@ import {
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 import { isPgErrorCode } from "~/lib/db/postgres-errors";
 import {
-  emitMachineCreated,
   emitMachineUpdated,
   toMachineOwnerRef,
 } from "~/lib/timeline/machine-lifecycle-helpers";
@@ -147,20 +152,8 @@ export type DeleteMachineResult = Result<
   "UNAUTHORIZED" | "NOT_FOUND" | "SERVER"
 >;
 
-/** Machine columns derived from a create/edit form's PinballMap link selection. */
-interface PbmLinkColumns {
-  pinballmapMachineId: number | null;
-  pinballmapExcluded: boolean;
-  pinballmapExcludedReason: string | null;
-  pinballmapListed: boolean;
-  manufacturer: string | null;
-  year: number | null;
-  opdbId: string | null;
-  ipdbId: number | null;
-}
-
 type ResolvePbmLinkResult =
-  { ok: true; columns: PbmLinkColumns } | { ok: false; message: string };
+  { ok: true; columns: MachinePbmColumns } | { ok: false; message: string };
 
 /**
  * Resolve the machine's PinballMap columns from the submitted link selection.
@@ -200,7 +193,7 @@ async function resolvePbmLinkColumns(input: {
     };
   }
 
-  const empty: PbmLinkColumns = {
+  const empty: MachinePbmColumns = {
     pinballmapMachineId: null,
     pinballmapExcluded: false,
     pinballmapExcludedReason: null,
@@ -427,105 +420,27 @@ export async function createMachineAction(
       return err("VALIDATION", "Selected user is not a guest.");
     }
 
-    // Atomic: promote + insert machine + add watcher
+    // Atomic promote + create, delegated to the service (transaction + owner
+    // watcher + lifecycle + notification planning). `promoteGuest.type` selects
+    // the owner column and gates the "added" notification — only an active
+    // promotion notified in the original.
     try {
-      const [machine] = await db.transaction(async (tx) => {
-        // Promote guest to member
-        if (targetActive) {
-          await tx
-            .update(userProfiles)
-            .set({ role: "member" })
-            .where(eq(userProfiles.id, forcePromoteUserId));
-        } else {
-          await tx
-            .update(invitedUsers)
-            .set({ role: "member" })
-            .where(eq(invitedUsers.id, forcePromoteUserId));
-        }
-
-        // Determine owner columns
-        const machineOwnerId = targetActive ? forcePromoteUserId : undefined;
-        const machineInvitedOwnerId = targetInvited
-          ? forcePromoteUserId
-          : undefined;
-
-        // Insert machine
-        const [newMachine] = await tx
-          .insert(machines)
-          .values({
-            name,
-            initials,
-            ownerId: machineOwnerId,
-            invitedOwnerId: machineInvitedOwnerId,
-            ...pbmColumns,
-          })
-          .returning();
-
-        if (!newMachine) {
-          throw new Error("Machine creation failed");
-        }
-
-        // Add owner as watcher
-        if (machineOwnerId) {
-          await tx
-            .insert(machineWatchers)
-            .values({
-              machineId: newMachine.id,
-              userId: machineOwnerId,
-              watchMode: "subscribe",
-            })
-            .onConflictDoUpdate({
-              target: [machineWatchers.machineId, machineWatchers.userId],
-              set: { watchMode: "subscribe" },
-            });
-        }
-
-        // Lifecycle: emit machine_added (and owner_set with a to_owner
-        // person-reference if owned — real OR invited). Atomic with the
-        // machine insert — if these fail, the machine rolls back.
-        await emitMachineCreated(
-          tx,
-          {
-            id: newMachine.id,
-            owner: toMachineOwnerRef(
-              newMachine.ownerId,
-              newMachine.invitedOwnerId
-            ),
-          },
-          user.id
-        );
-
-        return [newMachine];
+      const { machine, deliveryPlan } = await createMachine({
+        name,
+        initials,
+        actorUserId: user.id,
+        ownerId: targetActive ? forcePromoteUserId : null,
+        invitedOwnerId: targetInvited ? forcePromoteUserId : null,
+        presenceStatus,
+        description: descriptionColumn,
+        pbmColumns,
+        promoteGuest: {
+          userId: forcePromoteUserId,
+          type: targetActive ? "active" : "invited",
+        },
       });
 
-      // Post-commit side effect — best-effort: do not fail the action on notification errors
-      if (targetActive) {
-        try {
-          const channels = await getChannels();
-          await dispatchNotification(
-            await planNotification(
-              {
-                type: "machine_ownership_changed",
-                resourceId: machine.id,
-                resourceType: "machine",
-                actorId: user.id,
-                includeActor: false,
-                machineName: machine.name,
-                newStatus: "added",
-                additionalRecipientIds: [forcePromoteUserId],
-              },
-              undefined,
-              channels
-            )
-          );
-        } catch (sideEffectError: unknown) {
-          reportError(sideEffectError, {
-            action: "createMachineNotify",
-            bestEffort: true,
-            machineId: machine.id,
-          });
-        }
-      }
+      after(() => dispatchNotification(deliveryPlan));
 
       revalidatePath("/m");
       return ok({
@@ -600,60 +515,20 @@ export async function createMachineAction(
   }
   // If no ownerId provided, leave both undefined — DB stores NULL (no defaulting to caller)
 
-  // Insert machine + watcher + lifecycle events atomically.
+  // Insert machine + watcher + lifecycle events atomically (delegated to the
+  // service). No owner promotion here, so the returned plan carries no
+  // deliveries — creating a machine with an existing member as owner does not
+  // notify them, matching the original.
   try {
-    const [machine] = await db.transaction(async (tx) => {
-      const [newMachine] = await tx
-        .insert(machines)
-        .values({
-          name,
-          initials,
-          ownerId: finalOwnerId,
-          invitedOwnerId: finalInvitedOwnerId,
-          ...(presenceStatus !== undefined && { presenceStatus }),
-          ...(descriptionColumn !== undefined &&
-            descriptionColumn !== null && {
-              description: descriptionColumn,
-            }),
-          ...pbmColumns,
-        })
-        .returning();
-
-      if (!newMachine) {
-        throw new Error("Machine creation failed");
-      }
-
-      // Auto-add owner to machine_watchers (full subscribe mode)
-      if (finalOwnerId) {
-        await tx
-          .insert(machineWatchers)
-          .values({
-            machineId: newMachine.id,
-            userId: finalOwnerId,
-            watchMode: "subscribe",
-          })
-          .onConflictDoUpdate({
-            target: [machineWatchers.machineId, machineWatchers.userId],
-            set: { watchMode: "subscribe" },
-          });
-      }
-
-      // Lifecycle: emit machine_added (and owner_set with a to_owner
-      // person-reference if owned — real OR invited). Atomic with the machine
-      // insert — if these fail, the machine rolls back.
-      await emitMachineCreated(
-        tx,
-        {
-          id: newMachine.id,
-          owner: toMachineOwnerRef(
-            newMachine.ownerId,
-            newMachine.invitedOwnerId
-          ),
-        },
-        user.id
-      );
-
-      return [newMachine];
+    const { machine } = await createMachine({
+      name,
+      initials,
+      actorUserId: user.id,
+      ownerId: finalOwnerId,
+      invitedOwnerId: finalInvitedOwnerId,
+      presenceStatus,
+      description: descriptionColumn,
+      pbmColumns,
     });
 
     revalidatePath("/m");
@@ -881,7 +756,7 @@ export async function updateMachineAction(
     // submitted state is authoritative (clearing it unlinks), so it requires the
     // link permission and derives metadata from the catalog mirror. When the
     // marker is absent, link columns are left untouched.
-    let pbmColumns: PbmLinkColumns | null = null;
+    let pbmColumns: MachinePbmColumns | null = null;
     if (pbmFormPresent) {
       if (
         !checkPermission("machines.pinballmap.link", accessLevel, {
@@ -1575,44 +1450,26 @@ export async function updateMachinePresenceAction(
       );
     }
 
-    // No-op when the value is unchanged: skip the write entirely (no bumped
-    // `updatedAt`, no wasted write load, no timeline event). Radix's Select
-    // won't re-fire onValueChange for the current value, but a direct action
-    // call could, so guard here rather than rely on the client.
-    if (machine.presenceStatus === parsedPresence.data) {
-      return ok({ machineId: machine.id });
-    }
-
-    // Atomic: update + lifecycle emit. `emitMachineUpdated` only emits a
-    // `presence_changed` event when the value actually differs; name/owner are
-    // passed unchanged so no spurious name/owner events fire.
-    await db.transaction(async (tx) => {
-      await tx
-        .update(machines)
-        .set({ presenceStatus: parsedPresence.data })
-        .where(eq(machines.id, machine.id));
-
-      await emitMachineUpdated(
-        tx,
-        {
-          id: machine.id,
-          name: machine.name,
-          owner: toMachineOwnerRef(machine.ownerId, machine.invitedOwnerId),
-          presenceStatus: machine.presenceStatus,
-        },
-        {
-          name: machine.name,
-          ownerChanged: false,
-          owner: toMachineOwnerRef(machine.ownerId, machine.invitedOwnerId),
-          presenceStatus: parsedPresence.data,
-        },
-        user.id
-      );
+    // Delegate the mutation to the service, which owns the transaction + the
+    // `presence_changed` lifecycle emit and the unchanged-value no-op guard
+    // (skips the write entirely — no bumped `updatedAt`, no timeline row).
+    const { changed } = await updateMachinePresence({
+      machineId: machine.id,
+      presenceStatus: parsedPresence.data,
+      actorUserId: user.id,
+      current: {
+        name: machine.name,
+        ownerId: machine.ownerId,
+        invitedOwnerId: machine.invitedOwnerId,
+        presenceStatus: machine.presenceStatus,
+      },
     });
 
-    // Presence shows on both the Info and Service tabs (and the header), and a
-    // change emits a timeline row — revalidate the whole machine subtree.
-    revalidatePath(`/m/${machine.initials}`, "layout");
+    if (changed) {
+      // Presence shows on both the Info and Service tabs (and the header), and a
+      // change emits a timeline row — revalidate the whole machine subtree.
+      revalidatePath(`/m/${machine.initials}`, "layout");
+    }
 
     return ok({ machineId: machine.id });
   } catch (error: unknown) {

--- a/src/services/machines.ts
+++ b/src/services/machines.ts
@@ -229,11 +229,11 @@ export async function createMachine({
   machine: Machine;
   deliveryPlan: DeliveryPlan;
 }> {
-  // Resolve channels before the transaction (Supabase Vault RPC is an external
-  // round-trip — keep it out of the DB connection window). Only consumed on the
-  // active-promotion notification path, but resolving unconditionally keeps the
-  // control flow flat and matches the issues service.
-  const channels = await getChannels();
+  // `getChannels()` is a live Supabase Vault round-trip, so resolve it only when
+  // a notification will actually be planned (active-guest promotion) — every
+  // other create path discards it. Must happen before the transaction
+  // (CORE-ARCH-011: no external effects inside the DB connection window).
+  const channels = promoteGuest?.type === "active" ? await getChannels() : [];
 
   return db.transaction(async (tx) => {
     if (promoteGuest) {
@@ -361,9 +361,16 @@ export async function updateMachineOwner({
   machine: Machine;
   deliveryPlan: DeliveryPlan;
 }> {
-  const channels = await getChannels();
   const oldOwnerId = current.ownerId;
   const { ownerId: newOwnerId, invitedOwnerId: newInvitedOwnerId } = newOwner;
+
+  // A notification fires only when the active owner actually changes (old owner
+  // removed and/or new owner added). `getChannels()` is a live Vault round-trip,
+  // so resolve it only then, and before the transaction (CORE-ARCH-011).
+  const willNotify =
+    (oldOwnerId !== null && oldOwnerId !== newOwnerId) ||
+    (newOwnerId !== null && newOwnerId !== oldOwnerId);
+  const channels = willNotify ? await getChannels() : [];
 
   return db.transaction(async (tx) => {
     if (promoteGuest) {

--- a/src/services/machines.ts
+++ b/src/services/machines.ts
@@ -1,9 +1,60 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, type InferSelectModel } from "drizzle-orm";
 import { db } from "~/server/db";
-import { machineWatchers } from "~/server/db/schema";
+import {
+  machines,
+  machineWatchers,
+  userProfiles,
+  invitedUsers,
+} from "~/server/db/schema";
 import { type Result, ok, err } from "~/lib/result";
 import { z } from "zod";
-import { serverActionError } from "~/lib/observability/report-error";
+import {
+  reportError,
+  serverActionError,
+} from "~/lib/observability/report-error";
+import {
+  emitMachineCreated,
+  emitMachineUpdated,
+  toMachineOwnerRef,
+} from "~/lib/timeline/machine-lifecycle-helpers";
+import {
+  planNotification,
+  getChannels,
+  type DeliveryPlan,
+} from "~/lib/notifications";
+import { type MachinePresenceStatus } from "~/lib/machines/presence";
+import { type ProseMirrorDoc } from "~/lib/tiptap/types";
+
+export type Machine = InferSelectModel<typeof machines>;
+
+/**
+ * Machine columns derived from a create/edit form's PinballMap link selection.
+ * Callers resolve these (mutual-exclusion validation + catalog-derived metadata)
+ * and pass the finished column set to {@link createMachine}; the service simply
+ * spreads them into the insert. Defined here so both `m/actions.ts` and future
+ * MCP tools share one shape (single source of truth).
+ */
+export interface MachinePbmColumns {
+  pinballmapMachineId: number | null;
+  pinballmapExcluded: boolean;
+  pinballmapExcludedReason: string | null;
+  pinballmapListed: boolean;
+  manufacturer: string | null;
+  year: number | null;
+  opdbId: string | null;
+  ipdbId: number | null;
+}
+
+/**
+ * Identifies a guest user to promote to `member` inside the same transaction
+ * as a machine mutation. `type` selects the backing table (an active
+ * `user_profiles` row vs a pending `invited_users` row). Callers gate this on
+ * `admin.users.promote.guestToMember` before invoking the service.
+ */
+export interface PromoteGuest {
+  userId: string;
+  type: "active" | "invited";
+}
 
 const watchModeSchema = z.enum(["notify", "subscribe"]);
 
@@ -108,4 +159,376 @@ export async function updateMachineWatchMode({
       watchMode,
     });
   }
+}
+
+// --- Machine mutation services (createMachine / updateMachineOwner /
+//     updateMachinePresence) -------------------------------------------------
+//
+// These mirror `~/services/issues.ts`: a typed params object (with an explicit
+// `actorUserId`), the whole `db.transaction` — row writes, watcher
+// reconciliation, timeline emits, and notification *planning* — inside the
+// service, external channel config fetched before the transaction, and a
+// `{ machine, deliveryPlan }` result. Authorization stays in the caller (server
+// action or MCP tool): the caller authenticates, loads the machine for the
+// permission decision, runs `checkPermission()`, resolves owner identities, then
+// invokes the service and dispatches the returned plan post-commit via
+// `after(() => dispatchNotification(deliveryPlan))` (CORE-ARCH-011: no external
+// effects inside the transaction).
+
+/**
+ * Pre-loaded machine snapshot the owner/presence services need to compute
+ * timeline deltas (and the presence no-op guard) without re-reading a row the
+ * caller already fetched for its permission check.
+ */
+export interface MachineMutationSnapshot {
+  name: string;
+  ownerId: string | null;
+  invitedOwnerId: string | null;
+  presenceStatus: MachinePresenceStatus;
+}
+
+export interface CreateMachineParams {
+  name: string;
+  initials: string;
+  /** The acting user, attributed on the lifecycle timeline events. */
+  actorUserId: string;
+  /** Active owner (`user_profiles`), or null/undefined for none. */
+  ownerId?: string | null | undefined;
+  /** Invited owner (`invited_users`), or null/undefined for none. */
+  invitedOwnerId?: string | null | undefined;
+  presenceStatus?: MachinePresenceStatus | undefined;
+  description?: ProseMirrorDoc | null | undefined;
+  /** Resolved PinballMap columns to apply, or null to leave them at defaults. */
+  pbmColumns?: MachinePbmColumns | null | undefined;
+  /**
+   * When set, promote this guest to `member` inside the same transaction before
+   * the insert. Callers gate this on `admin.users.promote.guestToMember`.
+   */
+  promoteGuest?: PromoteGuest | null | undefined;
+}
+
+/**
+ * Create a machine, atomically: (optional) guest→member promotion, the machine
+ * insert, the owner's `subscribe` watcher row, and the `machine_added` /
+ * `owner_set` lifecycle events. When an active guest is promoted into ownership
+ * the new owner is notified (`machine_ownership_changed` → "added"), matching
+ * `createMachineAction`'s original post-commit dispatch; the plan is returned
+ * for the caller to deliver via `after()`.
+ */
+export async function createMachine({
+  name,
+  initials,
+  actorUserId,
+  ownerId,
+  invitedOwnerId,
+  presenceStatus,
+  description,
+  pbmColumns,
+  promoteGuest,
+}: CreateMachineParams): Promise<{
+  machine: Machine;
+  deliveryPlan: DeliveryPlan;
+}> {
+  // Resolve channels before the transaction (Supabase Vault RPC is an external
+  // round-trip — keep it out of the DB connection window). Only consumed on the
+  // active-promotion notification path, but resolving unconditionally keeps the
+  // control flow flat and matches the issues service.
+  const channels = await getChannels();
+
+  return db.transaction(async (tx) => {
+    if (promoteGuest) {
+      if (promoteGuest.type === "active") {
+        await tx
+          .update(userProfiles)
+          .set({ role: "member" })
+          .where(eq(userProfiles.id, promoteGuest.userId));
+      } else {
+        await tx
+          .update(invitedUsers)
+          .set({ role: "member" })
+          .where(eq(invitedUsers.id, promoteGuest.userId));
+      }
+    }
+
+    const [machine] = await tx
+      .insert(machines)
+      .values({
+        name,
+        initials,
+        ownerId: ownerId ?? undefined,
+        invitedOwnerId: invitedOwnerId ?? undefined,
+        ...(presenceStatus !== undefined && { presenceStatus }),
+        ...(description !== undefined &&
+          description !== null && { description }),
+        ...(pbmColumns ?? {}),
+      })
+      .returning();
+
+    if (!machine) {
+      throw new Error("Machine creation failed");
+    }
+
+    // Auto-subscribe an active owner to the machine (full subscribe mode).
+    if (ownerId) {
+      await tx
+        .insert(machineWatchers)
+        .values({
+          machineId: machine.id,
+          userId: ownerId,
+          watchMode: "subscribe",
+        })
+        .onConflictDoUpdate({
+          target: [machineWatchers.machineId, machineWatchers.userId],
+          set: { watchMode: "subscribe" },
+        });
+    }
+
+    // Lifecycle: `machine_added` (+ `owner_set` when owned). Atomic with the
+    // insert — a failed emit rolls the machine back.
+    await emitMachineCreated(
+      tx,
+      {
+        id: machine.id,
+        owner: toMachineOwnerRef(machine.ownerId, machine.invitedOwnerId),
+      },
+      actorUserId
+    );
+
+    // Notify a newly promoted active owner. Best-effort inside the tx (a
+    // planning failure must not roll back the committed machine), mirroring the
+    // issues service. Only the active-promotion path notified in the original.
+    const deliveries: DeliveryPlan["deliveries"] = [];
+    if (promoteGuest?.type === "active") {
+      try {
+        const plan = await planNotification(
+          {
+            type: "machine_ownership_changed",
+            resourceId: machine.id,
+            resourceType: "machine",
+            actorId: actorUserId,
+            includeActor: false,
+            machineName: machine.name,
+            newStatus: "added",
+            additionalRecipientIds: [promoteGuest.userId],
+          },
+          tx,
+          channels
+        );
+        deliveries.push(...plan.deliveries);
+      } catch (error) {
+        reportError(error, {
+          action: "createMachineNotify",
+          bestEffort: true,
+          machineId: machine.id,
+        });
+      }
+    }
+
+    return { machine, deliveryPlan: { deliveries } };
+  });
+}
+
+export interface UpdateMachineOwnerParams {
+  machineId: string;
+  actorUserId: string;
+  /** Current machine state, pre-loaded by the caller for the permission check. */
+  current: MachineMutationSnapshot;
+  /**
+   * The new owner. At most one id is set (active XOR invited); both null clears
+   * ownership. The caller resolves the raw name/UUID to the right column.
+   */
+  newOwner: { ownerId: string | null; invitedOwnerId: string | null };
+  /** Optional guest→member promotion for the incoming owner (see {@link PromoteGuest}). */
+  promoteGuest?: PromoteGuest | null | undefined;
+}
+
+/**
+ * Change (or clear) a machine's owner and nothing else — the focused slice of
+ * `updateMachineAction`'s owner logic, for the MCP `set_machine_owner` tool.
+ * Atomically: (optional) guest→member promotion, the owner-column update,
+ * watcher reconciliation (drop the old owner, subscribe the new), and the
+ * `owner_changed` lifecycle event. Name and presence are untouched. Removed and
+ * added owners are notified (`machine_ownership_changed`); the plan is returned
+ * for post-commit delivery.
+ */
+export async function updateMachineOwner({
+  machineId,
+  actorUserId,
+  current,
+  newOwner,
+  promoteGuest,
+}: UpdateMachineOwnerParams): Promise<{
+  machine: Machine;
+  deliveryPlan: DeliveryPlan;
+}> {
+  const channels = await getChannels();
+  const oldOwnerId = current.ownerId;
+  const { ownerId: newOwnerId, invitedOwnerId: newInvitedOwnerId } = newOwner;
+
+  return db.transaction(async (tx) => {
+    if (promoteGuest) {
+      if (promoteGuest.type === "active") {
+        await tx
+          .update(userProfiles)
+          .set({ role: "member" })
+          .where(eq(userProfiles.id, promoteGuest.userId));
+      } else {
+        await tx
+          .update(invitedUsers)
+          .set({ role: "member" })
+          .where(eq(invitedUsers.id, promoteGuest.userId));
+      }
+    }
+
+    const [machine] = await tx
+      .update(machines)
+      .set({ ownerId: newOwnerId, invitedOwnerId: newInvitedOwnerId })
+      .where(eq(machines.id, machineId))
+      .returning();
+
+    if (!machine) {
+      throw new Error("Machine not found");
+    }
+
+    // Reconcile watcher rows (roll back with the owner change if anything below
+    // throws). Old-owner removal + new-owner subscription mirror the action.
+    if (oldOwnerId && oldOwnerId !== newOwnerId) {
+      await tx
+        .delete(machineWatchers)
+        .where(
+          and(
+            eq(machineWatchers.machineId, machineId),
+            eq(machineWatchers.userId, oldOwnerId)
+          )
+        );
+    }
+    if (newOwnerId && newOwnerId !== oldOwnerId) {
+      await tx
+        .insert(machineWatchers)
+        .values({ machineId, userId: newOwnerId, watchMode: "subscribe" })
+        .onConflictDoUpdate({
+          target: [machineWatchers.machineId, machineWatchers.userId],
+          set: { watchMode: "subscribe" },
+        });
+    }
+
+    // Lifecycle: emit only `owner_changed`. Name is passed unchanged and
+    // presence is left `undefined` so no spurious name/presence events fire.
+    await emitMachineUpdated(
+      tx,
+      {
+        id: machineId,
+        name: current.name,
+        owner: toMachineOwnerRef(current.ownerId, current.invitedOwnerId),
+        presenceStatus: current.presenceStatus,
+      },
+      {
+        name: current.name,
+        ownerChanged: true,
+        owner: toMachineOwnerRef(newOwnerId, newInvitedOwnerId),
+        presenceStatus: undefined,
+      },
+      actorUserId
+    );
+
+    // Notifications planned in-tx (transactional in-app rows), delivered by the
+    // caller post-commit. Best-effort: a planning failure never rolls back the
+    // committed owner change.
+    const deliveries: DeliveryPlan["deliveries"] = [];
+    try {
+      if (oldOwnerId && oldOwnerId !== newOwnerId) {
+        const removed = await planNotification(
+          {
+            type: "machine_ownership_changed",
+            resourceId: machine.id,
+            resourceType: "machine",
+            actorId: actorUserId,
+            includeActor: false,
+            machineName: machine.name,
+            newStatus: "removed",
+            additionalRecipientIds: [oldOwnerId],
+          },
+          tx,
+          channels
+        );
+        deliveries.push(...removed.deliveries);
+      }
+      if (newOwnerId && newOwnerId !== oldOwnerId) {
+        const added = await planNotification(
+          {
+            type: "machine_ownership_changed",
+            resourceId: machine.id,
+            resourceType: "machine",
+            actorId: actorUserId,
+            includeActor: false,
+            machineName: machine.name,
+            newStatus: "added",
+            additionalRecipientIds: [newOwnerId],
+          },
+          tx,
+          channels
+        );
+        deliveries.push(...added.deliveries);
+      }
+    } catch (error) {
+      reportError(error, {
+        action: "updateMachineOwnerNotify",
+        bestEffort: true,
+        machineId: machine.id,
+      });
+    }
+
+    return { machine, deliveryPlan: { deliveries } };
+  });
+}
+
+export interface UpdateMachinePresenceParams {
+  machineId: string;
+  presenceStatus: MachinePresenceStatus;
+  actorUserId: string;
+  /** Current machine state, pre-loaded by the caller for the permission check. */
+  current: MachineMutationSnapshot;
+}
+
+/**
+ * Change a machine's presence (availability) and emit a `presence_changed`
+ * lifecycle event, atomically. Returns `{ changed: false }` without writing when
+ * the value is unchanged (no bumped `updatedAt`, no timeline row) — the caller
+ * skips revalidation in that case. No notifications.
+ */
+export async function updateMachinePresence({
+  machineId,
+  presenceStatus,
+  actorUserId,
+  current,
+}: UpdateMachinePresenceParams): Promise<{ changed: boolean }> {
+  if (current.presenceStatus === presenceStatus) {
+    return { changed: false };
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(machines)
+      .set({ presenceStatus })
+      .where(eq(machines.id, machineId));
+
+    await emitMachineUpdated(
+      tx,
+      {
+        id: machineId,
+        name: current.name,
+        owner: toMachineOwnerRef(current.ownerId, current.invitedOwnerId),
+        presenceStatus: current.presenceStatus,
+      },
+      {
+        name: current.name,
+        ownerChanged: false,
+        owner: toMachineOwnerRef(current.ownerId, current.invitedOwnerId),
+        presenceStatus,
+      },
+      actorUserId
+    );
+  });
+
+  return { changed: true };
 }

--- a/src/test/integration/machine-owner-promotion.test.ts
+++ b/src/test/integration/machine-owner-promotion.test.ts
@@ -54,9 +54,19 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+// Run `after()` callbacks synchronously so post-commit dispatch is exercised
+// inline (createMachineAction now delivers notifications via after()).
+vi.mock("next/server", () => ({
+  after: (cb: () => unknown) => {
+    void cb();
+  },
+}));
+
 vi.mock("~/lib/notifications", () => ({
   createNotification: vi.fn().mockResolvedValue(undefined),
   getChannels: vi.fn().mockResolvedValue([]),
+  planNotification: vi.fn().mockResolvedValue({ deliveries: [] }),
+  dispatchNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("~/lib/logger", () => ({

--- a/src/test/integration/machine-services.test.ts
+++ b/src/test/integration/machine-services.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Integration Test: machine mutation services (PP-u4ab.1)
+ *
+ * Worker-scoped PGlite (CORE-TEST-001). Exercises the extracted service
+ * functions in `~/services/machines` directly — the transaction, watcher
+ * reconciliation, lifecycle timeline emits, guest→member promotion, and the
+ * returned notification delivery plan — independently of the server-action
+ * wrappers (which are covered by the m/actions integration tests). Authorization
+ * lives in the callers, so these tests pass already-resolved inputs.
+ *
+ * `getChannels` is stubbed to `[]` to avoid the Vault round-trip; `planNotification`
+ * stays real so the services drive it with the arguments they would in production.
+ */
+
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  authUsers,
+  invitedUsers,
+  machineWatchers,
+  machines,
+  timelineEvents,
+  userProfiles,
+} from "~/server/db/schema";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import type * as NotificationsModule from "~/lib/notifications";
+
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+// Keep planNotification real; only stub getChannels so the service doesn't make
+// a Vault round-trip for the Discord config in the test environment.
+vi.mock("~/lib/notifications", async (importOriginal) => {
+  const actual = await importOriginal<typeof NotificationsModule>();
+  return { ...actual, getChannels: vi.fn().mockResolvedValue([]) };
+});
+
+import {
+  createMachine,
+  updateMachineOwner,
+  updateMachinePresence,
+  type MachineMutationSnapshot,
+} from "~/services/machines";
+
+describe("machine mutation services (PP-u4ab.1)", () => {
+  setupTestDb();
+
+  async function makeUser(
+    role: "guest" | "member" | "technician" | "admin" = "member"
+  ): Promise<string> {
+    const db = await getTestDb();
+    const id = randomUUID();
+    await db.insert(authUsers).values({ id, email: `${id}@example.com` });
+    await db.insert(userProfiles).values({
+      id,
+      email: `${id}@example.com`,
+      firstName: "Test",
+      lastName: "User",
+      role,
+    });
+    return id;
+  }
+
+  async function makeInvited(
+    role: "guest" | "member" = "member"
+  ): Promise<string> {
+    const db = await getTestDb();
+    const [row] = await db
+      .insert(invitedUsers)
+      .values({
+        firstName: "Invited",
+        lastName: "User",
+        email: `invited-${randomUUID()}@example.com`,
+        role,
+      })
+      .returning();
+    if (!row) throw new Error("failed to seed invited user");
+    return row.id;
+  }
+
+  let counter = 0;
+  function nextInitials(): string {
+    counter += 1;
+    return `SV${String(counter).padStart(3, "0")}`;
+  }
+
+  async function seedMachine(overrides?: {
+    ownerId?: string | null;
+    invitedOwnerId?: string | null;
+    presenceStatus?: "on_the_floor" | "off_the_floor";
+  }): Promise<{ id: string; initials: string }> {
+    const db = await getTestDb();
+    const [machine] = await db
+      .insert(machines)
+      .values({
+        name: "Seed Machine",
+        initials: nextInitials(),
+        ownerId: overrides?.ownerId ?? null,
+        invitedOwnerId: overrides?.invitedOwnerId ?? null,
+        presenceStatus: overrides?.presenceStatus ?? "on_the_floor",
+      })
+      .returning();
+    if (!machine) throw new Error("failed to seed machine");
+    return machine;
+  }
+
+  async function eventsFor(machineId: string) {
+    const db = await getTestDb();
+    return db
+      .select()
+      .from(timelineEvents)
+      .where(eq(timelineEvents.machineId, machineId));
+  }
+
+  async function eventKinds(machineId: string): Promise<string[]> {
+    const rows = await eventsFor(machineId);
+    return rows.flatMap((r) => {
+      const kind = r.eventData?.kind;
+      return kind ? [kind] : [];
+    });
+  }
+
+  async function watcher(machineId: string, userId: string) {
+    const db = await getTestDb();
+    const [row] = await db
+      .select()
+      .from(machineWatchers)
+      .where(
+        and(
+          eq(machineWatchers.machineId, machineId),
+          eq(machineWatchers.userId, userId)
+        )
+      );
+    return row;
+  }
+
+  async function snapshotOf(
+    machineId: string
+  ): Promise<MachineMutationSnapshot> {
+    const db = await getTestDb();
+    const [m] = await db
+      .select({
+        name: machines.name,
+        ownerId: machines.ownerId,
+        invitedOwnerId: machines.invitedOwnerId,
+        presenceStatus: machines.presenceStatus,
+      })
+      .from(machines)
+      .where(eq(machines.id, machineId));
+    if (!m) throw new Error("machine not found");
+    return m;
+  }
+
+  // --- createMachine -------------------------------------------------------
+
+  describe("createMachine", () => {
+    it("creates an unowned machine and emits machine_added only", async () => {
+      const actorId = await makeUser("admin");
+      const initials = nextInitials();
+
+      const { machine, deliveryPlan } = await createMachine({
+        name: "Medieval Madness",
+        initials,
+        actorUserId: actorId,
+      });
+
+      expect(machine.initials).toBe(initials);
+      expect(machine.ownerId).toBeNull();
+      expect(machine.presenceStatus).toBe("on_the_floor");
+      expect(deliveryPlan.deliveries).toEqual([]);
+
+      const kinds = await eventKinds(machine.id);
+      expect(kinds).toContain("machine_added");
+      expect(kinds).not.toContain("owner_set");
+    });
+
+    it("subscribes an active owner and emits owner_set", async () => {
+      const actorId = await makeUser("admin");
+      const ownerId = await makeUser("member");
+
+      const { machine } = await createMachine({
+        name: "Attack from Mars",
+        initials: nextInitials(),
+        actorUserId: actorId,
+        ownerId,
+      });
+
+      expect(machine.ownerId).toBe(ownerId);
+      const w = await watcher(machine.id, ownerId);
+      expect(w?.watchMode).toBe("subscribe");
+      expect(await eventKinds(machine.id)).toEqual(
+        expect.arrayContaining(["machine_added", "owner_set"])
+      );
+    });
+
+    it("applies presenceStatus and description", async () => {
+      const actorId = await makeUser("admin");
+      const description = {
+        type: "doc" as const,
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "needs new rubbers" }],
+          },
+        ],
+      };
+
+      const { machine } = await createMachine({
+        name: "Twilight Zone",
+        initials: nextInitials(),
+        actorUserId: actorId,
+        presenceStatus: "off_the_floor",
+        description,
+      });
+
+      expect(machine.presenceStatus).toBe("off_the_floor");
+      expect(machine.description).toEqual(description);
+    });
+
+    it("records an invited owner without adding a watcher row", async () => {
+      const actorId = await makeUser("admin");
+      const invitedOwnerId = await makeInvited("member");
+
+      const { machine } = await createMachine({
+        name: "Cirqus Voltaire",
+        initials: nextInitials(),
+        actorUserId: actorId,
+        invitedOwnerId,
+      });
+
+      expect(machine.invitedOwnerId).toBe(invitedOwnerId);
+      expect(machine.ownerId).toBeNull();
+      expect(await eventKinds(machine.id)).toEqual(
+        expect.arrayContaining(["machine_added", "owner_set"])
+      );
+    });
+
+    it("promotes an active guest to member and plans an added notification", async () => {
+      const actorId = await makeUser("admin");
+      const guestId = await makeUser("guest");
+
+      const { machine, deliveryPlan } = await createMachine({
+        name: "The Addams Family",
+        initials: nextInitials(),
+        actorUserId: actorId,
+        ownerId: guestId,
+        promoteGuest: { userId: guestId, type: "active" },
+      });
+
+      const db = await getTestDb();
+      const [promoted] = await db
+        .select({ role: userProfiles.role })
+        .from(userProfiles)
+        .where(eq(userProfiles.id, guestId));
+      expect(promoted?.role).toBe("member");
+      expect((await watcher(machine.id, guestId))?.watchMode).toBe("subscribe");
+      // The plan is returned for the caller to deliver post-commit.
+      expect(Array.isArray(deliveryPlan.deliveries)).toBe(true);
+    });
+  });
+
+  // --- updateMachineOwner --------------------------------------------------
+
+  describe("updateMachineOwner", () => {
+    it("assigns an owner to an unowned machine — watcher + owner_changed", async () => {
+      const actorId = await makeUser("admin");
+      const newOwnerId = await makeUser("member");
+      const seed = await seedMachine();
+
+      const { machine } = await updateMachineOwner({
+        machineId: seed.id,
+        actorUserId: actorId,
+        current: await snapshotOf(seed.id),
+        newOwner: { ownerId: newOwnerId, invitedOwnerId: null },
+      });
+
+      expect(machine.ownerId).toBe(newOwnerId);
+      expect((await watcher(seed.id, newOwnerId))?.watchMode).toBe("subscribe");
+      expect(await eventKinds(seed.id)).toContain("owner_changed");
+    });
+
+    it("swaps owners — drops the old watcher and subscribes the new", async () => {
+      const actorId = await makeUser("admin");
+      const oldOwnerId = await makeUser("member");
+      const newOwnerId = await makeUser("member");
+      const seed = await seedMachine({ ownerId: oldOwnerId });
+      // Mirror the create-time subscription of the existing owner.
+      const db = await getTestDb();
+      await db.insert(machineWatchers).values({
+        machineId: seed.id,
+        userId: oldOwnerId,
+        watchMode: "subscribe",
+      });
+
+      const { machine } = await updateMachineOwner({
+        machineId: seed.id,
+        actorUserId: actorId,
+        current: await snapshotOf(seed.id),
+        newOwner: { ownerId: newOwnerId, invitedOwnerId: null },
+      });
+
+      expect(machine.ownerId).toBe(newOwnerId);
+      expect(await watcher(seed.id, oldOwnerId)).toBeUndefined();
+      expect((await watcher(seed.id, newOwnerId))?.watchMode).toBe("subscribe");
+      expect(await eventKinds(seed.id)).toContain("owner_changed");
+    });
+
+    it("clears the owner and removes the watcher", async () => {
+      const actorId = await makeUser("admin");
+      const ownerId = await makeUser("member");
+      const seed = await seedMachine({ ownerId });
+      const db = await getTestDb();
+      await db.insert(machineWatchers).values({
+        machineId: seed.id,
+        userId: ownerId,
+        watchMode: "subscribe",
+      });
+
+      const { machine } = await updateMachineOwner({
+        machineId: seed.id,
+        actorUserId: actorId,
+        current: await snapshotOf(seed.id),
+        newOwner: { ownerId: null, invitedOwnerId: null },
+      });
+
+      expect(machine.ownerId).toBeNull();
+      expect(await watcher(seed.id, ownerId)).toBeUndefined();
+      expect(await eventKinds(seed.id)).toContain("owner_changed");
+    });
+
+    it("leaves the name and presence untouched", async () => {
+      const actorId = await makeUser("admin");
+      const newOwnerId = await makeUser("member");
+      const seed = await seedMachine({ presenceStatus: "off_the_floor" });
+
+      const { machine } = await updateMachineOwner({
+        machineId: seed.id,
+        actorUserId: actorId,
+        current: await snapshotOf(seed.id),
+        newOwner: { ownerId: newOwnerId, invitedOwnerId: null },
+      });
+
+      expect(machine.name).toBe("Seed Machine");
+      expect(machine.presenceStatus).toBe("off_the_floor");
+      const kinds = await eventKinds(seed.id);
+      expect(kinds).not.toContain("name_changed");
+      expect(kinds).not.toContain("presence_changed");
+    });
+
+    it("throws when the machine does not exist", async () => {
+      const actorId = await makeUser("admin");
+      await expect(
+        updateMachineOwner({
+          machineId: randomUUID(),
+          actorUserId: actorId,
+          current: {
+            name: "Ghost",
+            ownerId: null,
+            invitedOwnerId: null,
+            presenceStatus: "on_the_floor",
+          },
+          newOwner: { ownerId: null, invitedOwnerId: null },
+        })
+      ).rejects.toThrow(/not found/i);
+    });
+  });
+
+  // --- updateMachinePresence ----------------------------------------------
+
+  describe("updateMachinePresence", () => {
+    it("changes presence and emits presence_changed", async () => {
+      const actorId = await makeUser("admin");
+      const seed = await seedMachine({ presenceStatus: "on_the_floor" });
+
+      const { changed } = await updateMachinePresence({
+        machineId: seed.id,
+        presenceStatus: "off_the_floor",
+        actorUserId: actorId,
+        current: await snapshotOf(seed.id),
+      });
+
+      expect(changed).toBe(true);
+      const db = await getTestDb();
+      const [row] = await db
+        .select({ presenceStatus: machines.presenceStatus })
+        .from(machines)
+        .where(eq(machines.id, seed.id));
+      expect(row?.presenceStatus).toBe("off_the_floor");
+
+      const presence = (await eventsFor(seed.id)).filter(
+        (e) => e.eventData?.kind === "presence_changed"
+      );
+      expect(presence).toHaveLength(1);
+      expect(presence[0]?.eventData).toMatchObject({
+        kind: "presence_changed",
+        from: "on_the_floor",
+        to: "off_the_floor",
+      });
+    });
+
+    it("is a no-op with no event when the value is unchanged", async () => {
+      const actorId = await makeUser("admin");
+      const seed = await seedMachine({ presenceStatus: "on_the_floor" });
+
+      const { changed } = await updateMachinePresence({
+        machineId: seed.id,
+        presenceStatus: "on_the_floor",
+        actorUserId: actorId,
+        current: await snapshotOf(seed.id),
+      });
+
+      expect(changed).toBe(false);
+      expect(await eventKinds(seed.id)).not.toContain("presence_changed");
+    });
+  });
+});

--- a/src/test/integration/machine-timeline-actions.test.ts
+++ b/src/test/integration/machine-timeline-actions.test.ts
@@ -51,9 +51,19 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+// Run `after()` callbacks synchronously so post-commit dispatch is exercised
+// inline (createMachineAction now delivers notifications via after()).
+vi.mock("next/server", () => ({
+  after: (cb: () => unknown) => {
+    void cb();
+  },
+}));
+
 vi.mock("~/lib/notifications", () => ({
   createNotification: vi.fn().mockResolvedValue(undefined),
   getChannels: vi.fn().mockResolvedValue([]),
+  planNotification: vi.fn().mockResolvedValue({ deliveries: [] }),
+  dispatchNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("~/lib/logger", () => ({


### PR DESCRIPTION
## What

PR 1 of the MCP remote-admin epic (**PP-u4ab**). Behavior-preserving extraction of machine mutation logic into typed service functions in `src/services/machines.ts`, mirroring the `src/services/issues.ts` convention so PR 2's MCP tools can call the same code the web actions do.

Each service takes a params object + `actorUserId`, owns the whole `db.transaction` (row writes, watcher reconciliation, timeline emits, notification *planning*), resolves `getChannels()` before the transaction, and returns `{ machine, deliveryPlan }`. **Authorization stays in the callers** (CORE-ARCH-008); notification delivery moves to `after()` + `dispatchNotification` post-commit (CORE-ARCH-011).

## Services

- **`createMachine`** — both create paths (normal + guest→member promotion), owner `subscribe` watcher, `machine_added`/`owner_set` lifecycle, active-promote `machine_ownership_changed` notification.
- **`updateMachineOwner`** — owner-only slice for PR 2's `set_machine_owner` tool: watcher reconcile (drop old / subscribe new) + `owner_changed` + old/new-owner notifications. Name and presence untouched.
- **`updateMachinePresence`** — presence update + `presence_changed` emit + unchanged-value no-op guard.

`createMachineAction` and `updateMachinePresenceAction` become thin wrappers (net −143 lines in `actions.ts`).

## Two conscious calls (spec-sanctioned)

1. **`updateMachineAction` left untouched.** Its combined name+presence+owner+pbm+description edit stays one atomic transaction; splitting it out was explicitly out of scope ("don't balloon"). `updateMachineOwner` is therefore a standalone *second* instance of owner-change logic (Rule of Three not yet tripped) — it exists for the MCP tool.
2. **Minor behavior fix:** the `forcePromoteUserId` *create* path now honors `presenceStatus`/`description` (previously silently dropped from that branch's insert). No test pinned the old drop.

## Testing

- New `src/test/integration/machine-services.test.ts` (12 tests) exercises the three services directly at the PGlite integration layer (CORE-TEST-005).
- Existing machine action tests gained the standard `after()` + notification mock scaffolding (the refactor routes notifications through `after()`).
- Green locally: typecheck, lint, format, unit (1588), **build**, **PGlite integration (462)**, **supabase-integration (104)**. Full E2E left to CI.

Spec: `docs/superpowers/specs/2026-07-18-mcp-remote-admin.md` (§PR 1, on `feat/mcp-remote-admin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)