### PR TITLE
fix(pbm): throttle manual PinballMap sync to 20/hour (PP-fwe1)

### DIFF
--- a/src/app/(app)/m/pinballmap-actions.ts
+++ b/src/app/(app)/m/pinballmap-actions.ts
@@ -19,7 +19,11 @@ import { db } from "~/server/db";
 import { userProfiles } from "~/server/db/schema";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 import { type Result, ok, err } from "~/lib/result";
-import { syncLocationSnapshot } from "~/lib/pinballmap/state";
+import {
+  getPinballMapState,
+  syncLocationSnapshot,
+} from "~/lib/pinballmap/state";
+import { PBM_MANUAL_SYNC_MIN_INTERVAL_MS } from "~/lib/pinballmap/config";
 import { reconcileAfterSync } from "~/lib/pinballmap/sync";
 import { log } from "~/lib/logger";
 import {
@@ -120,7 +124,7 @@ export async function resolvePinballMapLinkAction(
 /** Result of an on-demand "Sync now" — the machine count and heals applied. */
 export type SyncPinballMapNowResult = Result<
   { machineCount: number; healed: number },
-  "UNAUTHORIZED" | "SERVER"
+  "UNAUTHORIZED" | "THROTTLED" | "SERVER"
 >;
 
 /**
@@ -129,14 +133,16 @@ export type SyncPinballMapNowResult = Result<
  *
  * Unlike the hourly cron, this does NOT gate on `state.enabled`: it's an
  * explicit human-initiated refresh, so the human is the caller who owns the
- * decision (CORE-PBM-001 is respected — a click is naturally rate-limited, and
- * the permission is technician+). Form-action shaped `(prevState, formData)` so
- * a `<form action={...}>` + `useActionState` button (control room, PP-o355.7)
- * can drop it in for progressive enhancement (CORE-ARCH-002).
+ * decision (CORE-PBM-001 is respected — the permission is technician+ and manual
+ * refreshes are throttled to `PBM_MANUAL_SYNC_MIN_INTERVAL_MS`, at most 20/hour).
+ * Pass a `force=true` form field to bypass the throttle. Form-action shaped
+ * `(prevState, formData)` so a `<form action={...}>` + `useActionState` button
+ * (control room, PP-o355.7) can drop it in for progressive enhancement
+ * (CORE-ARCH-002).
  */
 export async function syncPinballMapNowAction(
   _prevState: SyncPinballMapNowResult | undefined,
-  _formData: FormData
+  formData: FormData
 ): Promise<SyncPinballMapNowResult> {
   const supabase = await createClient();
   const {
@@ -156,6 +162,26 @@ export async function syncPinballMapNowAction(
       "UNAUTHORIZED",
       "Only technicians and admins can trigger a Pinball Map sync."
     );
+  }
+
+  // Conduct throttle (CORE-PBM-001): refuse a manual sync within
+  // PBM_MANUAL_SYNC_MIN_INTERVAL_MS of the last *successful* one, unless forced.
+  // `lastSyncedAt` is only written on the ok path, so a prior failure never
+  // blocks a retry.
+  if (formData.get("force") !== "true") {
+    const state = await getPinballMapState();
+    if (state?.lastSyncStatus === "ok" && state.lastSyncedAt) {
+      const sinceLastMs = Date.now() - state.lastSyncedAt.getTime();
+      if (sinceLastMs < PBM_MANUAL_SYNC_MIN_INTERVAL_MS) {
+        const retryMin = Math.ceil(
+          (PBM_MANUAL_SYNC_MIN_INTERVAL_MS - sinceLastMs) / 60_000
+        );
+        return err(
+          "THROTTLED",
+          `Pinball Map was synced moments ago. Try again in about ${retryMin} minute${retryMin === 1 ? "" : "s"}.`
+        );
+      }
+    }
   }
 
   try {

--- a/src/lib/pinballmap/config.ts
+++ b/src/lib/pinballmap/config.ts
@@ -29,3 +29,16 @@ export const PBM_USER_AGENT =
 
 /** Austin Pinball Collective's PBM location id. */
 export const APC_LOCATION_ID = 26454;
+
+/**
+ * Minimum gap between *manual* ("Sync now") location snapshot syncs — 3 minutes,
+ * i.e. at most 20 manual syncs/hour (CORE-PBM-001).
+ *
+ * The hourly cron already covers automated freshness; PBM's conduct concern is
+ * repeated polling loops, not a human clicking Sync-now a handful of times, so a
+ * strict one-call-per-hour cap on manual refreshes is needless friction. 20/hour
+ * is negligible against PBM's real limits while still killing stuck-key /
+ * double-click bursts. Enforced against the singleton's last *successful*
+ * `lastSyncedAt`; an explicit force bypasses it. (PP-fwe1, Tim 2026-07-19.)
+ */
+export const PBM_MANUAL_SYNC_MIN_INTERVAL_MS = 3 * 60 * 1000;

--- a/src/test/integration/pinballmap-sync-trigger.test.ts
+++ b/src/test/integration/pinballmap-sync-trigger.test.ts
@@ -140,4 +140,34 @@ describe("syncPinballMapNowAction", () => {
       expect(result.value.healed).toBe(0);
     }
   });
+
+  it("throttles a second manual sync within the min interval (CORE-PBM-001)", async () => {
+    const id = await seedUser("technician");
+    mockGetUser
+      .mockResolvedValueOnce({ data: { user: { id } } })
+      .mockResolvedValueOnce({ data: { user: { id } } });
+
+    const first = await syncPinballMapNowAction(undefined, new FormData());
+    expect(first.ok).toBe(true);
+
+    // A second click moments later is refused rather than hitting PBM again.
+    const second = await syncPinballMapNowAction(undefined, new FormData());
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.code).toBe("THROTTLED");
+  });
+
+  it("force=true bypasses the throttle", async () => {
+    const id = await seedUser("technician");
+    mockGetUser
+      .mockResolvedValueOnce({ data: { user: { id } } })
+      .mockResolvedValueOnce({ data: { user: { id } } });
+
+    const first = await syncPinballMapNowAction(undefined, new FormData());
+    expect(first.ok).toBe(true);
+
+    const forced = new FormData();
+    forced.set("force", "true");
+    const second = await syncPinballMapNowAction(undefined, forced);
+    expect(second.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## What

`syncPinballMapNowAction` fired a real PinballMap location fetch on **every** call with no server-side interval guard — a latent **CORE-PBM-001** conduct risk. It's not reachable today (no UI wires it), but **PP-o355.7** wires it to a technician-clickable "Sync now" button, so the throttle must exist first. This bead **blocks PP-o355.7**.

## Change

- Refuse a manual sync within `PBM_MANUAL_SYNC_MIN_INTERVAL_MS` (**3 min = at most 20/hour**) of the last **successful** sync, reusing the singleton's `lastSyncedAt` (gated on `lastSyncStatus='ok'`, so a prior failure never blocks a retry).
- A `force=true` form field bypasses the throttle.
- New `THROTTLED` variant on `SyncPinballMapNowResult` so the future button can surface a friendly "try again in ~N min" message.
- Integration tests for the throttled path and the force-bypass path (extends the existing `pinballmap-sync-trigger` suite).

## Why 20/hour (not 1/hour)

The hourly cron already covers automated freshness; PBM's conduct concern is repeated **polling loops**, not a human clicking Sync-now a handful of times. 20/hour is negligible against PBM's real limits while still killing stuck-key / double-click bursts. (Product call: Tim, 2026-07-19 — recorded on PP-fwe1.)

## Testing

- `pnpm run check` green (1588 unit/integration tests).
- New: throttle-refusal + force-bypass integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)