### PR TITLE
feat(a11y,forms): app-wide soft-keyboard resilience + reflow CI guard (PP-a0pl)

### DIFF
--- a/.agents/skills/pinpoint-design-bible/SKILL.md
+++ b/.agents/skills/pinpoint-design-bible/SKILL.md
@@ -626,6 +626,20 @@ These are not in PinPoint today. They require a per-feature opt-in here in §19 
 - **`interestfor` attribute** for tooltips — Chrome-only as of late 2025; defer.
 - **`closedby` attribute** on `<dialog>` — Limited availability (no Safari).
 
+### Adopted below the Baseline floor (safe-no-op progressive enhancements)
+
+A feature below the Widely-available floor may still be used **when the browsers
+that lack it degrade to a harmless no-op** (never a broken experience) and a
+Widely-available primitive already covers the same need as the floor. Each such
+feature is listed here with its status, why it degrades safely, and the
+cross-browser floor that carries the non-supporting browsers.
+
+| Feature                                         | Status                  | Degrades to                            | Cross-browser floor                                                 |
+| :---------------------------------------------- | :---------------------- | :------------------------------------- | :------------------------------------------------------------------ |
+| `interactive-widget=resizes-content` (viewport) | Limited (Chromium-only) | The browser default (`resizes-visual`) | `scrollIntoView`-on-focus + `scroll-margin` in the settings editors |
+
+- **`interactive-widget=resizes-content`** — exported once from the root layout (`src/app/layout.tsx`, PP-a0pl). On Chromium (Chrome/Edge/Android) the on-screen keyboard shrinks the **layout** viewport so content reflows above it; **iOS Safari and Firefox ignore it** and keep their own native focus-scroll. That's a strict improvement where honored and a no-op elsewhere — never a regression. The cross-browser floor that actually reaches a focused field on iOS is the `scrollIntoView({ block: "nearest" })` + `scroll-margin` on focus in `RowEditSheet`, `EditableCell`, and `InlineEditableField`. **Verification limit:** no headless tool has a real virtual keyboard, so the Playwright guard (`e2e/full/soft-keyboard-reflow.spec.ts`) proves reachability/reflow under a keyboard-open-height viewport, not pixel-exact keyboard geometry — the latter needs a real device (deferred; PP-a0pl Part 3).
+
 ### How to verify a feature's Baseline status
 
 The Google Chrome `modern-web-guidance` catalog tags each guide with its Baseline status. Search it before adopting any pattern:

--- a/e2e/full/soft-keyboard-reflow.spec.ts
+++ b/e2e/full/soft-keyboard-reflow.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Soft-keyboard reflow guard for the Machine Settings tab (PP-a0pl, Part 2).
+ *
+ * WHAT THIS PROVES (and what it can't):
+ *
+ * No headless browser has a real on-screen keyboard, so the true failure — the
+ * OS keyboard painting over a focused editor — is un-simulatable here (that
+ * needs a physical device or a paid real-device cloud; PP-a0pl Part 3). What we
+ * CAN do is drive the *consequence* of the fix: with the root
+ * `interactive-widget=resizes-content` viewport (src/app/layout.tsx), an open
+ * keyboard shrinks the layout viewport to a short window, and content must
+ * reflow / scroll so the focused field stays reachable. We reproduce that short
+ * window by pinning a keyboard-open-height viewport (390×430) and assert every
+ * key typing surface on the Settings tab lands inside it once focused.
+ *
+ * This is a REACHABILITY / REFLOW proxy, not a pixel-exact keyboard-geometry
+ * test — it catches gross regressions (a field trapped in a clipped or
+ * non-scrollable container, a permanently-occluding sticky element) rather than
+ * "the keyboard overlaps by N px". Same honest limit the RowEditSheet unit test
+ * records (src/test/unit/components/machines/RowEditSheet.test.tsx).
+ *
+ * Runs across every configured project — including "Mobile Safari" (WebKit),
+ * the closest headless proxy for iOS Safari, which ignores `interactive-widget`
+ * and therefore exercises the cross-browser `scrollIntoView`-on-focus floor.
+ */
+
+import { test, expect, type Locator } from "@playwright/test";
+import { STORAGE_STATE } from "../support/auth-state.js";
+import { seededMachines } from "../support/constants.js";
+import {
+  createTestMachine,
+  deleteTestMachine,
+  getProfileIdByEmail,
+  seedSettingsSet,
+} from "../support/supabase-admin.js";
+
+const machine = seededMachines.addamsFamily.initials;
+
+// A phone with the software keyboard open: an iPhone-12-class width with the
+// visible height collapsed to what remains above the keyboard. Under
+// `interactive-widget=resizes-content` this is exactly the geometry a real
+// keyboard produces, so it is a faithful stand-in for "keyboard is up".
+const KEYBOARD_OPEN = { width: 390, height: 430 } as const;
+
+/** After focusing a field, it must sit inside the (short) visible viewport. */
+async function expectReachable(locator: Locator): Promise<void> {
+  await expect(locator).toBeInViewport();
+}
+
+test.describe("Soft-keyboard reflow (PP-a0pl)", () => {
+  test.use({
+    storageState: STORAGE_STATE.admin,
+    viewport: KEYBOARD_OPEN,
+  });
+
+  test("machine-wide guidance editors stay reachable with the keyboard up", async ({
+    page,
+  }) => {
+    test.slow();
+    await page.goto(`/m/${machine}/settings`);
+
+    // The two always-open TipTap callouts stack near the top of the tab; the
+    // second one starts below the fold at keyboard-open height, so focusing it
+    // must scroll it into the short viewport (the exact reflow the fix enables).
+    for (const testId of [
+      "machine-settings-requests",
+      "machine-settings-instructions",
+    ]) {
+      const editor = page.getByTestId(testId).locator(".ProseMirror").first();
+      await editor.click();
+      await expect(editor).toBeFocused();
+      await expectReachable(editor);
+    }
+  });
+
+  test.describe("RowEditSheet input (isolated seeded machine)", () => {
+    let machineId: string;
+    let machineInitials: string;
+
+    test.beforeEach(async () => {
+      const adminId = await getProfileIdByEmail("admin@test.com");
+      const created = await createTestMachine(adminId);
+      machineId = created.id;
+      machineInitials = created.initials;
+      await seedSettingsSet(machineId, "PP-a0pl keyboard set", [
+        {
+          id: "e2e-software",
+          kind: "software",
+          baseline: "Factory",
+          rows: [{ id: "A.1 01", name: "Balls Per Game", value: "3" }],
+        },
+      ]);
+    });
+
+    test.afterEach(async () => {
+      // ON DELETE CASCADE drops the seeded set with the machine.
+      await deleteTestMachine(machineId);
+    });
+
+    test("a focused sheet input rides above the keyboard fold", async ({
+      page,
+    }) => {
+      test.slow();
+      await page.goto(`/m/${machineInitials}/settings`);
+
+      // Below md (390px < 767px) the settings row is tap-to-edit: tapping it
+      // opens the bottom RowEditSheet rather than an inline cell.
+      await page.getByText("Balls Per Game").click();
+      const sheet = page.getByRole("dialog");
+      await expect(sheet).toBeVisible();
+
+      // Focus the sheet's first text input and confirm it isn't stranded behind
+      // the (simulated) keyboard fold.
+      const firstInput = sheet.getByRole("textbox").first();
+      await firstInput.click();
+      await expect(firstInput).toBeFocused();
+      await expectReachable(firstInput);
+    });
+  });
+});

--- a/src/app/(app)/m/[initials]/(tabs)/settings/page.tsx
+++ b/src/app/(app)/m/[initials]/(tabs)/settings/page.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import type { Viewport } from "next";
 import { notFound } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { getMachineForLayout } from "~/app/(app)/m/[initials]/_data";
@@ -10,25 +9,9 @@ import { db } from "~/server/db";
 import { userProfiles } from "~/server/db/schema";
 import { SettingsTab } from "~/components/machines/settings/SettingsTab";
 
-/**
- * Soft-keyboard resilience (PP-a0pl, scoped to this settings-heavy page).
- *
- * The default `interactive-widget=resizes-visual` lets the on-screen keyboard
- * cover content: it shrinks only the *visual* viewport, so the layout doesn't
- * move and a focused editor / the RowEditSheet inputs / the Save-Cancel row can
- * end up hidden behind the keyboard. `resizes-content` shrinks the *layout*
- * viewport instead, so content reflows above the keyboard.
- *
- * Cross-browser: honored by Chromium (Chrome/Edge/Android); iOS Safari ignores
- * `interactive-widget` and keeps its own default focus-scroll — so this is a
- * strict improvement on Chromium and a harmless no-op on iOS. App-wide rollout,
- * the §19 Baseline write-up, and real-device iOS verification ride with PP-a0pl.
- */
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-  interactiveWidget: "resizes-content",
-};
+// The soft-keyboard `interactive-widget=resizes-content` viewport now ships
+// app-wide from the root layout (src/app/layout.tsx, PP-a0pl) — the per-page
+// export that used to live here has been folded into it.
 
 /**
  * Machine Settings Tab (/m/[initials]/settings) — PP-43q3.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type React from "react";
 import { cookies } from "next/headers";
 import "./globals.css";
@@ -18,6 +18,29 @@ export const metadata: Metadata = {
     icon: "/favicon.png",
     apple: "/apple-touch-icon.png",
   },
+};
+
+/**
+ * Soft-keyboard resilience, app-wide (PP-a0pl).
+ *
+ * The browser default `interactive-widget=resizes-visual` lets the on-screen
+ * keyboard cover content: it shrinks only the *visual* viewport, so the layout
+ * doesn't move and a focused input / the editors / the Save-Cancel row can end
+ * up hidden behind the keyboard. `resizes-content` shrinks the *layout*
+ * viewport instead, so content reflows above the keyboard — and, as a bonus,
+ * turns keyboard-open into a plain viewport-height reduction that Playwright can
+ * drive deterministically (see e2e/full/soft-keyboard-reflow.spec.ts).
+ *
+ * Cross-browser reality: honored by Chromium (Chrome/Edge/Android). iOS Safari
+ * *ignores* `interactive-widget` entirely and keeps its own native focus-scroll
+ * — so this is a strict improvement on Chromium and a harmless no-op on iOS,
+ * where the belt-and-suspenders `scrollIntoView`-on-focus in the settings
+ * editors does the reaching. Baseline write-up: design-bible §19.
+ */
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  interactiveWidget: "resizes-content",
 };
 
 /**

--- a/src/components/inline-editable-field.tsx
+++ b/src/components/inline-editable-field.tsx
@@ -250,6 +250,18 @@ export function InlineEditableField({
 
   const hasPresets = presets != null && presets.length > 0;
 
+  // Pull the focused editor above the on-screen keyboard once it resizes the
+  // content area. Belt-and-suspenders beyond the root `interactive-widget=
+  // resizes-content` viewport (PP-a0pl) — which iOS Safari ignores — mirroring
+  // RowEditSheet's focus handler. `scroll-margin` on the wrapper reserves the
+  // gap; `block: "nearest"` scrolls the minimum needed (a no-op when already
+  // fully visible, so desktop tab-through never jumps).
+  function handleEditorFocus(e: React.FocusEvent<HTMLDivElement>): void {
+    if (e.target instanceof HTMLElement) {
+      e.target.scrollIntoView({ block: "nearest" });
+    }
+  }
+
   function renderPresetControl(): React.JSX.Element | null {
     if (!presets || presets.length === 0) return null;
     return (
@@ -318,7 +330,10 @@ export function InlineEditableField({
       {editorOpen && hasPresets && <div>{renderPresetControl()}</div>}
 
       {editorOpen ? (
-        <div className="space-y-2">
+        <div
+          className="space-y-2 scroll-mt-4 scroll-mb-4"
+          onFocus={handleEditorFocus}
+        >
           <RichTextEditor
             key={editorSeed}
             content={editValue}

--- a/src/components/machines/settings/EditableCell.tsx
+++ b/src/components/machines/settings/EditableCell.tsx
@@ -102,7 +102,9 @@ export function EditableCell({
       ref={inputRef}
       value={draft}
       className={cn(
-        "h-7 px-1.5 py-0 max-md:text-[13px]",
+        // `scroll-my-2` reserves a gap so the focus `scrollIntoView` below lands
+        // the cell clear of the on-screen keyboard's top edge (PP-a0pl).
+        "h-7 scroll-my-2 px-1.5 py-0 max-md:text-[13px]",
         EDITABLE_FIELD_CLASS,
         EDITABLE_TEXT_CLASS,
         inputClassName
@@ -120,8 +122,14 @@ export function EditableCell({
             spellCheck: false,
           }
         : {})}
-      onFocus={() => {
+      onFocus={(e) => {
         isFocused.current = true;
+        // Pull the focused cell above the on-screen keyboard once it resizes the
+        // content area. Belt-and-suspenders beyond the root `interactive-widget=
+        // resizes-content` viewport (PP-a0pl), which iOS Safari ignores.
+        // `block: "nearest"` is a no-op when the cell is already visible, so
+        // desktop tab-through between inline cells never jumps.
+        e.currentTarget.scrollIntoView({ block: "nearest" });
       }}
       onChange={(e) => {
         const raw = e.target.value;


### PR DESCRIPTION
## What

App-wide rollout of the soft-keyboard occlusion fix that previously landed scoped to the Machine Settings page (PR #1388), plus a CI regression guard and docs. Closes the remaining work on **PP-a0pl**.

- **Root viewport export** (`src/app/layout.tsx`): `interactive-widget=resizes-content` now applies to *every* page — including the public anonymous issue-report form — so the on-screen keyboard reflows content above itself instead of covering it. Removed the now-redundant per-page export on the settings tab.
- **`scrollIntoView`-on-focus + `scroll-margin`** extended to `InlineEditableField` (the two machine-wide TipTap callouts) and `EditableCell`, matching the already-shipped `RowEditSheet` pattern. This is the **cross-browser floor**: iOS Safari and Firefox ignore `interactive-widget` entirely, so the focus-scroll is what actually keeps a focused field reachable there.
- **New guard** `e2e/full/soft-keyboard-reflow.spec.ts`: at keyboard-open-height geometry (390×430) it asserts focused settings fields stay inside the visible viewport. Runs on all projects incl. **Mobile Safari (WebKit)** — the closest headless iOS proxy.
- **Design-bible §19**: documents `interactive-widget` honestly as a *below-Baseline-floor* progressive enhancement (Chromium-only, safe iOS no-op, `scrollIntoView` floor, verification limit).

## Why this shape

Research pass (MWG + source): `interactive-widget` has **no Baseline/MWG guide** (it's Chromium-only, *not* Widely-available), and the `forms` guide prescribes exactly this approach. The CSS-native `scroll-initial-target` is Limited-availability, so we use the standard `scrollIntoView({block:"nearest"})` — not the non-standard `scrollIntoViewIfNeeded`.

## Verification

- ✅ `pnpm run check` green (types, lint, format, 1580 unit tests).
- ✅ **Guard passes locally on Firefox** (2/2): machine-wide editors reachable + `RowEditSheet` input rides above the fold (mobile tap-to-open at 390px works).
- ⚠️ **Honest limit:** no headless tool has a real virtual keyboard, so the guard is a **reachability/reflow proxy**, not pixel-exact keyboard geometry (that's PP-a0pl Part 3 — a paid real-device cloud, deferred). Documented in the spec header + §19.
- ⚠️ **No iPhone available for manual verification** — the fix is a strict Chromium/Android improvement and a safe iOS no-op backed by the `scrollIntoView` floor; CI's Mobile Safari (WebKit) run is the closest automated iOS check.

> Local Chromium/WebKit E2E are currently broken on the dev host (Chromium sandbox input-injection crash; WebKit missing `libicudata.so.74`) — pre-existing environment issues unrelated to this PR; a separate DevX bead tracks them. CI runs all engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)