### PR TITLE
fix(mcp): allow unauthenticated access to /.well-known OAuth metadata (PP-u4ab.2)

### DIFF
--- a/src/lib/supabase/middleware.test.ts
+++ b/src/lib/supabase/middleware.test.ts
@@ -211,6 +211,7 @@ describe("updateSession public route access", () => {
     "/terms",
     "/api/health",
     "/issues",
+    "/.well-known/oauth-protected-resource",
   ];
 
   it.each(publicRoutes)("allows unauthenticated access to %s", async (path) => {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -130,6 +130,10 @@ export async function updateSession(
     path.startsWith("/whats-new") ||
     path.startsWith("/privacy") ||
     path.startsWith("/terms") ||
+    // `.well-known` discovery endpoints (e.g. OAuth Protected Resource Metadata
+    // for the MCP server, RFC 9728) are fetched by clients BEFORE they hold a
+    // token, so they must never redirect to /login.
+    path.startsWith("/.well-known/") ||
     path.startsWith("/api");
 
   if (!user && !isPublic) {


### PR DESCRIPTION
## What

Follow-up to #1707. The MCP OAuth handshake broke at **discovery** on prod: the Supabase SSR middleware redirected `/.well-known/oauth-protected-resource` to `/login` because that path wasn't in the public-route allowlist.

OAuth/MCP clients fetch this RFC 9728 metadata **before** they hold a token, so it must be publicly reachable. The MCP endpoint itself was fine (`/api/*` is already public → correct 401 with `WWW-Authenticate` + `resource_metadata`), but the metadata URL it advertised 307'd to an HTML login page instead of returning JSON.

## Fix

Add `/.well-known/` to the `isPublic` allowlist in `src/lib/supabase/middleware.ts` (+ a `publicRoutes` test case).

## Verified against prod (post-#1707 deploy)

```
GET /api/mcp/mcp (no token)
  → 401  www-authenticate: Bearer ... resource_metadata="…/.well-known/oauth-protected-resource"   ✓

GET /.well-known/oauth-protected-resource
  → 307  location: /login?next=…   ✗  ← this PR fixes

Supabase OAuth AS metadata (issuer, registration_endpoint) → resolves ✓
```

Once this deploys, the discovery chain is unbroken and `claude mcp add … /api/mcp/mcp` can proceed to consent.

## Tests

`middleware.test.ts` `publicRoutes` now includes `/.well-known/oauth-protected-resource` (asserts no `/login` redirect). `pnpm run check` green (1600 unit).