### PR TITLE
fix(worktree): branch new worktrees off fresh origin/main, not stale root HEAD (PP-2cpf)

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -151,7 +151,7 @@ do_worktree_add() {
   local last_stderr=""
 
   for attempt in $(seq 1 "$max_retries"); do
-    last_stderr=$(git -C "$BASE_PATH" worktree add "$WORKTREE_PATH" -b "$BRANCH" 2>&1) && {
+    last_stderr=$(git -C "$BASE_PATH" worktree add "$WORKTREE_PATH" -b "$BRANCH" "$BASE_REF" 2>&1) && {
       echo "$WORKTREE_PATH"
       return 0
     }
@@ -178,8 +178,30 @@ do_worktree_add() {
   return 1
 }
 
+# --- Resolve the base ref: freshly-fetched origin/main, not the (often stale) root HEAD ---
+# The root checkout ($BASE_PATH) stays on `main` but is never fast-forwarded, so its HEAD
+# routinely trails origin/main by many commits (PP-2cpf, observed 12 behind). Branching a new
+# worktree off that stale HEAD silently poisons anything that reads local files — e.g. the
+# session briefing's `pnpm audit` flagging CVEs that were already patched upstream. Both bridge
+# sessions and Agent(isolation:worktree) dispatch come through here, so fixing it at this
+# chokepoint freshens every path.
+#
+# Best-effort: fetch origin/main and branch off the fetched SHA; fall back to HEAD when the
+# fetch fails (offline) so worktree creation never hard-depends on the network. The fetch runs
+# OUTSIDE the flock below so network latency never extends the cross-session lock hold.
+# GIT_HTTP_LOW_SPEED_* bounds a stalled fetch (<1KB/s for 15s aborts) so a flaky network
+# degrades to the HEAD fallback instead of hanging every worktree creation.
+BASE_REF="HEAD"
+if GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=15 \
+     git -C "$BASE_PATH" fetch --quiet origin main 2>/dev/null; then
+  FETCHED_SHA=$(git -C "$BASE_PATH" rev-parse --verify --quiet FETCH_HEAD 2>/dev/null || true)
+  if [ -n "$FETCHED_SHA" ]; then
+    BASE_REF="$FETCHED_SHA"
+  fi
+fi
+
 export -f do_worktree_add is_lock_contention ms_to_sleep_args
-export BASE_PATH BRANCH WORKTREE_PATH
+export BASE_PATH BRANCH WORKTREE_PATH BASE_REF
 
 # --- Acquire exclusive lock and run worktree add ---
 case "$LOCK_TOOL" in

--- a/scripts/tests/test_worktree_create_hook.py
+++ b/scripts/tests/test_worktree_create_hook.py
@@ -9,19 +9,40 @@ import pytest
 
 HOOK_PATH = Path(__file__).parent.parent.parent / ".claude/hooks/worktree-create.sh"
 
+# Default SHA the mock git returns for `rev-parse FETCH_HEAD` when a fetch "succeeds".
+MOCK_FETCH_SHA = "feedfacecafe0000000000000000000000000000"
+
 
 @pytest.fixture
 def mock_git(tmp_path: Path):
-    # Create a dummy git executable that records calls to a file
+    # Create a dummy git that logs every call and branches on the subcommand so the
+    # hook's fetch → rev-parse → worktree-add sequence can be exercised (PP-2cpf):
+    #   * `fetch`     — exit code from $MOCK_GIT_FETCH_EXIT (default 0 = success).
+    #   * `rev-parse` — print $MOCK_GIT_FETCH_SHA (default MOCK_FETCH_SHA) as FETCH_HEAD.
+    #   * anything else (e.g. `worktree add`) — exit 0.
+    # Global options like `-C <path>` are skipped when detecting the subcommand.
     git_bin_dir = tmp_path / "bin"
     git_bin_dir.mkdir()
     git_script = git_bin_dir / "git"
     calls_log = tmp_path / "git_calls.txt"
 
-    # Write dummy git script
     git_script.write_text(f"""#!/bin/bash
-# Simply log the arguments and exit 0
 echo "$@" >> {calls_log}
+sub=""
+skip_next=0
+for arg in "$@"; do
+  if [ "$skip_next" = "1" ]; then skip_next=0; continue; fi
+  case "$arg" in
+    -C) skip_next=1 ;;
+    -*) : ;;
+    *) sub="$arg"; break ;;
+  esac
+done
+case "$sub" in
+  fetch) exit ${{MOCK_GIT_FETCH_EXIT:-0}} ;;
+  rev-parse) echo "${{MOCK_GIT_FETCH_SHA:-{MOCK_FETCH_SHA}}}"; exit 0 ;;
+  *) exit 0 ;;
+esac
 """)
     git_script.chmod(0o755)
 
@@ -29,6 +50,13 @@ echo "$@" >> {calls_log}
         "bin_dir": git_bin_dir,
         "log_path": calls_log,
     }
+
+
+def _worktree_add_call(calls: list[str]) -> str:
+    """Return the single `worktree add` call from the recorded git invocations."""
+    matches = [c for c in calls if "worktree add" in c]
+    assert len(matches) == 1, f"expected exactly one worktree-add call, got: {calls}"
+    return matches[0]
 
 
 def run_hook_raw(
@@ -80,12 +108,12 @@ def test_hook_empirical_shape(mock_git: dict, tmp_path: Path) -> None:
 
     assert mock_git["log_path"].exists()
     calls = mock_git["log_path"].read_text().splitlines()
-    assert len(calls) == 1
 
     expected_branch = "worktree-agent-emp-test"
     expected_path = str(tmp_path / ".claude/worktrees/agent-emp-test")
+    add_call = _worktree_add_call(calls)
     assert (
-        f"-C {tmp_path} worktree add {expected_path} -b {expected_branch}" in calls[0]
+        f"-C {tmp_path} worktree add {expected_path} -b {expected_branch}" in add_call
     )
 
 
@@ -107,13 +135,67 @@ def test_hook_documented_shape(mock_git: dict, tmp_path: Path) -> None:
 
     assert mock_git["log_path"].exists()
     calls = mock_git["log_path"].read_text().splitlines()
-    assert len(calls) == 1
 
     expected_branch = "worktree-agent-doc-test"
     expected_path = str(tmp_path / "custom-path")
+    add_call = _worktree_add_call(calls)
     assert (
-        f"-C {tmp_path} worktree add {expected_path} -b {expected_branch}" in calls[0]
+        f"-C {tmp_path} worktree add {expected_path} -b {expected_branch}" in add_call
     )
+
+
+def test_hook_branches_off_fetched_origin_main(mock_git: dict, tmp_path: Path) -> None:
+    """On a successful fetch, the worktree branches off the fetched origin/main SHA."""
+    stdin_data = {
+        "session_id": "test-session",
+        "transcript_path": "test-path",
+        "cwd": str(tmp_path),
+        "hook_event_name": "WorktreeCreate",
+        "name": "agent-fresh",
+    }
+
+    env_mods = {
+        "PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}",
+        "MOCK_GIT_FETCH_EXIT": "0",
+        "MOCK_GIT_FETCH_SHA": MOCK_FETCH_SHA,
+    }
+
+    return_code, stdout, stderr = run_hook(stdin_data, tmp_path, env_mods)
+
+    assert return_code == 0, f"Hook failed with stderr: {stderr}"
+
+    calls = mock_git["log_path"].read_text().splitlines()
+    # The hook fetched origin/main before creating the worktree...
+    assert any("fetch --quiet origin main" in c for c in calls), calls
+    # ...and used the fetched SHA as the branch base, not the (stale) root HEAD.
+    add_call = _worktree_add_call(calls)
+    assert add_call.endswith(f"-b worktree-agent-fresh {MOCK_FETCH_SHA}"), add_call
+
+
+def test_hook_falls_back_to_head_when_fetch_fails(
+    mock_git: dict, tmp_path: Path
+) -> None:
+    """Offline (fetch fails) still creates the worktree, branching off HEAD."""
+    stdin_data = {
+        "session_id": "test-session",
+        "transcript_path": "test-path",
+        "cwd": str(tmp_path),
+        "hook_event_name": "WorktreeCreate",
+        "name": "agent-offline",
+    }
+
+    env_mods = {
+        "PATH": f"{mock_git['bin_dir']}:{os.environ['PATH']}",
+        "MOCK_GIT_FETCH_EXIT": "1",  # simulate no network
+    }
+
+    return_code, stdout, stderr = run_hook(stdin_data, tmp_path, env_mods)
+
+    assert return_code == 0, f"Hook failed with stderr: {stderr}"
+
+    calls = mock_git["log_path"].read_text().splitlines()
+    add_call = _worktree_add_call(calls)
+    assert add_call.endswith("-b worktree-agent-offline HEAD"), add_call
 
 
 def test_hook_missing_required_fields(mock_git: dict, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

The `WorktreeCreate` hook (`.claude/hooks/worktree-create.sh`) created every worktree with `git worktree add -b <branch>` off `$BASE_PATH` — the **root checkout** — at its current `HEAD`, with no fetch. The root checkout stays on `main` but is never fast-forwarded, so both **bridge sessions** (`CLAUDE_CODE_ENVIRONMENT_KIND=bridge`) and **`Agent(isolation:"worktree")` dispatch** started every new worktree N commits behind `origin/main` (observed **12 behind** this session).

A stale base silently poisons anything that reads local files — most visibly the session **briefing's `pnpm audit`** flagging CVEs that were already patched upstream (a known past false-"regression").

## Fix

Freshen at the chokepoint we already own. Before `git worktree add`:
- Best-effort `git fetch origin main` and branch off the fetched SHA (`FETCH_HEAD`).
- Fall back to `HEAD` when the fetch fails (offline) so worktree creation never hard-depends on the network.
- The fetch runs **outside the flock**, so network latency doesn't extend the cross-session lock hold.
- Bounded by `GIT_HTTP_LOW_SPEED_LIMIT/TIME` (<1 KB/s for 15s aborts) so a stalled network degrades to the fallback instead of hanging every worktree creation.

Fixes both bridge and agent-dispatched worktrees in one place; no bridge-config access required.

## Tests

`scripts/tests/test_worktree_create_hook.py`:
- Upgraded the mock `git` to branch on subcommand — `fetch` honors `$MOCK_GIT_FETCH_EXIT`, `rev-parse` returns a stub `FETCH_HEAD` SHA.
- New: branches off the fetched `origin/main` SHA on success.
- New: falls back to `HEAD` when the fetch fails (offline).
- Existing shape/validation tests updated for the new call sequence.

`pnpm run check` green (typecheck, lint, format, 110 pytest incl. 6 hook tests, shellcheck clean).

Bead: PP-2cpf

🤖 Generated with [Claude Code](https://claude.com/claude-code)