### PR TITLE
fix(deps): remove duplicate @types/node@26.1.1 keys breaking the lockfile (PP-nw4k)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2967,9 +2967,6 @@ packages:
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
-
   '@types/nodemailer@8.0.1':
     resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
 
@@ -8904,10 +8901,6 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@26.1.1':
-    dependencies:
-      undici-types: 8.3.0
 
   '@types/node@26.1.1':
     dependencies:


### PR DESCRIPTION
## The problem

`pnpm-lock.yaml` on `main` carries the key `'@types/node@26.1.1'` **twice** — once in `packages:` (lines 2967 / 2970) and once in `snapshots:` (8908 / 8912). pnpm parses the lockfile as strict YAML and rejects it outright:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken: duplicated mapping key (2970:3)
```

**CI is red for every PR against main**, dying at the very first job — `pnpm install --frozen-lockfile` in *Setup Dependencies* — before a single check runs. Example: [run 29973850094](https://github.com/timothyfroehlich/PinPoint/actions/runs/29973850094) on #1727.

Locally pnpm is more forgiving: it prints `[WARN] Ignoring broken lockfile` and re-resolves from scratch. That is worse than it sounds, because the fresh resolution **downgrades** installed packages and rewrites the lockfile on every command:

| Package | Lockfile intends | Re-resolution installs |
| --- | --- | --- |
| `@supabase/supabase-js` | 2.110.1 | 2.110.0 |
| `@types/node` | 26.1.1 | 26.0.0 |
| `@tiptap/*` | 3.27.3 | 3.27.2 |
| `@sentry/nextjs` | 10.64.0 | 10.63.0 |

That silently undoes the Dependabot bumps from #1718 / #1723, and produces the ~650 lines of phantom `pnpm-lock.yaml` churn that keeps showing up in worktrees. It is also the likely cause of local E2E `auth.setup.ts` failures in freshly-created worktrees (all three role logins bounce back to `/login`) — `node_modules` ends up holding a different `@supabase/ssr` / `supabase-js` than the tree was built against.

The 2026-07-21 huddle daily logged this as "transient `ERR_PNPM_BROKEN_LOCKFILE` during #1719/#1722 merge overlap — self-resolved, watch for recurrence." It did not self-resolve; the duplicate key is committed on `main`.

## The fix

Both duplicate pairs are **byte-identical**, so this deletes the second occurrence of each. 7 lines removed, zero version movement — the resolution graph is unchanged.

## Verification

- `pnpm install --frozen-lockfile` succeeds and leaves `pnpm-lock.yaml` untouched (previously: hard failure in CI, silent rewrite locally).
- Post-install the tree holds `@supabase/supabase-js@2.110.1` and `@types/node@26.1.1`, matching what the lockfile specifies.
- `pnpm run check` green (types, lint, format, 1629 unit tests, yamllint, actionlint, ruff, shellcheck).

Bead: PP-nw4k. Blocks #1727 (PP-u4ab.7) and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFcyx2WpvW76bvQ5AF2w8w