### PR TITLE
chore(deps): raise override floors for four same-day advisories (PP-2hax)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,17 +11,18 @@ overrides:
   serialize-javascript: '>=7.0.3'
   flatted: '>=3.4.2'
   webpack: '>=5.105.4'
-  brace-expansion: '>=5.0.7'
+  brace-expansion: '>=5.0.8'
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.18'
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
   undici: ^7.28.0
-  js-yaml: '>=4.3.0'
+  js-yaml: '>=5.2.2'
   fast-uri: '>=3.1.4 <4'
   sharp: '>=0.35.0'
+  '@hono/node-server': '>=2.0.5'
 
 importers:
 
@@ -47,7 +48,7 @@ importers:
         version: 1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/loader':
         specifier: ^3.1.1
-        version: 3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))
+        version: 3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.17)(react@19.2.7)
@@ -59,7 +60,7 @@ importers:
         version: 16.2.10
       '@next/mdx':
         specifier: ^16.2.3
-        version: 16.2.10(@mdx-js/loader@3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16)))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))
+        version: 16.2.10(@mdx-js/loader@3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22)))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -101,7 +102,7 @@ importers:
         version: 1.0.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@sentry/nextjs':
         specifier: ^10.48.0
-        version: 10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))
+        version: 10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))
       '@supabase/ssr':
         specifier: ^0.12.0
         version: 0.12.0(@supabase/supabase-js@2.110.1)
@@ -344,8 +345,8 @@ importers:
         specifier: ^13.1.3
         version: 13.1.3
       postcss:
-        specifier: '>=8.5.10'
-        version: 8.5.16
+        specifier: '>=8.5.18'
+        version: 8.5.22
       prettier:
         specifier: ^3.8.2
         version: 3.9.4
@@ -369,7 +370,7 @@ importers:
         version: 4.0.0(@typescript/typescript6@6.0.2)(vitest@4.1.10)
       webpack:
         specifier: '>=5.105.4'
-        version: 5.108.4(esbuild@0.28.1)(postcss@8.5.16)
+        version: 5.108.4(esbuild@0.28.1)(postcss@8.5.22)
 
 packages:
 
@@ -824,9 +825,9 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -3507,9 +3508,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browser-image-compression@2.0.2:
     resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
@@ -4666,8 +4667,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5365,8 +5366,8 @@ packages:
   postal-mime@2.7.4:
     resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -6865,7 +6866,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       minimatch: 10.2.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6901,7 +6902,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.12.31)':
     dependencies:
       hono: 4.12.31
 
@@ -7062,12 +7063,12 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@mdx-js/loader@3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))':
+  '@mdx-js/loader@3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.16)
+      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.22)
     transitivePeerDependencies:
       - supports-color
 
@@ -7109,7 +7110,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7140,11 +7141,11 @@ snapshots:
 
   '@next/env@16.2.11': {}
 
-  '@next/mdx@16.2.10(@mdx-js/loader@3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16)))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))':
+  '@next/mdx@16.2.10(@mdx-js/loader@3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22)))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))':
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      '@mdx-js/loader': 3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))
+      '@mdx-js/loader': 3.1.1(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
 
   '@next/swc-darwin-arm64@16.2.11':
@@ -8337,7 +8338,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/bundler-plugins@10.67.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))':
+  '@sentry/bundler-plugins@10.67.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))':
     dependencies:
       '@babel/core': 7.29.7
       '@sentry/cli': 2.58.6
@@ -8348,7 +8349,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
-      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.16)
+      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.22)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8413,7 +8414,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.64.0
 
-  '@sentry/nextjs@10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))':
+  '@sentry/nextjs@10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -8425,7 +8426,7 @@ snapshots:
       '@sentry/opentelemetry': 10.64.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/react': 10.64.0(react@19.2.7)
       '@sentry/vercel-edge': 10.64.0
-      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
@@ -8506,10 +8507,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.64.0
 
-  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))':
+  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))':
     dependencies:
-      '@sentry/bundler-plugins': 10.67.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))
-      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.16)
+      '@sentry/bundler-plugins': 10.67.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))
+      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.22)
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -8628,7 +8629,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.16
+      postcss: 8.5.22
       tailwindcss: 4.3.2
 
   '@testing-library/dom@10.4.1':
@@ -9478,7 +9479,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10692,7 +10693,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -11230,24 +11231,24 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.16)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16)):
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.22)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.16)
+      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.22)
     optionalDependencies:
       esbuild: 0.28.1
-      postcss: 8.5.16
+      postcss: 8.5.22
 
   minipass@7.1.3: {}
 
@@ -11271,7 +11272,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.42
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.16
+      postcss: 8.5.22
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -11518,7 +11519,7 @@ snapshots:
 
   postal-mime@2.7.4: {}
 
-  postcss@8.5.16:
+  postcss@8.5.22:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -12011,7 +12012,7 @@ snapshots:
       is-plain-object: 5.0.0
       launder: 1.7.1
       parse-srcset: 1.0.2
-      postcss: 8.5.16
+      postcss: 8.5.22
 
   saxes@6.0.0:
     dependencies:
@@ -12601,7 +12602,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.22
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -12667,7 +12668,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16):
+  webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -12685,7 +12686,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.16)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.16))
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.22)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.22))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,9 @@ allowBuilds:
   esbuild: false
   sharp: false
 
+minimumReleaseAgeExclude:
+  - js-yaml@5.2.2
+
 overrides:
   esbuild: '>=0.28.1'
   minimatch: '>=10.2.3'
@@ -21,17 +24,18 @@ overrides:
   serialize-javascript: '>=7.0.3'
   flatted: '>=3.4.2'
   webpack: '>=5.105.4'
-  brace-expansion: '>=5.0.7'
+  brace-expansion: '>=5.0.8'
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.18'
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
   undici: '^7.28.0'
-  js-yaml: '>=4.3.0'
+  js-yaml: '>=5.2.2'
   fast-uri: '>=3.1.4 <4'
   sharp: '>=0.35.0'
+  '@hono/node-server': '>=2.0.5'
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
## Summary

Four advisories published **2026-07-24** land on transitive deps that `pnpm-workspace.yaml` already overrides (or now does), at floors one patch too low. This is **unrelated to any feature work** — until the floors move, `pnpm audit --audit-level=high` (a `CI Gate` job) goes RED on *every* open PR's next push, forcing either an admin merge or a `/audit-override` on each one.

| Advisory | Sev | Package | Floor | Installed |
| --- | --- | --- | --- | --- |
| [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) | high | `js-yaml` | `>=4.3.0` → `>=5.2.2` | 5.2.1 → 5.2.2 |
| [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) | high | `postcss` | `>=8.5.10` → `>=8.5.18` | 8.5.16 → 8.5.22 |
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | high | `brace-expansion` | `>=5.0.7` → `>=5.0.8` | 5.0.7 → 5.0.8 |
| [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) | moderate | `@hono/node-server` | *new* `>=2.0.5` | 1.19.14 → 2.0.11 |

All four are **transitive** dev-or-build-time dependencies — none is a direct PinPoint dependency and none appears in application source. Only `pnpm-workspace.yaml` and `pnpm-lock.yaml` change. Same shape as #1711.

### Two things worth a second look

1. **`@hono/node-server` crosses a major boundary.** The advisory's patched range starts at `2.0.5`, so there is no 1.x fix — the override forces `2.0.11` past `@modelcontextprotocol/sdk`'s declared `^1.19.9`. The only symbol the SDK imports from it is `getRequestListener` (`server/streamableHttp.js`), which is still exported by 2.0.11. Our MCP route goes through `mcp-handler`'s `createMcpHandler` (web-standard Request/Response), and both `next build` and the full integration suite are green.
2. **`minimumReleaseAgeExclude: [js-yaml@5.2.2]`** was auto-added by `pnpm install` — 5.2.2 is newer than the configured release-age cooldown, and taking the same-day patch is precisely the point of this PR.

Otherwise the lockfile diff is pure resolution churn: the postcss version rewrites its peer-key path through `webpack` / `@mdx-js/loader` / `@next/mdx` / `@sentry/*`, with no other package changing version.

## Test Plan

- [x] `pnpm audit --audit-level=high` → *No known vulnerabilities found*
- [x] `pnpm audit --audit-level=moderate` → *No known vulnerabilities found* (nothing left to report)
- [x] `pnpm run check` → green (types, lint, format, 1632 unit tests, yamllint, actionlint, ruff, shellcheck)
- [x] `pnpm run build` → exit 0 (the postcss bump is the kind of thing that can break a Next build; it doesn't)
- [x] `pnpm run test:integration` → 51 files / 492 tests passed
- [x] `pnpm run test:integration:supabase` → 15 files / 107 tests passed
- [ ] Smoke E2E — could not run locally (known bazzite issue: headless Chromium won't accept form fill, and `auth-setup` is pinned to Chrome). CI owns the full suite.

## Related Issues

PP-2hax