### PR TITLE
chore(ci): bump supabase/setup-cli to v3.0.0 and drop the removed github-token input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,11 +498,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1
-          github-token: ${{ github.token }}
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -561,11 +560,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1
-          github-token: ${{ github.token }}
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -618,11 +616,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1
-          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -701,11 +698,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1
-          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -784,11 +780,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1
-          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -868,11 +863,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1
-          github-token: ${{ github.token }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0

--- a/.github/workflows/preview-control.yaml
+++ b/.github/workflows/preview-control.yaml
@@ -111,7 +111,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head_sha }}
           persist-credentials: false
 
-      - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+      - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         if: steps.parse.outputs.action == 'start' || steps.parse.outputs.action == 'stop'
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.

--- a/.github/workflows/preview-reaper.yaml
+++ b/.github/workflows/preview-reaper.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+      - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1

--- a/.github/workflows/preview-sync.yaml
+++ b/.github/workflows/preview-sync.yaml
@@ -52,7 +52,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf  # ratchet:supabase/setup-cli@v2.1.1
+      - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
           version: 2.109.1


### PR DESCRIPTION
Supersedes #1726 (Dependabot), which bumped only the `uses:` SHA.

## Why one change, not two

`supabase/setup-cli@v3.0.0` installs the Supabase CLI **from npm** instead of GitHub releases, so the `github-token` input is obsolete and was **removed** — v3.0.0's `action.yml` declares only `version`. (v2.1.1 declared `github-token` and piped it to `SUPABASE_CLI_GITHUB_TOKEN`; v3 has no such env.)

Dependabot never touches the `with:` block. Merging #1726 alone would leave call sites passing an input the action no longer declares. Actions **warns** rather than fails on undeclared inputs, so CI would stay green while the config quietly went dead — exactly the "merge now, clean up later" shape the repo's no-fast-follow rule exists to prevent. Hence both halves here.

## What changed

**1. Bumped all nine setup-cli pins** from `3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf` (v2.1.1) to `46f7f98c7f948ad727d22c1e67fab04c223a0520` (v3.0.0), preserving the `# ratchet:` comment format:

- `.github/workflows/ci.yml` — **6** call sites
- `.github/workflows/preview-sync.yaml` — 1
- `.github/workflows/preview-reaper.yaml` — 1
- `.github/workflows/preview-control.yaml` — 1

SHA verified against upstream: `gh api repos/supabase/setup-cli/git/ref/tags/v3.0.0` → `46f7f98c7f948ad727d22c1e67fab04c223a0520`.

**2. Removed the six now-dead `github-token: ${{ github.token }}` lines.** All six occurrences in the repo sat inside a setup-cli `with:` block in `ci.yml`; there are now **zero** `github-token` lines anywhere under `.github/`. The three preview workflows never passed a token.

The `version: 2.109.1` pins and their `# Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.` comments are untouched.

## Note on the original scope

The task was scoped as "3 call sites in ci.yml, 3 of 6 `github-token` lines belong to setup-cli." The repo actually has **6** setup-cli call sites in `ci.yml`, and **all 6** `github-token` lines belong to setup-cli — verified by reading each line's owning `uses:`. So all six were removed rather than three.

## Verification

- `pnpm run check` green, including **actionlint + yamllint** (the real gate for workflow YAML).
- Zero remaining occurrences of the old SHA anywhere in the repo.
- Zero remaining `github-token` under `.github/`.

## What to watch after merge

CI on #1726 already proved v3 works and that `version: 2.109.1` still resolves via npm — the **Supabase Integration Tests** job ran and passed there, which exercises the `ci.yml` path.

The residual unknown is **`preview-sync` / `preview-reaper` / `preview-control`**, which never run in PR CI. They pass no `github-token` and use the same `version:` pin, so risk is low. **The hourly Preview Reaper on `main` is the first real exercise** — worth a glance after merge.

Two v3 behaviors I checked while reviewing that ordering, both fine:

- v3 requires **Node 20+ and npm** already on PATH, else it installs Node 24 itself. In `ci.yml` every setup-cli step follows `pnpm install`, so Node is already up. In the preview workflows setup-cli runs *before* `setup-node`, but `ubuntu-latest` ships Node ≥ 20 preinstalled, so the action takes the skip path and does not override the job's later `node-version: '22'`.
- v3 installs to a temp `--prefix` under `RUNNER_TEMP` and `core.addPath`s `<tmp>/node_modules/.bin`. That path is independent of the Node toolchain, so the later `setup-node` in preview-sync/control cannot strip the `supabase` shim from PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyjMdpoTLmoSZDWyLtB1U1
