### PR TITLE
docs: changelog week of July 21, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 148, "lastUpdated": "2026-07-18" }
+{ "totalEntries": 156, "lastUpdated": "2026-07-25" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,23 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## July 21, 2026
+
+### New Features
+
+- **My Machines on Collections Page** — The "My Collections" page now shows a "My Machines" entry at the top linking to your owner collection, with a count of the machines you own
+- **Collection Edit Sharing** — Collection owners can now invite specific signed-in members as editors; editors can add or remove machines from the collection, and access can be revoked per person
+- **Pinball Map Listing Status** — Machine create and edit forms now show a live Pinball Map listing status card — whether the machine is linked, unlinked, or out of sync — with reconnect and verify actions
+
+### Bug Fixes
+
+- Status and priority badges on the dashboard's "Recently Reported Issues" cards no longer clip off the right edge of each card at wider screen sizes
+- "Pinball Map" is now spelled correctly (two words) throughout the app, matching the official brand name
+- Animations now pause when "Reduce Motion" is enabled in your system settings; interactive controls are fully keyboard-navigable; required form fields now show a visible indicator
+- On iOS and Android, the soft keyboard no longer pushes form fields out of view — the page resizes correctly when the keyboard opens
+- The invite-user dialog now submits correctly in all browsers, including those with JavaScript limited or disabled
+
+---
+
 ## July 14, 2026
 
 ### New Features


### PR DESCRIPTION
Weekly changelog entry for the week of July 21, 2026.

## New Features

- My Machines entry on the My Collections page (#1706)
- Collection edit sharing via per-account collaborators (#1697)
- Pinball Map listing status card on machine forms, read side (#1683)

## Bug Fixes

- Dashboard badge grid no longer clips off card right edge at wider viewports (#1699)
- "Pinball Map" brand name corrected to two words throughout the app (#1701)
- motion-reduce parity + keyboard-operable controls + required field indicators (#1691)
- Mobile soft-keyboard viewport resilience app-wide (#1709)
- Invite-user dialog works without JavaScript (#1692)

---
_Generated by [Claude Code](https://claude.ai/code/session_015EMtPZ4c8Y9GFZb8vqvCKd)_