### PR TITLE
feat(db): enforce CORE-ARCH-009 inside drizzle.config.ts (PP-22e4.1)

### DIFF
--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -366,6 +366,7 @@ trigger: always_on
 - **Why:** Production has real user data. `push` bypasses migration history, can drop columns silently, and corrupts the schema's relationship to `drizzle/meta` snapshots. Supabase migrations are disabled (`db.migrations.enabled = false`) — Drizzle is the single source of truth.
 - **Do:** Use `pnpm run db:generate` to author migrations, then `pnpm run db:migrate` to apply. Treat `drizzle/meta` snapshots as authoritative; never edit them by hand (see also `AGENTS.md` §5 Migration conflicts).
 - **Don't:** Run `drizzle-kit push` against any database (local, preview, prod). Don't use Supabase CLI migrations. Don't hand-edit `drizzle/meta/*.json`.
+- **Enforced by:** `drizzle.config.ts` calls `assertNotDrizzlePush()` (`scripts/lib/drizzle-push-guard.ts`) before any credential is resolved, so drizzle-kit refuses `push` no matter how it was invoked. `package.json`'s `db:_push` tripwire is a second, independent line of defense.
 
 **CORE-ARCH-010:** Rule of Three before abstracting
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,6 +1,13 @@
 import { loadEnvConfig } from "@next/env";
 import { defineConfig } from "drizzle-kit";
 
+import { assertNotDrizzlePush } from "./scripts/lib/drizzle-push-guard";
+
+// Safety: `drizzle-kit push` is banned (CORE-ARCH-009). This runs FIRST — before
+// env loading and before any credential is resolved — so a refusal can never
+// surface a connection string. Rationale: scripts/lib/drizzle-push-guard.ts.
+assertNotDrizzlePush();
+
 // Load Next.js environment variables (respects .env.local priority)
 loadEnvConfig(process.cwd());
 

--- a/scripts/lib/drizzle-push-guard.ts
+++ b/scripts/lib/drizzle-push-guard.ts
@@ -1,0 +1,64 @@
+// CORE-ARCH-009 enforcement, one layer below the shell.
+//
+// `drizzle-kit push` diffs the live database against the schema and applies the
+// delta directly, producing NO migration file. The next `db:generate` then
+// writes a migration against a snapshot that no longer matches reality, and the
+// `prevId` chain in `drizzle/meta` silently forks. Recovery means hand-repairing
+// binary-ish snapshot files (see the pinpoint-migration-conflicts skill), which
+// is exactly the state that folder is never supposed to enter.
+//
+// The guard lives here — and is invoked from `drizzle.config.ts`, which
+// drizzle-kit itself executes — rather than in a hook that pattern-matches the
+// shell string that launched the process. That placement is what makes it
+// airtight: no wrapper, quoting, subshell, heredoc, `sh -c`, `pnpm exec --`, or
+// `node node_modules/drizzle-kit/bin.cjs` spelling can route around it, because
+// every one of those spellings still ends up executing this module. It also
+// cannot fire on prose that merely NAMES the command, because it only runs when
+// drizzle-kit actually runs.
+//
+// `package.json`'s `db:_push` tripwire stays as a cheap, independent second
+// line of defense.
+
+/** `push`, plus the legacy dialect-suffixed spelling (`push:pg`, `push:mysql`). */
+const PUSH_SUBCOMMAND = /^push(:|$)/;
+
+export const DRIZZLE_PUSH_REFUSAL =
+  `REFUSED: drizzle-kit push is banned in this repo (CORE-ARCH-009).\n` +
+  `   It applies a schema delta straight to the database with no migration file,\n` +
+  `   which forks the prevId chain in drizzle/meta and corrupts the migration history.\n` +
+  `   Use \`pnpm run db:generate\` to write a migration, then \`pnpm run db:migrate\` to apply it.\n` +
+  `   To inspect the live schema without changing it: \`pnpm run db:studio\`.`;
+
+/**
+ * The drizzle-kit subcommand being run, or `undefined` when the config was
+ * loaded by something other than the drizzle-kit CLI (vitest, tsx, an editor).
+ *
+ * drizzle-kit's CLI shape is `drizzle-kit <command> [flags]`, and argv arrives
+ * as `[node, .../drizzle-kit/bin.cjs, "<command>", "--config=..."]` — so the
+ * subcommand is the first non-flag token after the script path.
+ */
+export function findDrizzleSubcommand(
+  argv: readonly string[]
+): string | undefined {
+  return argv.slice(2).find((token) => !token.startsWith("-"));
+}
+
+/** Is this argv a `drizzle-kit push` (or `push:<dialect>`) invocation? */
+export function isDrizzlePushInvocation(argv: readonly string[]): boolean {
+  const subcommand = findDrizzleSubcommand(argv);
+  return subcommand !== undefined && PUSH_SUBCOMMAND.test(subcommand);
+}
+
+/**
+ * Throw if drizzle-kit was invoked with `push`.
+ *
+ * Call this BEFORE resolving any credentials so a refusal can never surface a
+ * connection string. Sanctioned subcommands (generate, migrate, check, export,
+ * studio, up) fall straight through.
+ */
+export function assertNotDrizzlePush(
+  argv: readonly string[] = process.argv
+): void {
+  if (!isDrizzlePushInvocation(argv)) return;
+  throw new Error(DRIZZLE_PUSH_REFUSAL);
+}

--- a/src/test/unit/drizzle-push-guard.test.ts
+++ b/src/test/unit/drizzle-push-guard.test.ts
@@ -1,0 +1,138 @@
+// Unit tests for scripts/lib/drizzle-push-guard.ts — the CORE-ARCH-009 refusal
+// that `drizzle.config.ts` invokes, and therefore that drizzle-kit itself
+// executes on every run.
+//
+// The guard is pure argv inspection, so it is exercised directly rather than by
+// shelling out to drizzle-kit: spawning the real CLI would need a live database
+// for the sanctioned subcommands and would turn a millisecond assertion into a
+// multi-second one for no extra coverage.
+//
+// The argv fixtures below are the real shapes, captured from actual runs:
+//   [node, <repo>/node_modules/drizzle-kit/bin.cjs, "<command>", "--config=..."]
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertNotDrizzlePush,
+  DRIZZLE_PUSH_REFUSAL,
+  findDrizzleSubcommand,
+  isDrizzlePushInvocation,
+} from "../../../scripts/lib/drizzle-push-guard";
+
+const NODE = "/Users/x/.nvm/versions/node/v24.16.0/bin/node";
+const BIN = "/Users/x/Code/PinPoint/node_modules/drizzle-kit/bin.cjs";
+
+function argvFor(...args: string[]): string[] {
+  return [NODE, BIN, ...args];
+}
+
+describe("drizzle-push-guard — refuses push", () => {
+  it("refuses `drizzle-kit push`", () => {
+    const argv = argvFor("push", "--config=drizzle.config.ts");
+    expect(isDrizzlePushInvocation(argv)).toBe(true);
+    expect(() => assertNotDrizzlePush(argv)).toThrow(/CORE-ARCH-009/);
+  });
+
+  it("refuses the legacy dialect-suffixed `push:pg`", () => {
+    const argv = argvFor("push:pg", "--config=drizzle.config.ts");
+    expect(isDrizzlePushInvocation(argv)).toBe(true);
+    expect(() => assertNotDrizzlePush(argv)).toThrow(/CORE-ARCH-009/);
+  });
+
+  it("refuses push regardless of dialect suffix", () => {
+    for (const sub of ["push:mysql", "push:sqlite"]) {
+      expect(isDrizzlePushInvocation(argvFor(sub))).toBe(true);
+    }
+  });
+
+  it("refuses push even when flags precede the subcommand", () => {
+    expect(isDrizzlePushInvocation(argvFor("--verbose", "push"))).toBe(true);
+  });
+
+  it("refuses push with no trailing flags", () => {
+    expect(isDrizzlePushInvocation(argvFor("push"))).toBe(true);
+  });
+
+  it("points at the sanctioned workflow instead of just saying no", () => {
+    expect(DRIZZLE_PUSH_REFUSAL).toContain("CORE-ARCH-009");
+    expect(DRIZZLE_PUSH_REFUSAL).toContain("pnpm run db:generate");
+    expect(DRIZZLE_PUSH_REFUSAL).toContain("pnpm run db:migrate");
+    expect(DRIZZLE_PUSH_REFUSAL).toContain("pnpm run db:studio");
+  });
+
+  it("reads process.argv when no argv is passed", () => {
+    const original = process.argv;
+    try {
+      process.argv = argvFor("push", "--config=drizzle.config.ts");
+      expect(() => {
+        assertNotDrizzlePush();
+      }).toThrow(/CORE-ARCH-009/);
+    } finally {
+      process.argv = original;
+    }
+  });
+});
+
+describe("drizzle-push-guard — lets sanctioned subcommands through", () => {
+  // Every subcommand PinPoint actually uses: db:generate, db:migrate,
+  // check:migrations, drizzle-kit export (schema dump), db:studio.
+  for (const sub of [
+    "generate",
+    "migrate",
+    "check",
+    "export",
+    "studio",
+    "up",
+  ]) {
+    it(`allows \`drizzle-kit ${sub}\``, () => {
+      const argv = argvFor(sub, "--config=drizzle.config.ts");
+      expect(findDrizzleSubcommand(argv)).toBe(sub);
+      expect(isDrizzlePushInvocation(argv)).toBe(false);
+      expect(() => {
+        assertNotDrizzlePush(argv);
+      }).not.toThrow();
+    });
+  }
+
+  it("does not refuse a subcommand that merely starts with the letters", () => {
+    expect(isDrizzlePushInvocation(argvFor("pushed"))).toBe(false);
+    expect(isDrizzlePushInvocation(argvFor("pushup"))).toBe(false);
+  });
+
+  it("does not refuse when the config is loaded outside the drizzle-kit CLI", () => {
+    // vitest / tsx / an editor importing drizzle.config.ts: no subcommand at all.
+    expect(
+      findDrizzleSubcommand([NODE, "/path/to/vitest.mjs"])
+    ).toBeUndefined();
+    expect(isDrizzlePushInvocation([NODE, "/path/to/vitest.mjs"])).toBe(false);
+  });
+
+  it("does not refuse when only flags follow the script path", () => {
+    expect(isDrizzlePushInvocation(argvFor("--help"))).toBe(false);
+  });
+});
+
+describe("drizzle.config.ts wiring", () => {
+  const source = readFileSync(
+    path.resolve(process.cwd(), "drizzle.config.ts"),
+    "utf8"
+  );
+
+  it("calls the guard", () => {
+    expect(source).toContain("assertNotDrizzlePush()");
+  });
+
+  it("calls the guard before any credential is resolved", () => {
+    // A refusal must never be able to print a connection string, so the guard
+    // has to run ahead of env loading and the POSTGRES_URL reads.
+    const guardAt = source.indexOf("assertNotDrizzlePush()");
+    const envAt = source.indexOf("loadEnvConfig(");
+    const credentialAt = source.indexOf("process.env.POSTGRES_URL");
+
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(envAt).toBeGreaterThan(guardAt);
+    expect(credentialAt).toBeGreaterThan(guardAt);
+  });
+});


### PR DESCRIPTION
Bead: **PP-22e4.1** (parent PP-22e4 — blocking-hook review)

## What

Move CORE-ARCH-009 enforcement (`drizzle-kit push` is banned) out of the shell
and into `drizzle.config.ts`, which drizzle-kit itself executes.

- **`scripts/lib/drizzle-push-guard.ts`** (new) — pure argv inspection.
  `assertNotDrizzlePush(argv = process.argv)` throws on `push` and the legacy
  dialect-suffixed `push:pg` / `push:mysql`. `generate`, `migrate`, `check`,
  `export`, `studio`, `up` fall straight through, as does the "no subcommand"
  case (the config being imported by vitest / tsx / an editor).
- **`drizzle.config.ts`** — calls the guard as its **first statement**, ahead of
  `loadEnvConfig()` and every `POSTGRES_URL` read, so a refusal can never
  surface a connection string.
- **`src/test/unit/drizzle-push-guard.test.ts`** (new, 18 cases) — refusal for
  `push` / `push:pg` / other dialect suffixes / flags-before-subcommand, the
  `process.argv` default, the message contents, every sanctioned subcommand,
  the near-miss `pushed` / `pushup`, and two wiring assertions that
  `drizzle.config.ts` calls the guard *before* `loadEnvConfig` and the
  `process.env.POSTGRES_URL` reads.
- **`docs/NON_NEGOTIABLES.md`** — one "Enforced by" bullet on CORE-ARCH-009.

`package.json`'s `db:_push` tripwire is untouched; it stays as a cheap,
independent second line of defense.

## Why not a PreToolUse hook

The hook approach pattern-matches an arbitrary Bash string, and leaks in both
directions: it misses ordinary invocation shapes (multi-line commands,
`pnpm exec --`, `npx -y`, `sh -c`, `node node_modules/drizzle-kit/bin.cjs`) and
it fires on prose that merely *names* the command — its first real-world firing
blocked a `bd comments add` that just quoted it.

Enforcing inside the tool is strictly better on both counts. No shell wrapper,
quoting, subshell, or heredoc can route around it, because it runs *inside*
drizzle-kit rather than inspecting the string that launched it. And it cannot
false-positive on prose at all, because it only executes when drizzle-kit
executes.

The key mechanic — the config can see the subcommand — is verified, not assumed:

```
drizzle-kit check --config=<x>
  → argv = [node, .../drizzle-kit/bin.cjs, "check", "--config=..."]
```

## Coordination with #1738

`.claude/hooks/block-drizzle-push.cjs` is **not on `main`** — it exists only on
the unmerged branch `feat/context-enforcement-PP-22e4` (PR #1738). There is
nothing to delete here, so this PR only *adds* the config guard.

⚠️ **#1738 must drop the hook** — the file, its `.claude/settings.json`
registration, and `src/test/unit/hooks/block-drizzle-push.test.ts` — before or
when it lands, so the two enforcement mechanisms don't both ship. (The refusal
wording here is deliberately reused from that hook.)

## Verification

- `pnpm run check` — clean (exit 0).
- `pnpm run preflight` — unit (1655 passing), lint/format, `check:migrations`,
  and `next build` all green. The integration/smoke tail did **not** complete
  locally: the first attempt was hard-blocked by the host memory-pressure gate
  (swap 6.6 GB ≥ 6.5 GB, from other concurrent sessions) and the retry died on
  a `CONNECT_TIMEOUT` to the worktree's local Postgres with Docker itself
  unresponsive. Both are host-load failures ahead of any test running, not
  anything in this change. CI covered that tail: Integration Tests, Supabase
  Integration Tests, E2E Smoke (Chromium + Mobile Chrome), and E2E Full all
  green — **CI Gate SUCCESS**. Nothing here touches a runtime code path; the
  new module is only ever loaded by `drizzle.config.ts`.
- **By hand, against the real config:**
  - `pnpm exec drizzle-kit push` → refused, exit 1, prints the CORE-ARCH-009
    message. No connection string in the output.
  - `pnpm run db:generate` → works end to end ("No schema changes, nothing to
    migrate 😴").
  - `pnpm run check:migrations` (`drizzle-kit check`) → "Everything's fine 🐶🔥".
  - `pnpm run db:reset` (full migrate + seed chain) → clean.

Refusal output:

```
REFUSED: drizzle-kit push is banned in this repo (CORE-ARCH-009).
   It applies a schema delta straight to the database with no migration file,
   which forks the prevId chain in drizzle/meta and corrupts the migration history.
   Use `pnpm run db:generate` to write a migration, then `pnpm run db:migrate` to apply it.
   To inspect the live schema without changing it: `pnpm run db:studio`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYKDwYgY4u4tBRWmWxwBfH
