### PR TITLE
chore(deps): bump pnpm corepack pin 11.8.0 -> 11.9.0 (30-day cooldown)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinpoint",
   "version": "0.2.0",
-  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "type": "module",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"


### PR DESCRIPTION
## What

Bumps the `packageManager` corepack pin in `package.json` from `pnpm@11.8.0` to `pnpm@11.9.0` (version + integrity hash written by `corepack use pnpm@11.9.0`). One-line diff.

## Why now

Dependabot **cannot** bump the `packageManager` field — [dependabot-core#4830](https://github.com/dependabot/dependabot-core/issues/4830) is an open, unimplemented feature request, and Dependabot's pnpm support only updates deps *inside* the lockfile. The weekly chores session is this pin's only watcher (PP-w0eq); left unwatched it once rotted 9 months behind on 10.2.0 until npm's audit-endpoint retirement forced the jump.

## Version choice: 30-day cooldown

Per the chores runbook's supply-chain soak policy, we bump only to the newest stable pnpm **at least 30 days old**, never the just-released `latest`.

| | version | published |
|---|---|---|
| Previous pin | 11.8.0 | 2026-06-18 |
| **This pin** | **11.9.0** | **2026-06-23** (32 days old) |
| Next candidate (too new) | 11.10.0 | 2026-07-04 (21 days) |
| `latest` (deliberately not used) | 11.17.0 | 2026-07-23 |

Minor bump within pnpm 11 — no major-version migration involved.

## Release notes review (11.8.0 → 11.9.0)

Read before changing anything. **No breaking changes, no migration steps, nothing that affects this repo.**

The two minor changes are additive:
- Registries that can't supply an integrity checksum: pnpm now computes it from the downloaded tarball and stores it in the lockfile, and a lockfile entry still missing its integrity now fails closed (`ERR_PNPM_MISSING_TARBALL_INTEGRITY`) instead of being silently re-fetched. Our lockfile has no such entries — the frozen-lockfile install passes.
- `--exclude-peers` added to `pnpm sbom`. We don't run `pnpm sbom`.

The rest are bug fixes, several of which are net positives here:
- Fixed non-deterministic peer resolution that could churn the lockfile and cause intermittent `pnpm dedupe --check` failures in CI — removes a class of flake.
- Fixed a `pnpm audit` performance regression on lockfiles with dependency cycles (quadratic → linear via Tarjan's SCC), plus a non-recursive path walk. Relevant to us: the audit gate runs on every CI run.
- `pnpm audit --fix` now writes combined `minimumReleaseAgeExclude` entries (`pkg@a || b`) instead of one per version, and multiple exact-version entries for the same package now behave like a `||` disjunction. Our `pnpm-workspace.yaml` has a single entry (`js-yaml@5.2.2`), so this is a no-op for us today — but it's the correct behavior going forward.
- Windows-only `pnpm dlx` fixes (`EBUSY`, `MAX_PATH`), a hang on non-retryable network errors, and lockfile verification no longer mislabeling a registry fetch failure (403/401) as `ERR_PNPM_TARBALL_URL_MISMATCH`.

## Verification (all three gates green)

1. **`pnpm install --frozen-lockfile`** — clean, "Already up to date". `pnpm-lock.yaml` is **byte-identical**: sha256 `c2e6827b…` before and after the bump. `git status` shows only `package.json` modified. No lockfile churn.
2. **`pnpm audit --audit-level=high`** — resolves against the bulk advisory endpoint: *No known vulnerabilities found*.
3. **`pnpm run check`** — exit 0. 203 test files / 1655 unit tests passed, 110 pytest hook tests passed; types, lint, format, yamllint, actionlint, ruff, shellcheck all clean.

Pre-commit hooks ran clean (no `--no-verify`).

## Risk

Low. Single-line config change, no lockfile movement, minor bump inside pnpm 11, and the version has soaked for 32 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs5d6HryJJCeArggcxp2Xt