### PR TITLE
fix(ci): reserve Supabase ports from the kernel ephemeral range (PP-3w32)

### DIFF
--- a/.github/actions/setup-supabase/action.yml
+++ b/.github/actions/setup-supabase/action.yml
@@ -16,6 +16,40 @@ runs:
       shell: bash
       run: cp supabase/config.toml.template supabase/config.toml
 
+    - name: Reserve Supabase ports from the ephemeral range
+      shell: bash
+      run: |
+        # Supabase binds 54320-54329 (see supabase/config.toml.template). Linux
+        # allocates ephemeral source ports from ip_local_port_range, whose default
+        # (32768-60999) contains that whole block. So an ordinary outbound
+        # connection — the docker image pulls `supabase start` itself makes, for
+        # one — can be handed 54322 as its source port, and the subsequent bind()
+        # of the published host port then fails with "address already in use".
+        # A socket in TIME_WAIT holds the port for 60s, which outlives all three
+        # retries below, so the retry loop cannot recover from this.
+        #
+        # ip_local_reserved_ports excludes the block from automatic allocation:
+        # "Specify the ports which are reserved for known third-party
+        # applications. These ports will not be used by automatic port
+        # allocations." — Documentation/networking/ip-sysctl.rst
+        #
+        # Fails open: a runner that won't take the sysctl still starts Supabase.
+        # Signature `supabase-port-bind`, docs/runbooks/gha-flake-log.md.
+        range=$(cat /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null || echo unknown)
+        echo "::notice::ip_local_port_range=${range} — Supabase needs 54320-54329"
+
+        want=54320-54329
+        reserved=$(cat /proc/sys/net/ipv4/ip_local_reserved_ports 2>/dev/null || echo "")
+        if [ -n "$reserved" ]; then
+          want="${reserved},${want}"
+        fi
+
+        if sudo sysctl -w "net.ipv4.ip_local_reserved_ports=${want}" >/dev/null 2>&1; then
+          echo "::notice::ip_local_reserved_ports=$(cat /proc/sys/net/ipv4/ip_local_reserved_ports)"
+        else
+          echo "::warning::could not reserve 54320-54329; supabase start may lose a port race"
+        fi
+
     - name: Start Supabase (with retry)
       shell: bash
       run: |
@@ -26,6 +60,16 @@ runs:
             exit 0
           fi
           echo "::warning::supabase start failed (attempt $attempt/3)"
+
+          # Capture who holds the port BEFORE tearing anything down, so the next
+          # sighting diagnoses itself instead of costing another triage session.
+          # A socket with no owning container points at an ephemeral-port steal;
+          # a lingering docker-proxy or container points at a Docker host-port race.
+          echo "::group::port diagnostics (attempt $attempt/3)"
+          sudo ss -tanp 2>/dev/null | grep -E ':543[0-9]{2}\b' || echo "no sockets in 54300-54399"
+          docker ps -a --format '{{.Names}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null || true
+          echo "::endgroup::"
+
           supabase stop --no-backup 2>/dev/null || true
           docker rm -f $(docker ps -aq --filter "label=com.supabase.cli.project=pinpoint") 2>/dev/null || true
           sleep 10


### PR DESCRIPTION
## The flake

`supabase start` intermittently fails in CI:

```
failed to bind host port for 0.0.0.0:54322:172.18.0.2:5432/tcp: address already in use
```

Most recent: [run 30144157763](https://github.com/timothyfroehlich/PinPoint/actions/runs/30144157763) (PR #1730) — attempt 1 killed **Verify Migrations** at 04:33 UTC, attempt 2 killed **E2E Full (Chromium)** at 13:57 UTC on a different runner VM, attempt 3 went green with no code change. Logged against PP-3w32 as signature `supabase-port-bind`; a prior sighting on 2026-07-06 hit 54326.

## Diagnosis

Supabase binds **54320–54329**. Linux allocates ephemeral source ports from `ip_local_port_range`, default **32768–60999** — which contains that entire block. So an ordinary *outbound* connection (the Docker image pulls `supabase start` itself makes, among others) can be handed 54322 as its source port, and the subsequent `bind()` of the published host port fails with `EADDRINUSE`.

Supporting evidence from the logs:

- Fresh `ubuntu-latest` VM, first `supabase start` of the job — nothing we launched had bound the port.
- The retry loop's `docker rm -f` ran between attempts and changed nothing → **the holder is not a container**.
- All three retries fell inside 30 seconds (04:33:54 → 04:34:24). `TIME_WAIT` holds a port for 60s, so a lingering socket outlives every attempt. **The existing retry loop structurally cannot recover from this failure mode.**
- The failure lands ~1s after a Docker image pull completes — a burst of outbound connections.
- The earlier sighting was on a *different* port in the same block, so this isn't a specific service squatting on 54322.

## The fix

Reserve the block via `net.ipv4.ip_local_reserved_ports`, which the kernel documents as *"ports which are reserved for known third-party applications. These ports will not be used by automatic port allocations."* Same remedy [CloudFoundry applied](https://github.com/cloudfoundry/routing-release/issues/206) for the same failure mode. AWS ECS docs likewise advise against publishing a host port inside the ephemeral range — the collision is baked into Supabase's default port choices, not something we introduced.

Fails open: a runner that rejects the sysctl still starts Supabase.

## Honest caveat, and why the diagnostics are here

**The ephemeral-port mechanism is inferred from the log timeline and port arithmetic — not directly observed.** Nobody ran `ss` at the moment of failure. The competing explanation is a Docker daemon host-port race / lingering `docker-proxy`, which produces an identical error string. That's less likely for us (fresh VM, no prior Supabase run in the job to leave anything behind) but I can't exclude it from logs alone.

So this PR also dumps `ss -tanp` and `docker ps -a` **before** teardown on each failed attempt. The next sighting then diagnoses itself:

- a socket on 543xx with **no owning container** → ephemeral-port steal, this fix was right
- a lingering `docker-proxy` or container → Docker host-port race, needs a different fix

The reservation is harmless if the diagnosis is wrong; the diagnostics are what tell us.

Upstream has the identical symptom open and undiagnosed: [supabase/setup-cli#265](https://github.com/supabase/setup-cli/issues/265).

## Testing

`pnpm run check` green (includes actionlint, which shellchecks `run:` blocks). No migration, so this doesn't queue behind #1730. Real verification is CI itself exercising the changed action across every Supabase-using job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178hTxVwCeg3CPdPNKGKaaE