### PR TITLE
fix(workflow): name mark-claude-review.sh in the reviewed-gate FAIL (PP-jw0s)

### DIFF
--- a/scripts/workflow/AGENTS.md
+++ b/scripts/workflow/AGENTS.md
@@ -53,7 +53,7 @@ Scripts emit machine-parseable status with these prefixes:
 | `WAIT:`  | Transient state (e.g., GitHub computing mergeable)          | Retry; may resolve on its own |
 | `BLOCK:` | State mismatch requiring user action (e.g., merge conflict) | Resolve, push, retry          |
 
-The agent reads these tokens from script stdout to decide next steps. Scripts never emit prescriptive advice; the skill (pinpoint-pr-workflow) documents what to do for each token.
+The agent reads these tokens from script stdout to decide next steps. The skill (pinpoint-pr-workflow) documents what to do for each token; scripts emit prescriptive advice only where the remedy is otherwise undiscoverable. The one such case today is the `reviewed` gate, whose `FAIL:` line is followed by indented `remedy:` lines naming `mark-claude-review.sh` with the PR number already substituted (PP-jw0s). Continuation lines are indented and carry no status token, so token parsing is unaffected.
 
 ## MCP vs Script — When to use which
 

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -212,6 +212,8 @@ check_review_happened() {
     return 2
   fi
   echo "FAIL: reviewed: head commit has no Copilot or Claude review"
+  echo "  remedy: review the PR yourself, then attest the head commit with:"
+  echo "    bash scripts/workflow/mark-claude-review.sh $pr \"<one-line findings>\""
   return 1
 }
 


### PR DESCRIPTION
## Problem

When the `reviewed` gate in `scripts/workflow/_pr-gates.sh` fails, it printed only:

```
FAIL: reviewed: head commit has no Copilot or Claude review
```

There **is** a working escape path — `mark-claude-review.sh` posts a SHA-pinned attestation marker (`<!-- pinpoint-claude-review: <head_sha> -->`) that this same gate accepts on the PASS branch just above. But the failure message never named it, so an operator who didn't already know the helper existed had no way out short of `--force`, which is the wrong tool and explicitly discouraged.

Live occurrence: **PR #1735** (Dependabot minor-patch group) on 2026-07-26 — Copilot skipped the PR entirely, the gate hard-FAILed, and `mark-claude-review.sh` was the remedy. The gap was purely discoverability.

## Change

The `reviewed`-gate FAIL now renders:

```
FAIL: reviewed: head commit has no Copilot or Claude review
  remedy: review the PR yourself, then attest the head commit with:
    bash scripts/workflow/mark-claude-review.sh 1735 "<one-line findings>"
```

The PR number is interpolated from the gate's own `$pr` argument — no `<PR>` placeholder to hand-substitute.

Notes on the design:

- **Continuation lines carry no status token** and are indented, matching the existing `  (--force: ... bypassed)` continuation style in `merge-pr.sh`. `run_gate` captures gate output into a variable and `echo`s it verbatim, so multi-line output passes through intact and token parsing is unaffected.
- **The `WAIT:` branch above is deliberately left alone.** Waiting is the correct action inside the 600s Copilot window; a remedy hint there would encourage prematurely bypassing Copilot.
- `scripts/workflow/AGENTS.md` asserted "scripts never emit prescriptive advice" — that's now scoped to this one sanctioned exception rather than left stale.

This covers ask #2 from PP-jw0s. Asks #1 (detect the Copilot quota-limit review body and treat it as "no review") and #3 (document the marker in the `pinpoint-pr-workflow` skill) remain open on the bead.

## Verification

- `pnpm run check` clean (shellcheck included).
- Failure path rendered locally by sourcing `_pr-gates.sh` and calling `check_review_happened` with a stubbed `gh` shell function — no network, no real PR touched. Output above is the actual render; return code stays `1`.
- No test asserts on the old message string (`rg` over the repo; the only workflow-adjacent test, `src/test/unit/hooks/block-direct-merge.test.ts`, covers the merge-blocking hook and not gate output).

Refs PP-jw0s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs5d6HryJJCeArggcxp2Xt