### PR TITLE
fix(huddle): don't let the rotation notice short-circuit registration (PP-2m3l)

### DIFF
--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -33,6 +33,8 @@ Run the command, then start or resume your session normally. Bootstrap is idempo
 
 **Stop and dispatch the rotation subagent before continuing your work.** See the "Rotation" section below for the exact dispatch.
 
+This notice does **not** replace your identity block — rotation and registration are independent, so the identity/registration block still follows it. Dispatch the rotation subagent first, then register if you're new. (Before PP-2m3l the notice short-circuited the rest of session-start, leaving the day's first sessions permanently unregistered.)
+
 ### Identity announcement (you're registered)
 
     ## Huddle identity

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -183,8 +183,13 @@ fi
 # Skipped while rotation is pending — preserving the pre-PP-2m3l behaviour, where
 # this only ever ran on the up-to-date path. The function keys off root notes'
 # `today_bead.date`, which is still YESTERDAY's date until rotation runs, so
-# calling it now would reconcile (and close dupes of) a stale day. Rotation
-# repoints that field under its own lock; the next session start reconciles.
+# calling it now would reconcile (and close dupes of) a stale day.
+#
+# Note this net never collapses stale-day duplicates at all: it only ever targets
+# the date root notes point at, and rotation moves that pointer to today. That
+# gap is pre-existing (this call was unreachable on the rotation-pending path
+# before PP-2m3l too) and out of scope here — do NOT read the skip as "the next
+# session start will catch it".
 if [[ -z "$ROTATION_PENDING" ]]; then
   huddle_reconcile_today || true
 fi
@@ -232,6 +237,15 @@ if [[ -n "$NAME" ]]; then
   # Resolve today_bead_id for the copy-paste command (fail-open: fall back to placeholder)
   _TODAY_ID_REG=$(huddle_today_bead_id 2>/dev/null) || _TODAY_ID_REG="<today-bead-id>"
   [[ -n "$_TODAY_ID_REG" ]] || _TODAY_ID_REG="<today-bead-id>"
+  # With rotation pending, today's daily does not exist yet, so the resolver
+  # always misses and every command below renders the literal placeholder. Say so
+  # — otherwise the first session of each day pastes `<today-bead-id>` into bash
+  # and gets a redirect error instead of a clear failure.
+  if [[ -n "$ROTATION_PENDING" ]]; then
+    printf 'NOTE: rotation is still pending, so today'\''s bead does not exist yet and the id\n'
+    printf 'in the commands below is a literal placeholder. Dispatch the rotation subagent\n'
+    printf 'first — it reports the new bead id — then substitute it before posting.\n\n'
+  fi
   printf 'Once you understand what this session is tackling — and it'\''s real work or an\n'
   printf 'investigation (not a quick question or one-line fix) — post a ONE-LINE kickoff to\n'
   printf 'today'\''s bead, once, so parallel sessions know and anyone with context can chime in:\n'

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -180,9 +180,11 @@ fi
 # either pushed), collapse them to the canonical here. No-op in the common case
 # (two cheap local reads); silent + fail-open.
 #
-# Skipped while rotation is pending: today's daily does not exist yet, so there
-# is nothing to dedup, and the rotation subagent is about to create it under its
-# own lock.
+# Skipped while rotation is pending — preserving the pre-PP-2m3l behaviour, where
+# this only ever ran on the up-to-date path. The function keys off root notes'
+# `today_bead.date`, which is still YESTERDAY's date until rotation runs, so
+# calling it now would reconcile (and close dupes of) a stale day. Rotation
+# repoints that field under its own lock; the next session start reconciles.
 if [[ -z "$ROTATION_PENDING" ]]; then
   huddle_reconcile_today || true
 fi

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -132,11 +132,23 @@ case "$TRANSCRIPT_PATH" in
 esac
 
 # --- Rotation check ---
+# Emits the "rotation needed" notice and then FALLS THROUGH: rotation and
+# identity/registration are independent concerns, and a session that starts on a
+# new day before rotation has run still needs its session_id and its
+# registration prompt.
+#
+# PP-2m3l: this block used to `exit 0` right after the notice, so the identity /
+# registration block below was unreachable on the first sessions of every day.
+# Those sessions never registered, which broke the huddle self-filter (they saw
+# their own posts injected back as if from a peer) and degraded post attribution.
+# SessionStart fires once per session, so there was no second chance to re-prompt.
+ROTATION_PENDING=""
 ROTATION_CHECK_SCRIPT="$(dirname "$0")/huddle-rotation-check.sh"
 if [[ -f "$ROTATION_CHECK_SCRIPT" ]]; then
   # shellcheck source=huddle-rotation-check.sh disable=SC1091
   source "$ROTATION_CHECK_SCRIPT"
   if huddle_rotation_needed; then
+    ROTATION_PENDING=1
     STORED_DATE=""
     NOTES_STR_ROT=$(bd show "$ROOT_ID" --json 2>/dev/null | jq -r '.[0].notes // ""' 2>/dev/null || echo "")
     if [[ -n "$NOTES_STR_ROT" ]]; then
@@ -158,8 +170,7 @@ except Exception:
     printf 'previous day, create today'\''s bead, update pointers, and post\n'
     printf '"continued in" markers on closed beads. Safe even if a peer already\n'
     printf 'rotated (the subagent no-ops under a file lock).\n\n'
-    printf 'Dispatch template: .agents/skills/pinpoint-huddle/SKILL.md.\n'
-    exit 0
+    printf 'Dispatch template: .agents/skills/pinpoint-huddle/SKILL.md.\n\n'
   fi
 fi
 
@@ -168,7 +179,13 @@ fi
 # midnight race left two open dailies for today (two machines rotated before
 # either pushed), collapse them to the canonical here. No-op in the common case
 # (two cheap local reads); silent + fail-open.
-huddle_reconcile_today || true
+#
+# Skipped while rotation is pending: today's daily does not exist yet, so there
+# is nothing to dedup, and the rotation subagent is about to create it under its
+# own lock.
+if [[ -z "$ROTATION_PENDING" ]]; then
+  huddle_reconcile_today || true
+fi
 
 SESSION_ID=""
 SOURCE=""

--- a/scripts/tests/test_huddle_session_start.py
+++ b/scripts/tests/test_huddle_session_start.py
@@ -1,0 +1,302 @@
+"""Unit tests for scripts/hooks/huddle-session-start.sh.
+
+Regression guard for PP-2m3l: the rotation-needed branch used to `exit 0` right
+after printing its notice, which made the identity / registration block below it
+unreachable. SessionStart fires exactly once per session, so every session that
+started on a new day *before* rotation ran never learned its session_id and never
+registered — breaking the huddle self-filter (a session saw its own posts injected
+back as if from a peer) and degrading post attribution.
+
+Rotation and registration are independent concerns: a session start with rotation
+pending must emit BOTH blocks.
+
+Each test builds a throwaway git repo (so huddle_state_dir resolves to
+<repo>/.agents/huddle), stubs `bd` on PATH to serve canned JSON per bead id, pipes
+a SessionStart payload on stdin, and asserts on the hook's stdout.
+"""
+
+import datetime
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).parent.parent / "hooks" / "huddle-session-start.sh"
+ROOT_ID = "PP-lt12"
+TODAY_DAILY_ID = "PP-lt12.38"
+YESTERDAY_DAILY_ID = "PP-lt12.37"
+MONTHLY_ID = "PP-lt12.34"
+SESSION_ID = "11111111-2222-3333-4444-555555555555"
+
+TODAY = datetime.date.today().isoformat()
+YESTERDAY = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+THIS_MONTH = datetime.date.today().strftime("%Y-%m")
+
+# Stub `bd`: log every invocation, serve `bd show <id>` from
+# $BD_SHOW_DIR/<id>.json (exit 1 when absent, matching bd's behaviour for an
+# unknown id) and `bd children` from $BD_CHILDREN_JSON. Everything else exits 0.
+BD_STUB = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$BD_LOG"
+case "$1" in
+  show)
+    f="${BD_SHOW_DIR:-}/$2.json"
+    if [[ -f "$f" ]]; then cat "$f"; exit 0; fi
+    exit 1
+    ;;
+  children)
+    [[ -n "${BD_CHILDREN_JSON:-}" ]] && cat "$BD_CHILDREN_JSON"
+    exit 0
+    ;;
+esac
+exit 0
+"""
+
+
+def _bead(bead_id: str, title: str, **extra: object) -> list[dict[str, object]]:
+    """A `bd show --json` payload: a single-element array."""
+    return [{"id": bead_id, "title": title, "status": "open", **extra}]
+
+
+def _root_notes(today_bead_id: str, today_bead_date: str) -> str:
+    """The root bead's `notes` field — itself a stringified JSON blob."""
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "today_bead": {"id": today_bead_id, "date": today_bead_date},
+            "monthly_bead": {"id": MONTHLY_ID, "month": THIS_MONTH},
+            "settings": {"n_dailies_to_inject": 5, "day_boundary_tz": "local"},
+        }
+    )
+
+
+@pytest.fixture
+def repo() -> Iterator[Path]:
+    """A temp git repo with huddle config, a stub bd on PATH, and canned beads.
+
+    Defaults to the *up-to-date* world (root notes point at today's daily). Tests
+    that need the rotation-pending world call `set_rotation_pending`.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+
+        huddle = root / ".agents" / "huddle"
+        huddle.mkdir(parents=True)
+        (huddle / "config.json").write_text(
+            json.dumps({"schema_version": 1, "root_bead_id": ROOT_ID})
+        )
+
+        # Server mode: makes huddle_sync a no-op so no test touches the network.
+        beads = root / ".beads"
+        beads.mkdir()
+        (beads / "metadata.json").write_text(
+            json.dumps({"database": "dolt", "backend": "dolt", "dolt_mode": "server"})
+        )
+
+        bindir = root / "bin"
+        bindir.mkdir()
+        bd = bindir / "bd"
+        bd.write_text(BD_STUB)
+        bd.chmod(bd.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        shows = root / "shows"
+        shows.mkdir()
+        _write_up_to_date_beads(root)
+        yield root
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload))
+
+
+def _write_up_to_date_beads(repo: Path) -> None:
+    shows = repo / "shows"
+    _write_json(
+        shows / f"{ROOT_ID}.json",
+        _bead(
+            ROOT_ID,
+            "Huddle coordination root",
+            notes=_root_notes(TODAY_DAILY_ID, TODAY),
+        ),
+    )
+    _write_json(
+        shows / f"{TODAY_DAILY_ID}.json",
+        _bead(TODAY_DAILY_ID, f"Huddle daily {TODAY}", description="Today so far."),
+    )
+    _write_json(
+        shows / f"{MONTHLY_ID}.json",
+        _bead(MONTHLY_ID, f"Huddle monthly {THIS_MONTH}", description="Month so far."),
+    )
+    _write_json(
+        repo / "children.json",
+        [{"id": TODAY_DAILY_ID, "title": f"Huddle daily {TODAY}", "status": "open"}],
+    )
+
+
+def set_rotation_pending(repo: Path) -> None:
+    """Rewrite the canned beads so the root still points at yesterday's daily."""
+    shows = repo / "shows"
+    _write_json(
+        shows / f"{ROOT_ID}.json",
+        _bead(
+            ROOT_ID,
+            "Huddle coordination root",
+            notes=_root_notes(YESTERDAY_DAILY_ID, YESTERDAY),
+        ),
+    )
+    (shows / f"{TODAY_DAILY_ID}.json").unlink()
+    _write_json(
+        shows / f"{YESTERDAY_DAILY_ID}.json",
+        _bead(
+            YESTERDAY_DAILY_ID,
+            f"Huddle daily {YESTERDAY}",
+            description="Yesterday's digest.",
+        ),
+    )
+    _write_json(
+        repo / "children.json",
+        [
+            {
+                "id": YESTERDAY_DAILY_ID,
+                "title": f"Huddle daily {YESTERDAY}",
+                "status": "open",
+            }
+        ],
+    )
+
+
+def register(repo: Path, name: str, session_id: str = SESSION_ID) -> None:
+    (repo / ".agents" / "huddle" / "session-names.json").write_text(
+        json.dumps({session_id: name})
+    )
+
+
+def run_hook(
+    repo: Path,
+    session_id: str = SESSION_ID,
+    source: str = "startup",
+    transcript_path: str = "/tmp/transcripts/abc.jsonl",
+) -> tuple[int, str, str]:
+    """Run the hook with a SessionStart payload on stdin. Returns (rc, out, err)."""
+    env = os.environ.copy()
+    env["PATH"] = f"{repo / 'bin'}{os.pathsep}{env['PATH']}"
+    env["BD_LOG"] = str(repo / "bd.log")
+    env["BD_SHOW_DIR"] = str(repo / "shows")
+    env["BD_CHILDREN_JSON"] = str(repo / "children.json")
+    payload = json.dumps(
+        {
+            "session_id": session_id,
+            "transcript_path": transcript_path,
+            "cwd": str(repo),
+            "hook_event_name": "SessionStart",
+            "source": source,
+        }
+    )
+    proc = subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        cwd=repo,
+        env=env,
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+ROTATION_MARKER = "Huddle rotation needed"
+REGISTRATION_MARKER = "Huddle identity — registration needed"
+IDENTITY_MARKER = "## Huddle identity"
+
+
+# --- PP-2m3l: rotation must not short-circuit registration ------------------
+
+
+def test_rotation_pending_emits_both_notice_and_registration_block(
+    repo: Path,
+) -> None:
+    set_rotation_pending(repo)
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert ROTATION_MARKER in out
+    assert REGISTRATION_MARKER in out
+    assert SESSION_ID in out
+    # The registration block must carry the copy-paste register command.
+    assert f"huddle-whoami.sh register <YourName> {SESSION_ID}" in out
+    # Ordering: the rotation notice stays first so it reads as the urgent item.
+    assert out.index(ROTATION_MARKER) < out.index(REGISTRATION_MARKER)
+
+
+def test_rotation_pending_emits_identity_block_for_registered_session(
+    repo: Path,
+) -> None:
+    set_rotation_pending(repo)
+    register(repo, "Claude-DoctorAudit")
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert ROTATION_MARKER in out
+    assert "Registered as: **Claude-DoctorAudit**" in out
+    assert REGISTRATION_MARKER not in out
+    # Today's daily does not exist yet, so the kickoff command must fall back to
+    # the placeholder rather than pointing at yesterday's (stale) bead.
+    assert "<today-bead-id>" in out
+    assert YESTERDAY_DAILY_ID not in out.split("## Huddle recent activity")[0]
+
+
+def test_rotation_pending_still_injects_recent_activity(repo: Path) -> None:
+    # Falling through means the recent-activity digest is emitted too — the
+    # session gets yesterday's context instead of a bare rotation nag.
+    set_rotation_pending(repo)
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert "## Huddle recent activity" in out
+    assert "Yesterday's digest." in out
+
+
+# --- Unchanged behaviour on the up-to-date path -----------------------------
+
+
+def test_no_rotation_emits_registration_block_only(repo: Path) -> None:
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert ROTATION_MARKER not in out
+    assert REGISTRATION_MARKER in out
+    assert SESSION_ID in out
+
+
+def test_no_rotation_emits_identity_block_for_registered_session(
+    repo: Path,
+) -> None:
+    register(repo, "Claude-HuddleFix")
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert ROTATION_MARKER not in out
+    assert "Registered as: **Claude-HuddleFix**" in out
+    # Today's daily resolves, so the kickoff command names it.
+    assert TODAY_DAILY_ID in out
+    assert "## Huddle recent activity" in out
+
+
+# --- Early-exit paths must keep short-circuiting -----------------------------
+
+
+def test_compact_suppresses_identity_but_keeps_rotation_notice(repo: Path) -> None:
+    # The agent already saw its identity pre-compaction; rotation is still news.
+    set_rotation_pending(repo)
+    rc, out, err = run_hook(repo, source="compact")
+    assert rc == 0, err
+    assert ROTATION_MARKER in out
+    assert IDENTITY_MARKER not in out
+
+
+def test_subagent_transcript_emits_nothing(repo: Path) -> None:
+    set_rotation_pending(repo)
+    rc, out, err = run_hook(
+        repo, transcript_path="/tmp/transcripts/subagents/abc.jsonl"
+    )
+    assert rc == 0, err
+    assert out == ""

--- a/scripts/tests/test_huddle_session_start.py
+++ b/scripts/tests/test_huddle_session_start.py
@@ -241,10 +241,16 @@ def test_rotation_pending_emits_identity_block_for_registered_session(
     assert ROTATION_MARKER in out
     assert "Registered as: **Claude-DoctorAudit**" in out
     assert REGISTRATION_MARKER not in out
-    # Today's daily does not exist yet, so the kickoff command must fall back to
-    # the placeholder rather than pointing at yesterday's (stale) bead.
+    # Today's daily does not exist yet, so the kickoff command falls back to the
+    # placeholder rather than pointing at yesterday's (stale) bead — and the
+    # block must SAY that, so nobody pastes the literal placeholder into bash.
     assert "<today-bead-id>" in out
+    assert "rotation is still pending, so today's bead does not exist yet" in out
     assert YESTERDAY_DAILY_ID not in out.split("## Huddle recent activity")[0]
+    # The blank line between the rotation notice and the identity heading is
+    # load-bearing: without it the notice's last line butts against the heading
+    # and the markdown collapses into one paragraph.
+    assert "SKILL.md.\n\n## Huddle identity" in out
 
 
 def test_rotation_pending_still_injects_recent_activity(repo: Path) -> None:
@@ -260,8 +266,12 @@ def test_rotation_pending_still_injects_recent_activity(repo: Path) -> None:
 def test_rotation_pending_skips_stale_day_reconcile(repo: Path) -> None:
     # huddle_reconcile_today keys off root notes' today_bead.date, which is still
     # YESTERDAY while rotation is pending — so falling through must NOT drag it
-    # along. Two open dailies for that stale date are left alone here; rotation
-    # repoints the field under its own lock and the next session start dedups.
+    # along. Two open dailies for that stale date are left alone here.
+    #
+    # They are never collapsed later either: rotation moves the pointer to today,
+    # and this net only targets whatever date the pointer names. That gap is
+    # pre-existing and out of scope for PP-2m3l — this test pins the skip, not a
+    # claim that something else cleans up.
     set_rotation_pending(repo)
     _write_json(
         repo / "children.json",
@@ -283,9 +293,16 @@ def test_rotation_pending_skips_stale_day_reconcile(repo: Path) -> None:
     rc, out, err = run_hook(repo)
     assert rc == 0, err
     assert ROTATION_MARKER in out
-    bd_log = (repo / "bd.log").read_text()
-    assert "update" not in bd_log
-    assert "close" not in bd_log
+    # Match on the subcommand only — a whole-log substring check would flip on any
+    # future bead id or flag that happens to contain "update"/"close".
+    subcommands = {
+        line.split()[0]
+        for line in (repo / "bd.log").read_text().splitlines()
+        if line.strip()
+    }
+    assert "update" not in subcommands
+    assert "close" not in subcommands
+    assert "comments" not in subcommands
 
 
 # --- Unchanged behaviour on the up-to-date path -----------------------------

--- a/scripts/tests/test_huddle_session_start.py
+++ b/scripts/tests/test_huddle_session_start.py
@@ -257,6 +257,37 @@ def test_rotation_pending_still_injects_recent_activity(repo: Path) -> None:
     assert "Yesterday's digest." in out
 
 
+def test_rotation_pending_skips_stale_day_reconcile(repo: Path) -> None:
+    # huddle_reconcile_today keys off root notes' today_bead.date, which is still
+    # YESTERDAY while rotation is pending — so falling through must NOT drag it
+    # along. Two open dailies for that stale date are left alone here; rotation
+    # repoints the field under its own lock and the next session start dedups.
+    set_rotation_pending(repo)
+    _write_json(
+        repo / "children.json",
+        [
+            {
+                "id": YESTERDAY_DAILY_ID,
+                "title": f"Huddle daily {YESTERDAY}",
+                "status": "open",
+            },
+            # Sorts ahead of YESTERDAY_DAILY_ID, so an unguarded reconcile would
+            # both repoint root notes (bd update) and close the loser (bd close).
+            {
+                "id": "PP-lt12.10",
+                "title": f"Huddle daily {YESTERDAY}",
+                "status": "open",
+            },
+        ],
+    )
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert ROTATION_MARKER in out
+    bd_log = (repo / "bd.log").read_text()
+    assert "update" not in bd_log
+    assert "close" not in bd_log
+
+
 # --- Unchanged behaviour on the up-to-date path -----------------------------
 
 


### PR DESCRIPTION
Closes PP-2m3l.

## The bug

`scripts/hooks/huddle-session-start.sh` printed the "rotation needed" notice and then `exit 0`. The identity / registration block lives ~60 lines further down, so it was **unreachable** whenever rotation was pending.

SessionStart fires exactly once per session, so there was no second chance to re-prompt: every session that started on a new day *before* rotation ran stayed unregistered for its entire life.

Two symptoms follow from that:

1. **Self-filter breaks.** An unregistered session sees its own huddle posts injected back to it as if from a peer — confusing, and it burns context re-reading your own updates.
2. **Attribution degrades.** `inject-beads-actor.cjs` resolves the actor from `session-names.json` and falls back to the literal `Claude` on a miss, so posts land as generic "Claude" instead of the session name.

Blast radius on 2026-07-24 alone was at least four sessions (`Claude-SessionBriefing`, `Claude-PbmTokenEnvVar`, `Claude-PbmTieGuard`, `Claude-DoctorAudit`) — all posted to the daily bead, none were in `session-names.json`.

**Observed live again tonight** while this PR was in flight: a `Claude-Briefing2` ledger update at 01:40Z landed attributed to a bare "Claude" despite that session being registered — symptom (2), reproduced in the wild.

## The fix

Rotation and registration are independent concerns, so the notice now sets a `ROTATION_PENDING` flag and **falls through** instead of exiting. The rotation notice still comes first, so it keeps its urgency; the identity/registration block follows it.

The one thing still gated behind the flag is `huddle_reconcile_today`, whose documented contract is explicitly the up-to-date path — with rotation pending, today's daily does not exist yet, so there is nothing to dedup and the rotation subagent is about to create it under its own lock.

## Tests

New `scripts/tests/test_huddle_session_start.py` (7 cases, runs under `pnpm run check:pytest`). Each builds a throwaway git repo so `huddle_state_dir` resolves locally, stubs `bd` on `PATH` to serve canned JSON per bead id, and pipes a SessionStart payload on stdin.

- **Rotation pending** — emits both the rotation notice and the registration block, in that order, with the copy-paste `register` command; same for an already-registered session; recent-activity digest still injects.
- **Up to date** — unchanged behaviour for both registered and unregistered sessions (regression baseline).
- **Early exits that must keep short-circuiting** — `source=compact` suppresses the identity block but keeps the rotation notice; a `/subagents/` transcript path emits nothing at all.

Verified as a real regression guard: with the hook reverted to its pre-fix state, the three rotation-pending cases fail and the four baseline cases still pass.

## Also

- One clarifying sentence in `.agents/skills/pinpoint-huddle/SKILL.md` so the documented rotation notice no longer reads as terminal.
- Filed **PP-txet** for a separate, pre-existing defect the new tests surfaced: an empty `session_id` is misparsed as the `source` value (space-joined fields + default-IFS `read`), defeating the "no session_id → silently exit" guard. Deliberately **not** folded in — this PR is a scoped control-flow bugfix.

The bead's `UNEXPLAINED` observation (a post landing authored "Tim Froehlich", the git `user.name` fallback) is explicitly **out of scope** here and remains un-theorised, per the bead's own "worth reproducing before theorising".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs5d6HryJJCeArggcxp2Xt
