### PR TITLE
fix(scripts): orphan sweep reports Docker UNKNOWN instead of a false zero (PP-5o7b)

### DIFF
--- a/.claude/hooks/session-start-orphan-sweep.sh
+++ b/.claude/hooks/session-start-orphan-sweep.sh
@@ -6,7 +6,11 @@
 # orphan slot manifest entries and orphan Supabase Docker resources from
 # the failure modes documented in PP-qlzu (rm -rf without the hook, Claude
 # in Web sandbox sessions). When orphans are found the sweep prints a
-# single-line nudge to stderr telling you to run `--apply` manually.
+# single-line nudge to stderr telling you to run `--apply` manually. If Docker
+# can't be enumerated the nudge says UNKNOWN rather than reporting zero — a
+# false zero here is what let ~557 MB of orphan volumes accumulate unseen
+# (PP-5o7b) — and the sweep exits non-zero, which this hook deliberately
+# swallows so session start is never blocked.
 #
 # Why dry-run (not auto-apply): SessionStart fires on every Claude Code
 # session and can affect Docker resources across the host; we want the

--- a/scripts/tests/test_worktree_orphan_sweep.py
+++ b/scripts/tests/test_worktree_orphan_sweep.py
@@ -1,0 +1,414 @@
+"""Regression tests for worktree_orphan_sweep.py Docker enumeration (PP-5o7b).
+
+The bug these lock down: `docker volume ls --format '{{.Label "…"}}'` blows up on
+Podman (`can't evaluate field Label in type *types.VolumeListReport`, exit 125),
+and the old code swallowed that into an empty list. The sweep then printed
+`0 volume(s)` — a *false zero* that reads as "there are none" — so `--apply`
+removed the containers, claimed success, and left ~557 MB of volumes on disk
+while the 6-hourly SessionStart nudge stayed silent.
+
+So the invariant under test is not "volumes are listed", it is **a failed query
+must report UNKNOWN, never 0**, and `--apply` must not touch Docker when it
+can't see. Docker is mocked at the subprocess boundary; these tests never touch
+the real daemon.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import worktree_orphan_sweep as sweep  # noqa: E402
+
+LABEL = "com.supabase.cli.project"
+
+# The exact stderr the real Podman CLI emits for the old broken template.
+TEMPLATE_ERROR = (
+    'Error: template: ls:1:23: executing "ls" at <.Label>: '
+    "can't evaluate field Label in type *types.VolumeListReport"
+)
+
+
+def _kind(args: list[str]) -> str:
+    """Classify a docker argv so the stub can answer per-subcommand."""
+    if not args or args[0] != "docker":
+        return "other"
+    head = tuple(args[1:3])
+    if head == ("volume", "ls"):
+        return "volume_ls"
+    if head == ("volume", "inspect"):
+        return "volume_inspect"
+    if head == ("volume", "rm"):
+        return "volume_rm"
+    if args[1] == "ps":
+        return "ps"
+    if args[1] == "rm":
+        return "container_rm"
+    return "other"
+
+
+class DockerStub:
+    """Stands in for subprocess.run, answering docker calls from a script."""
+
+    def __init__(self, **responses: object) -> None:
+        # Each response is either a CompletedProcess-ish tuple
+        # (returncode, stdout, stderr) or an exception instance to raise.
+        self.responses = responses
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(args))
+        response = self.responses.get(_kind(args), (0, "", ""))
+        if isinstance(response, BaseException):
+            raise response
+        returncode, stdout, stderr = response  # type: ignore[misc]
+        check = bool(_kwargs.get("check"))
+        if check and returncode != 0:
+            raise subprocess.CalledProcessError(returncode, args, stdout, stderr)
+        return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+    def calls_of(self, kind: str) -> list[list[str]]:
+        return [c for c in self.calls if _kind(c) == kind]
+
+
+def install(monkeypatch: pytest.MonkeyPatch, stub: DockerStub) -> DockerStub:
+    monkeypatch.setattr(sweep.subprocess, "run", stub)
+    return stub
+
+
+class TestVolumeEnumeration:
+    """The enumeration itself has to work on both Docker and Podman."""
+
+    def test_lists_volumes_via_label_filter_not_the_broken_template(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stub = install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-alpha\n", ""),
+                volume_inspect=(0, "supabase_db_pinpoint-alpha|pinpoint-alpha\n", ""),
+            ),
+        )
+
+        assert sweep.get_supabase_volumes() == [
+            ("supabase_db_pinpoint-alpha", "pinpoint-alpha")
+        ]
+
+        ls = stub.calls_of("volume_ls")[0]
+        assert f"label={LABEL}" in ls
+        # `.Label` on `docker volume ls` is the construct that broke (PP-5o7b).
+        assert not any(".Label" in arg for arg in ls)
+
+    def test_ignores_volumes_from_other_projects(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_other\nsupabase_db_pinpoint-alpha\n", ""),
+                volume_inspect=(
+                    0,
+                    "supabase_db_other|someone-elses-stack\n"
+                    "supabase_db_pinpoint-alpha|pinpoint-alpha\n",
+                    "",
+                ),
+            ),
+        )
+
+        assert sweep.get_supabase_volumes() == [
+            ("supabase_db_pinpoint-alpha", "pinpoint-alpha")
+        ]
+
+    def test_no_labelled_volumes_skips_inspect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stub = install(monkeypatch, DockerStub(volume_ls=(0, "\n", "")))
+
+        assert sweep.get_supabase_volumes() == []
+        assert stub.calls_of("volume_inspect") == []
+
+    def test_volume_removed_mid_sweep_does_not_blind_the_rest(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A racing removal on a busy host is not a reason to report UNKNOWN."""
+        install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-alpha\nsupabase_db_gone\n", ""),
+                volume_inspect=(
+                    1,
+                    "supabase_db_pinpoint-alpha|pinpoint-alpha\n",
+                    "Error: no such volume supabase_db_gone",
+                ),
+            ),
+        )
+
+        assert sweep.get_supabase_volumes() == [
+            ("supabase_db_pinpoint-alpha", "pinpoint-alpha")
+        ]
+
+
+class TestFailedQueryIsUnknownNotZero:
+    """The core of PP-5o7b: unknown must never collapse into zero."""
+
+    @pytest.mark.parametrize(
+        ("failure", "expected_fragment"),
+        [
+            ((125, "", TEMPLATE_ERROR), "can't evaluate field Label"),
+            ((1, "", "Cannot connect to the Docker daemon"), "Cannot connect"),
+            ((1, "", ""), "exit status 1"),
+        ],
+    )
+    def test_volume_ls_failure_reports_unknown(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        failure: tuple[int, str, str],
+        expected_fragment: str,
+    ) -> None:
+        install(monkeypatch, DockerStub(volume_ls=failure))
+
+        result = sweep.get_supabase_resources_by_project(not_quiet=False)
+
+        assert result.is_unknown
+        assert expected_fragment in (result.unknown_reason or "")
+        assert result.by_project == {}
+
+    def test_volume_inspect_template_failure_reports_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-alpha\n", ""),
+                volume_inspect=(125, "", "Error: template: unsupported"),
+            ),
+        )
+
+        result = sweep.get_supabase_resources_by_project(not_quiet=False)
+
+        assert result.is_unknown
+
+    def test_container_query_failure_reports_unknown_even_if_volumes_listed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Half an answer is still unknown — a partial count is a false count."""
+        install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-alpha\n", ""),
+                volume_inspect=(0, "supabase_db_pinpoint-alpha|pinpoint-alpha\n", ""),
+                ps=(1, "", "Cannot connect to the Docker daemon"),
+            ),
+        )
+
+        result = sweep.get_supabase_resources_by_project(not_quiet=False)
+
+        assert result.is_unknown
+        assert result.by_project == {}
+
+    def test_docker_not_installed_is_a_real_zero_not_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No docker binary means there genuinely are no Docker resources."""
+        install(monkeypatch, DockerStub(volume_ls=FileNotFoundError(2, "No such file")))
+
+        result = sweep.get_supabase_resources_by_project(not_quiet=False)
+
+        assert not result.is_unknown
+        assert result.by_project == {}
+
+    def test_healthy_query_groups_by_project(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(
+                    0,
+                    "supabase_db_pinpoint-alpha\nsupabase_db_pinpoint-beta\n",
+                    "",
+                ),
+                volume_inspect=(
+                    0,
+                    "supabase_db_pinpoint-alpha|pinpoint-alpha\n"
+                    "supabase_db_pinpoint-beta|pinpoint-beta\n",
+                    "",
+                ),
+                ps=(0, "supabase_db_pinpoint-alpha|pinpoint-alpha\n", ""),
+            ),
+        )
+
+        result = sweep.get_supabase_resources_by_project(not_quiet=False)
+
+        assert not result.is_unknown
+        assert result.by_project == {
+            "pinpoint-alpha": {
+                "volumes": ["supabase_db_pinpoint-alpha"],
+                "containers": ["supabase_db_pinpoint-alpha"],
+            },
+            "pinpoint-beta": {
+                "volumes": ["supabase_db_pinpoint-beta"],
+                "containers": [],
+            },
+        }
+
+
+@pytest.fixture
+def isolated_main(monkeypatch: pytest.MonkeyPatch):
+    """Run main() without touching the real git worktrees or slot manifest."""
+
+    def _setup(*, active: set[str], orphan_slots: list[str]) -> list[str]:
+        deallocated: list[str] = []
+        monkeypatch.setattr(sweep, "get_active_worktree_branches", lambda _repo: {})
+        monkeypatch.setattr(sweep, "get_active_project_ids", lambda _wt: active)
+        monkeypatch.setattr(sweep, "get_orphan_slot_paths", lambda: orphan_slots)
+        monkeypatch.setattr(sweep, "_is_main_worktree_path", lambda _p: False)
+        monkeypatch.setattr(sweep, "deallocate_slot", deallocated.append)
+        return deallocated
+
+    return _setup
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, *argv: str) -> int:
+    monkeypatch.setattr(sys, "argv", ["worktree_orphan_sweep.py", *argv])
+    return sweep.main()
+
+
+class TestMainReportsUnknownLoudly:
+    def test_dry_run_never_prints_a_false_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        isolated_main,
+    ) -> None:
+        isolated_main(active=set(), orphan_slots=[])
+        install(monkeypatch, DockerStub(volume_ls=(125, "", TEMPLATE_ERROR)))
+
+        exit_code = _run_main(monkeypatch)
+
+        err = capsys.readouterr().err
+        assert exit_code == sweep.EXIT_DOCKER_UNKNOWN
+        assert "UNKNOWN" in err
+        assert "0 volume(s)" not in err
+        assert "No orphans found." not in err
+
+    def test_quiet_nudge_says_unknown_not_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        isolated_main,
+    ) -> None:
+        """The SessionStart hook runs --quiet; its one-liner must not under-report."""
+        isolated_main(active=set(), orphan_slots=["/gone/worktree"])
+        install(monkeypatch, DockerStub(volume_ls=(125, "", TEMPLATE_ERROR)))
+
+        exit_code = _run_main(monkeypatch, "--quiet")
+
+        err = capsys.readouterr().err
+        assert exit_code == sweep.EXIT_DOCKER_UNKNOWN
+        assert "UNKNOWN" in err
+        assert "0 Supabase Docker project orphan(s)" not in err
+
+    def test_apply_does_not_touch_docker_when_state_is_unknown(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        isolated_main,
+    ) -> None:
+        deallocated = isolated_main(active=set(), orphan_slots=["/gone/worktree"])
+        stub = install(monkeypatch, DockerStub(volume_ls=(125, "", TEMPLATE_ERROR)))
+
+        exit_code = _run_main(monkeypatch, "--apply")
+
+        err = capsys.readouterr().err
+        assert exit_code == sweep.EXIT_DOCKER_UNKNOWN
+        assert stub.calls_of("container_rm") == []
+        assert stub.calls_of("volume_rm") == []
+        assert "SKIPPED" in err
+        # Slot reclamation is independent of Docker and still runs.
+        assert deallocated == ["/gone/worktree"]
+
+
+class TestMainOrphanClassification:
+    def test_volumes_of_an_active_worktree_are_never_orphans(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        isolated_main,
+    ) -> None:
+        """A live worktree whose Supabase is merely stopped keeps its volume.
+
+        "No container" must not imply orphaned — that heuristic (and
+        `docker volume prune`) destroys a live worktree's local database.
+        """
+        isolated_main(active={"pinpoint-alpha"}, orphan_slots=[])
+        stub = install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-alpha\n", ""),
+                volume_inspect=(0, "supabase_db_pinpoint-alpha|pinpoint-alpha\n", ""),
+                ps=(0, "", ""),
+            ),
+        )
+
+        exit_code = _run_main(monkeypatch, "--apply")
+
+        assert exit_code == 0
+        assert stub.calls_of("volume_rm") == []
+        assert "No orphans found." in capsys.readouterr().err
+
+    def test_apply_removes_volumes_of_a_project_with_no_worktree(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        isolated_main,
+    ) -> None:
+        isolated_main(active={"pinpoint-alpha"}, orphan_slots=[])
+        stub = install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-dead\n", ""),
+                volume_inspect=(0, "supabase_db_pinpoint-dead|pinpoint-dead\n", ""),
+                ps=(0, "supabase_db_pinpoint-dead|pinpoint-dead\n", ""),
+            ),
+        )
+
+        exit_code = _run_main(monkeypatch, "--apply")
+
+        err = capsys.readouterr().err
+        assert exit_code == 0
+        assert stub.calls_of("volume_rm") == [
+            ["docker", "volume", "rm", "supabase_db_pinpoint-dead"]
+        ]
+        assert stub.calls_of("container_rm") == [
+            ["docker", "rm", "-f", "supabase_db_pinpoint-dead"]
+        ]
+        assert "1 volume(s)" in err
+
+    def test_dry_run_reports_volume_count_without_removing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        isolated_main,
+    ) -> None:
+        isolated_main(active=set(), orphan_slots=[])
+        stub = install(
+            monkeypatch,
+            DockerStub(
+                volume_ls=(0, "supabase_db_pinpoint-dead\n", ""),
+                volume_inspect=(0, "supabase_db_pinpoint-dead|pinpoint-dead\n", ""),
+                ps=(0, "", ""),
+            ),
+        )
+
+        exit_code = _run_main(monkeypatch)
+
+        err = capsys.readouterr().err
+        assert exit_code == 0
+        assert "pinpoint-dead: 0 container(s), 1 volume(s)" in err
+        assert stub.calls_of("volume_rm") == []

--- a/scripts/worktree_orphan_sweep.py
+++ b/scripts/worktree_orphan_sweep.py
@@ -21,6 +21,12 @@ This script reconciles three sources of truth:
 
 Defaults to dry-run; pass `--apply` to actually deallocate orphan slots and
 remove orphan Docker containers/volumes.
+
+**Unknown is never zero.** If Docker can't be queried, this script reports the
+Docker half of the sweep as UNKNOWN and refuses to reclaim Docker resources —
+it never prints `0 volume(s)` for a query it couldn't run. A false zero reads
+as "there are none", which is how ~557 MB of orphan volumes accumulated
+unnoticed behind the 6-hourly SessionStart nudge (PP-5o7b).
 """
 
 import argparse
@@ -28,8 +34,10 @@ import fcntl
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -38,6 +46,13 @@ from worktree_cleanup import MANIFEST_PATH, deallocate_slot  # noqa: E402
 from worktree_setup import branch_to_project_id  # noqa: E402
 
 _PROJECT_ID_LINE_RE = re.compile(r'^project_id\s*=\s*"([^"]+)"')
+
+SUPABASE_PROJECT_LABEL = "com.supabase.cli.project"
+
+#: Exit status when the Docker half of the sweep could not be enumerated. The
+#: SessionStart hook swallows exit codes, but a human (or any future caller)
+#: gets a non-zero signal that the report is incomplete.
+EXIT_DOCKER_UNKNOWN = 1
 
 
 def get_active_worktree_branches(repo_dir: Path) -> dict[str, str]:
@@ -134,71 +149,160 @@ def get_orphan_slot_paths() -> list[str]:
     return orphans
 
 
-def _docker_label_query(args: list[str], not_quiet: bool) -> list[tuple[str, str]]:
-    """Run a Docker command emitting `name|project_id` lines; return parsed pairs.
+class DockerNotInstalledError(RuntimeError):
+    """The `docker` binary is absent, so there are genuinely no Docker resources."""
 
-    Returns [] when Docker is missing or the daemon is unreachable; the SessionStart
-    hook must never block on Docker being down.
+
+class DockerUnavailableError(RuntimeError):
+    """Docker is installed but could not be enumerated.
+
+    Callers MUST surface this as *unknown*, never as an empty result. Swallowing
+    it into `[]` is what produced the `0 volume(s)` false zero in PP-5o7b:
+    `--apply` then removed the containers, reported success, and left the
+    volumes on disk.
     """
+
+
+@dataclass(frozen=True)
+class DockerSweepResult:
+    """Supabase Docker resources grouped by project_id, or an explicit unknown.
+
+    `unknown_reason is None` means `by_project` is trustworthy — an empty dict
+    really means "no Supabase Docker resources". Otherwise `by_project` is empty
+    only because we couldn't look, and no count derived from it may be reported
+    or acted on.
+    """
+
+    by_project: dict[str, dict[str, list[str]]] = field(default_factory=dict)
+    unknown_reason: str | None = None
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.unknown_reason is not None
+
+
+def _run_docker(args: list[str]) -> str:
+    """Run a docker command and return stdout, or raise rather than return empty."""
     try:
         result = subprocess.run(args, capture_output=True, text=True, check=True)
-    except FileNotFoundError:
-        if not_quiet:
-            print(
-                "Note: `docker` not installed; skipping Docker sweep.", file=sys.stderr
-            )
-        return []
+    except FileNotFoundError as exc:
+        raise DockerNotInstalledError("`docker` is not installed") from exc
+    except OSError as exc:
+        raise DockerUnavailableError(
+            f"could not run `{shlex.join(args)}`: {exc}"
+        ) from exc
     except subprocess.CalledProcessError as exc:
-        if not_quiet:
-            print(
-                f"Note: docker query failed ({exc.stderr.strip()}); skipping Docker sweep.",
-                file=sys.stderr,
-            )
+        detail = (
+            (exc.stderr or "").strip()
+            or (exc.stdout or "").strip()
+            or f"exit status {exc.returncode}"
+        )
+        raise DockerUnavailableError(f"`{shlex.join(args)}` failed: {detail}") from exc
+    return result.stdout
+
+
+def _parse_name_project_pairs(stdout: str) -> list[tuple[str, str]]:
+    """Parse `name|project_id` lines, keeping only PinPoint-owned projects."""
+    pairs: list[tuple[str, str]] = []
+    for line in stdout.splitlines():
+        name, sep, project = line.partition("|")
+        if sep and project.startswith("pinpoint-"):
+            pairs.append((name, project))
+    return pairs
+
+
+def get_supabase_volumes() -> list[tuple[str, str]]:
+    """Return `(volume_name, project_id)` for every Supabase-CLI-labeled volume.
+
+    Deliberately two calls. `docker volume ls --format '{{.Label "..."}}'` is NOT
+    portable: Podman's `*types.VolumeListReport` has no `Label` method, so the
+    whole command exits 125 with a template error (PP-5o7b). The label *filter*
+    is honoured by both engines, and `docker volume inspect` exposes the raw
+    `.Labels` map on both, so this pair works everywhere `docker volume rm` does.
+    """
+    names = [
+        line.strip()
+        for line in _run_docker(
+            [
+                "docker",
+                "volume",
+                "ls",
+                "--filter",
+                f"label={SUPABASE_PROJECT_LABEL}",
+                "--format",
+                "{{.Name}}",
+            ]
+        ).splitlines()
+        if line.strip()
+    ]
+    if not names:
         return []
 
-    out: list[tuple[str, str]] = []
-    for line in result.stdout.splitlines():
-        name, _, project = line.partition("|")
-        if project.startswith("pinpoint-"):
-            out.append((name, project))
-    return out
-
-
-def get_supabase_resources_by_project(
-    not_quiet: bool,
-) -> dict[str, dict[str, list[str]]]:
-    """Group Supabase Docker containers/volumes by their project_id label."""
-    grouped: dict[str, dict[str, list[str]]] = {}
-
-    volumes = _docker_label_query(
+    # Tolerate a partial failure here on purpose: on a host running many agent
+    # worktrees a volume can be removed between the `ls` and the `inspect`, and
+    # one racing removal shouldn't blind the whole sweep. A template/daemon
+    # failure yields no parseable output at all, and that still raises.
+    inspect = subprocess.run(
         [
             "docker",
             "volume",
-            "ls",
+            "inspect",
             "--format",
-            '{{.Name}}|{{.Label "com.supabase.cli.project"}}',
+            '{{.Name}}|{{index .Labels "' + SUPABASE_PROJECT_LABEL + '"}}',
+            *names,
         ],
-        not_quiet,
+        capture_output=True,
+        text=True,
     )
-    for name, project in volumes:
-        grouped.setdefault(project, {"volumes": [], "containers": []})
-        grouped[project]["volumes"].append(name)
+    pairs = _parse_name_project_pairs(inspect.stdout)
+    if inspect.returncode != 0 and not pairs:
+        detail = (inspect.stderr or "").strip() or f"exit status {inspect.returncode}"
+        raise DockerUnavailableError(f"`docker volume inspect` failed: {detail}")
+    return pairs
 
-    containers = _docker_label_query(
-        [
-            "docker",
-            "ps",
-            "-a",
-            "--format",
-            '{{.Names}}|{{.Label "com.supabase.cli.project"}}',
-        ],
-        not_quiet,
+
+def get_supabase_containers() -> list[tuple[str, str]]:
+    """Return `(container_name, project_id)` for every Supabase-CLI-labeled container."""
+    return _parse_name_project_pairs(
+        _run_docker(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"label={SUPABASE_PROJECT_LABEL}",
+                "--format",
+                '{{.Names}}|{{.Label "' + SUPABASE_PROJECT_LABEL + '"}}',
+            ]
+        )
     )
-    for name, project in containers:
-        grouped.setdefault(project, {"volumes": [], "containers": []})
-        grouped[project]["containers"].append(name)
 
-    return grouped
+
+def get_supabase_resources_by_project(not_quiet: bool) -> DockerSweepResult:
+    """Group Supabase Docker containers/volumes by their project_id label.
+
+    Any enumeration failure returns an *unknown* result rather than an empty
+    one — including a partial failure, since a project whose containers listed
+    but whose volumes didn't would otherwise report a false `0 volume(s)`.
+    """
+    try:
+        volumes = get_supabase_volumes()
+        containers = get_supabase_containers()
+    except DockerNotInstalledError as exc:
+        # No docker binary means there are genuinely no Docker resources here,
+        # so an empty (not unknown) result is the honest answer.
+        if not_quiet:
+            print(f"Note: {exc}; no Docker resources to sweep.", file=sys.stderr)
+        return DockerSweepResult()
+    except DockerUnavailableError as exc:
+        return DockerSweepResult(unknown_reason=str(exc))
+
+    grouped: dict[str, dict[str, list[str]]] = {}
+    for kind, pairs in (("volumes", volumes), ("containers", containers)):
+        for name, project in pairs:
+            grouped.setdefault(project, {"volumes": [], "containers": []})
+            grouped[project][kind].append(name)
+    return DockerSweepResult(by_project=grouped)
 
 
 def _is_main_worktree_path(path: str) -> bool:
@@ -256,13 +360,31 @@ def main() -> int:
         for path_str in orphan_slots:
             print(f"  - {path_str}", file=sys.stderr)
 
-    docker_by_project = get_supabase_resources_by_project(not_quiet)
+    docker = get_supabase_resources_by_project(not_quiet)
+    # An orphan is a project_id with no *active worktree*, never "a volume with
+    # no container": a live worktree whose Supabase is merely stopped keeps its
+    # volume and would be destroyed by a container-presence heuristic (or by
+    # `docker volume prune`). Don't reintroduce either.
     orphan_projects = {
         pid: res
-        for pid, res in docker_by_project.items()
+        for pid, res in docker.by_project.items()
         if pid not in active_project_ids
     }
-    if orphan_projects and not_quiet:
+
+    if docker.is_unknown:
+        # Never suppressed by --quiet: a silent false zero is worse than an error,
+        # and this is the line that keeps the SessionStart nudge honest.
+        print(
+            "worktree-orphan-sweep: Supabase Docker orphans are UNKNOWN, not zero — "
+            f"{docker.unknown_reason}. Containers/volumes were not counted"
+            + (
+                " and --apply will not reclaim any Docker resources."
+                if args.apply
+                else "."
+            ),
+            file=sys.stderr,
+        )
+    elif orphan_projects and not_quiet:
         print(
             f"Orphan Supabase Docker projects: {len(orphan_projects)}",
             file=sys.stderr,
@@ -276,8 +398,13 @@ def main() -> int:
 
     if not orphan_slots and not orphan_projects:
         if not_quiet:
-            print("No orphans found.", file=sys.stderr)
-        return 0
+            print(
+                "No slot orphans found; Docker orphans unknown (see above)."
+                if docker.is_unknown
+                else "No orphans found.",
+                file=sys.stderr,
+            )
+        return EXIT_DOCKER_UNKNOWN if docker.is_unknown else 0
 
     if not args.apply:
         if not_quiet:
@@ -285,13 +412,18 @@ def main() -> int:
         else:
             # Quiet dry-run still surfaces a single-line nudge so the SessionStart
             # hook isn't completely silent when there's something to reclaim.
+            docker_summary = (
+                "Supabase Docker project orphans UNKNOWN"
+                if docker.is_unknown
+                else f"{len(orphan_projects)} Supabase Docker project orphan(s)"
+            )
             print(
                 f"worktree-orphan-sweep: found {len(orphan_slots)} slot orphan(s), "
-                f"{len(orphan_projects)} Supabase Docker project orphan(s) "
+                f"{docker_summary} "
                 "(dry-run). Run: python3 scripts/worktree_orphan_sweep.py --apply",
                 file=sys.stderr,
             )
-        return 0
+        return EXIT_DOCKER_UNKNOWN if docker.is_unknown else 0
 
     for path_str in orphan_slots:
         if _is_main_worktree_path(path_str):
@@ -337,6 +469,14 @@ def main() -> int:
                     f"  removed {len(res['volumes'])} volume(s) for {pid}",
                     file=sys.stderr,
                 )
+
+    if docker.is_unknown:
+        print(
+            "Docker sweep SKIPPED (state unknown); no containers or volumes were "
+            "removed. Slot manifest orphans above were still reclaimed.",
+            file=sys.stderr,
+        )
+        return EXIT_DOCKER_UNKNOWN
 
     return 0
 

--- a/scripts/worktree_orphan_sweep.py
+++ b/scripts/worktree_orphan_sweep.py
@@ -238,10 +238,16 @@ def get_supabase_volumes() -> list[tuple[str, str]]:
     if not names:
         return []
 
-    # Tolerate a partial failure here on purpose: on a host running many agent
+    # Tolerate a *partial* failure on purpose: on a host running many agent
     # worktrees a volume can be removed between the `ls` and the `inspect`, and
-    # one racing removal shouldn't blind the whole sweep. A template/daemon
-    # failure yields no parseable output at all, and that still raises.
+    # one racing removal shouldn't blind the whole sweep. `inspect` still writes
+    # the volumes it did resolve to stdout, so those pairs stay trustworthy.
+    #
+    # Anything that leaves stdout empty is reported as unknown instead: a
+    # template or daemon failure, and also the (rare) case where every named
+    # volume raced away at once. Calling that last one "unknown" rather than
+    # "zero" is deliberate — under-claiming knowledge is the whole point of
+    # PP-5o7b, and the next sweep resolves it.
     inspect = subprocess.run(
         [
             "docker",


### PR DESCRIPTION
Fixes PP-5o7b.

## The bug

`scripts/worktree_orphan_sweep.py` enumerated Supabase volumes with

```
docker volume ls --format '{{.Name}}|{{.Label "com.supabase.cli.project"}}'
```

That template is not portable. On this host `docker` is Podman, whose
`*types.VolumeListReport` has no `Label` method, so the command exits **125**:

```
Error: template: ls:1:23: executing "ls" at <.Label>: can't evaluate field Label in type *types.VolumeListReport
```

`_docker_label_query` caught that and returned `[]`. The sweep then reported:

```
Note: docker query failed (...); skipping Docker sweep.
Orphan Supabase Docker projects: 1
  - pinpoint-feat-mcp-bearer-token: 5 container(s), 0 volume(s)
  removed 5 container(s) for pinpoint-feat-mcp-bearer-token
```

`0 volume(s)` is a **false zero** — it reads as "there are none". `--apply`
removed the containers, declared success, and left the volume on disk. Worse:
the SessionStart hook runs this sweep in dry-run every 6h and nudges only on
what it counts, so a host with hundreds of MB of leaked *volumes* and no leaked
*containers* looked perfectly clean. That's how ~557 MB across 8 volumes
accumulated unseen.

A false zero is worse than an error, so this PR fixes both halves.

## 1. Enumeration works on both engines

Volumes are now listed with the label **filter** — honoured by Docker and
Podman alike — and resolved to their project with `docker volume inspect`,
whose raw `.Labels` map both engines expose:

```
docker volume ls --filter label=com.supabase.cli.project --format '{{.Name}}'
docker volume inspect --format '{{.Name}}|{{index .Labels "com.supabase.cli.project"}}' <names…>
```

Two calls on purpose. A volume removed by another agent's cleanup *between* the
`ls` and the `inspect` is tolerated (that name is simply dropped) rather than
blinding the whole sweep — this host runs 30+ worktrees concurrently. A real
template/daemon failure produces no parseable output at all and still raises.

Verified against the live daemon read-only: 3 labeled volumes found, correctly
attributed, matching `docker volume ls --filter` by hand.

## 2. A failed query is UNKNOWN, never zero

`get_supabase_resources_by_project` now returns a `DockerSweepResult` carrying
an explicit `unknown_reason` instead of an indistinguishable empty dict. Any
enumeration failure sets it — **including a partial one**, since a project whose
containers listed but whose volumes didn't is exactly the false-count case.

Consequences, all of them load-bearing:

- The UNKNOWN warning prints **even under `--quiet`**, so the SessionStart nudge
  cannot under-report. That nudge is the standing alarm this bug silenced.
- The quiet one-liner says `Supabase Docker project orphans UNKNOWN` rather than
  a count.
- **`--apply` removes no Docker resource at all** in that state, and says
  `Docker sweep SKIPPED (state unknown)`. Slot-manifest reclamation is
  independent and still runs.
- The process exits non-zero (`EXIT_DOCKER_UNKNOWN`). The SessionStart hook
  already swallows exit codes behind `|| true`, so session start is unaffected.
- An absent `docker` binary stays a genuine zero — no binary means no Docker
  resources, and crying UNKNOWN there would be noise.

## What deliberately did not change

Orphan classification. A project is an orphan because it has **no active
worktree**, never because it has no container. `supabase_db_pinpoint-worktree-bridge-cse-01-8ea3ea5e`
has no container but belongs to a live worktree whose Supabase is merely
stopped; Docker counts it as unused. A container-presence heuristic — or
`docker volume prune` — would destroy a live worktree's local database. The
existing check against the active-worktree `project_id` set is correct and is
now covered by a test that pins it.

## Testing

`scripts/tests/test_worktree_orphan_sweep.py`, 17 tests, mocked at the
`subprocess` boundary — no real daemon, no dependence on local Docker state.
The regression that matters:

- a failing `docker volume ls` (the real Podman exit-125 stderr, a daemon-down
  error, and a bare non-zero exit) yields `is_unknown`, not an empty result
- `main()` dry-run prints `UNKNOWN` and **never** `0 volume(s)`, never claims
  "No orphans found.", and exits non-zero
- the `--quiet` nudge says UNKNOWN rather than `0 … orphan(s)`
- `--apply` under UNKNOWN issues **no** `docker rm` and **no** `docker volume rm`,
  while still deallocating slot orphans
- a volume whose project is an active worktree is never removed

Confirmed red against the pre-fix code: replaying the mock through the old
`main()` reproduces `1 container(s), 0 volume(s)` and exit 0.

`pnpm run check` passes (127 pytest, 1655 unit, lint/format/types/shellcheck).

## Safety note

Everything here was verified with **dry-run only** plus read-only `docker volume ls`
/ `docker ps` queries. `--apply` was never executed — several agents are running
live worktrees and Supabase stacks on this host, and removing one of their
volumes would destroy their work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs5d6HryJJCeArggcxp2Xt
