### PR TITLE
fix(hooks): resolve effective command before firing the memory gate (PP-yl8k)

### DIFF
--- a/.claude/hooks/block-heavy-under-pressure.cjs
+++ b/.claude/hooks/block-heavy-under-pressure.cjs
@@ -13,7 +13,8 @@
  * Honors FORCE_MEM_PRECHECK=skip (passed through to the shell script).
  * Passes through immediately in CI ($CI is set).
  *
- * Matched commands (substring search against the full command string):
+ * Matched commands (each shell segment's RESOLVED command must be the runner —
+ * a command that merely mentions one of these in an argument does NOT match):
  *   pnpm run test:integration
  *   pnpm run test:integration:supabase
  *   pnpm run build
@@ -29,11 +30,131 @@ const { execFileSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
-const HEAVY_PATTERNS = [
-  /pnpm\s+run\s+(test:integration|test:integration:supabase|build|smoke|e2e)\b/,
-  /\bvitest\s+run\b/,
-  /\bplaywright\s+test\b/,
-];
+// --- Pure classifier (unit-testable without spawning anything) ---------------
+// Decide whether a shell command string actually INVOKES one of the heavy
+// runners above. Mirrors the technique in block-main-worktree-branch-switch.cjs
+// (`classifyCommand`): resolve each segment's effective command instead of
+// regex-testing the raw string.
+//
+// The old implementation ran the heavy regexes against the whole command, so
+// any command whose TEXT named a heavy runner — `echo "how to run pnpm run
+// build"`, `bd comments add "…ran pnpm run smoke…"`, `rg "playwright test"
+// docs/`, `git commit -m "speed up vitest run"` — fired a memory probe that can
+// poll for up to five minutes. False positives are the cost that matters here:
+// the threat model is a well-meaning agent, not an attacker evading a filter,
+// so this deliberately does NOT try to be evasion-resistant.
+
+// `pnpm run <script>` is heavy for exactly these scripts. Anchored + \b so
+// `build` matches `build` (and today's `e2e:full`-style suffixes) but NOT
+// `buildx`. Same set as before this hook grew a classifier.
+const HEAVY_PNPM_SCRIPT =
+  /^(test:integration|test:integration:supabase|build|smoke|e2e)\b/;
+
+// Direct binaries: heavy only in their run/test subcommand form.
+// `vitest --version` and `playwright install` are NOT heavy.
+const HEAVY_BINARIES = new Map([
+  ["vitest", "run"],
+  ["playwright", "test"],
+]);
+
+// Package runners we step THROUGH to find the real command
+// (`pnpm exec playwright test` → `playwright test`).
+const PACKAGE_RUNNERS = new Set([
+  "pnpm",
+  "pnpx",
+  "npm",
+  "npx",
+  "yarn",
+  "bun",
+  "bunx",
+]);
+// Runner subcommands that hand the command slot to the next token.
+const RUNNER_EXEC_SUBCOMMANDS = new Set(["exec", "dlx", "x"]);
+// Runner subcommands that take a package.json SCRIPT name, not a binary.
+const RUNNER_RUN_SUBCOMMANDS = new Set(["run", "run-script"]);
+
+// Leading tokens that do not consume the command slot themselves.
+const WRAPPERS = new Set(["sudo", "env", "command", "time", "nice"]);
+const ENV_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*[+:]?=/;
+
+/** Strip one pair of surrounding matching quotes: `"build"` → `build`. */
+function unquote(token) {
+  const t = String(token || "");
+  return (t.startsWith('"') && t.endsWith('"') && t.length > 1) ||
+    (t.startsWith("'") && t.endsWith("'") && t.length > 1)
+    ? t.slice(1, -1)
+    : t;
+}
+
+/**
+ * Is this ONE segment a heavy invocation?
+ *
+ * Resolves the segment's effective command by skipping leading env assignments
+ * (VAR=value) and leading wrappers (sudo/env/command/time/nice), comparing on
+ * BASENAME so `./node_modules/.bin/playwright test` and
+ * `/usr/local/bin/pnpm run build` resolve correctly, then stepping through any
+ * package runner + subcommand so the effective argv becomes e.g.
+ * `playwright test`.
+ */
+function isHeavySegment(segment) {
+  const tokens = segment.split(/\s+/).filter(Boolean);
+
+  let cmdIdx = -1;
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (ENV_ASSIGN.test(t)) continue; // skip VAR=value
+    if (WRAPPERS.has(t)) continue; // skip wrapper command itself
+    cmdIdx = i;
+    break;
+  }
+  if (cmdIdx === -1) return false;
+
+  // Walk package runners. The hop cap just bounds pathological input; two hops
+  // covers every real shape (`pnpm exec playwright test`, `npx -y vitest run`).
+  let argv = tokens.slice(cmdIdx);
+  for (let hops = 0; hops < 3; hops++) {
+    const name = path.basename(unquote(argv[0]));
+
+    if (!PACKAGE_RUNNERS.has(name)) {
+      // Resolved to a real binary — heavy only in its run/test form.
+      const expected = HEAVY_BINARIES.get(name);
+      return expected !== undefined && unquote(argv[1] || "") === expected;
+    }
+
+    // Skip the runner's own flags (`npx -y …`, `pnpm --silent …`) to find its
+    // subcommand. A flag that takes a separate value (`pnpm -C dir run build`)
+    // simply resolves to something we don't recognise → not heavy. Fine: a
+    // missed exotic invocation is cheaper than a false positive.
+    let i = 1;
+    while (i < argv.length && argv[i].startsWith("-")) i++;
+    const sub = unquote(argv[i] || "");
+    if (!sub) return false;
+
+    if (RUNNER_RUN_SUBCOMMANDS.has(sub)) {
+      // `pnpm run <script>` — heaviness is decided by the script name.
+      return HEAVY_PNPM_SCRIPT.test(unquote(argv[i + 1] || ""));
+    }
+    // `pnpm exec <cmd>` / `pnpm dlx <cmd>` consume one more token;
+    // `npx <cmd>` / `yarn <cmd>` put the command right there.
+    argv = argv.slice(RUNNER_EXEC_SUBCOMMANDS.has(sub) ? i + 1 : i);
+    if (argv.length === 0) return false;
+  }
+  return false;
+}
+
+/**
+ * Does this command string invoke a heavy runner in ANY of its segments?
+ * Split on shell separators: && || ; | and newlines.
+ */
+function isHeavyCommand(command) {
+  const segments = String(command || "").split(/&&|\|\||;|\||\r?\n/);
+  return segments.some((raw) => {
+    const segment = raw.trim();
+    return segment !== "" && isHeavySegment(segment);
+  });
+}
+
+module.exports = { isHeavyCommand };
 
 async function main() {
   let inputData = "";
@@ -68,9 +189,8 @@ async function main() {
     process.exit(0);
   }
 
-  // Check if the command matches any heavy pattern
-  const isHeavy = HEAVY_PATTERNS.some((re) => re.test(command));
-  if (!isHeavy) {
+  // Check whether the command actually invokes a heavy runner
+  if (!isHeavyCommand(command)) {
     process.exit(0);
   }
 
@@ -142,4 +262,8 @@ async function main() {
   }
 }
 
-main().catch(() => process.exit(0));
+// --- Hook entrypoint ---------------------------------------------------------
+// Only run as a hook when invoked directly (not when require()'d by a test).
+if (require.main === module) {
+  main().catch(() => process.exit(0));
+}

--- a/src/test/unit/hooks/block-heavy-under-pressure.test.ts
+++ b/src/test/unit/hooks/block-heavy-under-pressure.test.ts
@@ -1,0 +1,246 @@
+// Unit tests for the `isHeavyCommand` classifier exported from
+// .claude/hooks/block-heavy-under-pressure.cjs.
+//
+// The classifier is pure (no exec/fs I/O) so these tests run without spawning
+// the memory precheck. They cover the fix for the false-positive where the
+// heavy-command regexes were tested against the WHOLE command string, so any
+// command that merely NAMED a heavy runner in an argument (echo, bd comments,
+// rg, a commit message) fired a memory probe that can poll for five minutes.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, it, expect } from "vitest";
+
+// Resolve the hook relative to the repo root (process.cwd() in vitest).
+const require = createRequire(import.meta.url);
+const hookPath = path.resolve(
+  process.cwd(),
+  ".claude/hooks/block-heavy-under-pressure.cjs"
+);
+const { isHeavyCommand } = require(hookPath) as {
+  isHeavyCommand: (cmd: string) => boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function expectHeavy(cmd: string) {
+  expect(
+    isHeavyCommand(cmd),
+    `Expected HEAVY (precheck runs) for: ${JSON.stringify(cmd)}`
+  ).toBe(true);
+}
+
+function expectNotHeavy(cmd: string) {
+  expect(
+    isHeavyCommand(cmd),
+    `Expected NOT heavy (allow immediately) for: ${JSON.stringify(cmd)}`
+  ).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Real heavy invocations — must still be detected
+// ---------------------------------------------------------------------------
+describe("real heavy invocations → HEAVY", () => {
+  it.each([
+    "pnpm run build",
+    "pnpm run smoke",
+    "pnpm run e2e",
+    "pnpm run test:integration",
+    "pnpm run test:integration:supabase",
+  ])("detects %s", (cmd) => {
+    expectHeavy(cmd);
+  });
+
+  it("detects vitest run", () => {
+    expectHeavy("vitest run");
+  });
+
+  it("detects playwright test", () => {
+    expectHeavy("playwright test");
+  });
+
+  it("detects a pnpm run script with flags after it", () => {
+    expectHeavy("pnpm run smoke --reporter=list");
+  });
+
+  it("detects e2e:* suffixed scripts (preserved from the old regex)", () => {
+    expectHeavy("pnpm run e2e:full");
+    expectHeavy("pnpm run e2e:all");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Package-runner and path forms — the classifier steps through / basenames
+// ---------------------------------------------------------------------------
+describe("package runners and absolute/relative paths → HEAVY", () => {
+  it("steps through pnpm exec", () => {
+    expectHeavy("pnpm exec playwright test --project=chromium");
+  });
+
+  it("steps through npx with its own flag", () => {
+    expectHeavy("npx -y playwright test");
+  });
+
+  it("steps through pnpm dlx", () => {
+    expectHeavy("pnpm dlx vitest run");
+  });
+
+  it("steps through npm exec", () => {
+    expectHeavy("npm exec vitest run");
+  });
+
+  it("steps through yarn / bun direct binary form", () => {
+    expectHeavy("yarn playwright test");
+    expectHeavy("bun vitest run");
+  });
+
+  it("resolves ./node_modules/.bin/<bin> on basename", () => {
+    expectHeavy("./node_modules/.bin/vitest run");
+    expectHeavy("./node_modules/.bin/playwright test");
+  });
+
+  it("resolves an absolute pnpm path on basename", () => {
+    expectHeavy("/usr/local/bin/pnpm run build");
+  });
+
+  it("skips leading env assignments and wrappers", () => {
+    expectHeavy("CI=1 pnpm run build");
+    expectHeavy("time pnpm run smoke");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound + multi-line commands — heavy if ANY segment invokes a heavy runner
+// ---------------------------------------------------------------------------
+describe("compound and multi-line commands → HEAVY if any segment is", () => {
+  it("detects a heavy command chained after cd", () => {
+    expectHeavy("cd packages/app && pnpm run build");
+  });
+
+  it("detects a heavy command on the second line", () => {
+    expectHeavy("git fetch origin\npnpm run test:integration");
+  });
+
+  it("detects a heavy command after a semicolon", () => {
+    expectHeavy("echo starting; playwright test e2e/foo.spec.ts");
+  });
+
+  it("detects a heavy command piped into another", () => {
+    expectHeavy("vitest run | tee out.log");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prose mentions (the false-positive fix) — must NOT be heavy
+// ---------------------------------------------------------------------------
+describe("prose mentioning a heavy command → NOT heavy (false-positive fix)", () => {
+  it("allows echo of instructions naming a heavy script", () => {
+    expectNotHeavy('echo "how to run pnpm run build"');
+  });
+
+  it("allows a bead comment describing a heavy run", () => {
+    expectNotHeavy('bd comments add "PP-x" "ran pnpm run smoke"');
+  });
+
+  it("allows ripgrep searching for a heavy command", () => {
+    expectNotHeavy('rg "playwright test" docs/');
+  });
+
+  it("allows a commit message naming a heavy command", () => {
+    expectNotHeavy('git commit -m "speed up vitest run"');
+  });
+
+  it("allows a heredoc whose body names heavy commands", () => {
+    expectNotHeavy(
+      [
+        "cat > /tmp/notes.md <<'EOF'",
+        "Release steps:",
+        "1. pnpm run build",
+        "2. pnpm run smoke",
+        "EOF",
+      ].join("\n")
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Near misses — similar but genuinely not heavy
+// ---------------------------------------------------------------------------
+describe("near misses → NOT heavy", () => {
+  it.each([
+    "pnpm run buildx",
+    "pnpm run lint",
+    "playwright install",
+    "vitest --version",
+    "pnpm run check",
+    "pnpm install",
+  ])("allows %s", (cmd) => {
+    expectNotHeavy(cmd);
+  });
+
+  it("allows an empty or whitespace-only command", () => {
+    expectNotHeavy("");
+    expectNotHeavy("   ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subprocess: the hook end-to-end, with a stub precheck that ALWAYS blocks.
+// This is what proves the classifier and the inline override actually keep the
+// (slow, up-to-5-minute) precheck from running — not just that they return
+// false in isolation.
+// ---------------------------------------------------------------------------
+const stubRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mem-precheck-stub-"));
+fs.mkdirSync(path.join(stubRoot, "scripts", "guard"), { recursive: true });
+fs.writeFileSync(
+  path.join(stubRoot, "scripts", "guard", "mem-precheck.sh"),
+  '#!/usr/bin/env bash\necho "STUB HARD-BLOCK" >&2\nexit 1\n'
+);
+
+afterAll(() => {
+  fs.rmSync(stubRoot, { recursive: true, force: true });
+});
+
+/** Run the hook as a subprocess against the always-blocking stub precheck. */
+function runHook(command: string): { status: number; stdout: string } {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLAUDE_PROJECT_DIR: stubRoot,
+  };
+  // The hook passes through unconditionally when $CI is set; drop it so the
+  // classifier is what decides here (CI is set on GitHub Actions runners).
+  delete env.CI;
+  const result = spawnSync("node", [hookPath], {
+    env,
+    input: JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
+    encoding: "utf8",
+  });
+  return { status: result.status ?? 1, stdout: result.stdout ?? "" };
+}
+
+describe("hook subprocess — the precheck only runs for real heavy commands", () => {
+  it("denies a genuine heavy command when the precheck hard-blocks", () => {
+    const { status, stdout } = runHook("pnpm run build");
+    expect(status).toBe(0); // hooks always exit 0; the decision is in stdout
+    expect(stdout).toContain('"permissionDecision":"deny"');
+    expect(stdout).toContain("STUB HARD-BLOCK");
+  });
+
+  it("short-circuits on the inline FORCE_MEM_PRECHECK=skip override", () => {
+    const { status, stdout } = runHook(
+      "FORCE_MEM_PRECHECK=skip pnpm run build"
+    );
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("never reaches the precheck for prose naming a heavy command", () => {
+    const { status, stdout } = runHook('echo "how to run pnpm run build"');
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem (PP-yl8k)

`.claude/hooks/block-heavy-under-pressure.cjs` decided a command was heavy with a bare regex test against the whole command string:

```js
const isHeavy = HEAVY_PATTERNS.some((re) => re.test(command));
```

So any command whose *text* merely named a heavy runner fired the memory probe — and that probe can poll for up to five minutes before denying. Real cases:

- an `echo` of instructions naming a heavy script
- `bd comments add "PP-x" "…ran the smoke suite…"`
- a ripgrep for a runner name in `docs/`
- a commit message mentioning a test runner

This one is not hypothetical: **creating the bead for this fix was itself denied**, because the bead description named the heavy scripts. A noisy guard is one people learn to route around, which is how a guard dies.

## Fix

Replace the bare regex test with a classifier that resolves the **effective command** of each shell segment, mirroring `classifyCommand()` in the sibling `block-main-worktree-branch-switch.cjs` — same technique, same structure, same commenting style:

1. Split on shell separators: `&&`, `||`, `;`, `|`, **and newlines** (the sibling misses newlines; this one doesn't).
2. Per segment, tokenize on whitespace and skip leading env assignments (`VAR=value`) and leading wrappers (`sudo`, `env`, `command`, `time`, `nice`).
3. Compare on **basename**, so `./node_modules/.bin/playwright test` and `/usr/local/bin/pnpm run build` resolve.
4. Step through a package runner and its subcommand (`pnpm exec`, `pnpm dlx`, `npx -y`, `npm exec`, `yarn`, `bun`) so the effective argv becomes e.g. `playwright test`.
5. Only then decide heaviness. **The heavy set is unchanged** — the same five `pnpm run` scripts (including their `e2e:full`-style suffixes, preserved from the old `\b`), plus `vitest run` and `playwright test`.

Everything else is untouched: the CI passthrough, the inline `FORCE_MEM_PRECHECK=skip` override, precheck path resolution, the `permissionDecision: "deny"` output, and the **fail-open** posture on every error path. The classifier is exported and the entrypoint is guarded by `require.main === module`, matching the sibling hook. The header comment no longer claims substring matching.

### Threat model

Explicitly **non-adversarial** — a well-meaning agent doing something dumb, not an attacker evading a filter. No shell AST parsing, no fail-closed-on-substitution, no exotic wrapper enumeration. A missed exotic invocation is far cheaper than a false positive.

## Tests

New `src/test/unit/hooks/block-heavy-under-pressure.test.ts` — the hook had **none**. 36 tests:

- **Still detects**: all five `pnpm run` scripts, `vitest run`, `playwright test`, `pnpm exec playwright test --project=chromium`, `npx -y playwright test`, `pnpm dlx` / `npm exec` / `yarn` / `bun` forms, `./node_modules/.bin/*`, `/usr/local/bin/pnpm run build`, env-assignment and wrapper prefixes, a heavy command chained after `cd x &&`, one on a second line, one after `;`, one piped.
- **No longer fires on prose**: echo, `bd comments add`, `rg`, `git commit -m`, and a heredoc body listing heavy commands.
- **Near-misses stay allowed**: `pnpm run buildx`, `pnpm run lint`, `playwright install`, `vitest --version`.
- **Subprocess end-to-end** against a stub precheck that always hard-blocks, proving the probe genuinely doesn't run: a real heavy command denies, the inline `FORCE_MEM_PRECHECK=skip` override short-circuits, and prose passes straight through.

`pnpm run check` clean (exit 0, 1691 unit tests). Hooks + tests only — no migrations, auth, or server actions, so `check` is the correct floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
