### PR TITLE
fix(workflow): treat cancelled CI runs as superseded, not failed (PP-r63o)

### DIFF
--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -142,10 +142,16 @@ def test_failing_conclusions(conclusion):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("conclusion", ["", None])
-def test_undecided_conclusion_is_not_a_failure(conclusion):
-    """An empty conclusion means "not decided yet" — status carries that state."""
-    assert not pr_watch._is_failing(conclusion)
+def test_completed_with_empty_conclusion_fails_safe(conclusion):
+    """A COMPLETED run whose conclusion hasn't populated must not read as green.
+
+    Callers gate on status first, so an empty conclusion reaching _is_failing
+    means GitHub called the run complete without saying how it went. Shrugging
+    at that would let the watcher report green on an unobserved outcome.
+    """
+    assert pr_watch._is_failing(conclusion)
     assert not pr_watch._is_passing(conclusion)
+    assert not pr_watch._is_superseded(conclusion)
 
 
 # ---------------------------------------------------------------------------
@@ -226,14 +232,29 @@ def test_ci_gate_state_prefers_live_gate_over_cancelled_leftover(monkeypatch):
 
 
 @pytest.mark.unit
-def test_ci_gate_state_picks_newest_when_all_superseded(monkeypatch):
+def test_ci_gate_state_prefers_older_failure_over_newer_cancellation(monkeypatch):
+    """Supersession must never mask a real verdict, even a newer cancellation.
+
+    Pins the FIRST key of the ranking (non-superseded wins) independently of
+    the second (recency): here the cancelled entry is the more recent one, so
+    a naive "newest wins" would hide the failure.
+    """
+    rollup = [
+        _gate("FAILURE", completed_at="2026-07-24T20:00:00Z"),
+        _gate("CANCELLED", completed_at="2026-07-24T23:26:45Z"),
+    ]
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=rollup))
+    assert pr_watch._ci_gate_state(PR) == ("COMPLETED", "FAILURE")
+
+
+@pytest.mark.unit
+def test_ci_gate_state_reports_cancelled_when_every_gate_is_superseded(monkeypatch):
     rollup = [
         _gate("CANCELLED", completed_at="2026-07-24T20:00:00Z"),
         _gate("CANCELLED", completed_at="2026-07-24T23:26:45Z"),
     ]
     monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=rollup))
-    status, conclusion = pr_watch._ci_gate_state(PR)
-    assert (status, conclusion) == ("COMPLETED", "CANCELLED")
+    assert pr_watch._ci_gate_state(PR) == ("COMPLETED", "CANCELLED")
 
 
 @pytest.mark.unit
@@ -398,6 +419,42 @@ def test_main_all_runs_cancelled_defers_to_ci_gate(
 
     assert pr_watch.main() == 0
     assert "failure(s) detected" not in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_main_fails_safe_on_completed_run_with_empty_conclusion(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """GitHub can report `completed` before the conclusion populates. That is
+    not a supersession and must not be shrugged off as green."""
+    runs = [
+        _run(777, "completed", "", "CI"),
+        _run(778, "in_progress", "", "CI"),
+    ]
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("", status="IN_PROGRESS")])
+    )
+
+    assert pr_watch.main() == 1
+    assert "1 failure(s) detected before watching started" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_main_announces_a_superseded_run_only_once(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """The startup loop re-lists runs on every retry — don't re-announce."""
+    runs = [_run(30133783967, "completed", "cancelled", "Preview Auto-Resync")]
+    monkeypatch.setattr(pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("SUCCESS")]))
+    monkeypatch.setattr(pr_watch, "STARTUP_RETRIES", 3)
+    # main() drives VERBOSE_MODE off argv, so ask for verbosity there — the
+    # superseded notice is an emit_event, suppressed in the default quiet mode.
+    monkeypatch.setattr(sys, "argv", ["pr-watch.py", "--verbose", str(PR)])
+    monkeypatch.setattr(pr_watch, "VERBOSE_MODE", pr_watch.VERBOSE_MODE)
+
+    assert pr_watch.main() == 0
+    out = capsys.readouterr().out
+    assert out.count("Preview Auto-Resync — superseded (cancelled)") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -1,0 +1,412 @@
+"""Regression tests for scripts/workflow/pr-watch.py cancellation handling (PP-r63o).
+
+Two bugs are covered:
+
+1. A `cancelled` run was classified as a failure — cancellation is routine
+   (a newer commit cancels the in-flight run via concurrency groups, and the
+   Preview Auto-Resync workflow cancels itself), so a normal push-twice cycle
+   emitted a spurious "✗ CI — failed" plus a failure artifact whose log body
+   read "(no log available)".
+2. The completed-runs scan and the CI Gate pre-check must only consider the
+   CURRENT head SHA, so a stale cancelled run from an older commit — or a
+   superseded CI Gate check left behind at the same commit — can't hard-exit
+   the watcher. `--force` was the workaround; it should no longer be needed.
+
+Everything is mocked at the `gh` CLI seam (`pr_watch.gh`) — these tests never
+reach GitHub (CORE-TEST-006).
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "workflow" / "pr-watch.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("pr_watch", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pr_watch"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pr_watch = _load_module()
+
+HEAD_SHA = "1c33d34bb30884376eaf066f0024551df5c58368"
+OLD_SHA = "3ab14b1f0000000000000000000000000000aaaa"
+BRANCH = "feat/example-branch"
+PR = 1734
+
+
+def _gate(conclusion: str, status: str = "COMPLETED", completed_at: str = "") -> dict:
+    return {
+        "name": pr_watch.CI_GATE_NAME,
+        "status": status,
+        "conclusion": conclusion,
+        "completedAt": completed_at,
+        "startedAt": completed_at,
+    }
+
+
+def _run(run_id: int, status: str, conclusion: str, name: str = "CI", sha=HEAD_SHA):
+    return {
+        "databaseId": run_id,
+        "status": status,
+        "conclusion": conclusion,
+        "name": name,
+        "headSha": sha,
+    }
+
+
+def make_gh(*, rollup=(), runs=(), merge_state="CLEAN", threads=(), labels=()):
+    """Build a fake `gh` that answers every call pr-watch makes.
+
+    Records each invocation on `.calls` so tests can assert what was queried.
+    """
+
+    def fake_gh(*args: str) -> str:
+        fake_gh.calls.append(args)
+        if args[:2] == ("pr", "view"):
+            fields = args[4]
+            if fields == "statusCheckRollup":
+                return json.dumps({"statusCheckRollup": list(rollup)})
+            if fields == "mergeStateStatus,labels":
+                return json.dumps(
+                    {
+                        "mergeStateStatus": merge_state,
+                        "labels": [{"name": n} for n in labels],
+                    }
+                )
+            if fields == "headRefName,headRefOid":
+                return json.dumps({"headRefName": BRANCH, "headRefOid": HEAD_SHA})
+        if args[:2] == ("api", "graphql"):
+            return json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "pageInfo": {
+                                        "hasNextPage": False,
+                                        "endCursor": None,
+                                    },
+                                    "nodes": list(threads),
+                                }
+                            }
+                        }
+                    }
+                }
+            )
+        if args[:2] == ("run", "list"):
+            return json.dumps(list(runs))
+        if args[0] == "api":  # Copilot review count
+            return "0"
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    fake_gh.calls = []
+    return fake_gh
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("conclusion", ["cancelled", "CANCELLED", "Cancelled"])
+def test_cancelled_is_neither_pass_nor_fail(conclusion):
+    assert pr_watch._is_superseded(conclusion)
+    assert not pr_watch._is_passing(conclusion)
+    assert not pr_watch._is_failing(conclusion)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("conclusion", ["success", "SUCCESS", "skipped", "neutral"])
+def test_passing_conclusions(conclusion):
+    assert pr_watch._is_passing(conclusion)
+    assert not pr_watch._is_failing(conclusion)
+    assert not pr_watch._is_superseded(conclusion)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("conclusion", ["failure", "FAILURE", "timed_out", "weird"])
+def test_failing_conclusions(conclusion):
+    assert pr_watch._is_failing(conclusion)
+    assert not pr_watch._is_passing(conclusion)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("conclusion", ["", None])
+def test_undecided_conclusion_is_not_a_failure(conclusion):
+    """An empty conclusion means "not decided yet" — status carries that state."""
+    assert not pr_watch._is_failing(conclusion)
+    assert not pr_watch._is_passing(conclusion)
+
+
+# ---------------------------------------------------------------------------
+# watch_run — a cancelled run is reported as superseded, with no artifact
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Stand-in for the `gh run watch` subprocess: already exited non-zero."""
+
+    returncode = 1
+
+    def poll(self):
+        return self.returncode
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+@pytest.fixture
+def stub_run_watch(monkeypatch):
+    monkeypatch.setattr(pr_watch.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    monkeypatch.setattr(pr_watch, "VERBOSE_MODE", True)
+
+
+@pytest.mark.unit
+def test_watch_run_cancelled_records_no_failure(monkeypatch, stub_run_watch, capsys):
+    monkeypatch.setattr(
+        pr_watch, "_run_conclusion", lambda _id: ("completed", "cancelled")
+    )
+    monkeypatch.setattr(
+        pr_watch,
+        "write_failure_artifact",
+        lambda _id: pytest.fail("no artifact should be written for a cancelled run"),
+    )
+
+    failures: list[int] = []
+    pr_watch.watch_run(
+        30133783967, "Preview Auto-Resync", pr_watch.threading.Event(), failures
+    )
+
+    out = capsys.readouterr().out
+    assert failures == []
+    assert "superseded" in out
+    assert "failed" not in out
+
+
+@pytest.mark.unit
+def test_watch_run_failure_still_records_failure(monkeypatch, stub_run_watch, capsys):
+    monkeypatch.setattr(
+        pr_watch, "_run_conclusion", lambda _id: ("completed", "failure")
+    )
+
+    failures: list[int] = []
+    pr_watch.watch_run(999, "CI", pr_watch.threading.Event(), failures)
+
+    assert failures == [999]
+    assert "✗  CI — failed" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _ci_gate_state — head-SHA-scoped, superseded leftovers don't shadow the live gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_ci_gate_state_prefers_live_gate_over_cancelled_leftover(monkeypatch):
+    """A re-run leaves a cancelled CI Gate check next to the live one."""
+    rollup = [
+        _gate("CANCELLED", completed_at="2026-07-24T23:26:45Z"),
+        _gate("", status="IN_PROGRESS", completed_at="2026-07-24T23:30:00Z"),
+    ]
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=rollup))
+    assert pr_watch._ci_gate_state(PR) == ("IN_PROGRESS", "")
+
+
+@pytest.mark.unit
+def test_ci_gate_state_picks_newest_when_all_superseded(monkeypatch):
+    rollup = [
+        _gate("CANCELLED", completed_at="2026-07-24T20:00:00Z"),
+        _gate("CANCELLED", completed_at="2026-07-24T23:26:45Z"),
+    ]
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=rollup))
+    status, conclusion = pr_watch._ci_gate_state(PR)
+    assert (status, conclusion) == ("COMPLETED", "CANCELLED")
+
+
+@pytest.mark.unit
+def test_ci_gate_state_absent(monkeypatch):
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[]))
+    assert pr_watch._ci_gate_state(PR) == ("", "")
+
+
+# ---------------------------------------------------------------------------
+# _pre_check_blocking — cancelled must not hard-exit the watcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pre_check_does_not_block_on_cancelled_ci_gate(monkeypatch):
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[_gate("CANCELLED")]))
+    ok, reason = pr_watch._pre_check_blocking(PR)
+    assert ok, reason
+
+
+@pytest.mark.unit
+def test_pre_check_still_blocks_on_failed_ci_gate(monkeypatch):
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[_gate("FAILURE")]))
+    ok, reason = pr_watch._pre_check_blocking(PR)
+    assert not ok
+    assert "CI Gate already failed" in reason
+
+
+@pytest.mark.unit
+def test_pre_check_passes_on_green_ci_gate(monkeypatch):
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[_gate("SUCCESS")]))
+    assert pr_watch._pre_check_blocking(PR) == (True, "")
+
+
+# ---------------------------------------------------------------------------
+# _finalize_via_ci_gate — cancelled gets a bounded grace, not an instant failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_finalize_waits_for_replacement_after_cancelled_gate(monkeypatch, capsys):
+    """Cancelled → a replacement run posts a green gate → success."""
+    states = [("COMPLETED", "CANCELLED"), ("IN_PROGRESS", ""), ("COMPLETED", "SUCCESS")]
+    monkeypatch.setattr(pr_watch, "_ci_gate_state", lambda _pr: states.pop(0))
+    monkeypatch.setattr(pr_watch.time, "sleep", lambda _s: None)
+
+    assert pr_watch._finalize_via_ci_gate(PR, timeout_sec=60, poll_sec=0) == 0
+    assert "CI Gate passed" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_finalize_gives_up_on_cancelled_gate_without_failure_wording(
+    monkeypatch, capsys
+):
+    """No replacement ever appears — exit 1, but reported as superseded."""
+    monkeypatch.setattr(
+        pr_watch, "_ci_gate_state", lambda _pr: ("COMPLETED", "CANCELLED")
+    )
+    monkeypatch.setattr(pr_watch.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(pr_watch, "SUPERSEDED_GATE_GRACE", 0)
+
+    assert pr_watch._finalize_via_ci_gate(PR, timeout_sec=60, poll_sec=0) == 1
+    out = capsys.readouterr().out
+    assert "superseded" in out
+    assert "CI Gate failed" not in out
+
+
+@pytest.mark.unit
+def test_finalize_fails_fast_on_real_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        pr_watch, "_ci_gate_state", lambda _pr: ("COMPLETED", "FAILURE")
+    )
+    monkeypatch.setattr(pr_watch.time, "sleep", lambda _s: None)
+
+    assert pr_watch._finalize_via_ci_gate(PR, timeout_sec=60, poll_sec=0) == 1
+    assert "CI Gate failed" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# main() — the completed-runs scan (the site that hard-exited the watcher)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_watch_loop(monkeypatch):
+    """Neutralize the threaded watch loop so main()'s scan logic is what's tested."""
+    monkeypatch.setattr(pr_watch, "watch_run", lambda *a, **k: None)
+    monkeypatch.setattr(pr_watch, "watch_reviews", lambda *a, **k: None)
+    monkeypatch.setattr(pr_watch, "_finalize_via_ci_gate", lambda *a, **k: 0)
+    monkeypatch.setattr(pr_watch.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        pr_watch,
+        "write_failure_artifact",
+        lambda run_id: f"tmp/gh-monitor/failure-{run_id}.md",
+    )
+    monkeypatch.setattr(sys, "argv", ["pr-watch.py", str(PR)])
+
+
+@pytest.mark.unit
+def test_main_does_not_exit_on_cancelled_run_at_head_sha(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """The exact PR #1734 shape: a self-cancelled Preview Auto-Resync at HEAD
+    alongside a live CI run. Before PP-r63o this exited 1 on every invocation
+    and --force did not help."""
+    runs = [
+        _run(30133783967, "completed", "cancelled", "Preview Auto-Resync"),
+        _run(30133783968, "in_progress", "", "CI"),
+    ]
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("", status="IN_PROGRESS")])
+    )
+
+    assert pr_watch.main() == 0
+    out = capsys.readouterr().out
+    assert "failure(s) detected" not in out
+
+
+@pytest.mark.unit
+def test_main_ignores_cancelled_run_from_an_older_commit(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """A run cancelled when THIS commit superseded it belongs to the old SHA."""
+    runs = [
+        _run(30132766363, "completed", "cancelled", "CI", sha=OLD_SHA),
+        _run(30132766999, "completed", "failure", "CI", sha=OLD_SHA),
+        _run(30133783968, "in_progress", "", "CI"),
+    ]
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("", status="IN_PROGRESS")])
+    )
+
+    assert pr_watch.main() == 0
+    assert "failure(s) detected" not in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_main_still_fails_on_real_early_failure(monkeypatch, stub_watch_loop, capsys):
+    runs = [
+        _run(555, "completed", "failure", "CI"),
+        _run(556, "in_progress", "", "CI"),
+    ]
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("", status="IN_PROGRESS")])
+    )
+
+    assert pr_watch.main() == 1
+    out = capsys.readouterr().out
+    assert "1 failure(s) detected before watching started" in out
+    assert "failure-555.md" in out
+
+
+@pytest.mark.unit
+def test_main_all_runs_cancelled_defers_to_ci_gate(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """No active runs and only cancelled completed runs — anchor on CI Gate
+    rather than reporting failures."""
+    runs = [_run(30133783967, "completed", "cancelled", "Preview Auto-Resync")]
+    monkeypatch.setattr(pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("SUCCESS")]))
+    monkeypatch.setattr(pr_watch, "STARTUP_RETRIES", 1)
+
+    assert pr_watch.main() == 0
+    assert "failure(s) detected" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# run_audit — a cancelled gate is "not ready", but not described as a failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_audit_reports_cancelled_gate_as_superseded(monkeypatch, capsys):
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[_gate("CANCELLED")]))
+    assert pr_watch.run_audit(PR) is False
+    assert "cancelled (superseded)" in capsys.readouterr().out

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -133,13 +133,18 @@ def _is_superseded(conclusion: str | None) -> bool:
 
 
 def _is_failing(conclusion: str | None) -> bool:
-    """True only for a real failure: not passing, not superseded, not empty.
+    """True for a real failure, given the conclusion of a COMPLETED run/check.
 
-    An empty conclusion means "not decided yet" and is never a failure here;
-    callers check `status` for that.
+    Fail-safe by construction: anything that isn't recognisably passing and
+    isn't a supersession counts as a failure, including an unrecognised
+    conclusion and an empty one. GitHub can briefly report a run as `completed`
+    before its conclusion is populated, and a watcher that shrugged at that
+    could report green without ever having observed the real outcome.
+
+    Every caller must gate on `status == "completed"` first — an empty
+    conclusion on a run that is still queued or in progress just means "not
+    decided yet", which `status` already tells you.
     """
-    if not conclusion:
-        return False
     return not _is_passing(conclusion) and not _is_superseded(conclusion)
 
 
@@ -308,7 +313,7 @@ def _pre_check_blocking(pr: int) -> tuple[bool, str]:
             # the watch loop waits for the replacement instead of hard-exiting.
             # Before PP-r63o this forced --force as a workaround.
             emit_event("CI Gate cancelled (superseded) — watching for a fresh run")
-        elif _is_failing(ci_conclusion) or not ci_conclusion:
+        elif _is_failing(ci_conclusion):
             return (
                 False,
                 f"CI Gate already failed (conclusion={ci_conclusion or 'unknown'})",

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -23,6 +23,11 @@ Usage: ./scripts/workflow/pr-watch.py [--check-ready | --force] [--verbose] <PR_
                  running under Claude Code's Monitor doesn't wake the
                  agent on every job transition.
 
+Cancelled runs are neither a pass nor a failure — they are reported as
+"superseded" (⊘) and never produce a failure artifact. Cancellation is routine
+here: pushing a second commit cancels the in-flight run via concurrency groups,
+and the Preview Auto-Resync workflow cancels itself the same way. (PP-r63o)
+
 Exit 0: all checks passed, or stopped for new Copilot review,
         or (with --check-ready) the PR is ready for human review.
 Exit 1: one or more checks failed, no matching runs found,
@@ -52,6 +57,11 @@ REVIEW_POLL_INTERVAL = 60  # seconds — GitHub rate limit friendly
 STARTUP_RETRIES = 6  # attempts to find runs for current SHA
 STARTUP_WAIT = 10  # seconds between startup retries
 LOG_DIR = "tmp/gh-monitor"
+
+# How long to keep polling for a replacement CI Gate after the current one came
+# back cancelled. A cancel almost always means a newer run is already queued;
+# this bounds the wait so a genuinely abandoned run still terminates.
+SUPERSEDED_GATE_GRACE = 180  # seconds
 
 _lock = threading.Lock()
 
@@ -92,6 +102,45 @@ def gh(*args: str) -> str:
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"gh {args[0]} failed")
     return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Run/check conclusion classification
+# ---------------------------------------------------------------------------
+#
+# Three classes, not two. `gh run list` reports conclusions lowercase and the
+# statusCheckRollup reports them uppercase, so every comparison goes through
+# these helpers rather than an inline set membership test.
+
+_PASSING_CONCLUSIONS = {"success", "skipped", "neutral"}
+
+# A cancelled run is neither a pass nor a failure — it is *superseded*. Pushing
+# a second commit cancels the in-flight run via concurrency groups, and the
+# Preview Auto-Resync workflow cancels itself the same way, so cancellation is
+# routine rather than exceptional. A cancelled run has no failed step, which is
+# why any failure artifact written for one reads "(no log available)". Treating
+# it as a failure produced false "✗ CI — failed" alarms and, worse, hard-exited
+# the watcher on every subsequent invocation at the same head SHA. (PP-r63o)
+_SUPERSEDED_CONCLUSIONS = {"cancelled"}
+
+
+def _is_passing(conclusion: str | None) -> bool:
+    return (conclusion or "").lower() in _PASSING_CONCLUSIONS
+
+
+def _is_superseded(conclusion: str | None) -> bool:
+    return (conclusion or "").lower() in _SUPERSEDED_CONCLUSIONS
+
+
+def _is_failing(conclusion: str | None) -> bool:
+    """True only for a real failure: not passing, not superseded, not empty.
+
+    An empty conclusion means "not decided yet" and is never a failure here;
+    callers check `status` for that.
+    """
+    if not conclusion:
+        return False
+    return not _is_passing(conclusion) and not _is_superseded(conclusion)
 
 
 # ---------------------------------------------------------------------------
@@ -143,13 +192,28 @@ def _unresolved_copilot(threads: list[dict]) -> int:
 
 
 def _ci_gate_state(pr: int) -> tuple[str, str]:
-    """Return (status, conclusion) for the CI Gate check, or ("", "") if absent."""
+    """Return (status, conclusion) for the CI Gate check, or ("", "") if absent.
+
+    GitHub scopes statusCheckRollup to the PR's current head commit, but that
+    commit can still carry MORE THAN ONE `CI Gate` entry — a re-run, or a run
+    cancelled by a concurrency group, leaves its superseded check behind next to
+    the live one. Returning the first match let a cancelled leftover shadow the
+    run we actually care about, so prefer a non-superseded entry and, among
+    equals, the most recent one. (PP-r63o)
+    """
     raw = gh("pr", "view", str(pr), "--json", "statusCheckRollup")
     rollup = json.loads(raw).get("statusCheckRollup", [])
-    for check in rollup:
-        if check.get("name") == CI_GATE_NAME:
-            return check.get("status", ""), check.get("conclusion", "")
-    return "", ""
+    gates = [c for c in rollup if c.get("name") == CI_GATE_NAME]
+    if not gates:
+        return "", ""
+
+    def rank(check: dict) -> tuple[int, str]:
+        not_superseded = 0 if _is_superseded(check.get("conclusion")) else 1
+        when = check.get("completedAt") or check.get("startedAt") or ""
+        return not_superseded, when
+
+    newest = max(gates, key=rank)
+    return newest.get("status", ""), newest.get("conclusion", "")
 
 
 def _finalize_via_ci_gate(pr: int, timeout_sec: int = 1200, poll_sec: int = 10) -> int:
@@ -162,16 +226,35 @@ def _finalize_via_ci_gate(pr: int, timeout_sec: int = 1200, poll_sec: int = 10) 
     """
     deadline = time.monotonic() + timeout_sec
     last_status = ""
+    superseded_deadline: float | None = None
     while time.monotonic() < deadline:
         status, conclusion = _ci_gate_state(pr)
         if status == "COMPLETED":
             # Match run_audit's pass criteria (SUCCESS / NEUTRAL / SKIPPED) so
             # the watcher and the audit can't disagree on the same CI Gate state.
-            if conclusion in ("SUCCESS", "NEUTRAL", "SKIPPED"):
+            if _is_passing(conclusion):
                 emit(f"CI Gate passed (conclusion={conclusion}) ✓")
                 return 0
+            if _is_superseded(conclusion):
+                # Cancelled is neither pass nor fail. A replacement run is
+                # normally already queued, so give it a bounded grace period to
+                # post a fresh CI Gate rather than declaring failure. (PP-r63o)
+                if superseded_deadline is None:
+                    superseded_deadline = time.monotonic() + SUPERSEDED_GATE_GRACE
+                    emit_event(
+                        "CI Gate cancelled (superseded) — waiting for a replacement run"
+                    )
+                elif time.monotonic() >= superseded_deadline:
+                    emit(
+                        "⊘  CI Gate cancelled (superseded) — no replacement run appeared"
+                    )
+                    return 1
+                time.sleep(poll_sec)
+                continue
             emit(f"CI Gate failed (conclusion={conclusion or 'unknown'})")
             return 1
+        # A fresh run posted a new gate — restart the supersession grace clock.
+        superseded_deadline = None
         if status != last_status:
             emit_event(
                 f"CI Gate {status.lower() or 'not yet posted'} — continuing to wait"
@@ -218,15 +301,18 @@ def _pre_check_blocking(pr: int) -> tuple[bool, str]:
         return False, f"merge state {merge_state} — resolve before watching"
 
     ci_status, ci_conclusion = _ci_gate_state(pr)
-    if ci_status == "COMPLETED" and ci_conclusion not in (
-        "SUCCESS",
-        "NEUTRAL",
-        "SKIPPED",
-    ):
-        return (
-            False,
-            f"CI Gate already failed (conclusion={ci_conclusion or 'unknown'})",
-        )
+    if ci_status == "COMPLETED":
+        if _is_superseded(ci_conclusion):
+            # Cancelled is not failed. A newer commit — or a self-cancelling
+            # side workflow like Preview Auto-Resync — superseded this gate;
+            # the watch loop waits for the replacement instead of hard-exiting.
+            # Before PP-r63o this forced --force as a workaround.
+            emit_event("CI Gate cancelled (superseded) — watching for a fresh run")
+        elif _is_failing(ci_conclusion) or not ci_conclusion:
+            return (
+                False,
+                f"CI Gate already failed (conclusion={ci_conclusion or 'unknown'})",
+            )
 
     unresolved = _unresolved_copilot(get_review_threads(pr))
     if unresolved > 0:
@@ -248,9 +334,14 @@ def run_audit(pr: int) -> bool:
         ci_check = (False, "CI Gate check not found")
     elif ci_status != "COMPLETED":
         ci_check = (False, f"in progress (status={ci_status})")
+    elif _is_superseded(ci_conclusion):
+        # Not a failure, but not a green gate either — the PR genuinely isn't
+        # ready until a replacement run posts one. Say why, so the reader
+        # pushes/re-runs rather than hunting for a broken test. (PP-r63o)
+        ci_check = (False, "cancelled (superseded) — needs a re-run or a new push")
     else:
         ci_check = (
-            ci_conclusion in ("SUCCESS", "NEUTRAL", "SKIPPED"),
+            _is_passing(ci_conclusion),
             f"conclusion={ci_conclusion or 'unknown'}",
         )
 
@@ -283,8 +374,6 @@ def run_audit(pr: int) -> bool:
 # ---------------------------------------------------------------------------
 # CI run watcher
 # ---------------------------------------------------------------------------
-
-_PASSING_CONCLUSIONS = {"success", "skipped", "neutral"}
 
 
 def _run_conclusion(run_id: int) -> tuple[str, str]:
@@ -328,7 +417,7 @@ def watch_run(
         status, conclusion = _run_conclusion(run_id)
 
         if proc.returncode == 0 and status not in ("queued", "in_progress"):
-            if conclusion in _PASSING_CONCLUSIONS:
+            if _is_passing(conclusion):
                 emit_event(f"✓  {name} — passed")
                 return
             # Exited 0 but API says non-passing — fall through to failure handling.
@@ -341,8 +430,15 @@ def watch_run(
             emit_event(f"↻  {name} — watcher restarted (run still in progress)")
             continue
 
-        if conclusion in _PASSING_CONCLUSIONS:
+        if _is_passing(conclusion):
             emit_event(f"✓  {name} — passed")
+            return
+
+        if _is_superseded(conclusion):
+            # Neither pass nor fail — a newer commit, or a self-cancelling side
+            # workflow, superseded this run. There is no failed step to log, so
+            # record no failure and write no artifact. (PP-r63o)
+            emit_event(f"⊘  {name} — superseded (cancelled)")
             return
 
         # Confirmed failure (or unrecognised conclusion — fail safe).
@@ -475,6 +571,7 @@ def main() -> int:
 
     active: list[dict] = []
     runs: list[dict] = []
+    announced_superseded: set[int] = set()
     for attempt in range(STARTUP_RETRIES):
         runs = json.loads(
             gh(
@@ -488,15 +585,24 @@ def main() -> int:
                 "databaseId,status,conclusion,name,headSha",
             )
         )
+        # Every scan below is scoped to the CURRENT head SHA. `gh run list`
+        # returns the branch's whole recent history, so an older commit's run —
+        # in particular one cancelled when this commit superseded it — must
+        # never influence the verdict for the commit we're watching. (PP-r63o)
         sha_runs = [r for r in runs if r["headSha"] == head_sha]
         active = [r for r in sha_runs if r["status"] in ("queued", "in_progress")]
 
-        # Fail fast if any run for this SHA already completed with a non-passing
-        # conclusion (e.g., a fast lint job failed before we started watching).
+        # Fail fast if any run for this SHA already completed with a real
+        # failure (e.g., a fast lint job failed before we started watching).
+        # Cancelled runs are excluded — they're superseded, not failed.
         completed = [r for r in sha_runs if r["status"] == "completed"]
-        early_failures = [
-            r for r in completed if r.get("conclusion") not in _PASSING_CONCLUSIONS
-        ]
+        for r in completed:
+            if _is_superseded(r.get("conclusion")) and r["databaseId"] not in (
+                announced_superseded
+            ):
+                announced_superseded.add(r["databaseId"])
+                emit_event(f"⊘  {r['name']} — superseded (cancelled)")
+        early_failures = [r for r in completed if _is_failing(r.get("conclusion"))]
         if early_failures:
             for r in early_failures:
                 path = write_failure_artifact(r["databaseId"])
@@ -519,9 +625,7 @@ def main() -> int:
         ]
         if completed:
             failures = [
-                r["databaseId"]
-                for r in completed
-                if r.get("conclusion") not in ("success", "skipped", "neutral")
+                r["databaseId"] for r in completed if _is_failing(r.get("conclusion"))
             ]
             if failures:
                 for run_id in failures:


### PR DESCRIPTION
Fixes PP-r63o.

`scripts/workflow/pr-watch.py` is the canonical CI watcher — AGENTS.md tells every agent to use it instead of hand-rolling a polling loop — so a false "✗ CI — failed" from it misleads every agent in the project. It had only two conclusion classes, passing and everything-else, so `cancelled` fell into the fail-safe branch.

Cancellation is routine here: pushing a second commit cancels the in-flight run via concurrency groups, and the Preview Auto-Resync workflow cancels itself the same way. A normal push-twice cycle therefore emitted a spurious failure plus an artifact whose log body read `(no log available)` — a cancelled run has no failed step to log.

It was a hard blocker, not just noise. Once any run for the current head SHA ended cancelled, the completed-runs scan in `main()` re-derived it from the API on every subsequent invocation and exited 1. `--force` skips only the readiness pre-check, not that scan, so there was no way to clear it. On PR #1734 the self-cancelling Preview Auto-Resync poisoned the watcher permanently.

## Part 1 — cancelled is its own class

`_is_passing` / `_is_superseded` / `_is_failing` replace the inline set-membership tests and normalise case (`gh run list` reports conclusions lowercase, `statusCheckRollup` uppercase). Every call site routes through them:

- `watch_run` emits `⊘ <name> — superseded (cancelled)`, records no failure and writes no artifact.
- The startup completed-runs scan excludes cancelled from `early_failures`, so a self-cancelled side workflow no longer hard-exits before watching starts.
- The no-active-runs fallback drops its duplicate hardcoded pass tuple.

`_is_failing` is fail-safe by construction: anything not recognisably passing and not a supersession is a failure, including an empty conclusion. GitHub can briefly report a run as `completed` before its conclusion populates, and every caller gates on `status` first.

## Part 2 — head-SHA-scoped pre-check

- `_ci_gate_state` returned the **first** rollup entry named `CI Gate`. GitHub scopes the rollup to the head commit, but that commit can carry more than one CI Gate check — a re-run or a concurrency-cancelled run leaves its superseded entry behind next to the live one. It now prefers a non-superseded entry, then the most recent, so a cancelled leftover can't shadow the live gate.
- `_pre_check_blocking` no longer treats a cancelled gate as "already failed"; it lets the watch loop wait for the replacement run. **This is the case `--force` was being used to work around.**
- `_finalize_via_ci_gate` gives a cancelled gate a bounded grace period (`SUPERSEDED_GATE_GRACE`, 180s) for a replacement to post, then reports it as superseded rather than failed. Without this the false alarm would just move to the final step.
- `run_audit` (`--check-ready`) still reports a cancelled gate as not-ready — it genuinely isn't green — but says `cancelled (superseded) — needs a re-run or a new push` instead of implying a broken test.

The run-list scans in `main()` were already head-SHA-filtered; that filter is now documented and pinned by a regression test.

## Tests

32 tests in `scripts/tests/test_pr_watch.py`, run by `pnpm run check:pytest`. Mocked at the `gh` CLI seam (`pr_watch.gh`, plus `subprocess.Popen` for the streaming `gh run watch`), so nothing reaches GitHub — CORE-TEST-006. **22 of them fail against the pre-fix script**, verified by checking out `origin/main`'s copy of the script and re-running. Fixtures use the real run shapes from PR #1734 (run `30133783967`, the self-cancelled Preview Auto-Resync at the current head SHA, and run `30132766363`, the CI run cancelled by a main-sync push at an older SHA).

## Out of scope, worth a follow-up

Claude-GhaFlakeTriage root-caused a different false-failure shape tonight: a `gh` API installation-quota 403 (5000/hr, shared across all agent sessions on this repo) redded run `30132971643` — harden-runner died on the identical 403 twenty-eight seconds before setup-cli did. That is adjacent to this bead but **not** fixable in this classification code: a quota 403 makes jobs genuinely conclude `failure`, so pr-watch is reporting it accurately. Distinguishing it needs log inspection, not conclusion classification. Not built here.

## Verification

`pnpm run check` exits 0 (142 pytest, 1655 vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs5d6HryJJCeArggcxp2Xt
