### PR TITLE
docs(chores): name all 9 Supabase CLI pin sites in the version-drift check

### DIFF
--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -39,7 +39,16 @@ Then work the checklist. For each item, note findings as a comment on the bead (
 ### Checklist
 
 1. **Stale version-pin checks** (Supabase CLI — PP-nlv6; pnpm corepack pin — PP-w0eq)
-   - **Supabase CLI pin.** Compare the pinned Supabase CLI version against the latest release. The pin lives in CI setup / config; a version-drift nudge belongs here, not in per-session briefing. If stale, file/refresh a bead to bump it (or bump it if trivial and verified).
+   - **Supabase CLI pin.** Compare the pinned Supabase CLI version against the latest release. A version-drift nudge belongs here, not in per-session briefing. If stale, file/refresh a bead to bump it (or bump it if trivial and verified).
+     - The pin is **9 sites across 4 files** — `ci.yml` (×6), plus `preview-control.yaml`, `preview-sync.yaml`, `preview-reaper.yaml` (×1 each). A bump is a multi-site edit: change **all nine or none**. A partial bump leaves jobs on mismatched CLI versions, which surfaces as a job-specific CI failure that reads like a flake rather than a bad edit.
+     - List every pin, then compare against the newest release:
+
+       ```bash
+       rg -n -A6 'uses: supabase/setup-cli' .github/workflows/*.y*ml | rg 'version:'
+       gh api /repos/supabase/cli/releases/latest --jq .tag_name
+       ```
+
+       (`-A6` matters — one call site has an extra `if:` line before `with:`, so a smaller window silently misses it and you'd bump 8 of 9.)
    - **pnpm corepack pin.** The pnpm binary is pinned in the `packageManager` field of `package.json` (corepack). **Dependabot cannot bump this field** — it's an open, unimplemented feature request ([dependabot-core#4830](https://github.com/dependabot/dependabot-core/issues/4830)); Dependabot's pnpm support only updates deps _inside_ the lockfile, never the corepack pin. So this is the only watcher it has, and it silently rots without it (that's how we ended up 9 months behind on 10.2.0 until npm's audit-endpoint retirement forced the jump — PP-w0eq).
      - **Apply a 30-day cooldown** (supply-chain soak — same rationale as the Dependabot npm cooldown): bump only to the newest stable pnpm ≥30 days old, never the just-released `latest`.
      - Find the newest eligible version:


### PR DESCRIPTION
## Why

The chores checklist's Supabase CLI pin item said the pin *"lives in CI setup / config"*. That undersells it — the version appears at **9 call sites across 4 workflow files**:

```
.github/workflows/ci.yml               x6  (lines 504, 566, 622, 704, 786, 869)
.github/workflows/preview-control.yaml x1  (line 118)
.github/workflows/preview-sync.yaml    x1  (line 58)
.github/workflows/preview-reaper.yaml  x1  (line 56)
```

So a bump is a multi-site edit, and a **partial** bump leaves jobs running mismatched CLI versions — which surfaces as a job-specific CI failure that reads like a flake rather than a bad edit. Exactly the kind of thing that costs a triage session to untangle.

## What changed

One checklist bullet in `.agents/skills/pinpoint-chores/SKILL.md`:

- Names the 9 sites and the 4 files, with an explicit **"change all nine or none"**.
- Adds a command that lists every pin alongside the newest release, so the comparison is one paste rather than a hunt.
- Documents the `-A6` window. This isn't incidental: `preview-control.yaml` carries an extra `if:` line before `with:`, so a smaller context window silently finds **8 of 9** — I hit that while writing this, and it's precisely the failure the bullet warns about.

## Context

Found while triaging PP-3w32 (GHA infra-flake ledger). The pin itself is **current** — 2.109.1 is the latest `supabase/cli` release, published 2026-07-07 — so this is drift-prevention, not a stale-pin fix.

Related, deliberately kept separate:
- **PP-nlv6** — the weekly check this bullet belongs to (version freshness).
- **PP-zvqt** — caching the pinned CLI *binary* to stop re-downloading it once per job. Different concern.

## Testing

`pnpm run check` green. Docs-only change to a skill file — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178hTxVwCeg3CPdPNKGKaaE