### PR TITLE
fix(hooks): stop the memory gate descending into heredoc bodies (PP-qota)

### DIFF
--- a/.claude/hooks/block-heavy-under-pressure.cjs
+++ b/.claude/hooks/block-heavy-under-pressure.cjs
@@ -14,7 +14,8 @@
  * Passes through immediately in CI ($CI is set).
  *
  * Matched commands (each shell segment's RESOLVED command must be the runner —
- * a command that merely mentions one of these in an argument does NOT match):
+ * a command that merely mentions one of these in an argument, or names one on a
+ * line inside a heredoc body, does NOT match):
  *   pnpm run test:integration
  *   pnpm run test:integration:supabase
  *   pnpm run build
@@ -144,10 +145,25 @@ function isHeavySegment(segment) {
 
 /**
  * Does this command string invoke a heavy runner in ANY of its segments?
- * Split on shell separators: && || ; | and newlines.
+ * Split on shell separators: && || ; | — deliberately NOT on newlines.
+ *
+ * Newlines are excluded on purpose (PP-qota). We have no shell parser, so
+ * splitting on them made the classifier descend into heredoc bodies and
+ * multi-line quoted arguments: any LINE beginning with a heavy invocation
+ * became its own "segment" and fired a memory probe that can poll for five
+ * minutes. `cat <<EOF > notes.md` / `pnpm run build` / `EOF` is a `cat`, and
+ * `bd comments add PP-x "…\npnpm run e2e\n…"` is a `bd`.
+ *
+ * Accepted cost: a genuine multi-line sequence —
+ *   cd foo
+ *   pnpm run build
+ * — is no longer gated (false negative). That is the right trade under the
+ * same principle documented above at the runner-flag walk: a missed exotic
+ * invocation is cheaper than a false positive. Agents overwhelmingly write
+ * that shape as `cd foo && pnpm run build`, which still gates.
  */
 function isHeavyCommand(command) {
-  const segments = String(command || "").split(/&&|\|\||;|\||\r?\n/);
+  const segments = String(command || "").split(/&&|\|\||;|\|/);
   return segments.some((raw) => {
     const segment = raw.trim();
     return segment !== "" && isHeavySegment(segment);

--- a/src/test/unit/hooks/block-heavy-under-pressure.test.ts
+++ b/src/test/unit/hooks/block-heavy-under-pressure.test.ts
@@ -6,6 +6,10 @@
 // heavy-command regexes were tested against the WHOLE command string, so any
 // command that merely NAMED a heavy runner in an argument (echo, bd comments,
 // rg, a commit message) fired a memory probe that can poll for five minutes.
+//
+// They also cover the follow-up fix (PP-qota): newlines are no longer treated
+// as segment separators, so heredoc bodies and multi-line quoted arguments
+// stop tripping the gate.
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -114,15 +118,12 @@ describe("package runners and absolute/relative paths → HEAVY", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Compound + multi-line commands — heavy if ANY segment invokes a heavy runner
+// Compound commands — heavy if ANY segment invokes a heavy runner.
+// Separators are && || ; | only; see the newline section below.
 // ---------------------------------------------------------------------------
-describe("compound and multi-line commands → HEAVY if any segment is", () => {
+describe("compound commands → HEAVY if any segment is", () => {
   it("detects a heavy command chained after cd", () => {
     expectHeavy("cd packages/app && pnpm run build");
-  });
-
-  it("detects a heavy command on the second line", () => {
-    expectHeavy("git fetch origin\npnpm run test:integration");
   });
 
   it("detects a heavy command after a semicolon", () => {
@@ -164,6 +165,54 @@ describe("prose mentioning a heavy command → NOT heavy (false-positive fix)", 
         "EOF",
       ].join("\n")
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Newlines are NOT segment separators (PP-qota).
+//
+// Without a shell parser, splitting on newlines made the classifier descend
+// into heredoc bodies and multi-line quoted arguments: any LINE that BEGAN
+// with a heavy invocation became its own "segment" and fired the (up to
+// five-minute) memory probe. Quoting was never the discriminator — a heredoc
+// line reading "Run pnpm run smoke first" only escaped because it started with
+// "Run". These cover the lines that DO start with a heavy invocation.
+// ---------------------------------------------------------------------------
+describe("newline bodies → NOT heavy (PP-qota)", () => {
+  it("allows a heredoc whose body LINE STARTS with a heavy invocation", () => {
+    expectNotHeavy(
+      ["cat <<EOF > notes.md", "pnpm run build", "EOF"].join("\n")
+    );
+  });
+
+  it("allows a heredoc body line starting with playwright test", () => {
+    expectNotHeavy(
+      [
+        "cat > /tmp/handoff.md <<'EOF'",
+        "playwright test e2e/foo.spec.ts",
+        "vitest run",
+        "EOF",
+      ].join("\n")
+    );
+  });
+
+  it("allows a multi-line quoted argument whose line starts with a heavy invocation", () => {
+    expectNotHeavy('bd comments add PP-x "line1\npnpm run e2e\nline3"');
+  });
+
+  it("allows a multi-line commit message body naming a heavy run", () => {
+    expectNotHeavy(
+      'git commit -m "fix: speed up CI\n\npnpm run build was slow"'
+    );
+  });
+
+  // Accepted cost of dropping the newline split: a GENUINE multi-line sequence
+  // is no longer gated. Correct trade — a missed exotic invocation is cheaper
+  // than a false positive, and agents write this as `cd foo && pnpm run build`,
+  // which still gates (see the compound-commands section).
+  it("accepts the false negative: a real newline-separated heavy sequence", () => {
+    expectNotHeavy("cd packages/app\npnpm run build");
+    expectNotHeavy("git fetch origin\npnpm run test:integration");
   });
 });
 
@@ -240,6 +289,14 @@ describe("hook subprocess — the precheck only runs for real heavy commands", (
 
   it("never reaches the precheck for prose naming a heavy command", () => {
     const { status, stdout } = runHook('echo "how to run pnpm run build"');
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("never reaches the precheck for a heredoc body line starting with a heavy invocation", () => {
+    const { status, stdout } = runHook(
+      ["cat <<EOF > notes.md", "pnpm run build", "EOF"].join("\n")
+    );
     expect(status).toBe(0);
     expect(stdout).toBe("");
   });


### PR DESCRIPTION
Fixes **PP-qota**. Follow-up to #1747.

## The defect

`isHeavyCommand()` in `.claude/hooks/block-heavy-under-pressure.cjs` split the command string on newlines as well as on shell separators:

```js
const segments = String(command || "").split(/&&|\|\||;|\||\r?\n/);
```

With no shell parser behind it, that made the classifier descend into **heredoc bodies and multi-line quoted arguments**. Any *line* that **began** with a heavy invocation became its own "command segment" and fired the memory precheck — which can poll for up to five minutes before letting the command through.

Confirmed on `main` after #1747:

| Command | Was | Should be |
| :-- | :-- | :-- |
| `cat <<EOF > notes.md` / `pnpm run build` / `EOF` | HEAVY | `cat` → not heavy |
| `bd comments add PP-x "line1\npnpm run e2e\nline3"` | HEAVY | `bd` → not heavy |

Quoting was never the discriminator — a heredoc line reading `Run pnpm run smoke first` only escaped because it starts with `Run`. The sole test was whether a line *started* with a heavy invocation. Reported by a session that hit it repeatedly while writing a handoff doc.

## The fix

Segment on `&& || ; |` only. A heredoc then resolves to `cat`, a bd comment to `bd`, and a bare `pnpm run build` / `pnpm exec playwright test` / `vitest run` still resolves heavy.

**Accepted cost, documented in a block comment at the split** so the next reader knows it was deliberate: a genuine multi-line sequence —

```
cd foo
pnpm run build
```

— is no longer gated. That is a false negative, and it is the right trade under the principle the hook already documents at the runner-flag walk: *a missed exotic invocation is cheaper than a false positive*. Agents overwhelmingly write that shape as `cd foo && pnpm run build`, which still gates. The threat model here is a well-meaning agent, not an attacker evading a filter.

## Tests

`src/test/unit/hooks/block-heavy-under-pressure.test.ts`: **36 → 41 tests, all green.**

- One existing case (`detects a heavy command on the second line`) asserted exactly the behavior this PR removes. It is replaced by an explicit `accepts the false negative: a real newline-separated heavy sequence` assertion in the new section, so the trade is pinned by a test rather than silently dropped.
- New `newline bodies → NOT heavy (PP-qota)` block: heredoc body line starting with `pnpm run build`; heredoc body lines starting with `playwright test` / `vitest run`; multi-line quoted `bd comments` argument; multi-line commit-message body.
- New end-to-end subprocess test proving the always-blocking **stub precheck is never reached** for the heredoc case — not just that the classifier returns `false` in isolation.

## Verification

All four cases #1747 fixed still classify correctly (no regression), and genuine invocations still gate:

```
OK  cat <<EOF > notes.md \n pnpm run build \n EOF         -> not heavy  (was HEAVY)
OK  bd comments add PP-x "line1 \n pnpm run e2e \n line3" -> not heavy  (was HEAVY)
OK  echo "how to run pnpm run build"                      -> not heavy
OK  rg "playwright test" docs/                            -> not heavy
OK  git commit -m "speed up vitest run"                   -> not heavy
OK  pnpm run build                                        -> HEAVY
OK  pnpm exec playwright test e2e/x.spec.ts               -> HEAVY
OK  vitest run                                            -> HEAVY
OK  cd packages/app && pnpm run build                     -> HEAVY
OK  echo hi; playwright test x                            -> HEAVY
OK  vitest run | tee out.log                              -> HEAVY
```

`pnpm run check` green (1759 tests). Hook + test change only — no UI, so no screenshots; `preflight` not warranted per AGENTS.md §5.

## Note for review

One residual false positive is **out of scope** and unchanged by this PR: because the splitter is quote-unaware, a separator *inside* a quoted string still splits. E.g. `git commit -m "cd app && pnpm run build"` classifies HEAVY. Fixing that needs quote-aware splitting, which is a bigger change than PP-qota; flagging it rather than silently widening scope. Happy to file a bead if you want it chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
