### PR TITLE
fix(hooks): verify-guard-stack checks registrations exist on disk (PP-ncla)

### DIFF
--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -7,9 +7,16 @@
  * session ran GUARDLESS for ~1.5h before it was caught. Nothing detected it.
  *
  * This canary reads .claude/settings.json at session start and warns (to
- * stderr) if any expected PreToolUse guard hook is missing from the wired
- * command strings, or if permissions.deny / permissions.ask have been
- * stripped. It is PURELY INFORMATIONAL:
+ * stderr) if the guard stack has degraded in EITHER direction:
+ *   - forward:  an expected PreToolUse guard hook is missing from the wired
+ *               command strings (a rewrite dropped a guard);
+ *   - reverse:  a wired command points at a script file that no longer exists
+ *               on disk (a cleanup deleted the file but left the
+ *               registration). A dead registration is silently no-guard: Node
+ *               / bash just fails to load a missing file on every matching
+ *               tool call.
+ * ...or if permissions.deny / permissions.ask have been stripped.
+ * It is PURELY INFORMATIONAL:
  *   - It NEVER blocks anything and NEVER exits non-zero.
  *   - Healthy path prints NOTHING (no session noise).
  *   - Any error (missing/unreadable/malformed settings.json) fails open with
@@ -25,6 +32,9 @@
  * relative to this hook file.
  */
 
+const path = require("node:path");
+const fs = require("node:fs");
+
 // Keep in sync when adding/removing a PreToolUse guard hook.
 const EXPECTED_GUARD_HOOKS = [
   "normalize-workspace-paths.cjs",
@@ -35,38 +45,157 @@ const EXPECTED_GUARD_HOOKS = [
   "block-worktree-dispatch-from-linked.cjs",
 ];
 
-// --- Pure evaluator (unit-testable without fs / exit / printing) -------------
+// --- Registered-script extraction --------------------------------------------
+// Hook `command` values are shell strings. For the reverse check we only need
+// the repo-relative script path they invoke, e.g.
+//   `node .claude/hooks/block-direct-merge.cjs`                    → .claude/hooks/block-direct-merge.cjs
+//   `bash "${CLAUDE_PROJECT_DIR:-.}"/scripts/hooks/huddle-poll.sh` → scripts/hooks/huddle-poll.sh
+//   `HUDDLE_THROTTLE_SECONDS=180 bash "$CLAUDE_PROJECT_DIR"/x.sh`  → x.sh
+//
+// DELIBERATELY CONSERVATIVE: anything we cannot resolve with confidence — an
+// absolute path, a bare binary on $PATH, an inline `node -e '…'` program, a
+// token with unresolved shell expansion or metacharacters — is SKIPPED, not
+// flagged. A missed exotic registration is far cheaper than a canary that
+// cries wolf every session.
+
+const SCRIPT_EXTENSIONS = new Set([".cjs", ".mjs", ".js", ".sh", ".py", ".ts"]);
+// Any of these in a token means shell machinery we won't try to interpret.
+const SHELL_METACHARS = /[(){}[\]|;&<>*?!`\\]/;
+// Flags that hand the rest of the command to an inline program (`node -e '…'`,
+// `bash -c '…'`). A path mentioned INSIDE such a program is a string, not a
+// registration — bail on the whole command rather than flag it.
+const INLINE_PROGRAM_FLAGS = new Set([
+  "-c",
+  "-e",
+  "-p",
+  "--eval",
+  "--print",
+  "--command",
+]);
+
+/**
+ * Extract the repo-relative script path(s) a hook command invokes.
+ * Returns [] when nothing resolvable is present.
+ */
+function extractScriptPaths(command) {
+  const found = [];
+  const rawTokens = String(command || "").split(/\s+/);
+  if (rawTokens.some((t) => INLINE_PROGRAM_FLAGS.has(t.replace(/["']/g, "")))) {
+    return found;
+  }
+
+  for (const rawToken of rawTokens) {
+    if (!rawToken) continue;
+
+    // Drop quoting, then substitute the one variable form our settings use.
+    const token = rawToken
+      .replace(/["']/g, "")
+      .replace(/\$\{CLAUDE_PROJECT_DIR(?::-[^}]*)?\}/g, ".")
+      .replace(/\$CLAUDE_PROJECT_DIR/g, ".");
+
+    if (token.startsWith("-")) continue; // a flag, not a path
+    if (!token.includes("/")) continue; // bare binary name / env assignment
+    if (token.startsWith("/") || token.startsWith("~")) continue; // absolute
+    if (token.includes("$") || SHELL_METACHARS.test(token)) continue; // unresolvable
+    if (!SCRIPT_EXTENSIONS.has(path.posix.extname(token))) continue;
+
+    const normalized = path.posix.normalize(token);
+    if (normalized.startsWith("..")) continue; // escapes the repo root
+    if (!found.includes(normalized)) found.push(normalized);
+  }
+  return found;
+}
+
+/**
+ * Does a repo-relative script path exist on disk?
+ *
+ * Resolves against the same candidate roots as block-heavy-under-pressure.cjs
+ * (CLAUDE_PROJECT_DIR → __dirname-relative → cwd) and counts the script as
+ * present if ANY candidate root has it. Inside a worktree the hook runs from
+ * the worktree's own .claude/hooks/, and CLAUDE_PROJECT_DIR may point at a
+ * different checkout — accepting any root keeps that from reading as a dead
+ * registration.
+ */
+function defaultScriptExists(relPath) {
+  const roots = [
+    process.env.CLAUDE_PROJECT_DIR,
+    path.join(__dirname, "..", ".."),
+    process.cwd(),
+  ].filter(Boolean);
+  return roots.some((root) => {
+    try {
+      return fs.existsSync(path.join(root, relPath));
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Every `command` string wired under one hook-event array. */
+function collectCommands(eventEntries) {
+  const commands = [];
+  if (!Array.isArray(eventEntries)) return commands;
+  for (const entry of eventEntries) {
+    const inner = entry?.hooks;
+    if (!Array.isArray(inner)) continue;
+    for (const h of inner) {
+      if (typeof h?.command === "string") {
+        commands.push(h.command);
+      }
+    }
+  }
+  return commands;
+}
+
+// --- Evaluator (unit-testable; only IO is the on-disk existence probe) -------
 // Given a parsed settings object, return the list of guard-stack problems as
-// human-readable strings. Empty array === healthy. No IO, no printing, no exit.
+// human-readable strings. Empty array === healthy. No printing, no exit.
+//
+// `options.exists` overrides the on-disk probe with a `(relPath) => boolean`
+// predicate, so tests can exercise the reverse check without touching the fs.
 //
 // Problems reported:
 //   - `missing PreToolUse hooks: <basename>, ...` when any EXPECTED_GUARD_HOOKS
 //     basename is absent from every wired PreToolUse command string.
+//   - `registered hooks missing from disk: <path>, ...` when a command wired
+//     under ANY hook event points at a script file that does not exist.
 //   - `permissions.deny empty/absent` / `permissions.ask empty/absent` when
 //     either is not a non-empty array.
-function evaluateGuardStack(settings) {
+function evaluateGuardStack(settings, options = {}) {
   const problems = [];
+  const exists =
+    typeof options.exists === "function" ? options.exists : defaultScriptExists;
 
-  // Collect every wired PreToolUse command string.
-  const preToolUse = settings?.hooks?.PreToolUse;
-  const commands = [];
-  if (Array.isArray(preToolUse)) {
-    for (const entry of preToolUse) {
-      const inner = entry?.hooks;
-      if (!Array.isArray(inner)) continue;
-      for (const h of inner) {
-        if (typeof h?.command === "string") {
-          commands.push(h.command);
-        }
-      }
-    }
-  }
+  // Forward: every expected guard hook must be wired under PreToolUse.
+  const commands = collectCommands(settings?.hooks?.PreToolUse);
 
   const missingHooks = EXPECTED_GUARD_HOOKS.filter(
     (basename) => !commands.some((cmd) => cmd.includes(basename)),
   );
   if (missingHooks.length > 0) {
     problems.push(`missing PreToolUse hooks: ${missingHooks.join(", ")}`);
+  }
+
+  // Reverse: every registered script — under ANY event, not just PreToolUse —
+  // must still exist on disk. A registration pointing at a deleted file is a
+  // guard that silently isn't there.
+  const hooksByEvent = settings?.hooks;
+  const deadRegistrations = [];
+  if (hooksByEvent && typeof hooksByEvent === "object") {
+    for (const eventEntries of Object.values(hooksByEvent)) {
+      for (const command of collectCommands(eventEntries)) {
+        for (const scriptPath of extractScriptPaths(command)) {
+          if (!exists(scriptPath) && !deadRegistrations.includes(scriptPath)) {
+            deadRegistrations.push(scriptPath);
+          }
+        }
+      }
+    }
+  }
+  if (deadRegistrations.length > 0) {
+    problems.push(
+      `registered hooks missing from disk: ${deadRegistrations.join(", ")}`,
+    );
   }
 
   // permissions.deny / permissions.ask must both be present, non-empty arrays.
@@ -84,9 +213,6 @@ function evaluateGuardStack(settings) {
 // settings, call evaluateGuardStack, print one warning line on problems (else
 // silent), and fail open on any error. Always exits 0.
 function main() {
-  const path = require("node:path");
-  const fs = require("node:fs");
-
   // Fail-open helper: a single one-line note, never a stack trace, never
   // non-zero. Collapse any embedded line breaks so it stays one line.
   const skip = (reason) => {
@@ -128,7 +254,7 @@ function main() {
   process.exit(0);
 }
 
-module.exports = { evaluateGuardStack, main };
+module.exports = { evaluateGuardStack, extractScriptPaths, main };
 
 // Only run as a hook when invoked directly (not when require()'d by a test).
 if (require.main === module) {

--- a/src/test/unit/hooks/verify-guard-stack.test.ts
+++ b/src/test/unit/hooks/verify-guard-stack.test.ts
@@ -1,11 +1,15 @@
 // Unit tests for .claude/hooks/verify-guard-stack.cjs — the SessionStart
 // guard-stack integrity canary.
 //
-// Two layers:
-//   1. Fast path — the pure `evaluateGuardStack(settings)` evaluator is
-//      exercised directly with in-memory fixture objects (no fs / exit / IO).
-//   2. Fail-open contract — a couple of subprocess cases spawn `node` on the
-//      hook with VERIFY_GUARD_SETTINGS pointed at a temp fixture, asserting the
+// Three layers:
+//   1. Fast path — `evaluateGuardStack(settings)` is exercised directly with
+//      in-memory fixture objects. Both directions: expected-hook-not-registered
+//      (forward) and registered-script-not-on-disk (reverse). The reverse check
+//      takes an injectable `exists` predicate so it needs no real files.
+//   2. The repo's own .claude/settings.json — asserted healthy in both
+//      directions, so `pnpm run check` goes red on a dead registration.
+//   3. Fail-open contract — a few subprocess cases spawn `node` on the hook
+//      with VERIFY_GUARD_SETTINGS pointed at a temp fixture, asserting the
 //      warn-only guarantee (always exit 0, one-line skip note, no stack trace).
 
 import { spawnSync } from "node:child_process";
@@ -21,8 +25,12 @@ const hookPath = path.resolve(
   process.cwd(),
   ".claude/hooks/verify-guard-stack.cjs"
 );
-const { evaluateGuardStack } = require(hookPath) as {
-  evaluateGuardStack: (settings: unknown) => string[];
+const { evaluateGuardStack, extractScriptPaths } = require(hookPath) as {
+  evaluateGuardStack: (
+    settings: unknown,
+    options?: { exists?: (relPath: string) => boolean }
+  ) => string[];
+  extractScriptPaths: (command: string) => string[];
 };
 
 // ---------------------------------------------------------------------------
@@ -194,6 +202,171 @@ describe("evaluateGuardStack — combinations", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Reverse direction: a registration whose script no longer exists on disk
+// ---------------------------------------------------------------------------
+
+/** Build settings wiring arbitrary command strings under a given hook event. */
+function settingsWithCommands(
+  event: "PostToolUse" | "SessionStart" | "UserPromptSubmit",
+  commands: string[]
+): unknown {
+  return {
+    permissions: { deny: ["Bash(x)"], ask: ["Bash(y)"] },
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: ALL_EXPECTED_HOOKS.map((b) => ({
+            type: "command",
+            command: `node .claude/hooks/${b}`,
+          })),
+        },
+      ],
+      [event]: [
+        { hooks: commands.map((command) => ({ type: "command", command })) },
+      ],
+    },
+  };
+}
+
+describe("extractScriptPaths", () => {
+  it("pulls the script path out of the command shapes settings.json uses", () => {
+    expect(
+      extractScriptPaths("node .claude/hooks/block-direct-merge.cjs")
+    ).toEqual([".claude/hooks/block-direct-merge.cjs"]);
+    expect(
+      extractScriptPaths(
+        'bash "${CLAUDE_PROJECT_DIR:-.}"/scripts/hooks/huddle-poll.sh'
+      )
+    ).toEqual(["scripts/hooks/huddle-poll.sh"]);
+    expect(
+      extractScriptPaths(
+        'HUDDLE_THROTTLE_SECONDS=180 bash "$CLAUDE_PROJECT_DIR"/scripts/hooks/huddle-poll.sh'
+      )
+    ).toEqual(["scripts/hooks/huddle-poll.sh"]);
+  });
+
+  it("skips commands that are not repo-relative script paths", () => {
+    // Inline programs, bare binaries on $PATH, flags, absolute paths, and
+    // unresolved shell expansion all yield nothing rather than a false alarm.
+    for (const command of [
+      `node -e "console.log(1)"`,
+      `bash -c 'echo hi'`,
+      "bd sync --quiet",
+      "echo 'scripts/hooks/nope'",
+      "bash /usr/local/bin/something.sh",
+      "bash ~/dotfiles/thing.sh",
+      'bash "$SOME_OTHER_DIR"/thing.sh',
+      "bash ../outside-the-repo.sh",
+    ]) {
+      expect(extractScriptPaths(command)).toEqual([]);
+    }
+  });
+});
+
+describe("evaluateGuardStack — registered-but-missing-from-disk", () => {
+  it("reports a PreToolUse registration whose script was deleted", () => {
+    // Every expected hook is wired, so the FORWARD check is clean — this is
+    // exactly the blind spot: the registration exists, the file does not.
+    const settings = settingsWithHooks([
+      ...ALL_EXPECTED_HOOKS,
+      "block-drizzle-push.cjs",
+    ]);
+    const problems = evaluateGuardStack(settings, {
+      exists: (relPath) => relPath !== ".claude/hooks/block-drizzle-push.cjs",
+    });
+    expect(problems).toEqual([
+      "registered hooks missing from disk: .claude/hooks/block-drizzle-push.cjs",
+    ]);
+  });
+
+  it("checks registrations under non-PreToolUse events too", () => {
+    const settings = settingsWithCommands("SessionStart", [
+      'bash "${CLAUDE_PROJECT_DIR:-.}"/scripts/hooks/deleted-session-hook.sh',
+    ]);
+    const problems = evaluateGuardStack(settings, {
+      exists: (relPath) => !relPath.includes("deleted-session-hook"),
+    });
+    expect(problems).toEqual([
+      "registered hooks missing from disk: scripts/hooks/deleted-session-hook.sh",
+    ]);
+  });
+
+  it("lists each dead registration once, in wiring order", () => {
+    const settings = settingsWithCommands("PostToolUse", [
+      "node .claude/hooks/gone-a.cjs",
+      'bash "${CLAUDE_PROJECT_DIR:-.}"/scripts/hooks/gone-b.sh',
+      "node .claude/hooks/gone-a.cjs",
+    ]);
+    const problems = evaluateGuardStack(settings, {
+      exists: (relPath) => !relPath.includes("gone-"),
+    });
+    expect(problems).toEqual([
+      "registered hooks missing from disk: .claude/hooks/gone-a.cjs, scripts/hooks/gone-b.sh",
+    ]);
+  });
+
+  it("stays silent when every registration resolves to a real file", () => {
+    // No `exists` override — this hits the real filesystem against the real
+    // repo, and every basename below is a file that exists.
+    const settings = settingsWithCommands("SessionStart", [
+      'bash "${CLAUDE_PROJECT_DIR:-.}"/scripts/hooks/huddle-session-start.sh',
+      "node .claude/hooks/verify-guard-stack.cjs",
+    ]);
+    expect(evaluateGuardStack(settings)).toEqual([]);
+  });
+
+  it("does not flag non-path commands (inline shell, $PATH binaries)", () => {
+    const settings = settingsWithCommands("PostToolUse", [
+      `node -e "process.exit(0)"`,
+      "bd sync --quiet",
+      `bash -c 'echo scripts/hooks/not-a-real-file.sh'`,
+    ]);
+    // Only the real PreToolUse guard files "exist"; anything pulled out of the
+    // three commands above would be reported.
+    expect(
+      evaluateGuardStack(settings, {
+        exists: (relPath) => relPath.startsWith(".claude/hooks/"),
+      })
+    ).toEqual([]);
+  });
+
+  it("reports both directions at once", () => {
+    const remaining = ALL_EXPECTED_HOOKS.filter(
+      (b) => b !== "block-direct-merge.cjs"
+    );
+    const settings = settingsWithHooks([
+      ...remaining,
+      "block-drizzle-push.cjs",
+    ]);
+    const problems = evaluateGuardStack(settings, {
+      exists: (relPath) => relPath !== ".claude/hooks/block-drizzle-push.cjs",
+    });
+    expect(problems).toEqual([
+      "missing PreToolUse hooks: block-direct-merge.cjs",
+      "registered hooks missing from disk: .claude/hooks/block-drizzle-push.cjs",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The real .claude/settings.json — this is the assertion that makes CI red
+// when a hook file is deleted without dropping its registration (or vice
+// versa). Both canary directions, checked against the repo as it actually is.
+// ---------------------------------------------------------------------------
+describe("the repo's own .claude/settings.json", () => {
+  it("has a healthy guard stack in both directions", () => {
+    const settings: unknown = JSON.parse(
+      fs.readFileSync(
+        path.resolve(process.cwd(), ".claude/settings.json"),
+        "utf8"
+      )
+    );
+    expect(evaluateGuardStack(settings)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Fail-open contract: subprocess execution of the hook (warn-only guarantee)
 // ---------------------------------------------------------------------------
 const tmpFiles: string[] = [];
@@ -301,5 +474,25 @@ describe("verify-guard-stack.cjs subprocess — fail-open contract", () => {
     expect(stderr).toContain("GUARD STACK DEGRADED");
     expect(stderr).toContain("block-direct-merge.cjs");
     expect(stderr).toContain("permissions.deny empty/absent");
+  });
+
+  it("dead registration → exit 0 (warn-only) naming the missing script", () => {
+    // Forward check clean, file gone: the failure mode this canary used to miss.
+    const file = writeTmp(
+      "settings.json",
+      JSON.stringify(
+        settingsWithHooks([...ALL_EXPECTED_HOOKS, "deleted-guard-fixture.cjs"]),
+        null,
+        2
+      )
+    );
+    const { status, stdout, stderr } = runHook(file);
+    expect(status).toBe(0); // never blocks
+    expect(stdout).toBe("");
+    expect(stderr).toContain("GUARD STACK DEGRADED");
+    expect(stderr).toContain(
+      "registered hooks missing from disk: .claude/hooks/deleted-guard-fixture.cjs"
+    );
+    expect(stderr).not.toContain("missing PreToolUse hooks");
   });
 });


### PR DESCRIPTION
Fixes **PP-ncla**.

## The defect

`.claude/hooks/verify-guard-stack.cjs` checked the guard stack in exactly one direction:

```js
const missingHooks = EXPECTED_GUARD_HOOKS.filter(
  (basename) => !commands.some((cmd) => cmd.includes(basename)),
);
```

That asserts every *expected* hook **is registered** in `.claude/settings.json`. It never asserted the converse — that every *registered* hook **still exists on disk**.

A registration pointing at a deleted file is silently dead. Node/bash just fail to load a missing file on every matching tool call, and the guard that entry was supposed to provide is simply absent. CI stayed green; nothing complained. The irony: this canary exists *because* a 2026-07-05 settings.json rewrite silently deleted the whole guard stack — and it missed the mirror-image failure.

## The fix

Adds the reverse check. For every command wired under **any** hook event (not just `PreToolUse` — `SessionStart`, `PostToolUse`, `WorktreeCreate`… all register scripts too), resolve the script path it points at and report it when the file is gone:

```
⚠️  GUARD STACK DEGRADED — registered hooks missing from disk: .claude/hooks/foo.cjs. …
```

**Path extraction is deliberately conservative.** A token is only treated as a registration when it is an unambiguous repo-relative script path with a known script extension. Skipped rather than flagged:

- absolute paths (`/usr/local/bin/x.sh`, `~/x.sh`)
- bare binaries on `$PATH` (`bd sync`)
- unresolved shell expansion (`"$SOME_OTHER_DIR"/x.sh`) and tokens with shell metacharacters
- inline programs — any command containing `-c` / `-e` / `--eval` etc., so a path *mentioned inside* `bash -c '…'` is not mistaken for a registration
- paths escaping the repo root

A missed exotic registration is far cheaper than a canary that cries wolf every session.

`${CLAUDE_PROJECT_DIR:-.}` (the form settings.json actually uses) is substituted, and existence resolves against the same candidate roots as `block-heavy-under-pressure.cjs` — `CLAUDE_PROJECT_DIR` → `__dirname`-relative → cwd, present under *any* root counts — so it behaves correctly inside worktrees, where hooks execute from the worktree's own `.claude/hooks/`.

The forward check and the `permissions.deny` / `permissions.ask` checks are untouched. **Fail-open posture is unchanged**: still warn-only, still `exit 0` always, still silent when healthy, still a one-line skip note on unreadable/malformed settings.

## What makes CI catch it

The hook itself is a warn-only SessionStart canary, so the enforcement teeth are in the test: `verify-guard-stack.test.ts` now loads the repo's real `.claude/settings.json` and asserts `evaluateGuardStack` returns no problems. A dead registration (or a dropped guard) turns `pnpm run check` red.

## Tests

Extends the existing `src/test/unit/hooks/verify-guard-stack.test.ts` (24 tests, all green):

- registration pointing at a nonexistent script → reported (with the forward check clean — the exact blind spot)
- non-`PreToolUse` events checked too; duplicates listed once, in wiring order
- all registrations valid → silent (this one hits the real filesystem)
- non-path commands (inline shell, `$PATH` binaries) → skipped, not flagged
- both directions reported together
- `extractScriptPaths` unit-covered on every command shape settings.json uses, plus the skip cases
- subprocess case: dead registration → exit 0, warning names the missing script

## Current state of `main`

**No dead registrations today.** All 19 hook commands across the 6 events resolve to files that exist. Verified by running the new evaluator against `.claude/settings.json` at `origin/main`, and by scanning the history — no settings.json commit ever registered `block-drizzle-push.cjs` or `block-loopback-literal.cjs` (the deletions in #1738 landed with their registrations already removed). So this is a guard against recurrence, not a fix for a live hole.

**Known scope limit (unchanged):** the canary only reads the tracked `.claude/settings.json`. Hooks registered in an untracked `.claude/settings.local.json` are outside its view, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
