### PR TITLE
fix(scripts): close three prod-safety gaps in the DB scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ How Tim wants agents to behave. (§1 has the one-line version; this is the detai
 ### Vercel
 
 - Vercel runs `pnpm run migrate:production` on build (production only).
-- Stuck migration fix: `POSTGRES_URL=<prod_url> tsx scripts/mark-migration-applied.ts <n>`.
+- Stuck migration fix: `MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<prod_url> tsx scripts/mark-migration-applied.ts <n>`. The token is required — the script refuses a remote target without it, and prompts once more when run in a TTY. It writes to `drizzle.__drizzle_migrations` without running the migration, so a wrong number makes prod's schema diverge from history permanently.
 
 ### Preview deployments (on-demand, TTL'd Supabase branches)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -161,11 +161,19 @@ For preview and production, we use **Automated Migrations** via Vercel build hoo
 
    ```bash
    # 1. Identify the failed migration number from Vercel build logs
-   # 2. Mark it as applied (replace 0001 with actual migration number):
-   POSTGRES_URL=<production-url> tsx scripts/mark-migration-applied.ts 0001
+   # 2. Mark it as applied (replace 0001 with actual migration number).
+   #    MARK_MIGRATION_FORCE_PRODUCTION=1 is required against a remote database:
+   #    the script refuses without it, and prompts once more when run in a TTY.
+   MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<production-url> \
+     tsx scripts/mark-migration-applied.ts 0001
 
    # 3. Trigger a redeployment (push a trivial change or use Vercel UI)
    ```
+
+   This records the migration as applied **without running its SQL**. Marking the
+   wrong number makes every future `migrate:production` skip a migration that
+   never ran, so prod's schema diverges from the migration history permanently —
+   double-check the number before you set the token.
 
    **Prevention:** Always use the automated migration system. Avoid manually running migrations in production/preview unless absolutely necessary.
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,6 +1,7 @@
 import { loadEnvConfig } from "@next/env";
 import { defineConfig } from "drizzle-kit";
 
+import { isCloudDatabaseUrl } from "./scripts/lib/db-target.mjs";
 import { assertNotDrizzlePush } from "./scripts/lib/drizzle-push-guard";
 
 // Safety: `drizzle-kit push` is banned (CORE-ARCH-009). This runs FIRST — before
@@ -50,11 +51,10 @@ if (!directUrl) {
   );
 }
 
-// Safety: prevent drizzle-kit from accidentally running against production
-const isProductionUrl = /supabase\.com|neon\.tech|rds\.amazonaws\.com/.test(
-  directUrl
-);
-if (isProductionUrl && !process.env.DRIZZLE_FORCE_PRODUCTION) {
+// Safety: prevent drizzle-kit from accidentally running against production.
+// The host match lives in scripts/lib/db-target.mjs so drizzle-kit and
+// scripts/mark-migration-applied.ts share one copy of it.
+if (isCloudDatabaseUrl(directUrl) && !process.env.DRIZZLE_FORCE_PRODUCTION) {
   throw new Error(
     `SAFETY: drizzle-kit would run against a production database!\n` +
       `   URL: ${directUrl.replace(/:[^:@]+@/, ":***@")}\n` +

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -49,6 +49,25 @@ if supabase db dump --data-only --schema public > "$BACKUP_FILE"; then
     # Show file size
     DU_OUT=$(du -h "$BACKUP_FILE" | cut -f1)
     echo -e "${BLUE}📊 Size: $DU_OUT${NC}"
+
+    # Residual-risk notice. This script REQUIRES the ambient `supabase link`
+    # state (it reads supabase/.temp/project-ref above and `supabase db dump`
+    # resolves the linked project + its stored DB password), so it deliberately
+    # does NOT unlink afterwards — that would turn one-time setup into a
+    # per-backup step and break the next `pnpm run db:backup`.
+    #
+    # Scope of the risk, stated precisely so nobody over- or under-reacts:
+    # a bare `supabase db reset` is LOCAL-only (verified against CLI 2.109.1 —
+    # remote requires an explicit `--linked` or `--db-url`). What DOES default
+    # to the linked project from this directory is `db dump`, `db push`,
+    # `db pull`, `migration up --linked`, `db reset --linked`, and `secrets`.
+    echo ""
+    echo -e "${YELLOW}⚠️  This directory is still linked to PRODUCTION ($PROD_REF).${NC}"
+    echo -e "${YELLOW}   Supabase CLI commands that default to the linked project —${NC}"
+    echo -e "${YELLOW}   db dump / db push / db pull / migration up --linked /${NC}"
+    echo -e "${YELLOW}   db reset --linked / secrets — will target prod from here.${NC}"
+    echo -e "${YELLOW}   (A bare 'supabase db reset' is local-only and is NOT affected.)${NC}"
+    echo -e "${BLUE}   Drop the link when you're done: supabase unlink${NC}"
 else
     echo -e "\033[0;31m❌ Backup failed!${NC}"
     # Remove empty or partial file

--- a/scripts/lib/db-target.mjs
+++ b/scripts/lib/db-target.mjs
@@ -1,0 +1,107 @@
+/**
+ * "Which database is this URL pointing at?" — the single home for that question.
+ *
+ * Two DIFFERENT questions live here; they are not interchangeable and the
+ * distinction is load-bearing:
+ *
+ *   isCloudDatabaseUrl()  — "is this ANY managed cloud Postgres?" A coarse host
+ *     match. It is true for PinPoint production AND for every ephemeral Supabase
+ *     preview branch, because they share the `*.pooler.supabase.com` host shape.
+ *     Use it where the cost of a false positive is a one-line env opt-in typed
+ *     by a human (drizzle-kit, mark-migration-applied) — never for something a
+ *     CI pipeline runs unattended, or you just teach CI to set the escape hatch.
+ *
+ *   isPinPointProductionTarget() — "is this THE production project?" Matches the
+ *     one and only prod project ref, which appears in every spelling of a
+ *     connection to it: the Supavisor username (`postgres.<ref>`), the direct
+ *     host (`db.<ref>.supabase.co`), and the Supabase API URL
+ *     (`https://<ref>.supabase.co`). Preview branches have their own refs, so
+ *     this is false for them — which is what makes it safe to enforce with NO
+ *     escape hatch on the remote-capable seed scripts.
+ *
+ * The API-URL case is exactly why the coarse regex is not sufficient on its own:
+ * `https://<ref>.supabase.co` does not contain the string "supabase.com".
+ */
+
+/**
+ * PinPoint's production Supabase project ref. There is exactly one project in
+ * the org, holding live member data with PITR disabled — the recovery floor is
+ * the previous nightly backup. Also hardcoded in scripts/backup-production.sh.
+ */
+export const PRODUCTION_PROJECT_REF = "udhesuizjsgxfeotqybn";
+
+/**
+ * Managed-Postgres host shapes. Extracted verbatim from drizzle.config.ts so
+ * there is one copy of this regex rather than a third divergent one.
+ */
+const CLOUD_HOST_PATTERN = /supabase\.com|neon\.tech|rds\.amazonaws\.com/;
+
+/**
+ * Is this connection string pointed at a managed cloud database (as opposed to
+ * a local Supabase stack)? True for preview branches too — see the module note.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isCloudDatabaseUrl(url) {
+  return CLOUD_HOST_PATTERN.test(url);
+}
+
+/**
+ * Is this value — a Postgres connection string OR a Supabase API URL — pointed
+ * at PinPoint production?
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isPinPointProductionTarget(value) {
+  return value.includes(PRODUCTION_PROJECT_REF);
+}
+
+/**
+ * A safe-to-print description of a connection target: host, port, and database
+ * name, with any credentials dropped. Falls back to a credential-redacted copy
+ * of the raw string when the value does not parse as a URL.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function describeTarget(value) {
+  try {
+    const parsed = new URL(value);
+    const port = parsed.port ? `:${parsed.port}` : "";
+    return `${parsed.hostname}${port}${parsed.pathname}`;
+  } catch {
+    return value.replace(/:\/\/[^@]+@/, "://***@");
+  }
+}
+
+/**
+ * Refuse to continue when `value` targets PinPoint production.
+ *
+ * There is deliberately NO escape hatch: every caller is a seed script whose
+ * whole job is writing demo content (fake users with published passwords, demo
+ * collections, a dev Discord bot token). None of that has any business in a
+ * database holding real member data, so "I meant it" is never a valid answer.
+ *
+ * Exits with status 2, matching assert-local-db.mjs.
+ *
+ * @param {string | undefined} value the connection string or API URL to check
+ * @param {string} envVarName the env var it came from, for the message
+ * @returns {void}
+ */
+export function assertNotPinPointProduction(value, envVarName) {
+  if (value === undefined || !isPinPointProductionTarget(value)) return;
+
+  console.error(
+    `❌ Refusing to run a seed script against PinPoint PRODUCTION.\n` +
+      `   ${envVarName} resolves to project ${PRODUCTION_PROJECT_REF} (${describeTarget(value)}).\n` +
+      `   Seed scripts write demo data — fake users with published passwords, demo\n` +
+      `   collections, dev tokens — into whatever they are pointed at. Production\n` +
+      `   holds real member data and has PITR disabled, so the recovery floor is\n` +
+      `   last night's backup.\n` +
+      `   There is no override. Point ${envVarName} at your local stack (or a\n` +
+      `   preview branch) and re-run.`
+  );
+  process.exit(2);
+}

--- a/scripts/mark-migration-applied.ts
+++ b/scripts/mark-migration-applied.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env tsx
 import postgres from "postgres";
+import { createInterface } from "node:readline/promises";
 import { readFileSync } from "fs";
 import { join } from "path";
+
+import { describeTarget, isCloudDatabaseUrl } from "./lib/db-target.mjs";
 
 interface MigrationEntry {
   idx: number;
@@ -22,11 +25,21 @@ interface MigrationJournal {
  * without actually running it. Use this when a migration was manually
  * applied before the auto-migration system was in place.
  *
- * Usage:
+ * Usage (local):
  *   POSTGRES_URL=<url> tsx scripts/mark-migration-applied.ts <migration-number>
  *
- * Example:
- *   POSTGRES_URL=postgres://... tsx scripts/mark-migration-applied.ts 0001
+ * Usage (production — the documented stuck-migration recovery path, AGENTS.md
+ * §7). This script stays prod-capable on purpose, so it takes an explicit
+ * opt-in token rather than a hard refusal:
+ *   MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<prod_url> \
+ *     tsx scripts/mark-migration-applied.ts <migration-number>
+ *
+ * Why the gate exists: this INSERTs straight into drizzle.__drizzle_migrations.
+ * Marking the WRONG number makes drizzle believe a migration ran when it did
+ * not, so the next `migrate:production` silently skips it and prod's schema
+ * diverges from the migration history permanently. That is slow-burn
+ * corruption — nightly backups do not catch it, because nothing looks broken
+ * until a later migration fails on a missing column.
  */
 
 const migrationNumber = process.argv[2];
@@ -65,6 +78,54 @@ if (!connectionString) {
     "❌ No database connection string found (checked POSTGRES_URL_NON_POOLING, POSTGRES_URL)"
   );
   process.exit(1);
+}
+
+// Production gate. Mirrors drizzle.config.ts's DRIZZLE_FORCE_PRODUCTION idiom
+// (same host match, same "set the token to mean it" shape) so there is one
+// convention here, not two. Runs BEFORE the client is constructed so a refusal
+// never opens a connection to prod. Not reachable from `vercel-build`, which
+// runs `migrate:production` only.
+const isProductionTarget = isCloudDatabaseUrl(connectionString);
+const forceProduction = Boolean(process.env["MARK_MIGRATION_FORCE_PRODUCTION"]);
+
+if (isProductionTarget && !forceProduction) {
+  console.error(
+    `❌ Refusing to write to drizzle.__drizzle_migrations on a remote database.\n` +
+      `   Target: ${describeTarget(connectionString)}\n` +
+      `   Migration: ${migrationNumber}\n\n` +
+      `   Marking a migration applied without running it makes future\n` +
+      `   \`migrate:production\` runs SKIP it — prod's schema then diverges from\n` +
+      `   the migration history permanently, and nightly backups do not catch it.\n\n` +
+      `   This IS the documented stuck-migration recovery path (AGENTS.md §7).\n` +
+      `   To proceed intentionally, re-run with:\n` +
+      `     MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<url> tsx scripts/mark-migration-applied.ts ${migrationNumber}`
+  );
+  process.exit(1);
+}
+
+/**
+ * Last-chance interactive confirm, shown only when a human is actually at the
+ * terminal. Non-TTY callers (CI, `| tee`, a wrapper script) never reach the
+ * prompt — the env token above is their whole gate — so this can never hang a
+ * pipeline.
+ */
+async function confirmProductionWrite(tag: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return true;
+
+  console.log(`\n⚠️  About to mark a migration applied on a REMOTE database.`);
+  console.log(`   Target:    ${describeTarget(connectionString ?? "")}`);
+  console.log(`   Migration: ${tag}`);
+  console.log(
+    `   This records the migration as done WITHOUT running its SQL.\n`
+  );
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question("   Continue? (y/N) ");
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
 }
 
 // `prepare: false`: REQUIRED if this ever connects over the `:6543` transaction
@@ -113,6 +174,14 @@ async function main() {
       if (firstMigration && "created_at" in firstMigration) {
         console.log(`   Applied at: ${firstMigration["created_at"]}`);
       }
+      return;
+    }
+
+    if (
+      isProductionTarget &&
+      !(await confirmProductionWrite(migrationEntry.tag))
+    ) {
+      console.log("🚫 Aborted — nothing was written.");
       return;
     }
 

--- a/scripts/migrate-production.ts
+++ b/scripts/migrate-production.ts
@@ -148,12 +148,14 @@ async function main() {
           "   1. Identify which migration failed (check error above)"
         );
         console.error(
-          "   2. Run: POSTGRES_URL=<url> tsx scripts/mark-migration-applied.ts <number>"
+          "   2. Run: MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<url> \\"
         );
-        console.error("   3. Redeploy to retry migrations");
+        console.error("        tsx scripts/mark-migration-applied.ts <number>");
         console.error(
-          "\n   Example: tsx scripts/mark-migration-applied.ts 0001"
+          "      (the token is required against a remote DB — the script refuses"
         );
+        console.error("       without it, and prompts once when run in a TTY)");
+        console.error("   3. Redeploy to retry migrations");
       }
     } else {
       console.error(error);

--- a/scripts/reset-preview-db.mjs
+++ b/scripts/reset-preview-db.mjs
@@ -1,3 +1,4 @@
+import { assertNotPinPointProduction } from "./lib/db-target.mjs";
 import { createScriptClient } from "./lib/pg-client.mjs";
 
 // Use POSTGRES_URL (transaction pooler, :6543, IPv4) — NOT POSTGRES_URL_NON_POOLING
@@ -9,11 +10,17 @@ if (!databaseUrl) {
   process.exit(1);
 }
 
-// Production safety guard. This script DROPs schemas and DELETEs auth users, so
-// it must never touch the production project. The preview workflows pass the
+// Production safety guard, layer 1 (unconditional). This script DROPs schemas
+// and DELETEs auth users, so it must never touch the production project — and
+// the PROD_PROJECT_REF check below only fires when the caller supplies that var,
+// which a hand-run `node scripts/reset-preview-db.mjs` does not.
+assertNotPinPointProduction(databaseUrl, "POSTGRES_URL");
+
+// Layer 2: whatever ref the caller declared. The preview workflows pass the
 // production project ref as PROD_PROJECT_REF (= SUPABASE_PROJECT_ID); a real
-// preview branch connects as postgres.<branch-ref>, so the prod ref must NOT
-// appear anywhere in the branch connection string.
+// preview branch connects as postgres.<branch-ref>, so the declared ref must NOT
+// appear anywhere in the branch connection string. Kept alongside layer 1 so the
+// workflows stay authoritative about their own target even if the ref changes.
 const prodRef = process.env.PROD_PROJECT_REF;
 if (prodRef && databaseUrl.includes(prodRef)) {
   console.error(

--- a/scripts/workflow/preview/preview-migrate-seed.sh
+++ b/scripts/workflow/preview/preview-migrate-seed.sh
@@ -84,7 +84,11 @@ SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY" \
 echo "::endgroup::"
 
 # PR-specific demo seeds go below this line (run only if their script exists, so
-# this stays a no-op on branches that don't carry them). Example for PR #1388:
+# this stays a no-op on branches that don't carry them). A seed added here must
+# be REMOTE-CAPABLE: the demo seeds that call `assertLocalDatabase`
+# (seed-collections, seed-machine-settings) exit 2 against a branch DB. Swap
+# their guard for `assertNotPinPointProduction` (scripts/lib/db-target.mjs)
+# before wiring one in. Example for PR #1388:
 #   [[ -f supabase/seed-machine-settings.mjs ]] && {
 #     echo "::group::Seed machine settings demo"
 #     node supabase/seed-machine-settings.mjs

--- a/src/test/unit/scripts/db-target-guards.test.ts
+++ b/src/test/unit/scripts/db-target-guards.test.ts
@@ -1,0 +1,363 @@
+// Regression tests for the prod-safety guards on the DB scripts.
+//
+// Two layers, deliberately:
+//   1. Pure-predicate tests against scripts/lib/db-target.mjs — fast, and they
+//      pin the ONE distinction that makes the design work (a Supabase preview
+//      branch is a cloud host but is NOT the production project).
+//   2. Real subprocess runs of the guarded scripts — spawnSync + exit codes,
+//      matching src/test/unit/hooks/*.test.ts. A guard that is exported but
+//      never actually invoked is the exact failure mode these catch, and only a
+//      real run proves the call site exists AND fires before any connection.
+//
+// The "passes the guard" cases point at localhost:1, where the socket is
+// refused instantly — so the assertion is "it got far enough to try to
+// connect", with no waiting on a timeout and no live database required.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  describeTarget,
+  isCloudDatabaseUrl,
+  isPinPointProductionTarget,
+  PRODUCTION_PROJECT_REF,
+} from "../../../../scripts/lib/db-target.mjs";
+
+const repoRoot = process.cwd();
+
+// Shapes taken from the real endpoints (AGENTS.md §7 / pinpoint-db-connections).
+const PROD_POOLER_URL = `postgres://postgres.${PRODUCTION_PROJECT_REF}:pw@aws-0-us-east-2.pooler.supabase.com:6543/postgres`;
+const PROD_DIRECT_URL = `postgres://postgres:pw@db.${PRODUCTION_PROJECT_REF}.supabase.co:5432/postgres`;
+const PROD_API_URL = `https://${PRODUCTION_PROJECT_REF}.supabase.co`;
+const PREVIEW_POOLER_URL =
+  "postgres://postgres.abcdefghijklmnopqrst:pw@aws-0-us-east-2.pooler.supabase.com:6543/postgres";
+const PREVIEW_API_URL = "https://abcdefghijklmnopqrst.supabase.co";
+// Deliberately port 1: local, so it passes the guard, and instantly refused.
+const LOCAL_URL = "postgres://postgres:pw@localhost:1/postgres";
+const LOCAL_API_URL = "http://localhost:54321";
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runScript(
+  relPath: string,
+  env: Record<string, string>,
+  argv: string[] = []
+): RunResult {
+  const result = spawnSync("node", [path.join(repoRoot, relPath), ...argv], {
+    encoding: "utf8",
+    cwd: repoRoot,
+    // Start from a clean slate so an ambient POSTGRES_URL from .env.local (or
+    // vitest's env passthrough) cannot decide the outcome of these assertions.
+    env: { NODE_ENV: "test", PATH: process.env.PATH ?? "", ...env },
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runTsxScript(
+  relPath: string,
+  env: Record<string, string>,
+  argv: string[] = []
+): RunResult {
+  const tsx = path.join(repoRoot, "node_modules", ".bin", "tsx");
+  const result = spawnSync(tsx, [path.join(repoRoot, relPath), ...argv], {
+    encoding: "utf8",
+    cwd: repoRoot,
+    env: { NODE_ENV: "test", PATH: process.env.PATH ?? "", ...env },
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("db-target — isCloudDatabaseUrl (coarse host match)", () => {
+  it("is true for the production pooler", () => {
+    expect(isCloudDatabaseUrl(PROD_POOLER_URL)).toBe(true);
+  });
+
+  it("is true for a preview branch pooler — same host shape as prod", () => {
+    // This is precisely why it cannot be the seed-script guard: the preview
+    // pipeline would trip it on every run.
+    expect(isCloudDatabaseUrl(PREVIEW_POOLER_URL)).toBe(true);
+  });
+
+  it("is true for the other managed hosts drizzle.config.ts listed", () => {
+    expect(isCloudDatabaseUrl("postgres://u:p@x.neon.tech/db")).toBe(true);
+    expect(isCloudDatabaseUrl("postgres://u:p@x.rds.amazonaws.com/db")).toBe(
+      true
+    );
+  });
+
+  it("is false for a local stack", () => {
+    expect(
+      isCloudDatabaseUrl(
+        "postgres://postgres:postgres@localhost:54322/postgres"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("db-target — isPinPointProductionTarget (exact project)", () => {
+  it("matches every spelling of a production connection", () => {
+    expect(isPinPointProductionTarget(PROD_POOLER_URL)).toBe(true);
+    expect(isPinPointProductionTarget(PROD_DIRECT_URL)).toBe(true);
+    // The API URL is the case the host regex misses entirely: ".supabase.co"
+    // does not contain the substring "supabase.com".
+    expect(isCloudDatabaseUrl(PROD_API_URL)).toBe(false);
+    expect(isPinPointProductionTarget(PROD_API_URL)).toBe(true);
+  });
+
+  it("does NOT match a preview branch — the whole point", () => {
+    expect(isPinPointProductionTarget(PREVIEW_POOLER_URL)).toBe(false);
+    expect(isPinPointProductionTarget(PREVIEW_API_URL)).toBe(false);
+  });
+
+  it("does not match a local stack", () => {
+    expect(isPinPointProductionTarget(LOCAL_URL)).toBe(false);
+  });
+});
+
+describe("db-target — describeTarget never leaks credentials", () => {
+  it("drops the password from a connection string", () => {
+    expect(describeTarget(PROD_POOLER_URL)).not.toContain("pw");
+    expect(describeTarget(PROD_POOLER_URL)).toContain(
+      "aws-0-us-east-2.pooler.supabase.com:6543"
+    );
+  });
+
+  it("redacts credentials even when the value does not parse as a URL", () => {
+    expect(describeTarget("not a url://user:secret@host/db")).not.toContain(
+      "secret"
+    );
+  });
+});
+
+describe("seed scripts — local-only demo seeds refuse remote targets", () => {
+  for (const script of [
+    "supabase/seed-collections.mjs",
+    "supabase/seed-machine-settings.mjs",
+  ]) {
+    it(`${script} refuses a production URL`, () => {
+      const { status, stderr } = runScript(script, {
+        POSTGRES_URL: PROD_POOLER_URL,
+      });
+      expect(status).toBe(2);
+      expect(stderr).toContain("Refusing to run destructive DB script");
+    });
+
+    it(`${script} refuses a preview-branch URL too (loopback allowlist)`, () => {
+      const { status } = runScript(script, {
+        POSTGRES_URL: PREVIEW_POOLER_URL,
+      });
+      expect(status).toBe(2);
+    });
+
+    it(`${script} lets a localhost URL through to the connection attempt`, () => {
+      const { status, stderr } = runScript(script, { POSTGRES_URL: LOCAL_URL });
+      expect(stderr).not.toContain("Refusing to run destructive DB script");
+      // Got past the guard and failed on the socket instead.
+      expect(stderr).toContain("ECONNREFUSED");
+      expect(status).not.toBe(2);
+    });
+  }
+});
+
+describe("seed scripts — remote-capable seeds refuse production only", () => {
+  for (const script of [
+    "supabase/seed-discord.mjs",
+    "supabase/seed-pinballmap-catalog.mjs",
+  ]) {
+    it(`${script} refuses the production project`, () => {
+      const { status, stderr } = runScript(script, {
+        POSTGRES_URL: PROD_POOLER_URL,
+        // seed-discord no-ops without a token; set one so the guard is what
+        // decides the exit, not the early "nothing to do" return.
+        DISCORD_BOT_TOKEN: "fake-token-for-test",
+      });
+      expect(status).toBe(2);
+      expect(stderr).toContain("PinPoint PRODUCTION");
+      expect(stderr).toContain("There is no override");
+    });
+
+    it(`${script} allows a preview-branch URL (preview pipeline must keep working)`, () => {
+      const { stderr } = runScript(script, {
+        POSTGRES_URL: PREVIEW_POOLER_URL,
+        DISCORD_BOT_TOKEN: "fake-token-for-test",
+      });
+      expect(stderr).not.toContain("PinPoint PRODUCTION");
+    });
+
+    it(`${script} allows a localhost URL through to the connection attempt`, () => {
+      const { stderr } = runScript(script, {
+        POSTGRES_URL: LOCAL_URL,
+        DISCORD_BOT_TOKEN: "fake-token-for-test",
+      });
+      expect(stderr).not.toContain("PinPoint PRODUCTION");
+      // These two catch their own connection error and print a bare "seed
+      // failed" line, so assert on that rather than on ECONNREFUSED: either way
+      // the run got past the guard and reached the database.
+      expect(stderr).toMatch(/seed failed/i);
+    });
+  }
+});
+
+describe("reset-preview-db.mjs — destructive, so guarded unconditionally", () => {
+  const script = "scripts/reset-preview-db.mjs";
+
+  it("refuses production even when PROD_PROJECT_REF is unset", () => {
+    // The pre-existing guard only fires when the caller supplies
+    // PROD_PROJECT_REF — which the preview workflows do and a hand-run does
+    // not. This script DROPs schemas and DELETEs auth.users.
+    const { status, stderr } = runScript(script, {
+      POSTGRES_URL: PROD_POOLER_URL,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("PinPoint PRODUCTION");
+  });
+
+  it("still honours the caller-declared PROD_PROJECT_REF", () => {
+    const { status, stderr } = runScript(script, {
+      POSTGRES_URL: PREVIEW_POOLER_URL,
+      PROD_PROJECT_REF: "abcdefghijklmnopqrst",
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain("references the production project");
+  });
+
+  it("allows an ordinary preview branch", () => {
+    const { stderr } = runScript(script, {
+      POSTGRES_URL: PREVIEW_POOLER_URL,
+    });
+    expect(stderr).not.toContain("PinPoint PRODUCTION");
+    expect(stderr).not.toContain("references the production project");
+  });
+});
+
+describe("seed-users.mjs — guards BOTH write endpoints", () => {
+  const baseEnv = {
+    SUPABASE_SERVICE_ROLE_KEY: "fake-service-role-key",
+  };
+
+  it("refuses when NEXT_PUBLIC_SUPABASE_URL is production, even with a local POSTGRES_URL", () => {
+    // The Admin API path (`supabase.auth.admin.createUser`) is driven by the
+    // API URL, NOT by POSTGRES_URL — guarding only the latter would still let
+    // admin@test.com et al. be created in production auth.
+    const { status, stderr } = runScript("supabase/seed-users.mjs", {
+      ...baseEnv,
+      NEXT_PUBLIC_SUPABASE_URL: PROD_API_URL,
+      POSTGRES_URL: LOCAL_URL,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("NEXT_PUBLIC_SUPABASE_URL");
+    expect(stderr).toContain("PinPoint PRODUCTION");
+  });
+
+  it("refuses when POSTGRES_URL is production, even with a local API URL", () => {
+    const { status, stderr } = runScript("supabase/seed-users.mjs", {
+      ...baseEnv,
+      NEXT_PUBLIC_SUPABASE_URL: LOCAL_API_URL,
+      POSTGRES_URL: PROD_POOLER_URL,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("POSTGRES_URL");
+    expect(stderr).toContain("PinPoint PRODUCTION");
+  });
+
+  it("allows a preview branch on both endpoints (preview pipeline)", () => {
+    const { stderr } = runScript("supabase/seed-users.mjs", {
+      ...baseEnv,
+      NEXT_PUBLIC_SUPABASE_URL: PREVIEW_API_URL,
+      POSTGRES_URL: PREVIEW_POOLER_URL,
+    });
+    expect(stderr).not.toContain("PinPoint PRODUCTION");
+  });
+
+  it("allows a fully local target", () => {
+    const { stderr } = runScript("supabase/seed-users.mjs", {
+      ...baseEnv,
+      NEXT_PUBLIC_SUPABASE_URL: LOCAL_API_URL,
+      POSTGRES_URL: LOCAL_URL,
+    });
+    expect(stderr).not.toContain("PinPoint PRODUCTION");
+  });
+});
+
+describe("mark-migration-applied.ts — production confirmation gate", () => {
+  const script = "scripts/mark-migration-applied.ts";
+
+  it("refuses a remote target with no opt-in token", () => {
+    const { status, stderr } = runTsxScript(
+      script,
+      { POSTGRES_URL: PROD_POOLER_URL },
+      ["0001"]
+    );
+    expect(status).toBe(1);
+    expect(stderr).toContain(
+      "Refusing to write to drizzle.__drizzle_migrations"
+    );
+    // The refusal has to name the token, or an operator mid-incident is stuck.
+    expect(stderr).toContain("MARK_MIGRATION_FORCE_PRODUCTION=1");
+    // …and it must not print the password.
+    expect(stderr).not.toContain(":pw@");
+  });
+
+  it("names the migration it was asked about", () => {
+    const { stderr } = runTsxScript(script, { POSTGRES_URL: PROD_POOLER_URL }, [
+      "0042",
+    ]);
+    expect(stderr).toContain("0042");
+  });
+
+  it("permits the prod path once the token is set, without hanging on a non-TTY", () => {
+    // spawnSync gives the child a pipe, not a TTY, so the interactive confirm
+    // must be skipped entirely — otherwise this test would time out, which is
+    // exactly the CI-hang regression it guards against.
+    const { status, stderr } = runTsxScript(
+      script,
+      {
+        POSTGRES_URL: PROD_POOLER_URL,
+        MARK_MIGRATION_FORCE_PRODUCTION: "1",
+      },
+      ["0001"]
+    );
+    expect(stderr).not.toContain("Refusing to write");
+    // Past the gate; it now fails on the (unreachable, fake-credential)
+    // connection rather than on the guard.
+    expect(status).toBe(1);
+    expect(stderr).toContain("Failed to mark migration as applied");
+  });
+
+  it("does not gate a localhost target at all", () => {
+    const { stderr } = runTsxScript(script, { POSTGRES_URL: LOCAL_URL }, [
+      "0001",
+    ]);
+    expect(stderr).not.toContain("Refusing to write");
+  });
+});
+
+describe("wiring — drizzle.config.ts uses the shared helper", () => {
+  it("imports isCloudDatabaseUrl instead of re-inlining the host regex", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(
+      path.resolve(repoRoot, "drizzle.config.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("scripts/lib/db-target.mjs");
+    expect(source).toContain("isCloudDatabaseUrl(directUrl)");
+    // A second copy of the regex is how this drifts.
+    expect(source).not.toContain("rds\\.amazonaws\\.com");
+    // The existing escape hatch must survive unchanged.
+    expect(source).toContain("DRIZZLE_FORCE_PRODUCTION");
+  });
+});

--- a/supabase/seed-collections.mjs
+++ b/supabase/seed-collections.mjs
@@ -13,12 +13,15 @@
  * of the same name (cascade clears its machine list) before re-inserting, so
  * re-seeding never duplicates.
  *
- * Demo data — DO NOT point at prod. Same no-host-guard model as the other seed
- * scripts (see seed-machine-settings.mjs): it targets whatever POSTGRES_URL is
- * set, which for db:reset / the preview pipeline is an ephemeral local/branch DB.
+ * Demo data, and local-only: `assertLocalDatabase` refuses any non-loopback
+ * POSTGRES_URL. Nothing wires this into the preview pipeline
+ * (scripts/workflow/preview/preview-migrate-seed.sh), so a hard loopback
+ * allowlist costs nothing and closes the "prod env loaded in this shell" path.
  */
 
 import postgres from "postgres";
+
+import { assertLocalDatabase } from "../scripts/assert-local-db.mjs";
 
 // Pooled POSTGRES_URL (:6543, IPv4) like the other seed scripts — NOT the
 // :5432 non-pooling URL, which is IPv6 and unreachable from CI runners.
@@ -28,6 +31,9 @@ if (!databaseUrl) {
   console.error("❌ POSTGRES_URL is not defined");
   process.exit(1);
 }
+
+// Before the client is constructed and before any network call: loopback only.
+assertLocalDatabase(databaseUrl);
 
 const COLLECTION_NAME = "APC Tournament Bank";
 // Fixed demo view-token (local only) so the shared-link flow is reachable in

--- a/supabase/seed-discord.mjs
+++ b/supabase/seed-discord.mjs
@@ -17,6 +17,7 @@
  * Loaded by Node's --env-file flag in the package.json script invocation.
  */
 
+import { assertNotPinPointProduction } from "../scripts/lib/db-target.mjs";
 import { createScriptClient } from "../scripts/lib/pg-client.mjs";
 
 const POSTGRES_URL = process.env.POSTGRES_URL;
@@ -25,6 +26,12 @@ if (!POSTGRES_URL) {
   console.error("❌ Missing POSTGRES_URL");
   process.exit(1);
 }
+
+// Remote-capable (a fresh non-prod environment may legitimately bootstrap its
+// bot token this way), so no loopback-only guard — but never production: this
+// would write a DEV bot token into the prod Vault whenever prod's
+// bot_token_vault_id happens to be NULL.
+assertNotPinPointProduction(POSTGRES_URL, "POSTGRES_URL");
 
 const envBotToken = process.env.DISCORD_BOT_TOKEN?.trim();
 const envGuildId = process.env.DISCORD_GUILD_ID?.trim();

--- a/supabase/seed-machine-settings.mjs
+++ b/supabase/seed-machine-settings.mjs
@@ -39,14 +39,18 @@
  * Deterministic: every run wipes AFM's existing sets and re-inserts these six,
  * so re-seeding never duplicates or leaves stale demo rows.
  *
- * Demo data — DO NOT point at prod. Like the other seed scripts (seed-users.mjs)
- * this runs against whatever POSTGRES_URL is set, with no host guard: local dev
- * (db:reset) and the on-demand preview pipeline both target ephemeral branch DBs.
- * Reaching prod requires deliberately exporting a prod POSTGRES_URL and running
- * by hand — which the read-only root checkout and AGENTS.md rules already forbid.
+ * Demo data, and local-only: `assertLocalDatabase` refuses any non-loopback
+ * POSTGRES_URL. Nothing currently wires this into the preview pipeline
+ * (scripts/workflow/preview/preview-migrate-seed.sh keeps it only as a
+ * commented-out example), so a hard loopback allowlist costs nothing and closes
+ * the "prod env loaded in this shell" path. If it is ever added to the preview
+ * pipeline, swap this for the `assertNotPinPointProduction` guard the
+ * remote-capable seeds use — do not just delete it.
  */
 
 import postgres from "postgres";
+
+import { assertLocalDatabase } from "../scripts/assert-local-db.mjs";
 
 // Use the pooled POSTGRES_URL (port :6543, IPv4) like seed-users.mjs — NOT
 // POSTGRES_URL_NON_POOLING (:5432), which resolves to IPv6 and is unreachable
@@ -59,6 +63,9 @@ if (!databaseUrl) {
   console.error("❌ POSTGRES_URL is not defined");
   process.exit(1);
 }
+
+// Before the client is constructed and before any network call: loopback only.
+assertLocalDatabase(databaseUrl);
 
 /** Wrap a single sentence of plain text in a minimal ProseMirror doc. */
 function doc(text) {

--- a/supabase/seed-pinballmap-catalog.mjs
+++ b/supabase/seed-pinballmap-catalog.mjs
@@ -20,6 +20,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { assertNotPinPointProduction } from "../scripts/lib/db-target.mjs";
 import { createScriptClient } from "../scripts/lib/pg-client.mjs";
 
 const POSTGRES_URL = process.env.POSTGRES_URL;
@@ -27,6 +28,12 @@ if (!POSTGRES_URL) {
   console.error("❌ Missing POSTGRES_URL");
   process.exit(1);
 }
+
+// Remote-capable — preview-migrate-seed.sh runs this against a preview branch —
+// so no loopback-only guard, but never production: prod fills this table from
+// the live PinballMap API on a weekly cron, and overwriting it with the offline
+// fixture mirror would silently shrink the machine-linking picker.
+assertNotPinPointProduction(POSTGRES_URL, "POSTGRES_URL");
 
 const fixturesDir = join(
   dirname(fileURLToPath(import.meta.url)),

--- a/supabase/seed-users.mjs
+++ b/supabase/seed-users.mjs
@@ -10,9 +10,18 @@
  *
  * Password for all test users: "TestPassword123"
  * DO NOT use these in production!
+ *
+ * Remote-capable ON PURPOSE: preview-migrate-seed.sh runs this against an
+ * ephemeral Supabase preview branch, so it cannot take the loopback-only
+ * `assertLocalDatabase` guard the demo seeds use. Instead it refuses the one
+ * target that is never legitimate — the production project — on BOTH endpoints
+ * it writes through. That distinction matters: this script creates real auth
+ * users via the Admin API against NEXT_PUBLIC_SUPABASE_URL, which is a
+ * DIFFERENT variable from POSTGRES_URL and could be pointed at prod on its own.
  */
 
 import { createClient } from "@supabase/supabase-js";
+import { assertNotPinPointProduction } from "../scripts/lib/db-target.mjs";
 import { createScriptClient } from "../scripts/lib/pg-client.mjs";
 import machinesData from "../src/test/data/machines.json" with { type: "json" };
 import usersData from "../src/test/data/users.json" with { type: "json" };
@@ -30,6 +39,12 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !POSTGRES_URL) {
   console.error("  - POSTGRES_URL");
   process.exit(1);
 }
+
+// Both write endpoints, checked before either client is constructed and before
+// any network call. `supabase.auth.admin.createUser` would otherwise mint
+// admin@test.com et al. in production auth.
+assertNotPinPointProduction(SUPABASE_URL, "NEXT_PUBLIC_SUPABASE_URL");
+assertNotPinPointProduction(POSTGRES_URL, "POSTGRES_URL");
 
 // Create Supabase Admin client
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,7 +23,11 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "src/**/*",
-    "middleware.ts"
+    "middleware.ts",
+    // Imported by scripts/mark-migration-applied.ts (a `**/*.ts` match). Under
+    // `composite: true` every file pulled into the program must be listed
+    // (TS6307), and the `**/*.ts` glob does not cover `.mjs`.
+    "scripts/lib/db-target.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Every script touched here resolved its target purely from an env var, so "which database" was whatever happened to be in the shell. `PinPoint-Prod` has `pitr_enabled: false` — the recovery floor is the previous nightly backup.

No new mechanism: this follows `scripts/assert-local-db.mjs` (hard loopback allowlist) and `scripts/lib/drizzle-push-guard.ts` (guard the *effect* at the lowest layer that can express it, so no shell wrapper routes around it). No PreToolUse hook — that approach was tried and rejected twice (#1738 → #1741).

## New shared module: `scripts/lib/db-target.mjs`

Two deliberately different questions, because conflating them is what would break things:

| predicate | question | true for a preview branch? | escape hatch |
| :-- | :-- | :-- | :-- |
| `isCloudDatabaseUrl()` | any managed cloud Postgres? | **yes** (same `*.pooler.supabase.com` host shape) | required — it's a human-typed opt-in |
| `isPinPointProductionTarget()` | *the* production project? | **no** (branches have their own refs) | none needed |

`isCloudDatabaseUrl` is the regex lifted verbatim out of `drizzle.config.ts`, which now imports it instead of keeping a second copy. `DRIZZLE_FORCE_PRODUCTION` behaviour is byte-for-byte preserved (verified by running `drizzle-kit check` against a prod-shaped URL — same refusal, same wording).

## Gap A — five seed scripts had no host guard

Split by each script's *actual sanctioned reach*, not by a blanket rule:

**Local-only demo seeds → `assertLocalDatabase` (loopback allowlist):**
- `seed-collections.mjs`
- `seed-machine-settings.mjs`

Neither is wired into the preview pipeline, so the hard allowlist costs nothing. The stale "no host guard, DO NOT point at prod" comments in both headers are replaced. `preview-migrate-seed.sh`'s "PR-specific demo seeds go below this line" comment now warns that these two would exit 2 on a branch DB.

**Remote-capable seeds → `assertNotPinPointProduction` (prod refused, no override):**
- `seed-users.mjs`
- `seed-discord.mjs`
- `seed-pinballmap-catalog.mjs`

⚠️ **This corrects the brief.** `seed-users.mjs` and `seed-pinballmap-catalog.mjs` are remote-capable *on purpose*: `scripts/workflow/preview/preview-migrate-seed.sh:83,97` runs them against an ephemeral Supabase preview branch. `assertLocalDatabase` on `seed-users.mjs` would break `/preview` outright. The 2026-06-18 pooler-cleanup plan made that call explicitly ("Seed scripts are remote-capable — do NOT add a local-only guard to `seed-users.mjs` / `seed-discord.mjs` … This **overrides** PP-z428's wording"). That decision stands; the prod hole it left open is what's closed here.

**`seed-users.mjs` guards two endpoints, not one.** It creates real auth users via `supabase.auth.admin.createUser` against `NEXT_PUBLIC_SUPABASE_URL` — a *different* variable from `POSTGRES_URL`, either of which could point at prod on its own. And the coarse host regex would not have caught it anyway: `https://<ref>.supabase.co` does not contain the substring `supabase.com`. The project-ref predicate does. This case is the main reason the module carries two predicates rather than one.

**`seed-timeline-backfill.mjs` needed no change.** Contrary to the brief, it already calls its own guard (`ALLOW_NONLOCAL_BACKFILL`, lines 46–56) — deliberately overridable, because it has a documented intentional prod one-shot.

**Found while working: `scripts/reset-preview-db.mjs`.** It `DROP SCHEMA public CASCADE` + `DELETE FROM auth.users`, and its existing prod check is conditional on the caller supplying `PROD_PROJECT_REF` — which the preview workflows do and a hand-run `node scripts/reset-preview-db.mjs` does not. Now guarded unconditionally, with the caller-declared check kept as layer 2.

## Gap B — `mark-migration-applied.ts` had zero prod check

Stays prod-capable, because it *is* the documented stuck-migration recovery path. Gate shape follows the `DRIZZLE_FORCE_PRODUCTION` precedent so there's one idiom:

1. `MARK_MIGRATION_FORCE_PRODUCTION=1` required against a remote target. The refusal prints the redacted target host and the migration number, and spells out the exact command to re-run — an operator mid-incident must not hit a wall.
2. A y/N confirm showing target + resolved migration tag, gated on `process.stdin.isTTY`, so a non-TTY caller never reaches the prompt and nothing can hang. Manually verified both ways (prompt renders and `n` aborts without writing; non-TTY sails through on the token alone).

Verified `mark-migration-applied.ts` is **not** on the Vercel build path — `vercel-build` is `migrate:production && next build`.

Token propagated to `scripts/migrate-production.ts:151`'s printed recovery instructions, `AGENTS.md` §7, and `docs/DEVELOPMENT.md`.

## Gap C — stale `supabase link` state: documented, not automated

**Decision: print a precise post-backup warning; do not unlink, do not re-plumb blind.**

`backup-production.sh` depends on the link twice over — its own preflight check reads `supabase/.temp/project-ref`, and the bare `supabase db dump` resolves both the project and its stored DB password from that state. Auto-unlinking would break the next `pnpm run db:backup`, which the brief ruled out.

**Correction to the stated footgun.** "A later bare `supabase db reset` hits production" is **false** on Supabase CLI 2.109.1 — bare `db reset` is local-only; remote requires an explicit `--linked` or `--db-url` (`supabase db reset --help`). The commands that genuinely default to the linked project are `db dump`, `db push`, `db pull`, `migration up --linked`, `db reset --linked`, `secrets` — and of those `db push`/`db pull` aren't live paths here (Supabase migration config is disabled, `supabase/migrations/` is gitignored). Real but narrow, so the warning names exactly that set and explicitly says bare `db reset` is unaffected.

The proper fix — `--db-url` / `--project-ref` + `SUPABASE_DB_PASSWORD` so the script never depends on ambient state, after which unlinking becomes safe — needs a real prod dump to validate and a prod credential sourced outside the CLI credential store. Filed as **PP-oifw** to pick up alongside the next hands-on prod backup, where a failed attempt is cheap to notice.

## Tests

`src/test/unit/scripts/db-target-guards.test.ts` (33 cases) — pure-predicate tests plus real `spawnSync` runs of every guarded script asserting exit codes, matching the `src/test/unit/hooks/*.test.ts` pattern. A guard that's exported but never actually *called* is the exact regression these catch. Coverage includes:

- prod URL refused (exit 2) / localhost passes through to the connection attempt, for each seed
- **preview-branch URL still passes** the remote-capable seeds — the check that keeps `/preview` working
- `seed-users.mjs` refused via `NEXT_PUBLIC_SUPABASE_URL` alone *and* via `POSTGRES_URL` alone
- Gap B: token required, token permits, no hang without a TTY, and the refusal never prints the password
- a wiring assertion that `drizzle.config.ts` imports the helper rather than re-inlining the regex

## Verification

`pnpm run preflight` — unit 1787 ✅, build ✅, integration 508 ✅, integration-supabase 104 ✅, smoke 160 ✅. The 28 remaining smoke failures are all `[Mobile Safari]` and all the same host error: `MiniBrowser: error while loading shared libraries: libicudata.so.74`. That's a missing system library on this Bazzite host, not a code failure — CI's runner has it.

Also verified by hand: `drizzle-kit check` still passes and still refuses `push`; the prod refusal in `drizzle.config.ts` is unchanged; `pnpm run db:fast-reset` runs the whole seed chain clean through the new guards.

Closes nothing on its own; PP-oifw tracks the Gap C follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFg3c81oW1jvLZvgV6K1Nh
