### PR TITLE
fix(agents): stop instructing agents to invoke /code-review (PP-lsb4)

### DIFF
--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -133,7 +133,7 @@ Work bead <ID>. First run `bd show <ID>` && `bd update <ID> --claim` — the bea
 
 ## Quality Gates
 
-Run `pnpm run check` before returning. Then self-review: run `/code-review` on your own diff (the model-invocable local review — **not** `ultra`, which is user-triggered/billed and you cannot launch) and address serious findings. After your final push, if Copilot hasn't reviewed your head commit within ~10 min, run `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` so the `reviewed` merge gate passes.
+Run `pnpm run check` before returning. Then self-review **by hand**: read your own diff (`git diff origin/main...HEAD`) against `REVIEW.md` — the canonical rubric — plus the bead's acceptance criteria and out-of-scope list, and fix what you find. Don't reach for `/code-review` or `ultra`: both are user-triggered harness surfaces (`ultra` is also billed) and an agent cannot launch either. After your final push, if Copilot hasn't reviewed your head commit within ~10 min, run `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` so the `reviewed` merge gate passes.
 
 ## Return Format
 
@@ -205,7 +205,7 @@ Or fallback: `gh pr edit <PR> --add-label ready-for-review`.
 
 The subagent self-reviews its own diff (Phase 3 template), but that can be skipped or Copilot can silently miss the head commit — so the lead re-checks at the handoff boundary. Before applying `ready-for-review` or handing a PR to Tim for `merge-pr.sh --human`, confirm the head commit is covered by **either** a Copilot review **or** a SHA-pinned Claude marker (`<!-- pinpoint-claude-review: <head_sha> -->`). If neither covers head:
 
-1. Run `/code-review` on the PR diff — the model-invocable **local** review. (`ultra` is the cloud multi-agent review; it is user-triggered and billed, so the agent cannot launch it.)
+1. Review the PR diff yourself — a deliberate manual pass over `git diff origin/main...HEAD` against `REVIEW.md` (the canonical rubric) and the bead's acceptance criteria. `/code-review` is a harness built-in that only Tim can trigger, and `ultra` is the cloud multi-agent review — user-triggered and billed. An agent can launch neither, so the manual pass is the backstop.
 2. Address serious findings (fix → have the subagent push → re-review; a fix re-arms the gate). Decline the rest.
 3. `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` to post the marker.
 

--- a/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
+++ b/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
@@ -13,7 +13,7 @@ Work bead {beads_id}. First run `bd show {beads_id}` && `bd update {beads_id} --
 
 ### Quality Gates
 
-Run `pnpm run check` before returning. Then self-review: run `/code-review` on your own diff (model-invocable **local** review — **not** `ultra`, which is user-triggered/billed and you cannot launch) and address serious findings. After your final push, if Copilot hasn't reviewed your head commit within ~10 min, run `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` so the `reviewed` merge gate passes.
+Run `pnpm run check` before returning. Then self-review **by hand**: read your own diff (`git diff origin/main...HEAD`) against `REVIEW.md` — the canonical rubric — plus the bead's acceptance criteria and out-of-scope list, and fix what you find. Don't reach for `/code-review` or `ultra`: both are user-triggered harness surfaces (`ultra` is also billed) and an agent cannot launch either. After your final push, if Copilot hasn't reviewed your head commit within ~10 min, run `bash scripts/workflow/mark-claude-review.sh <PR> "<summary>"` so the `reviewed` merge gate passes.
 
 ### Environment Setup
 

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -180,7 +180,7 @@ If head is newer than the latest Copilot review:
 
 - Elapsed < 600s → wait, Copilot may still be reviewing.
 - Elapsed >= 600s (or `request_copilot_review` yields nothing after another 60s) → **run a Claude fallback review instead of proceeding unreviewed.** Copilot silently skips `review_requested` events often enough that "no review" cannot be a merge path (per PR #1342 / #1326). The fallback:
-  1. Run `/code-review` against the PR diff (model-invocable local review — **not** `ultra`, which is user-triggered, billed, and the agent cannot launch).
+  1. Review the PR diff yourself — a deliberate manual pass over `git diff origin/main...HEAD` against `REVIEW.md`, the canonical rubric. (`/code-review` is a harness built-in that only Tim can trigger; `ultra` is user-triggered and billed. An agent can launch neither.)
   2. Address serious findings the same way you handle Copilot threads: fix → push → re-review. A fix changes the head SHA and re-arms the `reviewed` gate. Consciously decline the rest.
   3. `bash scripts/workflow/mark-claude-review.sh <PR> "<one-line findings summary>"` — posts the SHA-pinned sticky marker `<!-- pinpoint-claude-review: <head_sha> -->` that the `reviewed` gate detects.
 
@@ -289,7 +289,7 @@ On all PASS: script captures head SHA, calls `gh pr merge <PR> --squash --match-
 - Copilot has silently-skipped a merge-from-main commit and the diff was reviewed manually
 - The `threads` / `currency` / `reviewed` gates are known to fail and that's being explicitly accepted
 
-Prefer the Claude fallback (Phase 3.4 — run `/code-review` + `mark-claude-review.sh`) over asking Tim to `--force` a `reviewed`-gate failure: the fallback makes the guarantee true rather than skipping it, and you can do it before handoff.
+Prefer the Claude fallback (Phase 3.4 — manual diff review + `mark-claude-review.sh`) over asking Tim to `--force` a `reviewed`-gate failure: the fallback makes the guarantee true rather than skipping it, and you can do it before handoff.
 
 **`--bypass-merge-requirements`** — for CI/branch-protection issues:
 

--- a/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
+++ b/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
@@ -62,7 +62,7 @@ Everything above happens **in a worktree** — the root checkout is read-only (A
 
 ### `requesting-code-review` / `receiving-code-review`
 
-- Superpowers' reviewer-subagent is fine as an **optional local self-check**. The **authoritative** review gate is **CI Gate + `/code-review`** (see `pinpoint-pr-workflow`), not a plugin subagent.
+- Superpowers' reviewer-subagent is fine as an **optional local self-check**. The **authoritative** review gate is **CI Gate + the head-commit review requirement** in `pinpoint-pr-workflow` (Copilot, or your own manual pass over the diff plus `mark-claude-review.sh`), not a plugin subagent.
 - **Reply to review comments via MCP** (`add_reply_to_pull_request_comment` + resolve the thread with `pull_request_review_write method:"resolve_thread"`), **signed with your agent name** (`—Claude` / `—Gemini` / `—Codex` / `—Antigravity`, per AGENTS.md §5 "Review comments"). Declined comments still get a one-sentence reply — no silent ignores. Do not use the plugin's own reply flow.
 
 ### `finishing-a-development-branch` — the biggest override
@@ -79,17 +79,17 @@ Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally".
 
 ## 4. Quick reference
 
-| Superpowers step         | PinPoint override                                                                 |
-| :----------------------- | :-------------------------------------------------------------------------------- |
-| Spec written             | + create bead with `--spec-id` + `--acceptance` (§2)                              |
-| Plan written             | record path + branch in `--design` (§1)                                           |
-| Worktree create          | `EnterWorktree` / `Agent(isolation:"worktree")`, from main worktree               |
-| SDD dispatch             | clear the scale gate (count + cost, Tim's yes) first                              |
-| Code review              | CI Gate + `/code-review`; replies via MCP, signed with your agent name            |
-| Finish: "merge locally"  | ❌ prohibited → PR + human-only `merge-pr.sh --human` handoff + landing-the-plane |
-| Finish: tests            | tiered `pnpm run check`/`preflight`/`smoke`, not `npm test`                       |
-| Finish: worktree cleanup | `WorktreeRemove` hook / `worktree_cleanup.py`, on confirmation                    |
-| Close bead               | only after merge                                                                  |
+| Superpowers step         | PinPoint override                                                                                 |
+| :----------------------- | :------------------------------------------------------------------------------------------------ |
+| Spec written             | + create bead with `--spec-id` + `--acceptance` (§2)                                              |
+| Plan written             | record path + branch in `--design` (§1)                                                           |
+| Worktree create          | `EnterWorktree` / `Agent(isolation:"worktree")`, from main worktree                               |
+| SDD dispatch             | clear the scale gate (count + cost, Tim's yes) first                                              |
+| Code review              | CI Gate + `pinpoint-pr-workflow` head-commit review; replies via MCP, signed with your agent name |
+| Finish: "merge locally"  | ❌ prohibited → PR + human-only `merge-pr.sh --human` handoff + landing-the-plane                 |
+| Finish: tests            | tiered `pnpm run check`/`preflight`/`smoke`, not `npm test`                                       |
+| Finish: worktree cleanup | `WorktreeRemove` hook / `worktree_cleanup.py`, on confirmation                                    |
+| Close bead               | only after merge                                                                                  |
 
 ## Red flags — stop if you catch yourself
 

--- a/scripts/workflow/mark-claude-review.sh
+++ b/scripts/workflow/mark-claude-review.sh
@@ -10,8 +10,9 @@ set -euo pipefail
 # a fresh review. This is the Claude fallback for when Copilot silently skips.
 #
 # The helper only *attests* — the caller is responsible for having actually run the
-# review first (`/code-review`, the model-invocable local review). Same honesty model
-# as `merge-pr.sh --force`.
+# review first — a manual pass over the diff against REVIEW.md, since `/code-review`
+# is a user-triggered harness built-in an agent cannot launch. Same honesty model as
+# `merge-pr.sh --force`.
 #
 # Usage:
 #   bash scripts/workflow/mark-claude-review.sh <PR> ["one-line findings summary"]


### PR DESCRIPTION
## Problem

`pinpoint-orchestrator` told every dispatched subagent to self-review by running `/code-review`, calling it "the model-invocable local review". It isn't — `/code-review` is a Claude Code harness built-in that only the user can trigger. There is no `code-review` skill on disk and it never appears in the model-invocable skill list.

A dispatched agent hit this live on 2026-07-31 ("The `/code-review` skill is not model-invocable here") and burned a turn discovering the instruction was impossible. The worse case was the **lead backstop** (`Phase 4 → Ensure every PR is reviewed`): an impossible instruction there means the backstop silently doesn't happen, and the PR reaches Tim with only a `mark-claude-review.sh` marker attesting a review that was never performed in the prescribed way.

## Fix

Every site now prescribes what an agent can actually do: a deliberate manual pass over its own diff against `REVIEW.md` (the canonical rubric) plus the bead's acceptance criteria and out-of-scope list. The existing accurate note that `ultra` is user-triggered/billed and unlaunchable by an agent is preserved, and `/code-review` is now described the same way rather than as model-invocable.

The three sites named in the bead:

- `.agents/skills/pinpoint-orchestrator/SKILL.md:136` — Phase 3 agent prompt template
- `.agents/skills/pinpoint-orchestrator/SKILL.md:208` — Phase 4 lead backstop
- `.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md:16` — annotated template

Plus the same defect elsewhere, per the bead's repo-wide acceptance criterion:

- `.agents/skills/pinpoint-pr-workflow/SKILL.md:183` — Phase 3.4 "Claude fallback review" step 1 (an identical invoke instruction)
- `.agents/skills/pinpoint-pr-workflow/SKILL.md:292` — §4.4 escape-hatch pointer back to that fallback
- `.agents/skills/pinpoint-superpowers-bridge/SKILL.md:65,88` — claimed the authoritative review gate was "CI Gate + `/code-review`"
- `scripts/workflow/mark-claude-review.sh:13` — header comment asserting `/code-review` is "the model-invocable local review"

Left alone deliberately (descriptions, not invoke instructions — the bead says these are fine): `REVIEW.md`, `superpowers-bridge:59` (accurately calls it a built-in), and the dated records under `docs/plans/` and `docs/superpowers/`.

`CLAUDE.md:20` ("read it before launching the code-review skill") is arguably the same wording, but Claude-ContextRewrite has in-flight work on `CLAUDE.md`/`AGENTS.md` (#1769), so it was left to avoid a conflict.

## Verification

- `rg --hidden "model-invocable"` → zero hits repo-wide
- `rg --hidden "/code-review"` → remaining hits are descriptions only
- `pnpm run check` green (docs-only change; no preflight needed)
- Self-reviewed by hand — exactly the practice this PR writes into the skill, since `/code-review` was unavailable to me too

Closes PP-lsb4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbU3rdz9X3LJptWiR6dUTL