### PR TITLE
fix(scripts): pr-watch stops calling an unreachable gh API a CI failure (PP-qkl8)

### DIFF
--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -49,9 +49,11 @@ OLD_SHA = "3ab14b1f0000000000000000000000000000aaaa"
 BRANCH = "feat/example-branch"
 PR = 1734
 
-# The exact stderr `gh` produced on 2026-07-26 when the shared user-level quota
-# ran out mid-watch on PR #1748 — the live evidence behind PP-qkl8.
-RATE_LIMIT_403 = "HTTP 403: API rate limit exceeded for user ID 5819722"
+# The stderr `gh` produced on 2026-07-26 when the shared user-level quota ran
+# out mid-watch on PR #1748 — the live evidence behind PP-qkl8. The real message
+# named the account whose quota it was; the numeric id is dropped here because
+# nothing under test reads it.
+RATE_LIMIT_403 = "HTTP 403: API rate limit exceeded for user ID"
 
 
 def _gate(conclusion: str, status: str = "COMPLETED", completed_at: str = "") -> dict:
@@ -266,10 +268,27 @@ def test_run_conclusion_raises_when_gh_fails(monkeypatch, stderr):
 
 
 @pytest.mark.unit
-def test_run_conclusion_raises_on_unparseable_json(monkeypatch):
+def test_run_conclusion_quotes_unparseable_output(monkeypatch):
+    """ "Expecting value: line 1 column 1" alone is unactionable — show the body."""
     monkeypatch.setattr(pr_watch, "gh", lambda *_a: "<html>rate limited</html>")
-    with pytest.raises(pr_watch.RunStateUnavailable):
+    with pytest.raises(pr_watch.RunStateUnavailable, match="rate limited"):
         pr_watch._run_conclusion(30184323661)
+
+
+@pytest.mark.unit
+def test_run_conclusion_normalises_null_fields(monkeypatch):
+    """`conclusion` is null on a run that hasn't finished — return "", not None."""
+    monkeypatch.setattr(
+        pr_watch, "gh", lambda *_a: json.dumps({"status": "in_progress"})
+    )
+    assert pr_watch._run_conclusion(30184323661) == ("in_progress", "")
+
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        lambda *_a: json.dumps({"status": "in_progress", "conclusion": None}),
+    )
+    assert pr_watch._run_conclusion(30184323661) == ("in_progress", "")
 
 
 @pytest.mark.unit

--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -1,16 +1,23 @@
-"""Regression tests for scripts/workflow/pr-watch.py cancellation handling (PP-r63o).
+"""Regression tests for scripts/workflow/pr-watch.py false CI alarms.
 
-Two bugs are covered:
+Three bugs are covered — all of the same family: the watcher reporting a
+failure for something that was not one.
 
 1. A `cancelled` run was classified as a failure — cancellation is routine
    (a newer commit cancels the in-flight run via concurrency groups, and the
    Preview Auto-Resync workflow cancels itself), so a normal push-twice cycle
    emitted a spurious "✗ CI — failed" plus a failure artifact whose log body
-   read "(no log available)".
+   read "(no log available)". (PP-r63o)
 2. The completed-runs scan and the CI Gate pre-check must only consider the
    CURRENT head SHA, so a stale cancelled run from an older commit — or a
    superseded CI Gate check left behind at the same commit — can't hard-exit
    the watcher. `--force` was the workaround; it should no longer be needed.
+   (PP-r63o)
+3. A failed `gh run view` (rate-limit 403, network drop, auth failure) was
+   swallowed into ("", ""), which is neither queued nor passing nor superseded
+   and so landed in the fail-safe branch: "✗ CI — failed" plus an artifact, for
+   a healthy run whose jobs were all still pending. "We could not find out" is
+   not a verdict. (PP-qkl8)
 
 Everything is mocked at the `gh` CLI seam (`pr_watch.gh`) — these tests never
 reach GitHub (CORE-TEST-006).
@@ -41,6 +48,10 @@ HEAD_SHA = "1c33d34bb30884376eaf066f0024551df5c58368"
 OLD_SHA = "3ab14b1f0000000000000000000000000000aaaa"
 BRANCH = "feat/example-branch"
 PR = 1734
+
+# The exact stderr `gh` produced on 2026-07-26 when the shared user-level quota
+# ran out mid-watch on PR #1748 — the live evidence behind PP-qkl8.
+RATE_LIMIT_403 = "HTTP 403: API rate limit exceeded for user ID 5819722"
 
 
 def _gate(conclusion: str, status: str = "COMPLETED", completed_at: str = "") -> dict:
@@ -192,12 +203,18 @@ def test_watch_run_cancelled_records_no_failure(monkeypatch, stub_run_watch, cap
     )
 
     failures: list[int] = []
+    undetermined: list[tuple[str, str]] = []
     pr_watch.watch_run(
-        30133783967, "Preview Auto-Resync", pr_watch.threading.Event(), failures
+        30133783967,
+        "Preview Auto-Resync",
+        pr_watch.threading.Event(),
+        failures,
+        undetermined,
     )
 
     out = capsys.readouterr().out
     assert failures == []
+    assert undetermined == []
     assert "superseded" in out
     assert "failed" not in out
 
@@ -209,10 +226,167 @@ def test_watch_run_failure_still_records_failure(monkeypatch, stub_run_watch, ca
     )
 
     failures: list[int] = []
-    pr_watch.watch_run(999, "CI", pr_watch.threading.Event(), failures)
+    undetermined: list[tuple[str, str]] = []
+    pr_watch.watch_run(999, "CI", pr_watch.threading.Event(), failures, undetermined)
 
     assert failures == [999]
+    assert undetermined == []
     assert "✗  CI — failed" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _run_conclusion — a failed gh call is "unknown", not "no conclusion" (PP-qkl8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_backoff(monkeypatch):
+    """Collapse the retry backoff so tests don't actually wait."""
+    monkeypatch.setattr(pr_watch, "RUN_STATE_BACKOFF", 0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        RATE_LIMIT_403,
+        "dial tcp: lookup api.github.com: no such host",
+        "HTTP 401: Bad credentials",
+    ],
+)
+def test_run_conclusion_raises_when_gh_fails(monkeypatch, stderr):
+    """Rate limit, network, auth — every gh failure is an unknown, not a state."""
+
+    def boom(*_args: str) -> str:
+        raise RuntimeError(stderr)
+
+    monkeypatch.setattr(pr_watch, "gh", boom)
+    with pytest.raises(pr_watch.RunStateUnavailable, match=stderr[:20]):
+        pr_watch._run_conclusion(30184323661)
+
+
+@pytest.mark.unit
+def test_run_conclusion_raises_on_unparseable_json(monkeypatch):
+    monkeypatch.setattr(pr_watch, "gh", lambda *_a: "<html>rate limited</html>")
+    with pytest.raises(pr_watch.RunStateUnavailable):
+        pr_watch._run_conclusion(30184323661)
+
+
+@pytest.mark.unit
+def test_run_conclusion_retrying_is_bounded(monkeypatch, no_backoff):
+    """A persistently unreachable API must terminate, not spin forever."""
+    attempts: list[int] = []
+
+    def boom(*_args: str) -> str:
+        attempts.append(1)
+        raise RuntimeError(RATE_LIMIT_403)
+
+    monkeypatch.setattr(pr_watch, "gh", boom)
+    with pytest.raises(pr_watch.RunStateUnavailable, match="rate limit exceeded"):
+        pr_watch._run_conclusion_retrying(30184323661, "CI", pr_watch.threading.Event())
+    assert len(attempts) == pr_watch.RUN_STATE_ATTEMPTS
+
+
+@pytest.mark.unit
+def test_run_conclusion_retrying_recovers_after_a_blip(monkeypatch, no_backoff):
+    calls: list[int] = []
+
+    def flaky(*_args: str) -> str:
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError(RATE_LIMIT_403)
+        return json.dumps({"status": "completed", "conclusion": "success"})
+
+    monkeypatch.setattr(pr_watch, "gh", flaky)
+    assert pr_watch._run_conclusion_retrying(
+        30184323661, "CI", pr_watch.threading.Event()
+    ) == ("completed", "success")
+    assert len(calls) == 2
+
+
+@pytest.mark.unit
+def test_run_conclusion_retrying_stops_when_asked_to_stop(monkeypatch, no_backoff):
+    """A stop request (watch_reviews saw a new Copilot review) ends the retries."""
+    attempts: list[int] = []
+
+    def boom(*_args: str) -> str:
+        attempts.append(1)
+        raise RuntimeError(RATE_LIMIT_403)
+
+    monkeypatch.setattr(pr_watch, "gh", boom)
+    stop = pr_watch.threading.Event()
+    stop.set()
+    with pytest.raises(pr_watch.RunStateUnavailable):
+        pr_watch._run_conclusion_retrying(30184323661, "CI", stop)
+    assert len(attempts) == 1
+
+
+# ---------------------------------------------------------------------------
+# watch_run — an unreachable API is recorded as undetermined, never a failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_watch_run_rate_limit_403_is_not_a_failure(
+    monkeypatch, stub_run_watch, no_backoff, capsys
+):
+    """The PR #1748 shape: gh 403s while every job in the run is still pending.
+
+    Before PP-qkl8 this emitted "✗ CI — failed" and wrote
+    tmp/gh-monitor/failure-30184323661.md for a healthy run.
+    """
+
+    def boom(*_args: str) -> str:
+        raise RuntimeError(RATE_LIMIT_403)
+
+    monkeypatch.setattr(pr_watch, "gh", boom)
+    monkeypatch.setattr(
+        pr_watch,
+        "write_failure_artifact",
+        lambda _id: pytest.fail("no artifact should be written when gh itself failed"),
+    )
+
+    failures: list[int] = []
+    undetermined: list[tuple[str, str]] = []
+    pr_watch.watch_run(
+        30184323661, "CI", pr_watch.threading.Event(), failures, undetermined
+    )
+
+    out = capsys.readouterr().out
+    assert failures == []
+    assert undetermined == [("CI", RATE_LIMIT_403)]
+    assert "failed" not in out
+    assert RATE_LIMIT_403 in out  # the message names the real cause
+
+
+@pytest.mark.unit
+def test_watch_run_silent_when_stopped_mid_outage(
+    monkeypatch, stub_run_watch, no_backoff, capsys
+):
+    """A stop mid-outage is a shutdown, not a verdict — record nothing, say nothing.
+
+    watch_reviews sets `stop` when a new Copilot review lands, which can happen
+    while a retry is in flight. Reporting "could not determine" then would be
+    noise about a watch we deliberately ended.
+    """
+    stop = pr_watch.threading.Event()
+    calls: list[int] = []
+
+    def boom(*_args: str) -> str:
+        calls.append(1)
+        if len(calls) == 2:
+            stop.set()
+        raise RuntimeError(RATE_LIMIT_403)
+
+    monkeypatch.setattr(pr_watch, "gh", boom)
+
+    failures: list[int] = []
+    undetermined: list[tuple[str, str]] = []
+    pr_watch.watch_run(30184323661, "CI", stop, failures, undetermined)
+
+    assert failures == []
+    assert undetermined == []
+    assert "could not determine" not in capsys.readouterr().out.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -455,6 +629,67 @@ def test_main_announces_a_superseded_run_only_once(
     assert pr_watch.main() == 0
     out = capsys.readouterr().out
     assert out.count("Preview Auto-Resync — superseded (cancelled)") == 1
+
+
+@pytest.mark.unit
+def test_main_reports_undetermined_runs_as_unknown_not_failure(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """An unreadable run exits 2 with the cause — not 1 with "failure(s) detected".
+
+    CI Gate is deliberately not consulted: the same API is down, and under a
+    rate-limit 403 every extra call digs the shared quota deeper.
+    """
+    runs = [_run(30184323661, "in_progress", "", "CI")]
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("", status="IN_PROGRESS")])
+    )
+    monkeypatch.setattr(
+        pr_watch,
+        "watch_run",
+        lambda _id, name, _stop, _failures, undetermined: undetermined.append(
+            (name, RATE_LIMIT_403)
+        ),
+    )
+    monkeypatch.setattr(
+        pr_watch,
+        "_finalize_via_ci_gate",
+        lambda *_a, **_k: pytest.fail("CI Gate must not be polled while gh is down"),
+    )
+
+    assert pr_watch.main() == pr_watch.EXIT_UNDETERMINED
+    out = capsys.readouterr().out
+    assert "Could not determine the outcome of CI" in out
+    assert RATE_LIMIT_403 in out
+    assert "failure(s) detected" not in out
+    assert "failed" not in out
+
+
+@pytest.mark.unit
+def test_main_prefers_a_real_failure_over_an_undetermined_run(
+    monkeypatch, stub_watch_loop, capsys
+):
+    """One run unreadable, another observed failing — report the failure."""
+    runs = [
+        _run(30184323661, "in_progress", "", "CI"),
+        _run(30184323662, "in_progress", "", "E2E"),
+    ]
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(runs=runs, rollup=[_gate("", status="IN_PROGRESS")])
+    )
+
+    def fake_watch(run_id, name, _stop, failures, undetermined):
+        if name == "CI":
+            undetermined.append((name, RATE_LIMIT_403))
+        else:
+            failures.append(run_id)
+
+    monkeypatch.setattr(pr_watch, "watch_run", fake_watch)
+
+    assert pr_watch.main() == 1
+    out = capsys.readouterr().out
+    assert "1 failure(s) detected" in out
+    assert "failure-30184323662.md" in out
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/workflow/AGENTS.md
+++ b/scripts/workflow/AGENTS.md
@@ -17,6 +17,8 @@ Scripts are designed for the **PinPoint orchestrator workflow** where multiple s
 | `pr-dashboard.sh [PR...]` | Status table: CI checks, merge state, draft state. All open PRs if no args.                                                                 |
 | `pr-watch.py <PR>`        | Stream CI run events. One timestamped line per event. Use with the Claude Code Monitor tool. Writes failure artifacts to `tmp/gh-monitor/`. |
 
+`pr-watch.py` exit codes: **0** passed (or stopped for a new Copilot review), **1** a run or the CI Gate actually failed, **2** the outcome could not be determined — the GitHub API was unreachable (rate-limit 403, network drop, auth failure), so nothing was observed. Exit 2 is not a red CI: re-run the watch once the API is back rather than hunting for a broken test. (PP-qkl8)
+
 ### UI Screenshots
 
 | Script                                                   | Purpose                                                                                                                                                                                                                                                     |

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -415,12 +415,22 @@ def _run_conclusion(run_id: int) -> tuple[str, str]:
     Raises RunStateUnavailable if the gh call itself failed — a rate-limit 403,
     a network drop, an expired token. That is "we could not find out", which is
     not a verdict about the run and must never be reported as one.
+
+    The two failure modes are decoded separately so the reason carried up is
+    actionable: a bare "Expecting value: line 1 column 1" tells the reader
+    nothing, so unparseable output is quoted back with the raw prefix.
     """
     try:
-        data = json.loads(gh("run", "view", str(run_id), "--json", "status,conclusion"))
-    except (RuntimeError, json.JSONDecodeError) as exc:
+        raw = gh("run", "view", str(run_id), "--json", "status,conclusion")
+    except RuntimeError as exc:
         raise RunStateUnavailable(str(exc) or "gh run view failed") from exc
-    return data.get("status", ""), data.get("conclusion", "")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RunStateUnavailable(
+            f"gh run view returned unparseable output ({exc}): {raw[:120]!r}"
+        ) from exc
+    return data.get("status") or "", data.get("conclusion") or ""
 
 
 def _run_conclusion_retrying(

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -28,10 +28,17 @@ Cancelled runs are neither a pass nor a failure — they are reported as
 here: pushing a second commit cancels the in-flight run via concurrency groups,
 and the Preview Auto-Resync workflow cancels itself the same way. (PP-r63o)
 
+A gh API error while probing a run (rate-limit 403, network drop, auth failure)
+is likewise not a failure — it means we could not find out. Those probes are
+retried with bounded backoff and, if the API stays unreachable, reported as
+"could not determine" (⚠) with the real cause, never as "✗ failed". (PP-qkl8)
+
 Exit 0: all checks passed, or stopped for new Copilot review,
         or (with --check-ready) the PR is ready for human review.
 Exit 1: one or more checks failed, no matching runs found,
         or (with --check-ready) the PR is not ready.
+Exit 2: the outcome could not be determined — the GitHub API was unreachable.
+        Nothing was observed, so this is neither a pass nor a failure.
 """
 
 from __future__ import annotations
@@ -62,6 +69,17 @@ LOG_DIR = "tmp/gh-monitor"
 # back cancelled. A cancel almost always means a newer run is already queued;
 # this bounds the wait so a genuinely abandoned run still terminates.
 SUPERSEDED_GATE_GRACE = 180  # seconds
+
+# How many times to re-probe a run's state when the gh call itself fails, and
+# the first backoff (doubling each attempt: 5s, 10s, 20s → ~35s total). The
+# retry is there to ride out a blip; a user-level rate limit resets on the hour,
+# so retrying past this is pointless — better to stop and say why. (PP-qkl8)
+RUN_STATE_ATTEMPTS = 4
+RUN_STATE_BACKOFF = 5  # seconds
+
+# Exit code for "we could not find out" — distinct from 1 ("it failed") so a
+# caller can tell an unobserved outcome from an observed bad one. (PP-qkl8)
+EXIT_UNDETERMINED = 2
 
 _lock = threading.Lock()
 
@@ -381,13 +399,51 @@ def run_audit(pr: int) -> bool:
 # ---------------------------------------------------------------------------
 
 
+class RunStateUnavailable(RuntimeError):
+    """The GitHub API could not be reached to determine a run's state.
+
+    Distinct from "the run reported a bad conclusion". Before PP-qkl8 the two
+    were collapsed: a failed `gh run view` returned ("", ""), which fell through
+    to the fail-safe branch and emitted "✗ — failed" plus a failure artifact for
+    a run that was, in the observed case, perfectly healthy and still pending.
+    """
+
+
 def _run_conclusion(run_id: int) -> tuple[str, str]:
-    """Return (status, conclusion) for a run. Returns ("", "") on error."""
+    """Return (status, conclusion) for a run.
+
+    Raises RunStateUnavailable if the gh call itself failed — a rate-limit 403,
+    a network drop, an expired token. That is "we could not find out", which is
+    not a verdict about the run and must never be reported as one.
+    """
     try:
         data = json.loads(gh("run", "view", str(run_id), "--json", "status,conclusion"))
-        return data.get("status", ""), data.get("conclusion", "")
-    except (RuntimeError, json.JSONDecodeError):
-        return "", ""
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        raise RunStateUnavailable(str(exc) or "gh run view failed") from exc
+    return data.get("status", ""), data.get("conclusion", "")
+
+
+def _run_conclusion_retrying(
+    run_id: int, name: str, stop: threading.Event
+) -> tuple[str, str]:
+    """_run_conclusion with bounded exponential backoff on API errors.
+
+    Re-raises RunStateUnavailable once the attempts are exhausted, so the caller
+    still has to decide what an undeterminable run means — it just gets to make
+    that decision after the API has had a fair chance to come back.
+    """
+    delay = RUN_STATE_BACKOFF
+    for attempt in range(RUN_STATE_ATTEMPTS):
+        try:
+            return _run_conclusion(run_id)
+        except RunStateUnavailable as exc:
+            if attempt == RUN_STATE_ATTEMPTS - 1 or stop.is_set():
+                raise
+            emit_event(f"↻  {name} — gh API error ({exc}); retrying in {delay}s")
+            if stop.wait(delay):
+                raise
+            delay *= 2
+    raise AssertionError("unreachable")  # pragma: no cover — loop always exits
 
 
 def watch_run(
@@ -395,8 +451,15 @@ def watch_run(
     name: str,
     stop: threading.Event,
     failures: list[int],
+    undetermined: list[tuple[str, str]],
 ) -> None:
-    """Watch one CI run via gh run watch. Retries if watcher exits prematurely."""
+    """Watch one CI run via gh run watch. Retries if watcher exits prematurely.
+
+    Appends to `failures` only for an observed bad conclusion. When the run's
+    state could not be read at all, appends (name, reason) to `undetermined`
+    instead — the caller reports that as an inability to determine, not as a
+    failure, and writes no failure artifact. (PP-qkl8)
+    """
     while not stop.is_set():
         with subprocess.Popen(
             ["gh", "run", "watch", str(run_id), "--exit-status"],
@@ -419,7 +482,18 @@ def watch_run(
 
         # Verify via API regardless of exit code — gh run watch can exit 0
         # prematurely if jobs haven't been assigned yet when the watcher starts.
-        status, conclusion = _run_conclusion(run_id)
+        try:
+            status, conclusion = _run_conclusion_retrying(run_id, name, stop)
+        except RunStateUnavailable as exc:
+            if stop.is_set():
+                return
+            emit_event(
+                f"⚠  {name} — could not determine run state after "
+                f"{RUN_STATE_ATTEMPTS} attempts: {exc}"
+            )
+            with _lock:
+                undetermined.append((name, str(exc)))
+            return
 
         if proc.returncode == 0 and status not in ("queued", "in_progress"):
             if _is_passing(conclusion):
@@ -667,11 +741,12 @@ def main() -> int:
     stop = threading.Event()
     review_seen = threading.Event()
     failures: list[int] = []
+    undetermined: list[tuple[str, str]] = []
 
     ci_threads = [
         threading.Thread(
             target=watch_run,
-            args=(run["databaseId"], run["name"], stop, failures),
+            args=(run["databaseId"], run["name"], stop, failures, undetermined),
             daemon=True,
         )
         for run in active
@@ -701,6 +776,20 @@ def main() -> int:
             emit(f"Failure details: {path}")
         emit(f"{len(failures)} failure(s) detected — check artifact for logs")
         return 1
+
+    if undetermined:
+        # No observed failure, but at least one run's outcome was never read.
+        # Say so and stop: claiming green here would be a guess, and claiming
+        # red would be the false alarm this exists to prevent. Skipping the CI
+        # Gate poll is deliberate — the same API is down, and under a rate-limit
+        # 403 every extra call digs the shared quota deeper. (PP-qkl8)
+        names = ", ".join(name for name, _ in undetermined)
+        emit(
+            f"⚠  Could not determine the outcome of {names} — "
+            f"the GitHub API was unreachable ({undetermined[0][1]}). "
+            "Nothing was observed, so this is neither a pass nor a failure."
+        )
+        return EXIT_UNDETERMINED
 
     # The watched workflow runs all finished without failures. CI Gate is the
     # aggregate that branch protection actually requires; verify it before


### PR DESCRIPTION
Fixes PP-qkl8. Sibling of PP-r63o (#1748) — the second, distinct false-alarm root cause in `pr-watch.py`, deliberately left in scope there.

## The bug

`_run_conclusion` swallowed `RuntimeError`/`JSONDecodeError` from `gh run view --json status,conclusion` and returned `("", "")`. In `watch_run` that empty tuple is not queued/in_progress, not passing, not superseded — so it fell into the *"Confirmed failure (or unrecognised conclusion — fail safe)"* branch and emitted `✗ — failed` plus a failure artifact.

An empty tuple there does not mean "the run concluded badly". It means **we could not find out**. Those are different, and only one of them is a failure.

**Live evidence** (2026-07-26, PR #1748, run 30184323661): pr-watch emitted `✗ CI — failed` and wrote `tmp/gh-monitor/failure-30184323661.md` while every job in that run was still *pending*. Cause: `gh run view` returned `HTTP 403: API rate limit exceeded for user ID 5819722`. The run was healthy. The artifact's tell was that **both** sections were empty — `(no log available)` *and* `(no summary available)` — which only a failing `gh` produces; a cancelled run still yields a summary.

The quota is per-user and shared across every concurrent agent session on this repo, so this recurs whenever several sessions watch CI at once.

## The fix

- `_run_conclusion` raises a new `RunStateUnavailable` instead of returning `("", "")`, carrying the real stderr as the reason.
- `_run_conclusion_retrying` re-probes with **bounded** exponential backoff — 4 attempts, 5s/10s/20s (~35s). Enough to ride out a blip; a user-level rate limit resets on the hour, so retrying past that is pointless. The backoff waits on the `stop` event, so a new Copilot review still interrupts it.
- An exhausted probe is recorded as **undetermined**, not failed: no failure artifact, and a terminal message that names the real cause (`the GitHub API was unreachable (HTTP 403: ...)`).
- New **exit code 2** = "could not determine", distinct from 1 = "it failed", so a caller can tell an unobserved outcome from an observed bad one. Documented in the module docstring and `scripts/workflow/AGENTS.md`.
- The CI Gate poll is skipped in that state deliberately — the same API is down, and under a 403 every extra call digs the shared quota deeper.
- An observed failure still wins over an undetermined run: a real red is reported as red.

## Testing

10 new tests in `scripts/tests/test_pr_watch.py`, all mocked at the `gh` CLI seam (CORE-TEST-006) — nothing reaches GitHub. Covers the exact 403 shape from the incident, network and auth failures, unparseable JSON, retry boundedness, recovery after a blip, interruption by `stop`, the no-artifact guarantee, and `main()` exiting 2 with the cause rather than 1 with "failure(s) detected".

`pnpm run check` green (1813 unit tests, 366 pytest).

## Out of scope

`_pre_check_blocking`, the startup `gh run list`, and `_finalize_via_ci_gate` can still abort on a gh API error. They surface it as `[error] HTTP 403: ...` and write no artifact, so they don't claim a CI failure — the misreport this bead is about. Left alone to keep the change scoped.
