### PR TITLE
fix(hooks): shared command-resolution primitive closes the merge-guard bypasses (PP-6t3c, PP-ar8a)

### DIFF
--- a/.claude/hooks/block-direct-merge.cjs
+++ b/.claude/hooks/block-direct-merge.cjs
@@ -5,99 +5,191 @@
 // typing a `!`-prefixed command in Claude Code, which does not generate a
 // PreToolUse event and so is never seen by this hook.
 //
-// Blocks three shapes:
+// Blocks four shapes:
 //   1. `gh pr merge` (direct CLI merge)
 //   2. `gh api .../pulls/N/merge` with a write method (REST merge)
 //   3. `scripts/workflow/merge-pr.sh` (the gate-enforced merge script itself —
 //      gate-enforcement is not a substitute for human sign-off)
 //   4. mcp__github__merge_pull_request (MCP merge)
+//
+// HOW IT MATCHES (PP-6t3c, PP-ar8a). This used to regex a quote-stripped copy of
+// the command, which had the boundary wide open: `eval "gh pr merge 123"`,
+// `sh -c "…merge-pr.sh…"`, `env gh pr merge`, `time gh pr merge` and
+// `xargs -I{} gh pr merge {}` all ALLOWED on main, because the quote-stripping
+// erased the payload and the wrapper list was hardcoded and short. It now
+// resolves the effective command of every shell segment via
+// lib/resolve-command.cjs and matches on that.
+//
+// POSTURE ON `unresolvable`: this is a hard boundary, so an unknowable command
+// is treated as suspicious, not safe. When the resolver cannot statically know
+// what runs (`eval "$CMD"`, `sh -c "$X"`, `$(pick) pr merge`), the raw command
+// text is scanned for merge indicators and a hit BLOCKS. A resolvable command
+// never reaches that scan, so prose — `echo "run merge-pr.sh"`, `rg` over docs,
+// `bd comments add "… merge-pr.sh …"` — still passes.
 
-let input = "";
-process.stdin.on("data", (c) => (input += c));
-process.stdin.on("end", () => {
-  let payload;
-  try {
-    payload = JSON.parse(input);
-  } catch {
-    // Malformed payload — fail open to avoid breaking other hooks.
-    process.exit(0);
+const { resolveCommand } = require("./lib/resolve-command.cjs");
+
+// Raw-text indicators, used ONLY on the unresolvable path. Deliberately looser
+// than the resolved matchers — `$(pick) pr merge 1` and `eval "$CMD"` (with the
+// merge text elsewhere in the command) have no `gh` token adjacent to the
+// subcommand. Prose never reaches here: a resolvable command returns before the
+// scan, and only a dynamic COMMAND SLOT, a dynamic `eval`/`sh -c` payload, or
+// an unbalanced quote makes a command unresolvable.
+const RAW_MERGE_INDICATORS = [
+  { pattern: /\bpr\s+merge\b/, kind: "merge", detail: "gh pr merge" },
+  {
+    pattern: /\/pulls\/\d+\/merge\b/,
+    kind: "merge",
+    detail: "gh api PUT .../merge",
+  },
+  {
+    pattern: /\bmerge-pr\.sh\b/,
+    kind: "merge-script",
+    detail: "scripts/workflow/merge-pr.sh",
+  },
+];
+
+const HELP_FLAGS = new Set(["--help", "-h"]);
+const WRITE_METHODS = new Set(["PUT", "POST"]);
+const MERGE_API_PATH = /\/pulls\/\d+\/merge\b/;
+
+// gh flags that consume the NEXT token as their value. Skipping their values
+// keeps a repo selector from splitting the subcommand chain: `gh pr --repo o/r
+// merge 1` must read as `pr merge`, not `pr`, `o/r`, `merge`.
+const GH_VALUE_FLAGS = new Set(["-R", "--repo", "--hostname"]);
+
+/** gh's positional arguments — flag values removed, so the subcommand chain is
+ *  contiguous. Flags with `=` carry their value inline and need no skipping. */
+function ghPositionals(args) {
+  const positionals = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith("-")) {
+      if (GH_VALUE_FLAGS.has(a)) i++;
+      continue;
+    }
+    positionals.push(a);
+  }
+  return positionals;
+}
+
+/** Does `args` invoke `gh api` against a pulls/N/merge path with a write method? */
+function isGhApiMerge(args) {
+  if (!args.some((a) => MERGE_API_PATH.test(a))) return false;
+  let hasWriteMethod = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "-X" || a === "--method") {
+      if (WRITE_METHODS.has(String(args[i + 1] || "").toUpperCase())) {
+        hasWriteMethod = true;
+      }
+      continue;
+    }
+    const eq = /^(?:-X|--method)=(.+)$/.exec(a);
+    if (eq && WRITE_METHODS.has(eq[1].toUpperCase())) hasWriteMethod = true;
+  }
+  if (!hasWriteMethod) return false;
+  // `api` must be gh's subcommand, not a value of some flag.
+  return ghPositionals(args).includes("api");
+}
+
+/** Does `args` invoke `gh pr merge`? Adjacency in the positional chain, so
+ *  `gh -R o/r pr merge` matches while `gh pr list --search "pr merge"` — where
+ *  the search string is ONE quoted token — does not. */
+function isGhPrMerge(args) {
+  const positionals = ghPositionals(args);
+  return positionals.some(
+    (a, i) => a === "pr" && positionals[i + 1] === "merge"
+  );
+}
+
+/**
+ * Pure classifier. Returns { block, kind, detail }.
+ *   kind: "merge" | "merge-script" | null
+ * Exported so verify-guard-stack.cjs can probe that this guard still BLOCKS a
+ * known-bad command, not merely that it is still registered.
+ */
+function classifyMerge(toolName, command) {
+  if (toolName === "mcp__github__merge_pull_request") {
+    return { block: true, kind: "merge", detail: "MCP merge_pull_request" };
+  }
+  if (toolName !== "Bash") return { block: false, kind: null, detail: "" };
+
+  const cmd = String(command || "");
+  const { segments, unresolvable } = resolveCommand(cmd);
+
+  for (const segment of segments) {
+    if (segment.name === "merge-pr.sh") {
+      return {
+        block: true,
+        kind: "merge-script",
+        detail: "scripts/workflow/merge-pr.sh",
+      };
+    }
+    if (segment.name !== "gh") continue;
+    // `gh pr merge --help` / `gh api --help` document rather than merge.
+    if (segment.args.some((a) => HELP_FLAGS.has(a))) continue;
+    if (isGhPrMerge(segment.args)) {
+      return { block: true, kind: "merge", detail: "gh pr merge" };
+    }
+    if (isGhApiMerge(segment.args)) {
+      return { block: true, kind: "merge", detail: "gh api PUT .../merge" };
+    }
   }
 
-  const tool = payload.tool_name || "";
-  const toolInput = payload.tool_input || {};
-
-  let isMergeAttempt = false;
-  let isMergeScriptAttempt = false;
-  let detail = "";
-
-  if (tool === "Bash") {
-    const cmd = String(toolInput.command || "");
-    // Strip quoted content so mentions in `echo`/`rg`/docs/heredocs don't false-positive.
-    const stripped = cmd
-      .replace(/'[^']*'/g, "''")
-      .replace(/"(?:\\.|[^"\\])*"/g, '""');
-    const cmdStart = /(?:^|;|&&|\|\||\||&|\n|\$\(|<\(|\(|`)\s*/;
-
-    // Prefix gate: skip gh-related regex work when nothing gh-related is present, and
-    // pass any --help invocation symmetrically (`gh pr merge --help`, `gh api --help`).
-    if (cmd.includes("gh") && !/--help\b/.test(cmd)) {
-      const ghMerge = new RegExp(cmdStart.source + "gh\\s+pr\\s+merge\\b");
-      if (ghMerge.test(stripped)) {
-        isMergeAttempt = true;
-        detail = "gh pr merge";
-      }
-      // gh api ... /pulls/N/merge — AND three patterns so flag order doesn't matter.
-      // mergePath is the cheapest discriminator — test first to short-circuit.
-      const mergePath = /\/pulls\/\d+\/merge\b/;
-      const writeMethod = /(?:-X|--method)[\s=]+(?:PUT|POST)\b/;
-      const ghApiStart = new RegExp(cmdStart.source + "gh\\s+api\\b");
-      if (mergePath.test(stripped) && writeMethod.test(stripped) && ghApiStart.test(stripped)) {
-        isMergeAttempt = true;
-        detail = "gh api PUT .../merge";
+  if (unresolvable.length > 0) {
+    for (const { pattern, kind, detail } of RAW_MERGE_INDICATORS) {
+      if (pattern.test(cmd)) {
+        return { block: true, kind, detail: `${detail} (inside an unresolvable command)` };
       }
     }
+  }
 
-    // scripts/workflow/merge-pr.sh — detect at a command-start position, tolerating
-    // `bash`/`sh` wrappers, leading `VAR=val` assignments (bare or after `env`),
-    // and a relative/absolute path prefix ahead of the basename. Quote-stripped
-    // `stripped` reuses the same false-positive protection as the gh checks above
-    // (docs/echo mentions don't match).
-    const mergeScript = new RegExp(
-      cmdStart.source +
-        "(?:env\\s+)?" + // optional `env` wrapper
-        "(?:[A-Za-z_][A-Za-z0-9_]*=\\S+\\s+)*" + // optional leading VAR=val assignments (bare or after env)
-        "(?:(?:bash|sh)\\s+)?" + // optional interpreter wrapper
-        "(?:\\S*/)?" + // optional path prefix (relative or absolute)
-        "merge-pr\\.sh\\b"
+  return { block: false, kind: null, detail: "" };
+}
+
+module.exports = { classifyMerge };
+
+// --- Hook entrypoint ----------------------------------------------------------
+// Only run as a hook when invoked directly (not when require()'d by a test or by
+// the guard-stack canary).
+if (require.main === module) {
+  let input = "";
+  process.stdin.on("data", (c) => (input += c));
+  process.stdin.on("end", () => {
+    let payload;
+    try {
+      payload = JSON.parse(input);
+    } catch {
+      // Malformed payload — fail open to avoid breaking other hooks.
+      process.exit(0);
+    }
+
+    const { block, kind, detail } = classifyMerge(
+      payload.tool_name || "",
+      (payload.tool_input || {}).command
     );
-    if (mergeScript.test(stripped)) {
-      isMergeScriptAttempt = true;
-      detail = "scripts/workflow/merge-pr.sh";
-    }
-  } else if (tool === "mcp__github__merge_pull_request") {
-    isMergeAttempt = true;
-    detail = "MCP merge_pull_request";
-  }
 
-  if (isMergeScriptAttempt) {
+    if (!block) {
+      process.exit(0);
+    }
+
+    // No bypass sentinel — merging has no agent-usable escape hatch under the
+    // hard gate (PP-wi85). If merge-pr.sh itself is broken and a hotfix must
+    // ship, that is a human decision made in a human-run shell, not a hook bypass.
+    if (kind === "merge-script") {
+      console.error(
+        "Merge is human-only. You cannot run merge-pr.sh. Finish the PR (CI green, reviews " +
+          "resolved, screenshots posted if UI), then hand Tim the exact command to run himself: " +
+          `! scripts/workflow/merge-pr.sh <PR> --human [matched: ${detail}]`
+      );
+      process.exit(2);
+    }
+
     console.error(
-      "Merge is human-only. You cannot run merge-pr.sh. Finish the PR (CI green, reviews " +
-        "resolved, screenshots posted if UI), then hand Tim the exact command to run himself: " +
-        "! scripts/workflow/merge-pr.sh <PR> --human"
+      `Direct merge blocked: ${detail}. Merging is human-only — hand Tim the exact command to ` +
+        "run himself: ! scripts/workflow/merge-pr.sh <PR> --human"
     );
     process.exit(2);
-  }
-
-  if (!isMergeAttempt) {
-    process.exit(0);
-  }
-
-  // Block. No bypass sentinel — merging has no agent-usable escape hatch under
-  // the hard gate (PP-wi85). If merge-pr.sh itself is broken and a hotfix must
-  // ship, that is a human decision made in a human-run shell, not a hook bypass.
-  console.error(
-    `Direct merge blocked: ${detail}. Merging is human-only — hand Tim the exact command to ` +
-      "run himself: ! scripts/workflow/merge-pr.sh <PR> --human"
-  );
-  process.exit(2);
-});
+  });
+}

--- a/.claude/hooks/block-heavy-under-pressure.cjs
+++ b/.claude/hooks/block-heavy-under-pressure.cjs
@@ -30,20 +30,25 @@
 const { execFileSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
+const { resolveCommand } = require("./lib/resolve-command.cjs");
 
 // --- Pure classifier (unit-testable without spawning anything) ---------------
 // Decide whether a shell command string actually INVOKES one of the heavy
-// runners above. Mirrors the technique in block-main-worktree-branch-switch.cjs
-// (`classifyCommand`): resolve each segment's effective command instead of
-// regex-testing the raw string.
+// runners above. Command resolution — "what command is this segment?" — is
+// delegated to the shared lib/resolve-command.cjs primitive (PP-6t3c); this
+// file only holds the heavy/not-heavy POLICY on top of it.
 //
-// The old implementation ran the heavy regexes against the whole command, so
-// any command whose TEXT named a heavy runner — `echo "how to run pnpm run
+// The original implementation ran the heavy regexes against the whole command,
+// so any command whose TEXT named a heavy runner — `echo "how to run pnpm run
 // build"`, `bd comments add "…ran pnpm run smoke…"`, `rg "playwright test"
 // docs/`, `git commit -m "speed up vitest run"` — fired a memory probe that can
 // poll for up to five minutes. False positives are the cost that matters here:
 // the threat model is a well-meaning agent, not an attacker evading a filter,
 // so this deliberately does NOT try to be evasion-resistant.
+//
+// POSTURE ON `unresolvable`: ALLOW. A command whose runner cannot be known
+// statically is not worth a five-minute memory probe, and this gate protects
+// the host from thrash rather than enforcing a boundary.
 
 // `pnpm run <script>` is heavy for exactly these scripts. Anchored + \b so
 // `build` matches `build` (and today's `e2e:full`-style suffixes) but NOT
@@ -74,52 +79,28 @@ const RUNNER_EXEC_SUBCOMMANDS = new Set(["exec", "dlx", "x"]);
 // Runner subcommands that take a package.json SCRIPT name, not a binary.
 const RUNNER_RUN_SUBCOMMANDS = new Set(["run", "run-script"]);
 
-// Leading tokens that do not consume the command slot themselves.
-const WRAPPERS = new Set(["sudo", "env", "command", "time", "nice"]);
-const ENV_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*[+:]?=/;
-
-/** Strip one pair of surrounding matching quotes: `"build"` → `build`. */
-function unquote(token) {
-  const t = String(token || "");
-  return (t.startsWith('"') && t.endsWith('"') && t.length > 1) ||
-    (t.startsWith("'") && t.endsWith("'") && t.length > 1)
-    ? t.slice(1, -1)
-    : t;
-}
-
 /**
- * Is this ONE segment a heavy invocation?
+ * Is this ONE resolved segment a heavy invocation?
  *
- * Resolves the segment's effective command by skipping leading env assignments
- * (VAR=value) and leading wrappers (sudo/env/command/time/nice), comparing on
- * BASENAME so `./node_modules/.bin/playwright test` and
- * `/usr/local/bin/pnpm run build` resolve correctly, then stepping through any
+ * The shared primitive has already resolved the segment's effective command
+ * (leading `VAR=value` assignments and wrappers skipped, quotes stripped,
+ * `sh -c` / `eval` payloads re-parsed). All that is left is to compare on
+ * BASENAME — so `./node_modules/.bin/playwright test` and
+ * `/usr/local/bin/pnpm run build` resolve correctly — and step through any
  * package runner + subcommand so the effective argv becomes e.g.
  * `playwright test`.
  */
 function isHeavySegment(segment) {
-  const tokens = segment.split(/\s+/).filter(Boolean);
-
-  let cmdIdx = -1;
-  for (let i = 0; i < tokens.length; i++) {
-    const t = tokens[i];
-    if (ENV_ASSIGN.test(t)) continue; // skip VAR=value
-    if (WRAPPERS.has(t)) continue; // skip wrapper command itself
-    cmdIdx = i;
-    break;
-  }
-  if (cmdIdx === -1) return false;
-
   // Walk package runners. The hop cap just bounds pathological input; two hops
   // covers every real shape (`pnpm exec playwright test`, `npx -y vitest run`).
-  let argv = tokens.slice(cmdIdx);
+  let argv = [segment.name, ...segment.args];
   for (let hops = 0; hops < 3; hops++) {
-    const name = path.basename(unquote(argv[0]));
+    const name = path.basename(argv[0]);
 
     if (!PACKAGE_RUNNERS.has(name)) {
       // Resolved to a real binary — heavy only in its run/test form.
       const expected = HEAVY_BINARIES.get(name);
-      return expected !== undefined && unquote(argv[1] || "") === expected;
+      return expected !== undefined && (argv[1] || "") === expected;
     }
 
     // Skip the runner's own flags (`npx -y …`, `pnpm --silent …`) to find its
@@ -128,12 +109,12 @@ function isHeavySegment(segment) {
     // missed exotic invocation is cheaper than a false positive.
     let i = 1;
     while (i < argv.length && argv[i].startsWith("-")) i++;
-    const sub = unquote(argv[i] || "");
+    const sub = argv[i] || "";
     if (!sub) return false;
 
     if (RUNNER_RUN_SUBCOMMANDS.has(sub)) {
       // `pnpm run <script>` — heaviness is decided by the script name.
-      return HEAVY_PNPM_SCRIPT.test(unquote(argv[i + 1] || ""));
+      return HEAVY_PNPM_SCRIPT.test(argv[i + 1] || "");
     }
     // `pnpm exec <cmd>` / `pnpm dlx <cmd>` consume one more token;
     // `npx <cmd>` / `yarn <cmd>` put the command right there.
@@ -145,29 +126,28 @@ function isHeavySegment(segment) {
 
 /**
  * Does this command string invoke a heavy runner in ANY of its segments?
- * Split on shell separators: && || ; | — deliberately NOT on newlines.
+ * Separators are && || ; | & ( ) — deliberately NOT newlines.
  *
- * Newlines are excluded on purpose (PP-qota). We have no shell parser, so
- * splitting on them made the classifier descend into heredoc bodies and
- * multi-line quoted arguments: any LINE beginning with a heavy invocation
- * became its own "segment" and fired a memory probe that can poll for five
- * minutes. `cat <<EOF > notes.md` / `pnpm run build` / `EOF` is a `cat`, and
- * `bd comments add PP-x "…\npnpm run e2e\n…"` is a `bd`.
+ * Newlines stay excluded (PP-qota). The shared tokenizer now handles heredoc
+ * bodies and multi-line quoted arguments correctly on its own, so newline
+ * splitting would no longer descend into them — but this gate's cost function
+ * is asymmetric (a false positive costs a memory probe that can poll for five
+ * minutes) and the newline-split posture was chosen deliberately. Keeping
+ * `splitNewlines: false` means this refactor changes NO verdict here; revisit
+ * it as its own decision, not as a side effect of sharing a parser.
  *
- * Accepted cost: a genuine multi-line sequence —
+ * Accepted cost, unchanged: a genuine multi-line sequence —
  *   cd foo
  *   pnpm run build
- * — is no longer gated (false negative). That is the right trade under the
- * same principle documented above at the runner-flag walk: a missed exotic
- * invocation is cheaper than a false positive. Agents overwhelmingly write
- * that shape as `cd foo && pnpm run build`, which still gates.
+ * — is not gated (false negative). Same principle as the runner-flag walk
+ * above: a missed exotic invocation is cheaper than a false positive. Agents
+ * overwhelmingly write that shape as `cd foo && pnpm run build`, which gates.
  */
 function isHeavyCommand(command) {
-  const segments = String(command || "").split(/&&|\|\||;|\|/);
-  return segments.some((raw) => {
-    const segment = raw.trim();
-    return segment !== "" && isHeavySegment(segment);
+  const { segments } = resolveCommand(String(command || ""), {
+    splitNewlines: false,
   });
+  return segments.some(isHeavySegment);
 }
 
 module.exports = { isHeavyCommand };

--- a/.claude/hooks/block-main-worktree-branch-switch.cjs
+++ b/.claude/hooks/block-main-worktree-branch-switch.cjs
@@ -17,6 +17,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
+const { resolveCommand } = require("./lib/resolve-command.cjs");
 
 // --- Pure classifier (unit-testable without git) -----------------------------
 // Decide whether a shell command string should be BLOCKED because it switches
@@ -30,45 +31,26 @@ const { execFileSync } = require("node:child_process");
 //   - Otherwise BLOCK: `git checkout <other-branch>`, `git switch <other-branch>`,
 //     `git checkout -b|-B <name>`, `git switch -c|-C|--create <name>`,
 //     `git checkout -`, `git switch -`.
+//
+// Command resolution — "is this segment actually a `git` invocation?" — is
+// delegated to lib/resolve-command.cjs (PP-6t3c). That shared primitive is what
+// keeps `echo git checkout x` / `rg 'git checkout'` from reading as git, while
+// wrapper and quoting shapes this hook's own tokenizer used to fold on
+// (`sudo -u root git checkout x`, `eval "git checkout x"`, `sh -c "git switch x"`)
+// now resolve correctly.
+//
+// POSTURE ON `unresolvable`: FAIL OPEN, consistent with every other ambiguous
+// case in this hook (non-git commands, git errors, linked worktrees all ALLOW).
+// This guard has a documented single-use bypass sentinel and only fires in the
+// main worktree, so over-blocking costs more here than the residual risk of a
+// dynamically-constructed `git checkout` in the root checkout.
 function classifyCommand(command) {
-  const cmd = String(command || "");
-  // Split on shell separators: && || ; |
-  const segments = cmd.split(/&&|\|\||;|\|/);
+  const { segments } = resolveCommand(String(command || ""));
 
-  for (const rawSegment of segments) {
-    const segment = rawSegment.trim();
-    if (!segment) continue;
+  for (const segment of segments) {
+    if (segment.name !== "git") continue;
 
-    // Tokenize on whitespace. Good enough for the flag/branch checks below.
-    const tokens = segment.split(/\s+/).filter(Boolean);
-
-    // Resolve the effective command of the segment by skipping:
-    //   (a) leading environment-assignment tokens (VAR=value, VAR+=value, etc.)
-    //   (b) leading wrapper commands that do not consume the command slot
-    //       themselves: sudo, env, command, time, nice.
-    // Only if the resulting resolved command token is exactly "git" does this
-    // segment count as a git invocation. Anything else (e.g. `echo git checkout`,
-    // `rg git checkout`) is NOT a git invocation → skip to the next segment.
-    //
-    // Fail-open on wrappers-with-flags: if a wrapper is followed by its own flags
-    // (e.g. `sudo -u root git checkout`) before `git`, we stop scanning wrappers
-    // the moment we see a flag-like token, so the segment ALLOWS (the resolved
-    // command would be the flag, not `git`). This is intentionally conservative.
-    const WRAPPERS = new Set(["sudo", "env", "command", "time", "nice"]);
-    const ENV_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*[+:]?=/;
-
-    let cmdIdx = -1;
-    for (let i = 0; i < tokens.length; i++) {
-      const t = tokens[i];
-      if (ENV_ASSIGN.test(t)) continue; // skip VAR=value
-      if (WRAPPERS.has(t)) continue;    // skip wrapper command itself
-      cmdIdx = i;
-      break;
-    }
-    if (cmdIdx === -1 || tokens[cmdIdx] !== "git") continue;
-
-    // From here, `tokens[cmdIdx]` is exactly `git`.
-    const gitIdx = cmdIdx;
+    const tokens = segment.args;
 
     // Git global options that consume the NEXT token as their value
     // (e.g. `git -C path checkout`, `git --git-dir=... ` uses `=` so is self-contained).
@@ -85,7 +67,7 @@ function classifyCommand(command) {
 
     let subIdx = -1;
     let sub = "";
-    for (let i = gitIdx + 1; i < tokens.length; i++) {
+    for (let i = 0; i < tokens.length; i++) {
       const t = tokens[i];
       if (t === "checkout" || t === "switch") {
         subIdx = i;
@@ -156,19 +138,13 @@ function classifyCommand(command) {
       continue;
     }
 
-    // Strip a single pair of surrounding matching quotes so `git checkout "main"`
-    // / `git checkout 'main'` compare equal to `main` and ALLOW.
-    const unquoted =
-      (target.startsWith('"') && target.endsWith('"')) ||
-      (target.startsWith("'") && target.endsWith("'"))
-        ? target.slice(1, -1)
-        : target;
-
-    if (unquoted === "main") {
+    // Quotes are already stripped by the shared tokenizer, so `git checkout "main"`
+    // and `git checkout 'main'` both arrive here as `main` and ALLOW.
+    if (target === "main") {
       continue; // ALLOW switching to main.
     }
 
-    return { block: true, detail: `git ${sub} ${unquoted}` };
+    return { block: true, detail: `git ${sub} ${target}` };
   }
 
   return { block: false, detail: "" };

--- a/.claude/hooks/lib/resolve-command.cjs
+++ b/.claude/hooks/lib/resolve-command.cjs
@@ -73,33 +73,43 @@
 
 const path = require("node:path");
 
-// Wrappers that run another command rather than being the command. Value is the
-// set of the wrapper's OWN flags that consume a separate following token, plus
-// how many positional arguments the wrapper eats before the command starts
-// (`timeout 30 cmd`).
+// Wrappers that run another command rather than being the command. Each entry
+// carries:
+//   valueFlags   – the wrapper's OWN flags that consume a separate token
+//   payloadFlags – flags whose value is a shell PROGRAM, re-parsed rather than
+//                  skipped (GNU `env -S 'gh pr merge 123'`)
+//   positionals  – positional arguments the wrapper eats before the command
+//                  (`timeout 30 cmd`)
 //
 // Skipping a wrapper's flags is deliberate. The previous per-guard logic
 // stopped at the first flag-like token and gave up, which is exactly why
 // `sudo -u root chmod +x f` slipped past the chmod guard while `sudo chmod` did
-// not.
+// not. `payloadFlags` is the counterpart: skipping `-S`'s value would eat the
+// command itself.
+const makeWrapper = (valueFlags, options = {}) => ({
+  valueFlags: new Set(valueFlags),
+  payloadFlags: options.payloadFlags ?? [],
+  positionals: options.positionals ?? 0,
+});
+
 const WRAPPERS = new Map([
-  ["sudo", { valueFlags: new Set(["-u", "-g", "-U", "-p", "-r", "-t", "-C", "-D", "-h", "--user", "--group", "--other-user", "--prompt", "--role", "--type", "--close-from", "--chdir", "--host"]), positionals: 0 }],
-  ["doas", { valueFlags: new Set(["-u", "-C"]), positionals: 0 }],
-  ["env", { valueFlags: new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]), positionals: 0 }],
-  ["command", { valueFlags: new Set([]), positionals: 0 }],
-  ["builtin", { valueFlags: new Set([]), positionals: 0 }],
-  ["exec", { valueFlags: new Set(["-a"]), positionals: 0 }],
-  ["time", { valueFlags: new Set(["-o", "--output", "-f", "--format"]), positionals: 0 }],
-  ["nice", { valueFlags: new Set(["-n", "--adjustment"]), positionals: 0 }],
-  ["ionice", { valueFlags: new Set(["-c", "-n", "-p", "-P", "-u"]), positionals: 0 }],
-  ["nohup", { valueFlags: new Set([]), positionals: 0 }],
-  ["setsid", { valueFlags: new Set([]), positionals: 0 }],
-  ["stdbuf", { valueFlags: new Set(["-i", "-o", "-e", "--input", "--output", "--error"]), positionals: 0 }],
-  ["timeout", { valueFlags: new Set(["-s", "--signal", "-k", "--kill-after"]), positionals: 1 }],
+  ["sudo", makeWrapper(["-u", "-g", "-U", "-p", "-r", "-t", "-C", "-D", "-h", "--user", "--group", "--other-user", "--prompt", "--role", "--type", "--close-from", "--chdir", "--host"])],
+  ["doas", makeWrapper(["-u", "-C"])],
+  ["env", makeWrapper(["-u", "--unset", "-C", "--chdir"], { payloadFlags: ["--split-string", "-S"] })],
+  ["command", makeWrapper([])],
+  ["builtin", makeWrapper([])],
+  ["exec", makeWrapper(["-a"])],
+  ["time", makeWrapper(["-o", "--output", "-f", "--format"])],
+  ["nice", makeWrapper(["-n", "--adjustment"])],
+  ["ionice", makeWrapper(["-c", "-n", "-p", "-P", "-u"])],
+  ["nohup", makeWrapper([])],
+  ["setsid", makeWrapper([])],
+  ["stdbuf", makeWrapper(["-i", "-o", "-e", "--input", "--output", "--error"])],
+  ["timeout", makeWrapper(["-s", "--signal", "-k", "--kill-after"], { positionals: 1 })],
   // `xargs [flags] CMD ARGS…` — CMD really does run, with extra args appended
   // from stdin. Treating xargs as a wrapper is what closes
   // `xargs -I{} gh pr merge {} < prs.txt`.
-  ["xargs", { valueFlags: new Set(["-I", "-i", "-n", "-P", "-d", "-E", "-L", "-s", "-a", "--replace", "--max-args", "--max-procs", "--delimiter", "--eof", "--max-lines", "--max-chars", "--arg-file"]), positionals: 0 }],
+  ["xargs", makeWrapper(["-I", "-i", "-n", "-P", "-d", "-E", "-L", "-s", "-a", "--replace", "--max-args", "--max-procs", "--delimiter", "--eof", "--max-lines", "--max-chars", "--arg-file"])],
 ]);
 
 // Shells: `sh -c "<program>"` re-parses its argument, and `sh <file>` makes the
@@ -212,6 +222,9 @@ function tokenize(src) {
   };
   const pushOp = (value) => {
     flush();
+    // A redirect target cannot cross a separator, so a pending drop must not
+    // either — otherwise `cmd >; cmd2` would swallow `cmd2` in silence.
+    dropWords = 0;
     tokens.push({ type: "op", value });
   };
 
@@ -445,9 +458,54 @@ function splitSegments(tokens, splitNewlines) {
   return segments;
 }
 
-/** Skip leading `VAR=value` assignments and wrappers. Returns the index of the
- *  effective command word, or -1 if the segment has none. */
-function findCommandIndex(words) {
+/**
+ * Is `words[i]` one of this wrapper's PAYLOAD flags — a flag whose value is a
+ * shell program rather than a plain value? GNU `env -S 'gh pr merge 123'` is
+ * the one that matters: env splits the string and runs it.
+ *
+ * Returns a `{ kind: "payload", word }` slot, or null. Handles all three
+ * spellings: `-S STR`, `-SSTR`, `--split-string=STR`.
+ */
+function readPayloadFlag(wrapper, words, i) {
+  const word = words[i];
+  const flag = word.value;
+  for (const pf of wrapper.payloadFlags) {
+    if (flag === pf) {
+      const next = words[i + 1];
+      // `env -S` with nothing after it runs nothing — fall through to the
+      // ordinary flag walk rather than inventing an empty payload.
+      return next ? { kind: "payload", word: next } : null;
+    }
+    const attached = pf.startsWith("--")
+      ? flag.startsWith(`${pf}=`) && flag.slice(pf.length + 1)
+      : flag.length > pf.length && flag.startsWith(pf) && flag.slice(pf.length);
+    if (attached) {
+      return {
+        kind: "payload",
+        word: { value: attached, dynamic: word.dynamic, subs: [] },
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a segment's command slot past leading `VAR=value` assignments and
+ * wrappers. Returns one of:
+ *   { kind: "command", index }  – words[index] is the effective command
+ *   { kind: "payload", word }   – word.value is a shell program to re-parse
+ *   { kind: "none" }            – the segment is assignments-only (or empty),
+ *                                 which is a real "no command", not a failure
+ *
+ * There is deliberately NO "gave up" result. A wrapper that consumes the whole
+ * segment (`sudo -l`, `env`, `timeout 30`) resolves to the WRAPPER itself,
+ * because that is what actually runs. An earlier revision returned -1 there and
+ * `resolveSegment` dropped the segment in silence — which is how
+ * `env -S 'gh pr merge 123'` slipped past the merge guard: `-S` was modelled as
+ * an ordinary value flag, the scan ate the payload, and the segment vanished.
+ * A guard cannot pick a safe posture on a signal it never receives.
+ */
+function resolveCommandSlot(words) {
   let i = 0;
   while (i < words.length) {
     const w = words[i];
@@ -456,8 +514,9 @@ function findCommandIndex(words) {
       continue;
     }
     const wrapper = WRAPPERS.get(path.basename(w.value));
-    if (!wrapper) return i;
+    if (!wrapper) return { kind: "command", index: i };
 
+    const wrapperIdx = i;
     i++;
     // Skip the wrapper's own flags (and the values they consume).
     while (i < words.length && words[i].value.startsWith("-")) {
@@ -466,6 +525,9 @@ function findCommandIndex(words) {
         i++;
         break;
       }
+      const payload = readPayloadFlag(wrapper, words, i);
+      if (payload) return payload;
+
       // The value may already be attached — `--max-args=3`, `-I{}`, `-n1`.
       // Only a bare flag consumes the following token.
       const hasEquals = flag.includes("=");
@@ -477,8 +539,11 @@ function findCommandIndex(words) {
     }
     // Skip the wrapper's own positional arguments (`timeout 30 cmd`).
     for (let p = 0; p < wrapper.positionals && i < words.length; p++) i++;
+
+    // Nothing left after the wrapper — the wrapper IS the command.
+    if (i >= words.length) return { kind: "command", index: wrapperIdx };
   }
-  return -1;
+  return { kind: "none" };
 }
 
 /** Best-effort human-readable text for an unresolvable report. A word that is
@@ -503,11 +568,27 @@ function resolveSegment(words, out, depth, options) {
     }
   }
 
-  const cmdIdx = findCommandIndex(words);
-  if (cmdIdx === -1) return;
+  const slot = resolveCommandSlot(words);
 
-  const cmdWord = words[cmdIdx];
-  const argWords = words.slice(cmdIdx + 1);
+  // `env -S '<program>'` — GNU env splits the string and runs it.
+  if (slot.kind === "payload") {
+    if (slot.word.dynamic) {
+      out.unresolvable.push({
+        reason: "split-string-dynamic",
+        text: describeWords(words),
+      });
+      return;
+    }
+    resolveInto(slot.word.value, out, depth + 1, options);
+    return;
+  }
+
+  // Assignments-only segment (`FOO=bar; …`). A real "no command", not a
+  // parse failure — nothing to report.
+  if (slot.kind === "none") return;
+
+  const cmdWord = words[slot.index];
+  const argWords = words.slice(slot.index + 1);
 
   // The command slot itself is a substitution/variable → we cannot know what
   // runs. `$(pick-tool) pr merge 1`, `$CMD --squash`.
@@ -516,6 +597,25 @@ function resolveSegment(words, out, depth, options) {
       reason: "substituted-command",
       text: describeWords(words),
     });
+    return;
+  }
+
+  // A command slot containing whitespace is not a single binary. Either the
+  // shell fails to find it, or something we did not model splits it (a wrapper
+  // flag cluster like `env -iS 'gh pr merge 1'`). Report it AND re-parse it:
+  // a hard-boundary guard gets the signal, a fail-open guard still gets real
+  // segments.
+  if (/\s/.test(cmdWord.value)) {
+    out.unresolvable.push({
+      reason: "split-string-command",
+      text: describeWords(words),
+    });
+    resolveInto(
+      [cmdWord.value, ...argWords.map((w) => w.value)].join(" "),
+      out,
+      depth + 1,
+      options
+    );
     return;
   }
 
@@ -592,7 +692,27 @@ function resolveInto(command, out, depth, options) {
     out.unresolvable.push({ reason: "unbalanced-quote", text: src });
   }
   for (const words of splitSegments(tokens, options.splitNewlines)) {
+    const segmentsBefore = out.segments.length;
+    const unresolvableBefore = out.unresolvable.length;
     resolveSegment(words, out, depth, options);
+
+    // BACKSTOP — the invariant this module owes its callers: a segment that
+    // contains a real (non-assignment) word must produce EITHER a segment or an
+    // `unresolvable`. Never silence. A guard can pick a safe posture on any
+    // signal, but not on the absence of one — silence is how the merge boundary
+    // was bypassable in the first place. This should be unreachable; it exists
+    // so a future edit that reintroduces a dead end degrades to "I cannot tell"
+    // instead of "nothing to see here".
+    if (
+      out.segments.length === segmentsBefore &&
+      out.unresolvable.length === unresolvableBefore &&
+      words.some((w) => !ENV_ASSIGN.test(w.value))
+    ) {
+      out.unresolvable.push({
+        reason: "no-effective-command",
+        text: describeWords(words),
+      });
+    }
   }
 }
 

--- a/.claude/hooks/lib/resolve-command.cjs
+++ b/.claude/hooks/lib/resolve-command.cjs
@@ -43,9 +43,10 @@
  *
  * KNOWN LIMITATIONS (all fail toward `unresolvable`, never toward a silent
  * "not a match"):
- *   - ANSI-C quoting (`$'it\'s'`) is read as a plain single-quoted span, so the
- *     backslash-escaped quote reads as unbalanced. The command would not run in
- *     bash either; it is reported unresolvable rather than mis-parsed.
+ *   - ANSI-C quoting (`$'it\'s'`) is not supported. It is valid bash, but this
+ *     reads it as a plain single-quoted span, where the backslash-escaped quote
+ *     looks unbalanced — so a valid command using it is reported `unresolvable`
+ *     rather than resolved.
  *   - `find -exec cmd \;` and `watch cmd` are not treated as wrappers, so the
  *     inner command is seen as arguments.
  *   - Only ONE `-c` payload per shell invocation is followed.
@@ -214,7 +215,12 @@ function tokenize(src) {
     tokens.push({ type: "op", value });
   };
 
-  /** Consume heredoc bodies queued by `<<TAG` operators on the line just ended. */
+  /** Consume heredoc bodies queued by `<<TAG` operators on the line just ended.
+   *
+   *  The terminator must match the tag EXACTLY, as bash requires — only `<<-`
+   *  allows leading tabs, and nothing allows surrounding spaces. Accepting a
+   *  trimmed match would end the body early on an indented `EOF` inside it, and
+   *  the remaining body lines would then be parsed as real commands. */
   const consumeHeredocs = (from) => {
     let i = from;
     while (pendingHeredocs.length > 0) {
@@ -222,9 +228,13 @@ function tokenize(src) {
       for (;;) {
         const nl = src.indexOf("\n", i);
         const line = nl === -1 ? src.slice(i) : src.slice(i, nl);
-        const cmp = stripTabs ? line.replace(/^\t+/, "") : line;
+        // Tolerate CRLF input; that is a line ending, not body content.
+        const cmp = (stripTabs ? line.replace(/^\t+/, "") : line).replace(
+          /\r$/,
+          ""
+        );
         i = nl === -1 ? src.length : nl + 1;
-        if (cmp.trim() === tag || nl === -1) break;
+        if (cmp === tag || nl === -1) break;
       }
     }
     return i;

--- a/.claude/hooks/lib/resolve-command.cjs
+++ b/.claude/hooks/lib/resolve-command.cjs
@@ -1,0 +1,605 @@
+#!/usr/bin/env node
+/**
+ * .claude/hooks/lib/resolve-command.cjs
+ *
+ * ONE answer to "what command is this?", shared by every PreToolUse Bash guard.
+ *
+ * WHY THIS EXISTS (PP-6t3c, PP-ar8a). Each guard used to answer that question
+ * with its own regex, and each answered differently. The merge boundary
+ * (PP-wi85) was bypassable on `main`: `gh pr merge 123` blocked, but
+ * `eval "gh pr merge 123"`, `env gh pr merge 123`, `time gh pr merge 123` and
+ * `xargs -I{} gh pr merge {}` all sailed through, because a command the matcher
+ * could not parse silently read as "not a match".
+ *
+ * The missing concept was UNRESOLVABLE. A guard needs three answers, not two:
+ * "this is command X", "this is definitely not command X", and "I cannot tell".
+ * This module returns all three; each guard then picks its own posture on the
+ * third (the merge guard blocks, the memory gate allows).
+ *
+ * WHAT IT DOES
+ *   - Quote-aware tokenizer: quoted spans become ONE argument, never a command.
+ *     `echo "run merge-pr.sh"` resolves to `echo`, not `merge-pr.sh`.
+ *   - Heredoc bodies are consumed during tokenization (so quote-awareness still
+ *     applies to the `<<TAG` operator itself) and never parsed as commands.
+ *   - Redirections and their targets are dropped, not mistaken for arguments.
+ *   - Segments are split on real shell separators: && || ; | & newline ( ).
+ *   - Per segment, the EFFECTIVE command is resolved by skipping leading
+ *     `VAR=value` assignments and wrappers that do not consume the command slot
+ *     (`sudo`, `env`, `command`, `time`, `nice`, `xargs`, `timeout`, ...),
+ *     INCLUDING those wrappers' own flags — `sudo -u root chmod +x f` resolves
+ *     to `chmod`.
+ *   - Literal shell payloads are re-parsed, not skipped: `eval "…"`,
+ *     `sh -c "…"`, `bash -c '…'`, `$(…)` and backtick substitutions all
+ *     contribute their own segments.
+ *   - Anything whose command slot cannot be known statically — `eval "$CMD"`,
+ *     `sh -c "$X"`, `$(pick) pr merge`, an unbalanced quote — is reported in
+ *     `unresolvable` instead of being silently dropped.
+ *
+ * WHAT IT IS NOT: a shell. It does not expand variables, evaluate globs, or
+ * understand `for`/`if`/functions. The threat model is a well-meaning agent
+ * that wraps a command (accidentally or to "work around" a guard), not an
+ * attacker with unbounded shell tricks. Guards on a hard boundary should still
+ * treat `unresolvable` as suspicious rather than assuming it is safe.
+ *
+ * KNOWN LIMITATIONS (all fail toward `unresolvable`, never toward a silent
+ * "not a match"):
+ *   - ANSI-C quoting (`$'it\'s'`) is read as a plain single-quoted span, so the
+ *     backslash-escaped quote reads as unbalanced. The command would not run in
+ *     bash either; it is reported unresolvable rather than mis-parsed.
+ *   - `find -exec cmd \;` and `watch cmd` are not treated as wrappers, so the
+ *     inner command is seen as arguments.
+ *   - Only ONE `-c` payload per shell invocation is followed.
+ *
+ * API
+ *   resolveCommand(commandString, options?) → {
+ *     segments:     Segment[],       // { command, name, args, raw }
+ *     unresolvable: Unresolvable[],  // { reason, text }
+ *   }
+ *
+ *   Segment.command  the resolved command token, unquoted, as written
+ *                    (e.g. "./scripts/workflow/merge-pr.sh")
+ *   Segment.name     its basename (e.g. "merge-pr.sh") — what guards match on
+ *   Segment.args     the tokens after it, unquoted, in order
+ *   Segment.raw      normalized reconstruction (`[command, ...args].join(" ")`),
+ *                    for messages only — NOT source-exact
+ *
+ *   options.splitNewlines  default true. Pass false to keep a newline from
+ *                          separating segments (block-heavy-under-pressure
+ *                          deliberately does this — see PP-qota).
+ */
+
+"use strict";
+
+const path = require("node:path");
+
+// Wrappers that run another command rather than being the command. Value is the
+// set of the wrapper's OWN flags that consume a separate following token, plus
+// how many positional arguments the wrapper eats before the command starts
+// (`timeout 30 cmd`).
+//
+// Skipping a wrapper's flags is deliberate. The previous per-guard logic
+// stopped at the first flag-like token and gave up, which is exactly why
+// `sudo -u root chmod +x f` slipped past the chmod guard while `sudo chmod` did
+// not.
+const WRAPPERS = new Map([
+  ["sudo", { valueFlags: new Set(["-u", "-g", "-U", "-p", "-r", "-t", "-C", "-D", "-h", "--user", "--group", "--other-user", "--prompt", "--role", "--type", "--close-from", "--chdir", "--host"]), positionals: 0 }],
+  ["doas", { valueFlags: new Set(["-u", "-C"]), positionals: 0 }],
+  ["env", { valueFlags: new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]), positionals: 0 }],
+  ["command", { valueFlags: new Set([]), positionals: 0 }],
+  ["builtin", { valueFlags: new Set([]), positionals: 0 }],
+  ["exec", { valueFlags: new Set(["-a"]), positionals: 0 }],
+  ["time", { valueFlags: new Set(["-o", "--output", "-f", "--format"]), positionals: 0 }],
+  ["nice", { valueFlags: new Set(["-n", "--adjustment"]), positionals: 0 }],
+  ["ionice", { valueFlags: new Set(["-c", "-n", "-p", "-P", "-u"]), positionals: 0 }],
+  ["nohup", { valueFlags: new Set([]), positionals: 0 }],
+  ["setsid", { valueFlags: new Set([]), positionals: 0 }],
+  ["stdbuf", { valueFlags: new Set(["-i", "-o", "-e", "--input", "--output", "--error"]), positionals: 0 }],
+  ["timeout", { valueFlags: new Set(["-s", "--signal", "-k", "--kill-after"]), positionals: 1 }],
+  // `xargs [flags] CMD ARGS…` — CMD really does run, with extra args appended
+  // from stdin. Treating xargs as a wrapper is what closes
+  // `xargs -I{} gh pr merge {} < prs.txt`.
+  ["xargs", { valueFlags: new Set(["-I", "-i", "-n", "-P", "-d", "-E", "-L", "-s", "-a", "--replace", "--max-args", "--max-procs", "--delimiter", "--eof", "--max-lines", "--max-chars", "--arg-file"]), positionals: 0 }],
+]);
+
+// Shells: `sh -c "<program>"` re-parses its argument, and `sh <file>` makes the
+// file the effective command (`bash scripts/workflow/merge-pr.sh`).
+const SHELLS = new Set(["sh", "bash", "zsh", "dash", "ksh", "ash"]);
+
+const ENV_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*[+:]?=/;
+
+// How deep to follow eval / sh -c / $() nesting before giving up. Two levels is
+// already exotic; the cap only bounds pathological input.
+const MAX_DEPTH = 5;
+
+// --- Tokenizer ---------------------------------------------------------------
+
+/**
+ * Read a balanced `$( … )` / `<( … )` / `>( … )` span starting at the open
+ * paren index. Skips over quoted spans so a `)` inside quotes does not close
+ * it. Returns { body, next } where `next` is the index just past the `)`.
+ */
+function readParenSpan(src, openIdx) {
+  let depth = 0;
+  let i = openIdx;
+  const n = src.length;
+  const start = openIdx + 1;
+  while (i < n) {
+    const c = src[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      const close = findQuoteEnd(src, i);
+      i = close === -1 ? n : close + 1;
+      continue;
+    }
+    if (c === "(") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (c === ")") {
+      depth--;
+      i++;
+      if (depth === 0) return { body: src.slice(start, i - 1), next: i };
+      continue;
+    }
+    i++;
+  }
+  return { body: src.slice(start), next: n, unterminated: true };
+}
+
+/** Index of the closing quote matching the one at `openIdx`, or -1. */
+function findQuoteEnd(src, openIdx) {
+  const q = src[openIdx];
+  for (let i = openIdx + 1; i < src.length; i++) {
+    if (q === '"' && src[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (src[i] === q) return i;
+  }
+  return -1;
+}
+
+/** Read a backtick span. Returns { body, next }. */
+function readBacktickSpan(src, openIdx) {
+  for (let i = openIdx + 1; i < src.length; i++) {
+    if (src[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (src[i] === "`") return { body: src.slice(openIdx + 1, i), next: i + 1 };
+  }
+  return { body: src.slice(openIdx + 1), next: src.length, unterminated: true };
+}
+
+/**
+ * Tokenize a command string into words and separator operators.
+ *
+ * Returns { tokens, unbalanced } where each token is either
+ *   { type: "word", value, quoted, dynamic, subs }
+ *     value   – unquoted text
+ *     quoted  – any part of it came from inside quotes
+ *     dynamic – contains a variable/substitution, so its literal text is
+ *               not the whole story
+ *     subs    – bodies of `$( )` / backtick substitutions found inside it
+ * or
+ *   { type: "op", value }  – one of && || ;; ; |& | & ( ) \n
+ */
+function tokenize(src) {
+  const tokens = [];
+  let unbalanced = false;
+  let cur = null;
+  let dropWords = 0;
+  const pendingHeredocs = [];
+
+  const ensure = () => {
+    if (!cur) cur = { value: "", quoted: false, dynamic: false, subs: [] };
+    return cur;
+  };
+  const flush = () => {
+    if (!cur) return;
+    const word = cur;
+    cur = null;
+    if (dropWords > 0) {
+      dropWords--;
+      return;
+    }
+    tokens.push({ type: "word", ...word });
+  };
+  const pushOp = (value) => {
+    flush();
+    tokens.push({ type: "op", value });
+  };
+
+  /** Consume heredoc bodies queued by `<<TAG` operators on the line just ended. */
+  const consumeHeredocs = (from) => {
+    let i = from;
+    while (pendingHeredocs.length > 0) {
+      const { tag, stripTabs } = pendingHeredocs.shift();
+      for (;;) {
+        const nl = src.indexOf("\n", i);
+        const line = nl === -1 ? src.slice(i) : src.slice(i, nl);
+        const cmp = stripTabs ? line.replace(/^\t+/, "") : line;
+        i = nl === -1 ? src.length : nl + 1;
+        if (cmp.trim() === tag || nl === -1) break;
+      }
+    }
+    return i;
+  };
+
+  let i = 0;
+  const n = src.length;
+
+  while (i < n) {
+    const c = src[i];
+
+    if (c === "\n") {
+      pushOp("\n");
+      i = consumeHeredocs(i + 1);
+      continue;
+    }
+
+    if (c === " " || c === "\t" || c === "\r") {
+      flush();
+      i++;
+      continue;
+    }
+
+    if (c === "\\") {
+      if (src[i + 1] === "\n") {
+        i += 2; // line continuation
+        continue;
+      }
+      ensure().value += src[i + 1] ?? "";
+      i += 2;
+      continue;
+    }
+
+    if (c === "'") {
+      const end = findQuoteEnd(src, i);
+      const t = ensure();
+      t.quoted = true;
+      if (end === -1) {
+        unbalanced = true;
+        t.value += src.slice(i + 1);
+        i = n;
+        continue;
+      }
+      t.value += src.slice(i + 1, end);
+      i = end + 1;
+      continue;
+    }
+
+    if (c === '"') {
+      const t = ensure();
+      t.quoted = true;
+      i++;
+      let closed = false;
+      while (i < n) {
+        const d = src[i];
+        if (d === "\\") {
+          t.value += src[i + 1] ?? "";
+          i += 2;
+          continue;
+        }
+        if (d === '"') {
+          closed = true;
+          i++;
+          break;
+        }
+        if (d === "$" && src[i + 1] === "(") {
+          const span = readParenSpan(src, i + 1);
+          t.subs.push(span.body);
+          t.dynamic = true;
+          i = span.next;
+          continue;
+        }
+        if (d === "`") {
+          const span = readBacktickSpan(src, i);
+          t.subs.push(span.body);
+          t.dynamic = true;
+          i = span.next;
+          continue;
+        }
+        if (d === "$") {
+          t.dynamic = true;
+          t.value += d;
+          i++;
+          continue;
+        }
+        t.value += d;
+        i++;
+      }
+      if (!closed) unbalanced = true;
+      continue;
+    }
+
+    if (c === "$" && src[i + 1] === "(") {
+      const span = readParenSpan(src, i + 1);
+      const t = ensure();
+      t.subs.push(span.body);
+      t.dynamic = true;
+      i = span.next;
+      continue;
+    }
+
+    if (c === "`") {
+      const span = readBacktickSpan(src, i);
+      const t = ensure();
+      t.subs.push(span.body);
+      t.dynamic = true;
+      i = span.next;
+      continue;
+    }
+
+    if (c === "$") {
+      ensure().dynamic = true;
+      ensure().value += c;
+      i++;
+      continue;
+    }
+
+    // Process substitution: <( … ) / >( … ) — the body is a real command.
+    if ((c === "<" || c === ">") && src[i + 1] === "(") {
+      const span = readParenSpan(src, i + 1);
+      const t = ensure();
+      t.subs.push(span.body);
+      t.dynamic = true;
+      i = span.next;
+      continue;
+    }
+
+    // Heredoc: `<<TAG`, `<<-TAG`, `<<'TAG'`. Detected HERE, inside the
+    // quote-aware walk, so `echo "use <<EOF"` cannot swallow the rest of the
+    // input as a heredoc body.
+    if (c === "<" && src[i + 1] === "<" && src[i + 2] !== "<") {
+      let j = i + 2;
+      let stripTabs = false;
+      if (src[j] === "-") {
+        stripTabs = true;
+        j++;
+      }
+      while (src[j] === " " || src[j] === "\t") j++;
+      let tag = "";
+      if (src[j] === "'" || src[j] === '"') {
+        const q = src[j];
+        j++;
+        while (j < n && src[j] !== q) tag += src[j++];
+        j++;
+      } else {
+        while (j < n && /[A-Za-z0-9_]/.test(src[j])) tag += src[j++];
+      }
+      if (tag) {
+        pendingHeredocs.push({ tag, stripTabs });
+        flush();
+        i = j;
+        continue;
+      }
+    }
+
+    // Plain redirection: drop the operator and its target word, and drop a
+    // bare leading fd digit (`2>&1`) that is already in the current token.
+    if (c === "<" || c === ">") {
+      if (cur && !cur.quoted && /^\d+$/.test(cur.value)) cur = null;
+      flush();
+      i++;
+      while (i < n && (src[i] === ">" || src[i] === "<" || src[i] === "&")) i++;
+      dropWords++;
+      continue;
+    }
+
+    const two = src.slice(i, i + 2);
+    if (two === "&&" || two === "||" || two === ";;" || two === "|&") {
+      pushOp(two);
+      i += 2;
+      continue;
+    }
+    if (c === ";" || c === "|" || c === "&" || c === "(" || c === ")") {
+      pushOp(c);
+      i++;
+      continue;
+    }
+
+    ensure().value += c;
+    i++;
+  }
+
+  flush();
+  return { tokens, unbalanced };
+}
+
+// --- Segment resolution -------------------------------------------------------
+
+/** Split a token stream into per-segment word arrays. */
+function splitSegments(tokens, splitNewlines) {
+  const segments = [];
+  let current = [];
+  for (const token of tokens) {
+    if (token.type === "op") {
+      if (token.value === "\n" && !splitNewlines) {
+        // Newline is not a separator for this caller: keep accumulating. The
+        // words on the next line join this segment and (being neither the
+        // command slot nor a recognised wrapper) simply read as arguments.
+        continue;
+      }
+      if (current.length > 0) segments.push(current);
+      current = [];
+      continue;
+    }
+    current.push(token);
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+/** Skip leading `VAR=value` assignments and wrappers. Returns the index of the
+ *  effective command word, or -1 if the segment has none. */
+function findCommandIndex(words) {
+  let i = 0;
+  while (i < words.length) {
+    const w = words[i];
+    if (ENV_ASSIGN.test(w.value)) {
+      i++;
+      continue;
+    }
+    const wrapper = WRAPPERS.get(path.basename(w.value));
+    if (!wrapper) return i;
+
+    i++;
+    // Skip the wrapper's own flags (and the values they consume).
+    while (i < words.length && words[i].value.startsWith("-")) {
+      const flag = words[i].value;
+      if (flag === "--") {
+        i++;
+        break;
+      }
+      // The value may already be attached — `--max-args=3`, `-I{}`, `-n1`.
+      // Only a bare flag consumes the following token.
+      const hasEquals = flag.includes("=");
+      const bare = hasEquals ? flag.slice(0, flag.indexOf("=")) : flag;
+      const attachedShortValue =
+        !hasEquals && !bare.startsWith("--") && flag.length > 2;
+      i++;
+      if (!hasEquals && !attachedShortValue && wrapper.valueFlags.has(bare)) i++;
+    }
+    // Skip the wrapper's own positional arguments (`timeout 30 cmd`).
+    for (let p = 0; p < wrapper.positionals && i < words.length; p++) i++;
+  }
+  return -1;
+}
+
+/** Best-effort human-readable text for an unresolvable report. A word that is
+ *  purely a substitution has an empty literal value, so fall back to the
+ *  substitution body — `$(pick) pr merge` should not report as just `pr merge`. */
+function describeWords(words) {
+  return words
+    .map((w) => (w.value === "" && w.subs.length > 0 ? `$(${w.subs.join("; ")})` : w.value))
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Resolve one segment into zero or more Segments, following literal shell
+ * payloads. Pushes into `out.segments` / `out.unresolvable`.
+ */
+function resolveSegment(words, out, depth, options) {
+  // Any substitution anywhere in the segment is itself a command to resolve.
+  for (const w of words) {
+    for (const body of w.subs) {
+      resolveInto(body, out, depth + 1, options);
+    }
+  }
+
+  const cmdIdx = findCommandIndex(words);
+  if (cmdIdx === -1) return;
+
+  const cmdWord = words[cmdIdx];
+  const argWords = words.slice(cmdIdx + 1);
+
+  // The command slot itself is a substitution/variable → we cannot know what
+  // runs. `$(pick-tool) pr merge 1`, `$CMD --squash`.
+  if (cmdWord.dynamic) {
+    out.unresolvable.push({
+      reason: "substituted-command",
+      text: describeWords(words),
+    });
+    return;
+  }
+
+  const name = path.basename(cmdWord.value);
+
+  if (name === "eval") {
+    // bash concatenates eval's arguments and re-parses the result.
+    if (argWords.some((w) => w.dynamic)) {
+      out.unresolvable.push({
+        reason: "eval-dynamic",
+        text: `eval ${argWords.map((w) => w.value).join(" ")}`.trim(),
+      });
+      return;
+    }
+    resolveInto(argWords.map((w) => w.value).join(" "), out, depth + 1, options);
+    return;
+  }
+
+  if (SHELLS.has(name)) {
+    // `-c`, and combined short-flag forms that end in it (`bash -lc "…"`).
+    const dashCIdx = argWords.findIndex((w) => /^-[A-Za-z]*c$/.test(w.value));
+    if (dashCIdx !== -1) {
+      const payload = argWords[dashCIdx + 1];
+      if (!payload) return;
+      if (payload.dynamic) {
+        out.unresolvable.push({
+          reason: "shell-c-dynamic",
+          text: `${name} -c ${payload.value}`.trim(),
+        });
+        return;
+      }
+      resolveInto(payload.value, out, depth + 1, options);
+      return;
+    }
+    // `bash script.sh args…` — the script is the effective command.
+    const scriptIdx = argWords.findIndex((w) => !w.value.startsWith("-"));
+    if (scriptIdx !== -1) {
+      const script = argWords[scriptIdx];
+      if (script.dynamic) {
+        out.unresolvable.push({
+          reason: "substituted-command",
+          text: `${name} ${script.value}`.trim(),
+        });
+        return;
+      }
+      pushSegment(out, script.value, argWords.slice(scriptIdx + 1));
+      return;
+    }
+  }
+
+  pushSegment(out, cmdWord.value, argWords);
+}
+
+function pushSegment(out, command, argWords) {
+  const args = argWords.map((w) => w.value);
+  out.segments.push({
+    command,
+    name: path.basename(command),
+    args,
+    raw: [command, ...args].join(" "),
+  });
+}
+
+function resolveInto(command, out, depth, options) {
+  if (depth > MAX_DEPTH) {
+    out.unresolvable.push({ reason: "depth-limit", text: String(command) });
+    return;
+  }
+  const src = String(command || "");
+  if (src.trim() === "") return;
+
+  const { tokens, unbalanced } = tokenize(src);
+  if (unbalanced) {
+    out.unresolvable.push({ reason: "unbalanced-quote", text: src });
+  }
+  for (const words of splitSegments(tokens, options.splitNewlines)) {
+    resolveSegment(words, out, depth, options);
+  }
+}
+
+/**
+ * Resolve a shell command string into its effective per-segment commands.
+ *
+ * @param {string} command
+ * @param {{ splitNewlines?: boolean }} [options]
+ * @returns {{ segments: Array<{command: string, name: string, args: string[], raw: string}>,
+ *             unresolvable: Array<{reason: string, text: string}> }}
+ */
+function resolveCommand(command, options = {}) {
+  const out = { segments: [], unresolvable: [] };
+  resolveInto(command, out, 0, {
+    splitNewlines: options.splitNewlines !== false,
+  });
+  return out;
+}
+
+module.exports = { resolveCommand, WRAPPERS, SHELLS };

--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -16,6 +16,12 @@
  *               / bash just fails to load a missing file on every matching
  *               tool call.
  * ...or if permissions.deny / permissions.ask have been stripped.
+ *
+ * It ALSO probes behaviour, not just registration (PP-6t3c). Registration is a
+ * weak proxy: on 2026-07-26 the merge guard was fully registered, fully present
+ * on disk — and allowed `eval "gh pr merge 123"`. A guard that no longer blocks
+ * a known-bad command is as degraded as a missing one, so each guard's exported
+ * pure classifier is called here with a small BLOCK/ALLOW table.
  * It is PURELY INFORMATIONAL:
  *   - It NEVER blocks anything and NEVER exits non-zero.
  *   - Healthy path prints NOTHING (no session noise).
@@ -208,10 +214,108 @@ function evaluateGuardStack(settings, options = {}) {
   return problems;
 }
 
+// --- Behaviour probes ---------------------------------------------------------
+// "Is the guard still wired?" is not the same question as "does the guard still
+// block?". Each entry names a guard, the pure classifier it exports, and a few
+// commands with their required verdicts. Probes run IN-PROCESS against the
+// exported classifier (no subprocess, no git, no fs) so this stays well inside
+// the SessionStart hook's 5 s budget.
+//
+// Keep the ALLOW rows: a guard that starts blocking everything is also broken,
+// and these are the exact prose shapes agents legitimately type.
+const BEHAVIOR_PROBES = [
+  {
+    hook: "block-direct-merge.cjs",
+    export: "classifyMerge",
+    // classifyMerge(toolName, command) → { block }
+    verdict: (fn, command) => fn("Bash", command).block,
+    mustBlock: [
+      "gh pr merge 123 --squash",
+      'eval "gh pr merge 123 --squash"',
+      'sh -c "scripts/workflow/merge-pr.sh 123 --human"',
+      "xargs -I{} gh pr merge {} < prs.txt",
+      "gh api -X PUT repos/o/r/pulls/123/merge",
+    ],
+    mustAllow: ["gh pr view 123", 'echo "run merge-pr.sh when ready"'],
+  },
+  {
+    hook: "block-main-worktree-branch-switch.cjs",
+    export: "classifyCommand",
+    verdict: (fn, command) => fn(command).block,
+    mustBlock: ["git checkout feature/x", 'eval "git switch feature/x"'],
+    mustAllow: ["git checkout main", "echo git checkout feature/x"],
+  },
+  {
+    hook: "block-heavy-under-pressure.cjs",
+    export: "isHeavyCommand",
+    verdict: (fn, command) => fn(command),
+    mustBlock: ["pnpm run build", "pnpm exec playwright test"],
+    mustAllow: ['echo "how to run pnpm run build"', "pnpm run lint"],
+  },
+];
+
+/**
+ * Run the behaviour probes. Returns a list of human-readable problems; empty
+ * === healthy. Never throws — a guard that cannot even be loaded is reported as
+ * a problem rather than crashing the canary.
+ *
+ * `options.load` overrides module loading with a `(basename) => module`
+ * function so tests can inject a deliberately-broken guard.
+ */
+function evaluateGuardBehavior(options = {}) {
+  const problems = [];
+  const load =
+    typeof options.load === "function"
+      ? options.load
+      : (basename) => require(path.join(__dirname, basename));
+
+  for (const probe of BEHAVIOR_PROBES) {
+    let fn;
+    try {
+      const mod = load(probe.hook);
+      fn = mod && mod[probe.export];
+    } catch (err) {
+      problems.push(
+        `${probe.hook} could not be loaded (${err && err.code ? err.code : "error"})`,
+      );
+      continue;
+    }
+    if (typeof fn !== "function") {
+      problems.push(`${probe.hook} no longer exports ${probe.export}()`);
+      continue;
+    }
+
+    const failures = [];
+    for (const command of probe.mustBlock) {
+      let blocked;
+      try {
+        blocked = probe.verdict(fn, command) === true;
+      } catch {
+        blocked = false;
+      }
+      if (!blocked) failures.push(`allows ${JSON.stringify(command)}`);
+    }
+    for (const command of probe.mustAllow) {
+      let blocked;
+      try {
+        blocked = probe.verdict(fn, command) === true;
+      } catch {
+        blocked = true;
+      }
+      if (blocked) failures.push(`blocks ${JSON.stringify(command)}`);
+    }
+    if (failures.length > 0) {
+      problems.push(`${probe.hook} ${failures.join(", ")}`);
+    }
+  }
+
+  return problems;
+}
+
 // --- Hook entrypoint ---------------------------------------------------------
 // Does the IO: resolve path (incl. VERIFY_GUARD_SETTINGS override), read/parse
-// settings, call evaluateGuardStack, print one warning line on problems (else
-// silent), and fail open on any error. Always exits 0.
+// settings, call evaluateGuardStack + evaluateGuardBehavior, print one warning
+// line on problems (else silent), and fail open on any error. Always exits 0.
 function main() {
   // Fail-open helper: a single one-line note, never a stack trace, never
   // non-zero. Collapse any embedded line breaks so it stays one line.
@@ -241,7 +345,7 @@ function main() {
     return;
   }
 
-  const problems = evaluateGuardStack(settings);
+  const problems = [...evaluateGuardStack(settings), ...evaluateGuardBehavior()];
   if (problems.length === 0) {
     // Healthy — stay silent.
     process.exit(0);
@@ -254,7 +358,13 @@ function main() {
   process.exit(0);
 }
 
-module.exports = { evaluateGuardStack, extractScriptPaths, main };
+module.exports = {
+  evaluateGuardStack,
+  evaluateGuardBehavior,
+  extractScriptPaths,
+  main,
+  BEHAVIOR_PROBES,
+};
 
 // Only run as a hook when invoked directly (not when require()'d by a test).
 if (require.main === module) {

--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -234,9 +234,14 @@ const BEHAVIOR_PROBES = [
       'eval "gh pr merge 123 --squash"',
       'sh -c "scripts/workflow/merge-pr.sh 123 --human"',
       "xargs -I{} gh pr merge {} < prs.txt",
+      "env -S 'gh pr merge 123'",
       "gh api -X PUT repos/o/r/pulls/123/merge",
     ],
-    mustAllow: ["gh pr view 123", 'echo "run merge-pr.sh when ready"'],
+    mustAllow: [
+      "gh pr view 123",
+      'echo "run merge-pr.sh when ready"',
+      "env | rg merge-pr.sh",
+    ],
   },
   {
     hook: "block-main-worktree-branch-switch.cjs",

--- a/src/test/unit/hooks/block-direct-merge.test.ts
+++ b/src/test/unit/hooks/block-direct-merge.test.ts
@@ -306,6 +306,52 @@ describe("block-direct-merge.cjs — wrapped invocations (PP-6t3c, PP-ar8a)", ()
 });
 
 // ---------------------------------------------------------------------------
+// `env -S` (GNU split-string) — found by review on this PR, same bug class.
+//
+// The first cut of the shared resolver modelled `-S` as an ordinary value flag,
+// so the wrapper scan ate the payload and the segment resolved to NOTHING —
+// which this guard read as "not a merge" and allowed. A fix that closed
+// eval/sh -c/xargs while opening a fresh `env -S` hole would have replaced one
+// bypass with another while looking like a fix.
+// ---------------------------------------------------------------------------
+describe("block-direct-merge.cjs — env -S split-string", () => {
+  it.each([
+    "env -S 'gh pr merge 123'",
+    'env -S "gh pr merge 123"',
+    "env --split-string='gh pr merge 123'",
+    "env -S'gh pr merge 123'",
+    "env -i -S 'gh pr merge 123'",
+    "env -iS 'gh pr merge 123'",
+    "env -u FOO -S 'scripts/workflow/merge-pr.sh 1 --human'",
+    "env -S 'gh api -X PUT repos/o/r/pulls/1/merge'",
+    "sudo env -S 'gh pr merge 1'",
+    "xargs env -S 'gh pr merge 1'",
+  ])("blocks %s", (command) => {
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(2);
+  });
+
+  it("blocks a dynamic split-string payload that names a merge elsewhere", () => {
+    const { status } = runHook(bashPayload("P='gh pr merge 1'; env -S \"$P\""));
+    expect(status).toBe(2);
+  });
+
+  it.each([
+    "env",
+    "env | rg merge-pr.sh",
+    "sudo -l",
+    "timeout 30",
+    "env -u NODE_OPTIONS pnpm run check",
+  ])("does NOT block %s (wrapper consumed the segment)", (command) => {
+    // These resolve to the wrapper itself. Reporting them unresolvable instead
+    // would push this guard onto its raw-text fallback for ordinary commands,
+    // and `env | rg merge-pr.sh` would block.
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Prose must still pass. A guard that blocks the words is as broken as one
 // that misses the command — agents legitimately write these every session.
 // ---------------------------------------------------------------------------

--- a/src/test/unit/hooks/block-direct-merge.test.ts
+++ b/src/test/unit/hooks/block-direct-merge.test.ts
@@ -194,6 +194,151 @@ describe("block-direct-merge.cjs — no bypass sentinel", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Wrapper bypasses (PP-6t3c finding A, PP-ar8a).
+//
+// Every row below EXITED 0 on main. The hook regexed a quote-stripped copy of
+// the command against a short hardcoded wrapper list, so wrapping the merge in
+// `eval`/`sh -c` erased the payload entirely and `env`/`time`/`xargs` were
+// simply not in the list. That defeated PP-wi85 — merging is human-only via
+// ANY path — for any agent that wrapped the command, accidentally or not.
+//
+// This is main's first regression suite for a guard caught misfiring: both
+// earlier attempts (#1736, #1738) were closed before merge, so the lesson only
+// ever lived in commit messages.
+// ---------------------------------------------------------------------------
+describe("block-direct-merge.cjs — wrapped invocations (PP-6t3c, PP-ar8a)", () => {
+  it.each([
+    'eval "gh pr merge 123 --squash"',
+    "eval 'gh pr merge 123'",
+    'sh -c "gh pr merge 123"',
+    'bash -c "gh pr merge 123"',
+    'zsh -c "gh pr merge 123"',
+    "env gh pr merge 123",
+    "time gh pr merge 123",
+    "command gh pr merge 123",
+    "nice gh pr merge 123",
+    "sudo gh pr merge 123",
+    "timeout 60 gh pr merge 123",
+    "xargs -I{} gh pr merge {} < prs.txt",
+    "GH_TOKEN=x gh pr merge 123",
+    "$(echo gh) pr merge 123",
+    "`gh pr merge 123`",
+  ])("blocks %s", (command) => {
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(2);
+  });
+
+  it.each([
+    'eval "scripts/workflow/merge-pr.sh 123 --human"',
+    'sh -c "scripts/workflow/merge-pr.sh 123 --human"',
+    'bash -c "./scripts/workflow/merge-pr.sh 123"',
+    "env scripts/workflow/merge-pr.sh 123",
+    "time scripts/workflow/merge-pr.sh 123",
+    "xargs -I{} scripts/workflow/merge-pr.sh {}",
+    "sudo -u root scripts/workflow/merge-pr.sh 123",
+  ])("blocks %s", (command) => {
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(2);
+  });
+
+  it.each([
+    'eval "gh api -X PUT repos/o/r/pulls/123/merge"',
+    'sh -c "gh api --method PUT repos/o/r/pulls/123/merge"',
+    "env gh api -X POST repos/o/r/pulls/123/merge",
+  ])("blocks %s", (command) => {
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(2);
+  });
+
+  it.each([
+    "gh -R owner/repo pr merge 123",
+    "gh pr --repo owner/repo merge 123",
+    "gh --repo=owner/repo pr merge 123",
+  ])("blocks %s (repo selector between gh and its subcommand)", (command) => {
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(2);
+  });
+
+  it("does NOT block `gh pr list` with a quoted search naming a merge", () => {
+    const { status } = runHook(
+      bashPayload('gh pr list --search "pr merge blocked"')
+    );
+    expect(status).toBe(0);
+  });
+
+  it("blocks `gh api --method=PUT` (attached flag value)", () => {
+    const { status } = runHook(
+      bashPayload("gh api --method=PUT repos/o/r/pulls/123/merge")
+    );
+    expect(status).toBe(2);
+  });
+
+  it("blocks a merge chained behind a --help on a DIFFERENT segment", () => {
+    // The old prefix gate tested `--help` against the WHOLE command, so one
+    // `--help` anywhere disarmed every gh check in the command.
+    const { status } = runHook(
+      bashPayload("gh pr view --help && gh pr merge 123")
+    );
+    expect(status).toBe(2);
+  });
+
+  it("blocks a merge on a later LINE of a multi-line command", () => {
+    const { status } = runHook(
+      bashPayload("git fetch origin\ngh pr merge 123 --squash")
+    );
+    expect(status).toBe(2);
+  });
+
+  it("blocks when the command is unresolvable but names a merge", () => {
+    // `eval "$CMD"` cannot be resolved statically. On a hard boundary an
+    // unknowable command is suspicious, not safe, so the raw text is scanned.
+    const { status } = runHook(
+      bashPayload('CMD="gh pr merge 123"; eval "$CMD"')
+    );
+    expect(status).toBe(2);
+  });
+
+  it("does NOT block an unresolvable command with no merge indicator", () => {
+    const { status } = runHook(bashPayload('eval "$EDITOR notes.md"'));
+    expect(status).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prose must still pass. A guard that blocks the words is as broken as one
+// that misses the command — agents legitimately write these every session.
+// ---------------------------------------------------------------------------
+describe("block-direct-merge.cjs — prose mentions still pass", () => {
+  it.each([
+    'echo "run merge-pr.sh when ready"',
+    "echo 'hand Tim: scripts/workflow/merge-pr.sh <PR> --human'",
+    'rg "gh pr merge" docs/',
+    'bd comments add PP-x "ready to merge — gh pr merge is human-only"',
+    'git commit -m "docs: explain why gh pr merge is blocked"',
+    "gh pr merge --help",
+    "gh api repos/o/r/pulls/123/merge",
+    "gh pr view 123",
+  ])("allows %s", (command) => {
+    const { status } = runHook(bashPayload(command));
+    expect(status).toBe(0);
+  });
+
+  it("allows a heredoc whose BODY names the merge command", () => {
+    const { status } = runHook(
+      bashPayload(
+        [
+          "cat > /tmp/handoff.md <<'EOF'",
+          "gh pr merge 123 --squash",
+          "scripts/workflow/merge-pr.sh 123 --human",
+          "EOF",
+        ].join("\n")
+      )
+    );
+    expect(status).toBe(0);
+  });
+});
+
 describe("block-direct-merge.cjs — fail-open contract", () => {
   it("malformed JSON on stdin → exit 0", () => {
     const result = spawnSync("node", [hookPath], {

--- a/src/test/unit/hooks/block-main-worktree-branch-switch.test.ts
+++ b/src/test/unit/hooks/block-main-worktree-branch-switch.test.ts
@@ -96,6 +96,26 @@ describe("wrapper/env-prefixed real git invocations → BLOCK", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Shapes the hook's own tokenizer used to fold on, now handled by the shared
+// lib/resolve-command.cjs primitive (PP-6t3c). The wrapper/quoting class itself
+// is tested once in resolve-command.test.ts; these prove this guard's policy
+// actually rides on it.
+// ---------------------------------------------------------------------------
+describe("wrapped/quoted git invocations → BLOCK (PP-6t3c)", () => {
+  it.each([
+    'eval "git checkout feature/x"',
+    'sh -c "git switch feature/x"',
+    'bash -c "git checkout -b new-branch"',
+    "sudo -u root git checkout feature/x",
+    "timeout 30 git switch feature/x",
+    "/usr/bin/git checkout feature/x",
+    "git status\ngit checkout feature/x",
+  ])("blocks %s", (cmd) => {
+    expectBlock(cmd);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // git-as-argument (false-positive fix) — must ALLOW
 // ---------------------------------------------------------------------------
 describe("git as argument, not command → ALLOW (false-positive fix)", () => {

--- a/src/test/unit/hooks/resolve-command.test.ts
+++ b/src/test/unit/hooks/resolve-command.test.ts
@@ -1,0 +1,331 @@
+// Unit tests for .claude/hooks/lib/resolve-command.cjs — the shared
+// command-resolution primitive every PreToolUse Bash guard sits on (PP-6t3c).
+//
+// This is where the wrapper/quoting/substitution class is tested ONCE. The
+// guards' own suites cover their policy (what counts as a merge, a branch
+// switch, a heavy run); they should NOT each re-test `eval`, `sh -c`, `xargs`,
+// heredocs and friends.
+//
+// The class this file exists for: on 2026-07-26 every one of the "wrapped"
+// rows below RESOLVED TO NOTHING in the merge guard, which read that as
+// "not a merge" and allowed it.
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+interface Segment {
+  command: string;
+  name: string;
+  args: string[];
+  raw: string;
+}
+interface Unresolvable {
+  reason: string;
+  text: string;
+}
+interface Resolution {
+  segments: Segment[];
+  unresolvable: Unresolvable[];
+}
+
+const require = createRequire(import.meta.url);
+const libPath = path.resolve(
+  process.cwd(),
+  ".claude/hooks/lib/resolve-command.cjs"
+);
+const { resolveCommand } = require(libPath) as {
+  resolveCommand: (
+    cmd: string,
+    options?: { splitNewlines?: boolean }
+  ) => Resolution;
+};
+
+/** The resolved command basenames, in order. */
+function names(cmd: string, options?: { splitNewlines?: boolean }): string[] {
+  return resolveCommand(cmd, options).segments.map((s) => s.name);
+}
+
+/** The first segment, asserted to exist. */
+function firstSegment(cmd: string): Segment {
+  const { segments } = resolveCommand(cmd);
+  const first = segments[0];
+  if (first === undefined) {
+    throw new Error(`expected at least one segment for ${JSON.stringify(cmd)}`);
+  }
+  return first;
+}
+
+// ---------------------------------------------------------------------------
+// Plain invocations
+// ---------------------------------------------------------------------------
+describe("plain commands", () => {
+  it("resolves the command and its arguments", () => {
+    const seg = firstSegment("gh pr merge 123 --squash");
+    expect(seg.name).toBe("gh");
+    expect(seg.args).toEqual(["pr", "merge", "123", "--squash"]);
+  });
+
+  it("keeps the command as written and exposes its basename separately", () => {
+    const seg = firstSegment("./scripts/workflow/merge-pr.sh 123 --human");
+    expect(seg.command).toBe("./scripts/workflow/merge-pr.sh");
+    expect(seg.name).toBe("merge-pr.sh");
+  });
+
+  it("returns no segments for an empty or whitespace-only command", () => {
+    expect(resolveCommand("").segments).toEqual([]);
+    expect(resolveCommand("   ").segments).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Separators
+// ---------------------------------------------------------------------------
+describe("shell separators", () => {
+  it.each([
+    ["a && b", ["a", "b"]],
+    ["a || b", ["a", "b"]],
+    ["a ; b", ["a", "b"]],
+    ["a | b", ["a", "b"]],
+    ["a & b", ["a", "b"]],
+    ["a\nb", ["a", "b"]],
+    ["(a) && b", ["a", "b"]],
+  ])("splits %s", (cmd, expected) => {
+    expect(names(cmd)).toEqual(expected);
+  });
+
+  it("keeps newlines out of the split when splitNewlines is false", () => {
+    // block-heavy-under-pressure's posture (PP-qota).
+    expect(names("cd foo\npnpm run build", { splitNewlines: false })).toEqual([
+      "cd",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wrappers — the class that folded the guards
+// ---------------------------------------------------------------------------
+describe("wrappers resolve through to the real command", () => {
+  it.each([
+    "env gh pr merge 123",
+    "time gh pr merge 123",
+    "command gh pr merge 123",
+    "nice gh pr merge 123",
+    "sudo gh pr merge 123",
+    "nohup gh pr merge 123",
+    "setsid gh pr merge 123",
+    "timeout 30 gh pr merge 123",
+    "xargs -I{} gh pr merge {}",
+    "xargs -n 1 -P 4 gh pr merge",
+    "FOO=1 gh pr merge 123",
+    "FOO=1 BAR=2 gh pr merge 123",
+    "env FOO=bar gh pr merge 123",
+    "/usr/bin/env gh pr merge 123",
+  ])("resolves %s to gh", (cmd) => {
+    expect(names(cmd)).toEqual(["gh"]);
+  });
+
+  it("skips a wrapper's own flags AND their values", () => {
+    // The old per-guard logic gave up at the first flag after a wrapper, so
+    // `sudo chmod` blocked but `sudo -u root chmod` did not.
+    expect(names("sudo -u root chmod +x f")).toEqual(["chmod"]);
+    expect(names("nice -n 10 pnpm run build")).toEqual(["pnpm"]);
+    expect(names("stdbuf -o0 vitest run")).toEqual(["vitest"]);
+  });
+
+  it("does not consume a following token for an attached flag value", () => {
+    expect(firstSegment("xargs --max-args=1 gh pr merge").name).toBe("gh");
+    expect(firstSegment("xargs -I{} gh pr merge {}").args).toEqual([
+      "pr",
+      "merge",
+      "{}",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shell payloads — eval / sh -c / substitutions
+// ---------------------------------------------------------------------------
+describe("literal shell payloads are re-parsed, not skipped", () => {
+  it.each([
+    'eval "gh pr merge 123"',
+    "eval 'gh pr merge 123'",
+    'sh -c "gh pr merge 123"',
+    'bash -c "gh pr merge 123"',
+    "zsh -c 'gh pr merge 123'",
+    'bash -lc "gh pr merge 123"',
+    'env sh -c "gh pr merge 123"',
+    'xargs sh -c "gh pr merge 123"',
+  ])("resolves %s to gh", (cmd) => {
+    expect(names(cmd)).toEqual(["gh"]);
+  });
+
+  it("treats `bash <script>` as an invocation of the script", () => {
+    expect(names("bash scripts/workflow/merge-pr.sh 123")).toEqual([
+      "merge-pr.sh",
+    ]);
+    expect(names("sh ./scripts/workflow/merge-pr.sh 123")).toEqual([
+      "merge-pr.sh",
+    ]);
+  });
+
+  it("resolves commands inside $() and backtick substitutions", () => {
+    expect(names("$(gh pr merge 5)")).toContain("gh");
+    expect(names("`gh pr merge 5`")).toContain("gh");
+    expect(names('echo "$(gh pr merge 5)"')).toContain("gh");
+  });
+
+  it("resolves commands inside process substitution", () => {
+    expect(names("diff <(gh pr merge 5) b")).toContain("gh");
+  });
+
+  it("stops recursing at the depth cap instead of hanging", () => {
+    const nested = 'eval "eval \\"eval \\\\\\"gh pr merge 1\\\\\\"\\""';
+    // Whatever it resolves to, it must terminate and report something.
+    const result = resolveCommand(nested);
+    expect(result.segments.length + result.unresolvable.length).toBeGreaterThan(
+      0
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Quoting — prose must NOT read as a command
+// ---------------------------------------------------------------------------
+describe("quoted spans are arguments, never commands", () => {
+  it.each([
+    ['echo "run merge-pr.sh when ready"', "echo"],
+    ["echo 'scripts/workflow/merge-pr.sh <PR> --human'", "echo"],
+    ['rg "merge-pr.sh" docs/', "rg"],
+    ['git commit -m "speed up vitest run"', "git"],
+    ['bd comments add PP-x "ran pnpm run smoke"', "bd"],
+    ["echo git checkout feature/x", "echo"],
+  ])("resolves %s to %s only", (cmd, expected) => {
+    expect(names(cmd)).toEqual([expected]);
+  });
+
+  it("strips quotes from arguments", () => {
+    expect(firstSegment('git checkout "main"').args).toEqual([
+      "checkout",
+      "main",
+    ]);
+  });
+
+  it("keeps a multi-line quoted argument as ONE argument", () => {
+    const seg = firstSegment(
+      'bd comments add PP-x "line1\npnpm run e2e\nline3"'
+    );
+    expect(seg.name).toBe("bd");
+    expect(seg.args.at(-1)).toBe("line1\npnpm run e2e\nline3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heredocs and redirections
+// ---------------------------------------------------------------------------
+describe("heredoc bodies are never parsed as commands", () => {
+  it("drops a heredoc body", () => {
+    expect(
+      names(["cat <<EOF > notes.md", "gh pr merge 123", "EOF"].join("\n"))
+    ).toEqual(["cat"]);
+  });
+
+  it("drops a quoted-tag heredoc body", () => {
+    expect(
+      names(
+        [
+          "cat > /tmp/x.md <<'EOF'",
+          "scripts/workflow/merge-pr.sh 1",
+          "EOF",
+        ].join("\n")
+      )
+    ).toEqual(["cat"]);
+  });
+
+  it("drops an indented (<<-) heredoc body", () => {
+    expect(
+      names(["cat <<-EOF", "\tgh pr merge 1", "\tEOF"].join("\n"))
+    ).toEqual(["cat"]);
+  });
+
+  it("resumes parsing after the heredoc terminator", () => {
+    expect(
+      names(["cat <<EOF", "body line", "EOF", "gh pr merge 1"].join("\n"))
+    ).toEqual(["cat", "gh"]);
+  });
+
+  it("does not treat a QUOTED << as a heredoc (it would swallow the rest)", () => {
+    expect(names('echo "use <<EOF here"\ngh pr merge 1')).toEqual([
+      "echo",
+      "gh",
+    ]);
+  });
+
+  it("drops redirections and their targets from the arguments", () => {
+    expect(firstSegment("gh pr merge 1 > out.log 2>&1").args).toEqual([
+      "pr",
+      "merge",
+      "1",
+    ]);
+    expect(firstSegment("xargs -I{} gh pr merge {} < prs.txt").args).toEqual([
+      "pr",
+      "merge",
+      "{}",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unresolvable — the signal every guard was missing
+// ---------------------------------------------------------------------------
+describe("unresolvable", () => {
+  it("reports a dynamic eval payload rather than silently allowing it", () => {
+    const { segments, unresolvable } = resolveCommand('eval "$CMD"');
+    expect(segments).toEqual([]);
+    expect(unresolvable.map((u) => u.reason)).toContain("eval-dynamic");
+  });
+
+  it("reports a dynamic `sh -c` payload", () => {
+    expect(
+      resolveCommand('sh -c "$PAYLOAD"').unresolvable.map((u) => u.reason)
+    ).toContain("shell-c-dynamic");
+  });
+
+  it("reports a substituted command slot", () => {
+    expect(
+      resolveCommand("$(pick-tool) pr merge 1").unresolvable.map(
+        (u) => u.reason
+      )
+    ).toContain("substituted-command");
+    expect(
+      resolveCommand("$GH pr merge 1").unresolvable.map((u) => u.reason)
+    ).toContain("substituted-command");
+  });
+
+  it("reports an unbalanced quote", () => {
+    expect(
+      resolveCommand('echo "unterminated').unresolvable.map((u) => u.reason)
+    ).toContain("unbalanced-quote");
+  });
+
+  it("stays empty for ordinary commands, including prose mentions", () => {
+    for (const cmd of [
+      "gh pr view 123",
+      'echo "run merge-pr.sh when ready"',
+      'rg "gh pr merge" docs/',
+      "git status && git checkout main",
+      'git commit -m "note: $ signs and stuff"',
+    ]) {
+      expect(
+        resolveCommand(cmd).unresolvable,
+        `expected no unresolvable for ${JSON.stringify(cmd)}`
+      ).toEqual([]);
+    }
+  });
+
+  it("does not flag a variable in an ARGUMENT — only in the command slot", () => {
+    const { segments, unresolvable } = resolveCommand("gh pr view $NUMBER");
+    expect(segments.map((s) => s.name)).toEqual(["gh"]);
+    expect(unresolvable).toEqual([]);
+  });
+});

--- a/src/test/unit/hooks/resolve-command.test.ts
+++ b/src/test/unit/hooks/resolve-command.test.ts
@@ -298,6 +298,63 @@ describe("heredoc bodies are never parsed as commands", () => {
 });
 
 // ---------------------------------------------------------------------------
+// `env -S` (GNU split-string) and the silent-drop class it exposed.
+//
+// `-S` was first modelled as an ordinary value flag, so the wrapper scan ATE
+// the payload, the segment yielded no command, and `resolveSegment` returned in
+// silence — no segment AND no `unresolvable`. A hard-boundary guard reading
+// that as "not a merge" fails open, which is the exact failure mode this module
+// exists to remove.
+// ---------------------------------------------------------------------------
+describe("env -S / --split-string re-parses its payload", () => {
+  it.each([
+    "env -S 'gh pr merge 123'",
+    'env -S "gh pr merge 123"',
+    "env --split-string='gh pr merge 123'",
+    "env -S'gh pr merge 123'",
+    "env -i -S 'gh pr merge 123'",
+    "env -u FOO -S 'gh pr merge 123'",
+    "sudo env -S 'gh pr merge 123'",
+    "xargs env -S 'gh pr merge 123'",
+  ])("resolves %s to gh", (cmd) => {
+    expect(names(cmd)).toEqual(["gh"]);
+  });
+
+  it("reports a dynamic split-string payload instead of dropping it", () => {
+    const { segments, unresolvable } = resolveCommand('env -S "$PAYLOAD"');
+    expect(segments).toEqual([]);
+    expect(unresolvable.map((u) => u.reason)).toContain("split-string-dynamic");
+  });
+
+  it("handles an unmodelled flag cluster by resolving AND flagging it", () => {
+    // `-iS` is not modelled, so the payload lands in the command slot as a
+    // whitespace-containing token. Both outputs are produced on purpose: the
+    // real segment for fail-open guards, the signal for hard-boundary ones.
+    const { segments, unresolvable } = resolveCommand(
+      "env -iS 'gh pr merge 1'"
+    );
+    expect(segments.map((s) => s.name)).toContain("gh");
+    expect(unresolvable.map((u) => u.reason)).toContain("split-string-command");
+  });
+});
+
+describe("a wrapper that consumes the whole segment resolves to the wrapper", () => {
+  // The alternative — reporting these unresolvable — would make a hard-boundary
+  // guard fall back to a raw-text scan on ordinary commands, so `env | rg
+  // merge-pr.sh` would block. They are real invocations of the wrapper itself.
+  it.each([
+    ["env", "env"],
+    ["sudo -l", "sudo"],
+    ["xargs", "xargs"],
+    ["timeout 30", "timeout"],
+  ])("resolves %s to %s with no unresolvable", (cmd, expected) => {
+    const { segments, unresolvable } = resolveCommand(cmd);
+    expect(segments.map((s) => s.name)).toEqual([expected]);
+    expect(unresolvable).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unresolvable — the signal every guard was missing
 // ---------------------------------------------------------------------------
 describe("unresolvable", () => {
@@ -349,5 +406,68 @@ describe("unresolvable", () => {
     const { segments, unresolvable } = resolveCommand("gh pr view $NUMBER");
     expect(segments.map((s) => s.name)).toEqual(["gh"]);
     expect(unresolvable).toEqual([]);
+  });
+
+  it("stays empty for an assignments-only segment (a real 'no command')", () => {
+    expect(resolveCommand("FOO=bar")).toEqual({
+      segments: [],
+      unresolvable: [],
+    });
+    const { segments, unresolvable } = resolveCommand(
+      "CMD='pr merge'; echo hi"
+    );
+    expect(segments.map((s) => s.name)).toEqual(["echo"]);
+    expect(unresolvable).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The backstop invariant
+// ---------------------------------------------------------------------------
+describe("no segment is ever dropped in silence", () => {
+  it.each([
+    "sh -c", // -c with no payload
+    "eval", // eval with no words
+    'sh -c ""', // empty payload
+  ])("reports %s rather than returning nothing", (cmd) => {
+    const { segments, unresolvable } = resolveCommand(cmd);
+    expect(
+      segments.length + unresolvable.length,
+      `${JSON.stringify(cmd)} produced neither a segment nor an unresolvable`
+    ).toBeGreaterThan(0);
+  });
+
+  it("holds across a broad sweep of wrapper and payload shapes", () => {
+    // The invariant, asserted directly: any command with a real (non-assignment)
+    // word must yield a segment or an unresolvable — never silence.
+    for (const cmd of [
+      "env -S 'gh pr merge 1'",
+      "env -S",
+      "env -u",
+      "sudo",
+      "sudo --",
+      "timeout",
+      "timeout 30",
+      "xargs -I",
+      "xargs -I{}",
+      "nice -n",
+      "stdbuf -o",
+      "bash -c",
+      "bash",
+      "command",
+      "$X",
+      "eval $X",
+      "cmd >; cmd2",
+    ]) {
+      const { segments, unresolvable } = resolveCommand(cmd);
+      expect(
+        segments.length + unresolvable.length,
+        `${JSON.stringify(cmd)} produced neither a segment nor an unresolvable`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not let a redirect drop the command after a separator", () => {
+    expect(names("cmd >; cmd2")).toEqual(["cmd", "cmd2"]);
   });
 });

--- a/src/test/unit/hooks/resolve-command.test.ts
+++ b/src/test/unit/hooks/resolve-command.test.ts
@@ -248,6 +248,28 @@ describe("heredoc bodies are never parsed as commands", () => {
     ).toEqual(["cat"]);
   });
 
+  it("requires an EXACT terminator — an indented EOF is still body", () => {
+    // Trimming before comparing would end the body here and parse the rest of
+    // it as real commands.
+    expect(
+      names(
+        ["cat <<EOF", "  EOF", "gh pr merge 1", "EOF", "echo done"].join("\n")
+      )
+    ).toEqual(["cat", "echo"]);
+  });
+
+  it("does not accept a terminator with trailing spaces", () => {
+    expect(
+      names(["cat <<EOF", "EOF  ", "gh pr merge 1", "EOF"].join("\n"))
+    ).toEqual(["cat"]);
+  });
+
+  it("accepts a CRLF terminator line", () => {
+    expect(
+      names(["cat <<EOF", "body", "EOF", "echo done"].join("\r\n"))
+    ).toEqual(["cat", "echo"]);
+  });
+
   it("resumes parsing after the heredoc terminator", () => {
     expect(
       names(["cat <<EOF", "body line", "EOF", "gh pr merge 1"].join("\n"))

--- a/src/test/unit/hooks/verify-guard-stack.test.ts
+++ b/src/test/unit/hooks/verify-guard-stack.test.ts
@@ -8,7 +8,11 @@
 //      takes an injectable `exists` predicate so it needs no real files.
 //   2. The repo's own .claude/settings.json — asserted healthy in both
 //      directions, so `pnpm run check` goes red on a dead registration.
-//   3. Fail-open contract — a few subprocess cases spawn `node` on the hook
+//   3. Behaviour probes — `evaluateGuardBehavior()` calls each guard's exported
+//      pure classifier with a known-bad and a known-good command. Registration
+//      is a weak proxy for a working guard: the merge guard was fully wired and
+//      present on disk while allowing `eval "gh pr merge 123"` (PP-6t3c).
+//   4. Fail-open contract — a few subprocess cases spawn `node` on the hook
 //      with VERIFY_GUARD_SETTINGS pointed at a temp fixture, asserting the
 //      warn-only guarantee (always exit 0, one-line skip note, no stack trace).
 
@@ -25,12 +29,28 @@ const hookPath = path.resolve(
   process.cwd(),
   ".claude/hooks/verify-guard-stack.cjs"
 );
-const { evaluateGuardStack, extractScriptPaths } = require(hookPath) as {
+interface BehaviorProbe {
+  hook: string;
+  export: string;
+  mustBlock: string[];
+  mustAllow: string[];
+}
+
+const {
+  evaluateGuardStack,
+  evaluateGuardBehavior,
+  extractScriptPaths,
+  BEHAVIOR_PROBES,
+} = require(hookPath) as {
   evaluateGuardStack: (
     settings: unknown,
     options?: { exists?: (relPath: string) => boolean }
   ) => string[];
+  evaluateGuardBehavior: (options?: {
+    load?: (basename: string) => unknown;
+  }) => string[];
   extractScriptPaths: (command: string) => string[];
+  BEHAVIOR_PROBES: BehaviorProbe[];
 };
 
 // ---------------------------------------------------------------------------
@@ -363,6 +383,85 @@ describe("the repo's own .claude/settings.json", () => {
       )
     );
     expect(evaluateGuardStack(settings)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behaviour probes (PP-6t3c): the canary used to answer only "is the guard
+// registered?". A registered, on-disk, silently-permissive guard reads as
+// healthy under that question — which is exactly what the merge guard was.
+// ---------------------------------------------------------------------------
+describe("evaluateGuardBehavior — the real guards", () => {
+  it("reports no problems: every guard still blocks its known-bad commands", () => {
+    expect(evaluateGuardBehavior()).toEqual([]);
+  });
+
+  it("covers the merge guard's wrapper bypasses", () => {
+    const mergeProbe = BEHAVIOR_PROBES.find(
+      (p) => p.hook === "block-direct-merge.cjs"
+    );
+    expect(mergeProbe).toBeDefined();
+    expect(mergeProbe?.mustBlock).toContain('eval "gh pr merge 123 --squash"');
+  });
+});
+
+describe("evaluateGuardBehavior — degradation is reported, never thrown", () => {
+  it("reports a guard that stopped blocking", () => {
+    const problems = evaluateGuardBehavior({
+      load: () => ({
+        classifyMerge: () => ({ block: false }),
+        classifyCommand: () => ({ block: false }),
+        isHeavyCommand: () => false,
+      }),
+    });
+    expect(problems.join("\n")).toContain("block-direct-merge.cjs allows");
+    expect(problems.join("\n")).toContain(
+      'eval \\"gh pr merge 123 --squash\\"'
+    );
+  });
+
+  it("reports a guard that started blocking everything", () => {
+    const problems = evaluateGuardBehavior({
+      load: () => ({
+        classifyMerge: () => ({ block: true }),
+        classifyCommand: () => ({ block: true }),
+        isHeavyCommand: () => true,
+      }),
+    });
+    expect(problems.join("\n")).toContain("blocks");
+    expect(problems).toHaveLength(BEHAVIOR_PROBES.length);
+  });
+
+  it("reports a guard that lost its exported classifier", () => {
+    const problems = evaluateGuardBehavior({ load: () => ({}) });
+    expect(problems.join("\n")).toContain("no longer exports");
+  });
+
+  it("reports — does not throw — when a guard cannot be loaded at all", () => {
+    const problems = evaluateGuardBehavior({
+      load: () => {
+        throw Object.assign(new Error("boom"), { code: "MODULE_NOT_FOUND" });
+      },
+    });
+    expect(problems).toHaveLength(BEHAVIOR_PROBES.length);
+    expect(problems.join("\n")).toContain("could not be loaded");
+  });
+
+  it("reports — does not throw — when a classifier itself throws", () => {
+    const problems = evaluateGuardBehavior({
+      load: () => ({
+        classifyMerge: () => {
+          throw new Error("boom");
+        },
+        classifyCommand: () => {
+          throw new Error("boom");
+        },
+        isHeavyCommand: () => {
+          throw new Error("boom");
+        },
+      }),
+    });
+    expect(problems).toHaveLength(BEHAVIOR_PROBES.length);
   });
 });
 


### PR DESCRIPTION
## The bug

`block-direct-merge.cjs` is what enforces the human-only merge boundary (PP-wi85, AGENTS.md §2.2.6). On `main` it was bypassable. Verified by executing the hook with real PreToolUse payloads — every row below exited **0 (allowed)**:

```
BLOCK  gh pr merge 123 --squash          ← control case
allow  eval "gh pr merge 123 --squash"
allow  sh -c "scripts/workflow/merge-pr.sh 123 --human"
allow  env gh pr merge 123
allow  time gh pr merge 123
allow  command / nice gh pr merge 123
allow  xargs -I{} gh pr merge {} < prs.txt
```

Two causes, one class. The hook built a **quote-stripped** copy of the command before matching (to avoid false-positiving on prose), which erased an `eval`/`sh -c` payload entirely — and the wrapper list it did have was a short hardcoded regex alternation that never contained `env`, `time`, `xargs`. A command it could not parse silently read as *"not a match"*.

## The fix

The real problem was structural: each PreToolUse Bash guard answered *"what command is this?"* with its own matcher, and each answered differently. This PR adds one shared primitive and rewrites the guards as thin policies over it.

**`.claude/hooks/lib/resolve-command.cjs`** returns per-segment `{command, name, args, raw}` plus an explicit **`unresolvable`** list:

- **Quote-aware tokenizer** — a quoted span is ONE argument, never a command. `echo "run merge-pr.sh"`, `rg "gh pr merge" docs/`, `bd comments add PP-x "…"` all still pass.
- **Heredoc bodies** consumed during tokenization, detected *inside* the quote-aware walk so a quoted `<<EOF` can't swallow the rest of the input.
- **Redirections and their targets** dropped rather than read as arguments.
- **Wrappers resolved through, including their own flags.** `sudo -u root chmod +x f` resolves to `chmod`; the old per-guard logic gave up at the first flag-like token.
- **Literal shell payloads re-parsed**: `eval`, `sh -c` / `bash -lc`, `$(…)`, backticks, process substitution.
- **`unresolvable`** — the concept every guard was missing. `eval "$CMD"`, `sh -c "$X"`, `$(pick) pr merge` are *reported*, not silently dropped.

Each guard picks its own posture on `unresolvable`, documented in-file:

| guard | posture on `unresolvable` | why |
|---|---|---|
| `block-direct-merge` | **block** (scan raw text for merge indicators) | hard boundary; an unknowable command is suspicious, not safe |
| `block-main-worktree-branch-switch` | allow | already fails open in every ambiguous case, and has a bypass sentinel |
| `block-heavy-under-pressure` | allow | a 5-minute memory probe is not worth a guess |

**`verify-guard-stack.cjs` now probes behaviour, not just registration.** The merge guard was fully wired *and* present on disk the entire time it was permissive — "is it registered?" was never the right question. Each guard's exported pure classifier is now called at SessionStart with a small BLOCK/ALLOW table.

## No guard gets more permissive

Every previously-blocking case still blocks (all 127 pre-existing hook tests pass unchanged). Several cases got **stricter**, all in the correct direction:

- `--help` anywhere in a command used to disarm *every* `gh` check in it; now it's per-segment.
- `/usr/bin/git checkout <branch>` now resolves as `git`.
- A merge on a later **line** of a multi-line command now blocks.

`block-heavy-under-pressure` keeps `splitNewlines: false`, so PP-qota's deliberate newline posture is **unchanged** by this refactor. The shared tokenizer would now make newline-splitting safe there, but that trade deserves its own decision rather than riding along on a parser change.

## Tests

`src/test/unit/hooks/resolve-command.test.ts` (new, 59 cases) is where the wrapper/quoting/substitution class is tested **once**; the guards' own suites cover policy. `block-direct-merge.test.ts` gains the full bypass table in both directions — the wrapped invocations that must block, and the prose mentions that must not.

This is `main`'s first regression suite for a guard *caught misfiring and fixed*. Both earlier attempts at this class (#1736, #1738) were closed before merge, so the lesson only ever lived in commit messages.

## Scope

Closes **PP-6t3c** findings A and C, and **PP-ar8a** (same class, filed independently during a prod DB-safety audit — closed as a duplicate).

Not in scope, with reasons:

- **Finding B** (`block-dangerous-commands.cjs`, the `chmod` guard) — that file was deleted from this repo in ff276edf (PP-53h0). The copy that still runs lives in `~/dotfiles`, a different repo. The primitive's wrapper-flag skipping is exactly what fixes it, so porting it there is a one-line change whenever the dotfiles repo is next touched.
- **Finding D** (`block-heavy-under-pressure` matching prose) — already fixed by 2c1c6fa5 (PP-yl8k); it now rides the shared primitive instead of its own copy of the technique.
- `block-drizzle-push.cjs` — never landed; it was deleted with #1738.
- `inject-beads-actor.cjs` is an attribution transformer, not a guard (fail-open by design, and both its failure modes are harmless), so it keeps its own cheap regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VypoeEVeXdF7Y3KfyWYeP8
