### PR TITLE
fix(worktrees): cleanup targets the pinned Supabase project id (PP-rbbp)

### DIFF
--- a/scripts/tests/test_worktree_cleanup.py
+++ b/scripts/tests/test_worktree_cleanup.py
@@ -1,4 +1,4 @@
-"""Regression tests for worktree_cleanup.py's two silent-failure bugs.
+"""Regression tests for worktree_cleanup.py's silent-failure bugs.
 
 **PP-omz3 — a missing target used to be a silent success.** Handed a path that
 isn't on disk, the script warned and returned, i.e. exit 0. Nothing ran: no
@@ -13,6 +13,13 @@ indistinguishable from "this project has no volumes". Teardown continued,
 removed the worktree, deallocated the slot, and exited 0 while the volumes
 stayed on disk. Same false-zero class as PP-5o7b / PR #1746 in
 `worktree_orphan_sweep.py`, whose UNKNOWN-not-zero shape this follows.
+
+**PP-rbbp — the project id used to be derived from the branch.** PP-4936 pinned
+each worktree's Supabase project id in its `supabase/config.toml` so it stops
+following the branch. Cleanup kept re-deriving it from the branch name, so on a
+worktree whose branch was renamed after setup the volume query filtered on a
+label no volume carries: a clean, wrong zero, and the volumes leaked past a
+teardown that exited 0. The pinned id now wins, with the branch as fallback.
 
 Everything is mocked at the subprocess boundary: these tests never touch the
 real Docker daemon, Supabase, git worktrees, or the slot manifest.
@@ -32,6 +39,21 @@ import worktree_cleanup as cleanup  # noqa: E402
 LABEL = "com.supabase.cli.project"
 BRANCH = "agent-alpha"
 PROJECT_ID = "pinpoint-agent-alpha"
+
+# The branch a worktree ends up on after `git checkout -b` inside it. Its
+# derived id is NOT the one the already-running stack is labelled with — that
+# divergence is the whole of PP-rbbp.
+RENAMED_BRANCH = "fix/renamed-after-setup"
+RENAMED_PROJECT_ID = "pinpoint-fix-renamed-after-setup"
+
+
+def pin_project_id(worktree: Path, project_id: str) -> None:
+    """Write a `supabase/config.toml` shaped like the one setup generates."""
+    config_dir = worktree / "supabase"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.toml").write_text(
+        f'project_id = "{project_id}"\n\n[api]\nport = 54421\n'
+    )
 
 
 def _kind(args: list[str]) -> str:
@@ -180,6 +202,59 @@ class TestListProjectVolumes:
 
         assert not query.is_unknown
         assert query.volumes == ()
+
+
+# --------------------------------------------------------------------------- #
+# PP-rbbp: which project id cleanup targets
+# --------------------------------------------------------------------------- #
+
+
+class TestResolveProjectId:
+    def test_pinned_id_wins_over_the_branch_derived_one(self, tmp_path: Path) -> None:
+        """The PP-rbbp core: the stack is labelled with the pinned id, not the branch."""
+        pin_project_id(tmp_path, PROJECT_ID)
+
+        assert cleanup.resolve_project_id(tmp_path, RENAMED_BRANCH) == PROJECT_ID
+
+    def test_divergence_is_announced(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pin_project_id(tmp_path, PROJECT_ID)
+
+        cleanup.resolve_project_id(tmp_path, RENAMED_BRANCH)
+
+        err = capsys.readouterr().err
+        assert PROJECT_ID in err
+        assert RENAMED_PROJECT_ID in err
+
+    def test_agreement_is_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The common case — branch never renamed — has nothing to report."""
+        pin_project_id(tmp_path, PROJECT_ID)
+
+        assert cleanup.resolve_project_id(tmp_path, BRANCH) == PROJECT_ID
+        assert capsys.readouterr().err == ""
+
+    def test_missing_config_falls_back_to_the_branch(self, tmp_path: Path) -> None:
+        """A worktree set up before PP-4936 has no pinned id to honour."""
+        assert cleanup.resolve_project_id(tmp_path, BRANCH) == PROJECT_ID
+
+    @pytest.mark.parametrize(
+        "config_body",
+        [
+            "[api]\nport = 54421\n",  # no project_id at all
+            'project_id = "not-a-pinpoint-id"\n',  # outside the generated shape
+            'project_id = "pinpoint"\n',  # the bare template value
+        ],
+    )
+    def test_unusable_pinned_id_falls_back_to_the_branch(
+        self, tmp_path: Path, config_body: str
+    ) -> None:
+        (tmp_path / "supabase").mkdir()
+        (tmp_path / "supabase" / "config.toml").write_text(config_body)
+
+        assert cleanup.resolve_project_id(tmp_path, BRANCH) == PROJECT_ID
 
 
 # --------------------------------------------------------------------------- #
@@ -354,6 +429,54 @@ class TestMainTeardown:
         assert "Removed 1 Docker volume(s)" in err
         assert f"Cleaned up worktree: {fake_worktree}" in err
         assert deallocated == [str(fake_worktree)]
+
+    def test_renamed_branch_still_tears_down_the_pinned_project(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        fake_worktree: Path,
+        deallocated: list[str],
+    ) -> None:
+        """PP-rbbp end to end: the branch moved, the volume labels did not."""
+        pin_project_id(fake_worktree, PROJECT_ID)
+        stub = install(
+            monkeypatch,
+            RunStub(
+                rev_parse=(0, f"{RENAMED_BRANCH}\n", ""),
+                volume_ls=(0, f"supabase_db_{PROJECT_ID}\n", ""),
+            ),
+        )
+
+        exit_code = _run_main(monkeypatch, fake_worktree)
+
+        assert exit_code == cleanup.EXIT_OK
+        ls = stub.calls_of("volume_ls")[0]
+        assert f"label={LABEL}={PROJECT_ID}" in ls
+        # The branch-derived id is what leaked the volumes; it must not be queried.
+        assert f"label={LABEL}={RENAMED_PROJECT_ID}" not in ls
+        assert stub.calls_of("volume_rm") == [
+            ["docker", "volume", "rm", f"supabase_db_{PROJECT_ID}"]
+        ]
+        assert "Removed 1 Docker volume(s)" in capsys.readouterr().err
+        assert deallocated == [str(fake_worktree)]
+
+    def test_worktree_without_a_pinned_id_uses_the_branch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_worktree: Path,
+        deallocated: list[str],
+    ) -> None:
+        """Pre-PP-4936 worktrees have no config.toml — the branch is all there is."""
+        stub = install(
+            monkeypatch,
+            RunStub(
+                rev_parse=(0, f"{RENAMED_BRANCH}\n", ""),
+                volume_ls=(0, "", ""),
+            ),
+        )
+
+        assert _run_main(monkeypatch, fake_worktree) == cleanup.EXIT_OK
+        assert f"label={LABEL}={RENAMED_PROJECT_ID}" in stub.calls_of("volume_ls")[0]
 
     def test_no_volumes_is_a_clean_success(
         self,

--- a/scripts/worktree_cleanup.py
+++ b/scripts/worktree_cleanup.py
@@ -20,6 +20,12 @@ rules follow from that, both of them regressions we have actually shipped:
   into `volumes = []`, indistinguishable from "no volumes exist", after which
   the worktree was removed and the slot deallocated while the volumes leaked.
   An unqueryable Docker now yields an explicit unknown and a non-zero exit.
+
+Targeting matters as much as reporting: the Supabase project id comes from the
+worktree's pinned `supabase/config.toml`, not from its current branch name
+(PP-rbbp). Since PP-4936 the pinned id no longer follows the branch, so a
+branch-derived id goes stale the moment the branch is renamed — and a volume
+query filtered on a label nothing carries returns a clean, wrong zero.
 """
 
 import fcntl
@@ -30,10 +36,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-# Reuse the project-id derivation from worktree_setup so cleanup targets the
+# Reuse the project-id resolution from worktree_setup so cleanup targets the
 # same container/volume names that setup created. (Python auto-adds this
 # script's directory to sys.path when invoked as `python3 worktree_cleanup.py`.)
-from worktree_setup import branch_to_project_id  # noqa: E402
+from worktree_setup import branch_to_project_id, read_pinned_project_id  # noqa: E402
 
 MANIFEST_PATH = Path.home() / ".config" / "pinpoint" / "worktree-slots.json"
 
@@ -57,6 +63,44 @@ EXIT_STALE_TARGET = 3
 #: — the same name with a different value, deliberately. In that script 1 is free;
 #: here it already means "failed", and callers distinguish these codes per script.
 EXIT_DOCKER_UNKNOWN = 4
+
+
+def resolve_project_id(worktree_path: Path, branch: str) -> str:
+    """Pick the Supabase project id whose containers and volumes to tear down.
+
+    A pinned id recorded in the worktree's `supabase/config.toml` always wins.
+    That file is what the Supabase CLI itself reads, so it is the authoritative
+    record of the id the stack was started under — and since PP-4936 it survives
+    a `git checkout -b` inside a live worktree instead of following the branch.
+    Deriving from the branch here would then target a label no volume carries,
+    the `docker volume ls --filter` query would return an honest-looking zero,
+    and the volumes would leak (PP-rbbp).
+
+    Falls back to `branch_to_project_id(branch)` only when there is no usable
+    pinned id — a worktree set up before PP-4936, or a config.toml that is
+    missing, unreadable, or carries an id outside the shape setup generates.
+    Same precedence as `worktree_orphan_sweep.get_active_project_ids()`.
+
+    This deliberately does not call `worktree_setup.resolve_project_id`, whose
+    precedence is identical: its divergence message is written for the setup
+    path ("keeping pinned … renaming it would orphan this worktree's running
+    stack"), which is the wrong story to tell during a teardown. Two callers is
+    below the Rule of Three; if a third appears, hoist the shared body and pass
+    the message in.
+    """
+    derived = branch_to_project_id(branch)
+    pinned = read_pinned_project_id(worktree_path)
+    if pinned is None:
+        return derived
+    if pinned != derived:
+        print(
+            f"Note: tearing down pinned Supabase project_id '{pinned}' from "
+            f"{worktree_path / 'supabase' / 'config.toml'} — branch '{branch}' "
+            f"would derive '{derived}', but the running stack and its volumes "
+            "are labelled with the pinned id.",
+            file=sys.stderr,
+        )
+    return pinned
 
 
 def deallocate_slot(worktree_path: str) -> None:
@@ -323,7 +367,7 @@ def main() -> int:
             branch = ""
 
     if branch:
-        project_id = branch_to_project_id(branch)
+        project_id = resolve_project_id(worktree_path, branch)
 
         # Stop Supabase. Failures here are non-fatal: a missing project_ref or
         # a stack that was never started both look like errors but don't block


### PR DESCRIPTION
## What

`scripts/worktree_cleanup.py` derived the Supabase project id from the worktree's current branch name. PP-4936 (#1775) pinned that id in each worktree's `supabase/config.toml` so it no longer follows the branch — which made cleanup's derivation wrong for any worktree whose branch was renamed after setup.

The consequence is a silent leak. Cleanup runs:

```
docker volume ls --filter label=com.supabase.cli.project=<project_id> -q
```

With a stale branch-derived id, that filter matches a label no volume carries. The query succeeds and returns nothing, so cleanup removes the worktree, deallocates the slot, prints "Cleaned up worktree", and exits 0 — while the Supabase volumes stay on disk. Same false-zero family as PP-3w4g, arriving by a different route: there the query failed and was read as zero; here the query succeeds against the wrong target.

## How

New `resolve_project_id(worktree_path, branch)` in `worktree_cleanup.py`:

- A pinned id from `supabase/config.toml` (via `worktree_setup.read_pinned_project_id`, added by #1775) always wins — that file is what the Supabase CLI itself reads, so it is the authoritative record of the id the running stack was started under.
- Falls back to `branch_to_project_id(branch)` only when there is no usable pinned id: a worktree set up before PP-4936, or a `config.toml` that is missing, unreadable, or carries an id outside the shape setup generates.
- Same precedence `worktree_orphan_sweep.get_active_project_ids()` already uses.
- Announces a divergence on stderr so a rename is visible in the hook's output.

It deliberately does not call `worktree_setup.resolve_project_id`, whose logic is identical but whose divergence message is written for the setup path ("renaming it would orphan this worktree's running stack") — the wrong story to tell during a teardown. Two callers is below the Rule of Three; the docstring records what to do at the third.

## Out of scope (deliberate)

- **The `--filter` query form is untouched.** PP-3w4g established that the portable `label=<k>=<v>` + `-q` form is correct; the existing test asserting the Podman-incompatible `{{.Label …}}` template never reappears still passes.
- **The `git_marker_present` gate from PP-qlzu is untouched.** A worktree with no `.git` marker still skips the Supabase/Docker phase. It could now resolve a pinned id from `config.toml` without a branch, but `worktree_orphan_sweep.py` already reclaims exactly that case (`get_orphan_slot_paths` flags entries "missing on disk or w/o .git marker"), so this is covered rather than gapped.

## Tests

`scripts/tests/test_worktree_cleanup.py`, all mocked at the subprocess boundary — no real Docker, Supabase, git worktrees, or slot manifest.

- `TestResolveProjectId` — pinned id wins over the branch-derived one; divergence is announced; agreement is silent; missing `config.toml` falls back; three unusable-config shapes (no `project_id`, an id outside the `pinpoint-*` shape, the bare template value) fall back.
- `TestMainTeardown::test_renamed_branch_still_tears_down_the_pinned_project` — end-to-end `main()`: asserts the `volume ls` filter carries the pinned id, that the branch-derived id is *not* queried, and that the pinned volume is actually removed. This test fails against the old `branch_to_project_id(branch)` call (verified).
- `TestMainTeardown::test_worktree_without_a_pinned_id_uses_the_branch` — the fallback still targets the branch-derived id.

`pnpm run check` green (364 pytest, 1813 vitest, ruff/format clean).

Closes PP-rbbp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VypoeEVeXdF7Y3KfyWYeP8