### PR TITLE
fix(huddle): stop an empty session_id parsing as the source value (PP-txet)

### DIFF
--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -215,16 +215,31 @@ fi
 SESSION_ID=""
 SOURCE=""
 if [[ -n "$INPUT" ]]; then
+  # The two fields are joined on STX (\x02) and split with IFS=STX, matching
+  # huddle-pr-announce.sh. The separator must be a NON-whitespace byte: bash
+  # treats space/tab/newline as "IFS whitespace" even when IFS names only one of
+  # them, which means leading separators are skipped and runs collapse. That is
+  # exactly how PP-txet bit — the fields were space-joined and read with the
+  # default IFS, so `{"session_id": "", "source": "startup"}` produced
+  # " startup" and parsed as SESSION_ID=startup, SOURCE="". The empty-session_id
+  # guard below never fired, the hook announced `startup` as the session id, and
+  # the compact check further down compared against an emptied SOURCE.
+  # A tab separator would NOT have fixed this; STX splits into a genuine empty
+  # leading field.
+  _SEP=$(printf '\002')
   # python3 failure is handled by the read's `|| { … }` fallback; ignore masked return.
   # shellcheck disable=SC2312
-  read -r SESSION_ID SOURCE <<<"$(
-    printf '%s' "$INPUT" | python3 -c "
-import sys, json
+  IFS="$_SEP" read -r SESSION_ID SOURCE <<<"$(
+    printf '%s' "$INPUT" | SEP="$_SEP" python3 -c "
+import os, sys, json
+sid = src = ''
 try:
     p = json.load(sys.stdin)
-    print((p.get('session_id') or '') + ' ' + (p.get('source') or ''))
+    sid = str(p.get('session_id') or '').strip()
+    src = str(p.get('source') or '').strip()
 except Exception:
-    print(' ')
+    pass
+print(sid + os.environ['SEP'] + src)
 " 2>/dev/null
   )" || { SESSION_ID=""; SOURCE=""; }
 fi

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -233,8 +233,11 @@ if [[ -n "$INPUT" ]]; then
   # The IFS prefix assignment does not persist — `read` is a regular builtin —
   # so the daily-injection loop further down still gets the default IFS.
   _SEP=$(printf '\002')
-  # python3 failure is handled by the read's `|| { … }` fallback; ignore masked return.
-  # shellcheck disable=SC2312
+  # A python3 or JSON failure is absorbed by the parse itself: sid/src stay empty,
+  # the here-string is a bare separator, and the `[[ -z "$SESSION_ID" ]]` guard
+  # below exits. The `|| { … }` is belt-and-braces for `read` itself failing — it
+  # rarely fires, since a here-string always supplies a trailing newline.
+  # shellcheck disable=SC2312  # the masked $(...) return is handled as described
   IFS="$_SEP" read -r SESSION_ID SOURCE <<<"$(
     printf '%s' "$INPUT" | SEP="$_SEP" python3 -c "
 import os, sys, json

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -215,17 +215,23 @@ fi
 SESSION_ID=""
 SOURCE=""
 if [[ -n "$INPUT" ]]; then
-  # The two fields are joined on STX (\x02) and split with IFS=STX, matching
-  # huddle-pr-announce.sh. The separator must be a NON-whitespace byte: bash
-  # treats space/tab/newline as "IFS whitespace" even when IFS names only one of
-  # them, which means leading separators are skipped and runs collapse. That is
-  # exactly how PP-txet bit — the fields were space-joined and read with the
-  # default IFS, so `{"session_id": "", "source": "startup"}` produced
-  # " startup" and parsed as SESSION_ID=startup, SOURCE="". The empty-session_id
-  # guard below never fired, the hook announced `startup` as the session id, and
-  # the compact check further down compared against an emptied SOURCE.
-  # A tab separator would NOT have fixed this; STX splits into a genuine empty
-  # leading field.
+  # The two fields are joined on STX (\x02) and split with IFS=STX — the same
+  # separator convention huddle-pr-announce.sh uses, and for the same reason.
+  # It must be a NON-whitespace byte: bash treats space/tab/newline as "IFS
+  # whitespace" even when IFS names only one of them, which means leading
+  # separators are skipped and runs collapse. That is exactly how PP-txet bit —
+  # the fields were space-joined and read with the default IFS, so
+  # `{"session_id": "", "source": "startup"}` produced " startup" and parsed as
+  # SESSION_ID=startup, SOURCE="". The empty-session_id guard below never fired,
+  # the hook announced `startup` as the session id, and the compact check
+  # further down compared against an emptied SOURCE. A tab separator would NOT
+  # have fixed this; STX splits into a genuine empty leading field.
+  #
+  # str() + strip() on the python side keep a non-string or whitespace-only
+  # field from reading as a truthy session_id.
+  #
+  # The IFS prefix assignment does not persist — `read` is a regular builtin —
+  # so the daily-injection loop further down still gets the default IFS.
   _SEP=$(printf '\002')
   # python3 failure is handled by the read's `|| { … }` fallback; ignore masked return.
   # shellcheck disable=SC2312

--- a/scripts/tests/test_huddle_session_start.py
+++ b/scripts/tests/test_huddle_session_start.py
@@ -176,36 +176,46 @@ def register(repo: Path, name: str, session_id: str = SESSION_ID) -> None:
     )
 
 
+def run_hook_payload(repo: Path, payload: dict[str, object]) -> tuple[int, str, str]:
+    """Run the hook with an arbitrary stdin payload. Returns (rc, out, err).
+
+    Takes the payload dict verbatim so a test can omit a key or vary the key
+    order — `json.dumps` preserves insertion order, which is what makes the
+    "field ordering" cases in PP-txet expressible.
+    """
+    env = os.environ.copy()
+    env["PATH"] = f"{repo / 'bin'}{os.pathsep}{env['PATH']}"
+    env["BD_LOG"] = str(repo / "bd.log")
+    env["BD_SHOW_DIR"] = str(repo / "shows")
+    env["BD_CHILDREN_JSON"] = str(repo / "children.json")
+    proc = subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        cwd=repo,
+        env=env,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
 def run_hook(
     repo: Path,
     session_id: str = SESSION_ID,
     source: str = "startup",
     transcript_path: str = "/tmp/transcripts/abc.jsonl",
 ) -> tuple[int, str, str]:
-    """Run the hook with a SessionStart payload on stdin. Returns (rc, out, err)."""
-    env = os.environ.copy()
-    env["PATH"] = f"{repo / 'bin'}{os.pathsep}{env['PATH']}"
-    env["BD_LOG"] = str(repo / "bd.log")
-    env["BD_SHOW_DIR"] = str(repo / "shows")
-    env["BD_CHILDREN_JSON"] = str(repo / "children.json")
-    payload = json.dumps(
+    """Run the hook with a well-formed SessionStart payload on stdin."""
+    return run_hook_payload(
+        repo,
         {
             "session_id": session_id,
             "transcript_path": transcript_path,
             "cwd": str(repo),
             "hook_event_name": "SessionStart",
             "source": source,
-        }
+        },
     )
-    proc = subprocess.run(
-        ["bash", str(HOOK_PATH)],
-        cwd=repo,
-        env=env,
-        input=payload,
-        capture_output=True,
-        text=True,
-    )
-    return proc.returncode, proc.stdout, proc.stderr
 
 
 ROTATION_MARKER = "Huddle rotation needed"
@@ -434,6 +444,104 @@ def test_identity_block_prompts_on_added_scope(repo: Path) -> None:
     assert "THE KICKOFF IS NOT THE LAST POST" in out
     assert "scope gets ADDED" in out
     assert "CHANGE DIRECTION" in out
+
+
+# --- PP-txet: the session_id / source parse must not collapse an empty field --
+#
+# The two fields were space-joined by the inline python and read back with the
+# default IFS, which skips leading whitespace. `{"session_id": "", "source":
+# "startup"}` therefore printed " startup" and parsed as SESSION_ID=startup,
+# SOURCE="" — the "no session_id, exit silently" guard never fired, the hook
+# announced the literal `startup` as the session id, and the compact
+# suppression check compared against an empty SOURCE.
+#
+# Claude Code always sends a session_id, so this was latent there; it bites
+# adapter-supplied payloads (.agents/hooks/antigravity-bootstrap.cjs), where an
+# empty or missing session_id is plausible.
+
+
+def test_missing_session_id_emits_rotation_notice_only(repo: Path) -> None:
+    """Empty session_id: the rotation notice still fires, nothing else does."""
+    set_rotation_pending(repo)
+    rc, out, err = run_hook(repo, session_id="")
+    assert rc == 0, err
+    assert ROTATION_MARKER in out
+    assert IDENTITY_MARKER not in out
+    assert REGISTRATION_MARKER not in out
+    # The pre-fix parse announced `source` as the session id. No part of the
+    # rotation notice contains that word, so this pins the actual defect.
+    assert "startup" not in out
+
+
+def test_missing_session_id_on_the_up_to_date_path_emits_nothing(repo: Path) -> None:
+    rc, out, err = run_hook(repo, session_id="")
+    assert rc == 0, err
+    assert out == ""
+
+
+def test_absent_session_id_key_emits_nothing(repo: Path) -> None:
+    """A payload that omits `session_id` entirely, not just an empty string."""
+    rc, out, err = run_hook_payload(
+        repo,
+        {
+            "transcript_path": "/tmp/transcripts/abc.jsonl",
+            "cwd": str(repo),
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        },
+    )
+    assert rc == 0, err
+    assert out == ""
+
+
+def test_compact_stays_suppressed_when_session_id_is_missing(repo: Path) -> None:
+    """The worst pre-fix case: an empty session_id defeated the compact check.
+
+    SESSION_ID took `compact` and SOURCE emptied out, so the hook skipped the
+    condensed post-compaction block and emitted the full registration wall
+    instead — naming `compact` as the session id.
+    """
+    register(repo, "Claude-HuddleFix")
+    rc, out, err = run_hook(repo, session_id="", source="compact")
+    assert rc == 0, err
+    assert out == ""
+
+
+def test_compact_is_suppressed_when_source_precedes_session_id(repo: Path) -> None:
+    """Key order in the JSON payload must not change which block is emitted."""
+    register(repo, "Claude-HuddleFix")
+    rc, out, err = run_hook_payload(
+        repo,
+        {
+            "source": "compact",
+            "hook_event_name": "SessionStart",
+            "cwd": str(repo),
+            "transcript_path": "/tmp/transcripts/abc.jsonl",
+            "session_id": SESSION_ID,
+        },
+    )
+    assert rc == 0, err
+    assert "## Huddle identity (post-compaction)" in out
+    # The full startup-only registration/etiquette wall stays suppressed.
+    assert "self-filter active" not in out
+    assert REGISTRATION_MARKER not in out
+
+
+def test_absent_source_key_still_emits_the_startup_block(repo: Path) -> None:
+    """A missing `source` leaves an empty trailing field, not a shifted one."""
+    register(repo, "Claude-HuddleFix")
+    rc, out, err = run_hook_payload(
+        repo,
+        {
+            "session_id": SESSION_ID,
+            "transcript_path": "/tmp/transcripts/abc.jsonl",
+            "cwd": str(repo),
+            "hook_event_name": "SessionStart",
+        },
+    )
+    assert rc == 0, err
+    assert "Registered as: **Claude-HuddleFix**" in out
+    assert "## Huddle identity (post-compaction)" not in out
 
 
 # --- Early-exit paths must keep short-circuiting -----------------------------


### PR DESCRIPTION
Closes PP-txet.

## The bug

`huddle-session-start.sh` joined `session_id` and `source` with a **space** and read them back with the default `IFS`, which skips leading whitespace. A payload of `{"session_id": "", "source": "startup"}` printed `" startup"`, and `read -r SESSION_ID SOURCE` parsed that as `SESSION_ID=startup`, `SOURCE=""`.

Three things followed from that one collapse:

- the "no session_id, silently exit" guard never fired;
- the hook emitted a registration block announcing the literal `startup` as the session id;
- the compact-suppression check (`SOURCE == compact`) compared against an emptied `SOURCE`, so `{"session_id": "", "source": "compact"}` got the full startup registration wall instead of the condensed post-compaction block.

Claude Code always sends a `session_id`, so this was latent there. It matters for adapter-supplied payloads — `.agents/hooks/antigravity-bootstrap.cjs` synthesizes the Claude shape for Antigravity, where an empty or missing `session_id` is plausible.

## The fix

Join on **STX (`\x02`)** and split with `IFS=STX`, matching the convention already established in `huddle-pr-announce.sh`.

The separator has to be a **non-whitespace** byte. The bead's original fix sketch proposed a tab — that would **not** have worked: bash treats space, tab and newline as "IFS whitespace" even when `IFS` names only one of them, so leading separators are still skipped and runs still collapse. Verified empirically before choosing STX:

```
IFS=$'\t' read -r A B <<< $'\tcompact'   ->  A=[compact] B=[]     # still broken
IFS=$'\x02' read -r C D <<< $'\x02compact' -> C=[]      D=[compact] # correct
```

The python side also coerces with `str()` and strips, so a whitespace-only `session_id` reads as absent rather than as a truthy id, and a non-string value can't raise mid-expression.

`IFS="$_SEP" read` is a prefix assignment on a *regular* builtin, so it does not persist — verified that `IFS` is unchanged afterwards, which matters because the daily-injection loop further down does its own splitting.

## Tests

6 new pytest cases in `scripts/tests/test_huddle_session_start.py`. **Four fail against the pre-fix script**:

- `test_missing_session_id_emits_rotation_notice_only` (the case dropped from the PP-2m3l branch — it was not recoverable from git history or dangling objects, so it is rewritten here)
- `test_missing_session_id_on_the_up_to_date_path_emits_nothing`
- `test_absent_session_id_key_emits_nothing`
- `test_compact_stays_suppressed_when_session_id_is_missing`

Two pin behaviour the fix must not regress: JSON key order (`test_compact_is_suppressed_when_source_precedes_session_id`), and a payload with no `source` key leaving an empty *trailing* field rather than a shifted one (`test_absent_source_key_still_emits_the_startup_block`).

`run_hook` is refactored onto a `run_hook_payload` primitive so a test can omit a key or vary key order; the existing call sites are unchanged.

## Out of scope

Filed **PP-788v** for the adjacent (different) defect observed live tonight: a subagent registering a huddle identity wrote the *parent* session's id into `session-names.json`, silently reassigning the orchestrator's name. Two compounding causes — a subagent has no way to learn its own `session_id` (both huddle hooks skip subagents, and `whoami discover` returns the newest *top-level* transcript by construction), and `register`'s duplicate check only guards name→different-sid, never sid→different-name, so the write is an unconditional overwrite. Deliberately not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VypoeEVeXdF7Y3KfyWYeP8
