### PR TITLE
fix(scripts): portable backup discovery in seed-from-backup.sh (PP-euhg)

### DIFF
--- a/scripts/seed-from-backup.sh
+++ b/scripts/seed-from-backup.sh
@@ -18,18 +18,51 @@ BACKUP_FILE=$1
 if [ -z "$BACKUP_FILE" ]; then
     echo -e "${BLUE}🔍 No backup file specified. Looking for the latest one in $BACKUP_DIR...${NC}"
 
-    # Use find for robust file resolution, handling spaces and special characters
-    BACKUP_FILE=$(
-        find "$BACKUP_DIR" -maxdepth 1 -type f -name 'pinpoint_prod_*.sql' -printf '%T@ %p\n' 2>/dev/null \
-            | sort -nr \
-            | head -n 1 \
-            | cut -d' ' -f2-
-    )
-
-    if [ -z "$BACKUP_FILE" ]; then
-        echo -e "${RED}❌ No backup files found in $BACKUP_DIR${NC}"
+    # "Missing directory", "unlistable directory" and "directory with no dumps"
+    # are three different problems. Report them separately — collapsing a failed
+    # lookup into "no backups found" is the exact bug being fixed here.
+    if [ ! -d "$BACKUP_DIR" ]; then
+        echo -e "${RED}❌ Backup directory does not exist: $BACKUP_DIR${NC}"
+        echo -e "${YELLOW}   Run 'pnpm run db:backup' to create one.${NC}"
         exit 1
     fi
+
+    # An unreadable/unsearchable directory yields the same empty glob as an empty
+    # one, so check before matching rather than misreporting the result after.
+    if [ ! -r "$BACKUP_DIR" ] || [ ! -x "$BACKUP_DIR" ]; then
+        echo -e "${RED}❌ Backup lookup failed: cannot list $BACKUP_DIR (permission denied).${NC}"
+        echo -e "${YELLOW}   This is not the same as having no backups — fix the directory permissions.${NC}"
+        exit 1
+    fi
+
+    # Backups are named pinpoint_prod_<YYYYmmdd_HHMMSS>.sql, so lexicographic
+    # order IS chronological order — the newest is simply the greatest name.
+    # A plain glob needs no stat() and no find(1) extension, so it behaves
+    # identically under GNU and BSD userlands. (This used to be
+    # `find -printf '%T@ %p\n' 2>/dev/null`; -printf is GNU findutils only, so
+    # on macOS find errored, the redirect ate the message, and the script
+    # claimed the directory was empty — PP-euhg.)
+    shopt -s nullglob
+    backup_candidates=("$BACKUP_DIR"/pinpoint_prod_*.sql)
+    shopt -u nullglob
+
+    if [ ${#backup_candidates[@]} -eq 0 ]; then
+        echo -e "${RED}❌ No backup files found in $BACKUP_DIR${NC}"
+        echo -e "${YELLOW}   Expected files named pinpoint_prod_<YYYYmmdd_HHMMSS>.sql.${NC}"
+        echo -e "${YELLOW}   Run 'pnpm run db:backup' to create one.${NC}"
+        exit 1
+    fi
+
+    # Pick the greatest name. An explicit loop (rather than ${arr[-1]}) keeps
+    # this working on macOS's stock bash 3.2, which has no negative indexing.
+    BACKUP_FILE=${backup_candidates[0]}
+    for candidate in "${backup_candidates[@]}"; do
+        if [[ $candidate > $BACKUP_FILE ]]; then
+            BACKUP_FILE=$candidate
+        fi
+    done
+
+    echo -e "${GREEN}✓ Found ${#backup_candidates[@]} backup(s); using the newest${NC}"
 fi
 
 if [ ! -f "$BACKUP_FILE" ]; then

--- a/scripts/seed-from-backup.sh
+++ b/scripts/seed-from-backup.sh
@@ -22,8 +22,14 @@ if [ -z "$BACKUP_FILE" ]; then
     # are three different problems. Report them separately — collapsing a failed
     # lookup into "no backups found" is the exact bug being fixed here.
     if [ ! -d "$BACKUP_DIR" ]; then
-        echo -e "${RED}❌ Backup directory does not exist: $BACKUP_DIR${NC}"
-        echo -e "${YELLOW}   Run 'pnpm run db:backup' to create one.${NC}"
+        if [ -e "$BACKUP_DIR" ]; then
+            # Not "missing" — something is there, it just isn't a directory, and
+            # "run db:backup" would be bad advice because that would fail too.
+            echo -e "${RED}❌ $BACKUP_DIR exists but is not a directory.${NC}"
+        else
+            echo -e "${RED}❌ Backup directory does not exist: $BACKUP_DIR${NC}"
+            echo -e "${YELLOW}   Run 'pnpm run db:backup' to create one.${NC}"
+        fi
         exit 1
     fi
 
@@ -42,8 +48,17 @@ if [ -z "$BACKUP_FILE" ]; then
     # `find -printf '%T@ %p\n' 2>/dev/null`; -printf is GNU findutils only, so
     # on macOS find errored, the redirect ate the message, and the script
     # claimed the directory was empty — PP-euhg.)
+    #
+    # The glob spells out 8 date digits + 6 time digits rather than using a bare
+    # `*`, because that literal shape is what makes "greatest name == newest"
+    # true. It mirrors `date +%Y%m%d_%H%M%S` in scripts/backup-production.sh. A
+    # loose `pinpoint_prod_*.sql` would also match a hand-named file like
+    # pinpoint_prod_manual.sql, which sorts above every timestamp and would be
+    # picked as the "newest" backup.
     shopt -s nullglob
-    backup_candidates=("$BACKUP_DIR"/pinpoint_prod_*.sql)
+    backup_candidates=(
+        "$BACKUP_DIR"/pinpoint_prod_[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9].sql
+    )
     shopt -u nullglob
 
     if [ ${#backup_candidates[@]} -eq 0 ]; then

--- a/scripts/seed-from-backup.sh
+++ b/scripts/seed-from-backup.sh
@@ -18,9 +18,9 @@ BACKUP_FILE=$1
 if [ -z "$BACKUP_FILE" ]; then
     echo -e "${BLUE}🔍 No backup file specified. Looking for the latest one in $BACKUP_DIR...${NC}"
 
-    # "Missing directory", "unlistable directory" and "directory with no dumps"
-    # are three different problems. Report them separately — collapsing a failed
-    # lookup into "no backups found" is the exact bug being fixed here.
+    # Missing directory, non-directory, unlistable directory and directory-with-
+    # no-dumps are four different problems. Report them separately — collapsing a
+    # failed lookup into "no backups found" is the exact bug being fixed here.
     if [ ! -d "$BACKUP_DIR" ]; then
         if [ -e "$BACKUP_DIR" ]; then
             # Not "missing" — something is there, it just isn't a directory, and

--- a/scripts/tests/test_seed_from_backup.py
+++ b/scripts/tests/test_seed_from_backup.py
@@ -126,18 +126,51 @@ def test_selects_newest_by_filename_not_mtime(tmp_path: Path) -> None:
     assert "pinpoint_prod_20260101_010101.sql" not in result.stdout
 
 
-def test_handles_filename_with_spaces(tmp_path: Path) -> None:
-    """The old find pipeline split on whitespace; the glob must not."""
+def test_ignores_names_without_a_timestamp(tmp_path: Path) -> None:
+    """'Greatest name == newest' only holds for the timestamped shape, so the
+    glob must not match hand-named dumps. `pinpoint_prod_manual.sql` sorts above
+    every timestamp and would otherwise hijack the selection."""
     home = tmp_path / "home"
     home.mkdir()
     backup_dir = make_backup_dir(home)
-    (backup_dir / "pinpoint_prod_20260101_000000 copy.sql").write_text("")
+    (backup_dir / "pinpoint_prod_20260102_000000.sql").write_text("")
+    (backup_dir / "pinpoint_prod_manual.sql").write_text("")
+    (backup_dir / "pinpoint_prod_20260103.sql").write_text("")  # date, no time
+
+    result = run_discovery(home, tmp_path)
+
+    assert "Found 1 backup(s)" in result.stdout
+    assert str(backup_dir / "pinpoint_prod_20260102_000000.sql") in result.stdout
+    assert "pinpoint_prod_manual.sql" not in result.stdout
+
+
+def test_handles_a_home_directory_containing_a_space(tmp_path: Path) -> None:
+    """macOS home directories are routinely `/Users/First Last`. The array/glob
+    path must carry that through without word-splitting the resolved path."""
+    home = tmp_path / "Some User"
+    home.mkdir()
+    backup_dir = make_backup_dir(home)
+    (backup_dir / "pinpoint_prod_20260101_000000.sql").write_text("")
     (backup_dir / "pinpoint_prod_20260102_000000.sql").write_text("")
 
     result = run_discovery(home, tmp_path)
 
     assert "Found 2 backup(s)" in result.stdout
     assert str(backup_dir / "pinpoint_prod_20260102_000000.sql") in result.stdout
+
+
+def test_reports_a_non_directory_path_accurately(tmp_path: Path) -> None:
+    """A regular file sitting at the backup path is not a missing directory, and
+    'run db:backup to create one' would be bad advice — that would fail too."""
+    home = tmp_path / "home"
+    (home / ".pinpoint").mkdir(parents=True)
+    (home / ".pinpoint" / "db-backups").write_text("not a directory")
+
+    result = run_discovery(home, tmp_path)
+
+    assert result.returncode == 1
+    assert "exists but is not a directory" in result.stdout
+    assert "does not exist" not in result.stdout
 
 
 def test_explicit_argument_skips_discovery(tmp_path: Path) -> None:

--- a/scripts/tests/test_seed_from_backup.py
+++ b/scripts/tests/test_seed_from_backup.py
@@ -1,0 +1,153 @@
+"""Tests for the backup auto-discovery block in scripts/seed-from-backup.sh.
+
+The regression under test (PP-euhg): discovery used `find -printf '%T@ %p\\n'`,
+a GNU findutils extension. On macOS's BSD find the flag is an error, the
+`2>/dev/null` swallowed it, and the empty result was reported as **"No backup
+files found"** — so the script blamed the directory for a failure in its own
+lookup, and `pnpm run db:seed:from-prod` with no argument was dead on the
+primary dev machine while looking merely unlucky.
+
+Discovery now globs `pinpoint_prod_<YYYYmmdd_HHMMSS>.sql` and takes the greatest
+name. Because those names sort lexicographically in timestamp order, that needs
+no `stat()` and no `find(1)` extension, so GNU and BSD userlands agree without
+branching on OS.
+
+`test_selects_newest_by_filename_not_mtime` is the load-bearing one: it fails on
+Linux if anyone reinstates an mtime-ordered lookup (`find -printf '%T@'`, `ls
+-t`, `stat`), which is the only class of change that could reintroduce the
+macOS-only break. The rest pin the three now-distinct failure reports.
+
+Every test answers "n" at the confirmation prompt, so the script aborts before
+it can reach a database, and runs with cwd set to a scratch dir so the
+`.env.local` lookup could not find a real connection string even if it did.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parent.parent / "seed-from-backup.sh"
+
+
+def run_discovery(
+    home: Path, cwd: Path, *args: str
+) -> subprocess.CompletedProcess[str]:
+    """Run the script with $HOME pointed at a scratch dir, declining the prompt."""
+    env = dict(os.environ, HOME=str(home))
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH), *args],
+        input="n\n",
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=30,
+    )
+
+
+def make_backup_dir(home: Path) -> Path:
+    backup_dir = home / ".pinpoint" / "db-backups"
+    backup_dir.mkdir(parents=True)
+    return backup_dir
+
+
+def test_reports_missing_directory_distinctly(tmp_path: Path) -> None:
+    """A directory that does not exist is its own diagnosis, not 'no backups'."""
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = run_discovery(home, tmp_path)
+
+    assert result.returncode == 1
+    assert "Backup directory does not exist" in result.stdout
+    assert "No backup files found" not in result.stdout
+
+
+def test_reports_empty_directory_as_empty(tmp_path: Path) -> None:
+    """A readable directory holding no dumps really is empty — say so."""
+    home = tmp_path / "home"
+    home.mkdir()
+    backup_dir = make_backup_dir(home)
+    (backup_dir / "notes.txt").write_text("not a dump")
+
+    result = run_discovery(home, tmp_path)
+
+    assert result.returncode == 1
+    assert "No backup files found" in result.stdout
+    assert "lookup failed" not in result.stdout
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root ignores directory permissions, so the glob succeeds"
+)
+def test_unlistable_directory_is_a_lookup_failure_not_emptiness(tmp_path: Path) -> None:
+    """The PP-euhg failure mode in its remaining form: the glob comes back empty
+    because the lookup could not run, and that must not read as 'no backups'."""
+    home = tmp_path / "home"
+    home.mkdir()
+    backup_dir = make_backup_dir(home)
+    (backup_dir / "pinpoint_prod_20260101_000000.sql").write_text("")
+    backup_dir.chmod(0o000)
+    try:
+        result = run_discovery(home, tmp_path)
+    finally:
+        backup_dir.chmod(0o755)
+
+    assert result.returncode == 1
+    assert "Backup lookup failed" in result.stdout
+    assert "No backup files found" not in result.stdout
+
+
+def test_selects_newest_by_filename_not_mtime(tmp_path: Path) -> None:
+    """Newest == greatest filename. mtimes are set to contradict the names, so an
+    mtime-ordered lookup (find -printf / ls -t / stat) picks a different file."""
+    home = tmp_path / "home"
+    home.mkdir()
+    backup_dir = make_backup_dir(home)
+
+    # Name order: 20260101 < 20260615 < 20260731. mtime order is the reverse, so
+    # mtime-newest is 20260101 — the file a stat-based lookup would choose.
+    names_oldest_first = [
+        "pinpoint_prod_20260101_010101.sql",
+        "pinpoint_prod_20260615_120000.sql",
+        "pinpoint_prod_20260731_235959.sql",
+    ]
+    for index, name in enumerate(reversed(names_oldest_first)):
+        path = backup_dir / name
+        path.write_text("")
+        os.utime(path, (1_700_000_000 + index * 60, 1_700_000_000 + index * 60))
+
+    result = run_discovery(home, tmp_path)
+
+    assert "Found 3 backup(s)" in result.stdout
+    assert str(backup_dir / "pinpoint_prod_20260731_235959.sql") in result.stdout
+    assert "pinpoint_prod_20260101_010101.sql" not in result.stdout
+
+
+def test_handles_filename_with_spaces(tmp_path: Path) -> None:
+    """The old find pipeline split on whitespace; the glob must not."""
+    home = tmp_path / "home"
+    home.mkdir()
+    backup_dir = make_backup_dir(home)
+    (backup_dir / "pinpoint_prod_20260101_000000 copy.sql").write_text("")
+    (backup_dir / "pinpoint_prod_20260102_000000.sql").write_text("")
+
+    result = run_discovery(home, tmp_path)
+
+    assert "Found 2 backup(s)" in result.stdout
+    assert str(backup_dir / "pinpoint_prod_20260102_000000.sql") in result.stdout
+
+
+def test_explicit_argument_skips_discovery(tmp_path: Path) -> None:
+    """An explicit path is still honoured, and does not consult $HOME at all."""
+    home = tmp_path / "home"
+    home.mkdir()  # deliberately no backup dir
+    explicit = tmp_path / "elsewhere.sql"
+    explicit.write_text("")
+
+    result = run_discovery(home, tmp_path, str(explicit))
+
+    assert "No backup file specified" not in result.stdout
+    assert str(explicit) in result.stdout

--- a/scripts/tests/test_seed_from_backup.py
+++ b/scripts/tests/test_seed_from_backup.py
@@ -12,10 +12,15 @@ name. Because those names sort lexicographically in timestamp order, that needs
 no `stat()` and no `find(1)` extension, so GNU and BSD userlands agree without
 branching on OS.
 
-`test_selects_newest_by_filename_not_mtime` is the load-bearing one: it fails on
-Linux if anyone reinstates an mtime-ordered lookup (`find -printf '%T@'`, `ls
--t`, `stat`), which is the only class of change that could reintroduce the
-macOS-only break. The rest pin the three now-distinct failure reports.
+Two tests carry the weight:
+
+- `test_selects_newest_by_filename_not_mtime` fails on Linux if anyone reinstates
+  an mtime-ordered lookup (`find -printf '%T@'`, `ls -t`, `stat`), which is the
+  only class of change that could reintroduce the macOS-only break.
+- `test_ignores_names_without_a_timestamp` pins the precondition that makes
+  name-ordering valid at all: the glob must match only the timestamped shape.
+
+The rest pin the four now-distinct failure reports.
 
 Every test answers "n" at the confirmation prompt, so the script aborts before
 it can reach a database, and runs with cwd set to a scratch dir so the


### PR DESCRIPTION
## Problem

`pnpm run db:seed:from-prod` with no argument resolved the newest dump with:

```bash
find "$BACKUP_DIR" -maxdepth 1 -type f -name 'pinpoint_prod_*.sql' -printf '%T@ %p\n' 2>/dev/null
```

`-printf` is a **GNU findutils extension**. macOS ships BSD `find`, which errors on the flag; the `2>/dev/null` swallowed the message, `BACKUP_FILE` came back empty, and the script reported **"No backup files found"** — even with dumps sitting in `~/.pinpoint/db-backups`.

So on the primary dev machine the no-arg form was dead, and it looked like an empty directory rather than a broken lookup. **The lie was the bug**; the break was the smaller half.

## Fix

Dumps are named `pinpoint_prod_<YYYYmmdd_HHMMSS>.sql`, so **lexicographic order is already chronological order**. Discovery now globs and takes the greatest name.

That needs no `stat()`, no `find(1)`, and therefore **no branching on OS** — GNU and BSD agree because neither userland is consulted. The selection loop uses an explicit comparison rather than `${arr[-1]}` so it also runs on macOS's stock bash 3.2, which has no negative array indexing.

### Honest failure

The three conditions the old code collapsed into one message are now reported separately:

| condition | message |
| :--- | :--- |
| directory missing | `Backup directory does not exist: …` |
| directory present but unlistable | `Backup lookup failed: cannot list … (permission denied).` + `This is not the same as having no backups` |
| directory readable, no dumps | `No backup files found in …` + the expected filename pattern |

The middle row is the one remaining way an empty glob can mean "the lookup didn't run", so it is checked explicitly rather than misreported after the fact. The `2>/dev/null` is gone — a glob has no stderr to hide.

## Tests

`scripts/tests/test_seed_from_backup.py` (6 cases) drives the real bash, matching the existing `test_pr_gates.py` convention. Every case answers `n` at the confirmation prompt and runs with `cwd` in a scratch dir, so nothing can reach a database.

The load-bearing case is `test_selects_newest_by_filename_not_mtime`: it sets mtimes to **contradict** the filenames, so it fails on Linux CI if anyone reinstates an mtime-ordered lookup (`find -printf '%T@'`, `ls -t`, `stat`) — the only change class that could reintroduce the macOS-only break. Verified against the old implementation: both `find -printf` and `ls -t` select `pinpoint_prod_20260101_010101.sql`, which the test explicitly asserts is *not* chosen.

## Portability sweep

Swept the rest of the script and all of `scripts/` + `.claude/hooks/` for the same class (`-printf`, `stat -c/-f`, `sed -i`, `readlink -f`, `date -d`, `sha256sum`, `base64 -w`, `-newermt`, `-regextype`, `xargs -r`). No other unguarded GNU-only flags — the two live sites already carry BSD fallbacks:

- `.claude/hooks/session-start-orphan-sweep.sh:43` — `stat -c %Y || stat -f %m`
- `scripts/workflow/_pr-gates.sh:153,248` — `date -d` feature-tested with a `date -jf` fallback

Nothing to fix inline, so no follow-up bead filed.

## Note on verification

Developed on Bazzite (Linux/GNU findutils), where the original bug is **not reproducible** — `find -printf` works fine here. The fix is reasoned from portability rather than from a local repro, and deliberately takes the option that needs no OS branching at all rather than one that branches correctly. The bead's `Verify` step (running the no-arg form on macOS against the real `~/.pinpoint/db-backups`) is still worth a spot-check on the Mac.

Closes PP-euhg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VypoeEVeXdF7Y3KfyWYeP8
