### PR TITLE
fix(scripts): key the review gates to the request, not the head push (PP-lzaw)

### DIFF
--- a/scripts/tests/test_pr_gates.py
+++ b/scripts/tests/test_pr_gates.py
@@ -1,11 +1,21 @@
 """Unit tests for the currency and reviewed gates in scripts/workflow/_pr-gates.sh.
 
 These two gates decide whether a PR may merge, so their edge cases are worth pinning
-down. The regression under test (PP-jw0s): Copilot posts a *review object* even when
-it reviewed nothing — quota exhaustion, or no analyzable files — and a login-only
-filter counted that as a review, so both gates could go green on a review that read
-nothing. That is strictly worse than no review, because no-review has an honest path
-(the SHA-pinned Claude marker).
+down. Two regressions are covered.
+
+PP-jw0s: Copilot posts a *review object* even when it reviewed nothing — quota
+exhaustion, or no analyzable files — and a login-only filter counted that as a review,
+so both gates could go green on a review that read nothing. That is strictly worse than
+no review, because no-review has an honest path (the SHA-pinned Claude marker).
+
+PP-lzaw: Copilot review is request-only on this repo since 2026-08-01. The gates used to
+measure their 600s window from the HEAD PUSH, which only made sense when Copilot arrived
+unprompted — under request-only that timer counts down against a review nobody asked
+for, and every un-re-requested PR lands on the `reviewed` FAIL whose remedy is the Claude
+marker, making the fallback the default path. The gates now key to the review REQUEST and
+report six distinct states. Coverage is judged by `commit_id` rather than by comparing
+submitted_at against the head commit date, which read "covers head" for a review of an
+earlier tree submitted after a later push (observed on PR #1784).
 
 Every test drives the real bash through a stubbed `gh`, so the jq filters and the
 BSD/GNU date branching are exercised rather than mocked away.
@@ -34,10 +44,15 @@ NO_FILES_BODY = "Copilot wasn't able to review any files in this pull request."
 HEAD_SHA = "d084c14a43af3ac021f0838f5c7bf4b77f72fb62"
 OTHER_SHA = "0000000000000000000000000000000000000000"
 
-# check_copilot_currency / check_review_happened both hold for 600s after a head push
-# before escalating. Ages either side of that boundary select the WAIT vs terminal path.
-FRESH_HEAD_AGE = 60
-STALE_HEAD_AGE = 1200
+# Both gates hold for 600s after a review REQUEST before escalating. Ages either side of
+# that boundary select the WAIT vs terminal path.
+FRESH = 60
+STALE = 1200
+
+# Deliberately older than STALE. Paired with a fresh request it proves the timer is keyed
+# to the request and no longer to the push: under the old behaviour a head this old with
+# no review was an immediate `reviewed` FAIL.
+ANCIENT = 4000
 
 
 def _iso(epoch: float) -> str:
@@ -50,18 +65,46 @@ def gate_env(
     reviews: list[dict],
     comments: list[dict],
     head_age_seconds: int,
+    request_ages: list[int] | None = None,
     head_sha: str = HEAD_SHA,
 ) -> Iterator[dict]:
     """Yield an env dict wiring a fake `gh` that answers every call the gates make.
 
     The stub dispatches on the joined argument string rather than parsing flags — it
-    only needs to distinguish the five shapes `_pr-gates.sh` actually issues.
+    only needs to distinguish the six shapes `_pr-gates.sh` actually issues.
+
+    `request_ages` is a list of "seconds ago" for Copilot `review_requested` timeline
+    events. `None` means the PR has none at all — which does not occur in practice while
+    the repo's PR-open auto-request is enabled, but is the state the gates must report
+    distinctly the moment it is switched off.
     """
     now = time.time()
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         (tmp_path / "reviews.json").write_text(json.dumps(reviews))
         (tmp_path / "comments.json").write_text(json.dumps(comments))
+        (tmp_path / "timeline.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "event": "review_requested",
+                        "created_at": _iso(now - age),
+                        "actor": {"login": "timothyfroehlich"},
+                        "requested_reviewer": {"login": "Copilot"},
+                    }
+                    for age in (request_ages or [])
+                ]
+                # A human reviewer request must not be mistaken for a Copilot one.
+                + [
+                    {
+                        "event": "review_requested",
+                        "created_at": _iso(now),
+                        "actor": {"login": "timothyfroehlich"},
+                        "requested_reviewer": {"login": "some-human"},
+                    }
+                ]
+            )
+        )
 
         gh_stub = tmp_path / "gh"
         gh_stub.write_text(
@@ -72,8 +115,9 @@ def gate_env(
             '  *"--json headRefOid"*) printf \'{"headRefOid":"%s"}\\n\' "$STUB_HEAD_SHA" ;;\n'
             '  *"nameWithOwner"*) printf "acme/widget\\n" ;;\n'
             '  *"/commits/"*) printf "%s\\n" "$STUB_HEAD_DATE" ;;\n'
-            '  *"/issues/"*"/comments") cat "$STUB_COMMENTS" ;;\n'
-            '  *"/pulls/"*"/reviews") cat "$STUB_REVIEWS" ;;\n'
+            '  *"/issues/"*"/timeline"*) cat "$STUB_TIMELINE" ;;\n'
+            '  *"/issues/"*"/comments"*) cat "$STUB_COMMENTS" ;;\n'
+            '  *"/pulls/"*"/reviews"*) cat "$STUB_REVIEWS" ;;\n'
             '  *) printf "UNEXPECTED gh call: %s\\n" "$args" >&2; exit 1 ;;\n'
             "esac\n"
         )
@@ -87,6 +131,7 @@ def gate_env(
         env["STUB_HEAD_DATE"] = _iso(now - head_age_seconds)
         env["STUB_REVIEWS"] = str(tmp_path / "reviews.json")
         env["STUB_COMMENTS"] = str(tmp_path / "comments.json")
+        env["STUB_TIMELINE"] = str(tmp_path / "timeline.json")
         yield env
 
 
@@ -100,10 +145,11 @@ def run_gate(fn: str, env: dict) -> subprocess.CompletedProcess:
     )
 
 
-def copilot_review(body: str, age_seconds: int) -> dict:
+def copilot_review(body: str, age_seconds: int, commit_id: str = HEAD_SHA) -> dict:
     return {
         "user": {"login": "copilot-pull-request-reviewer[bot]"},
         "submitted_at": _iso(time.time() - age_seconds),
+        "commit_id": commit_id,
         "body": body,
     }
 
@@ -112,20 +158,271 @@ def claude_marker(sha: str) -> dict:
     return {"body": f"<!-- pinpoint-claude-review: {sha} -->\nClaude review of head"}
 
 
-# --- The PP-jw0s regression: a non-review must not count as a review ----------------
+BOTH_GATES = ["check_copilot_currency", "check_review_happened"]
+REQUEST_CMD = 'gh pr edit 123 --add-reviewer "@copilot"'
+
+
+# --- The merge bar is UNCHANGED: an unreviewed head cannot pass `reviewed` ----------
+
+
+@pytest.mark.parametrize(
+    "state,reviews,head_age,request_ages",
+    [
+        ("never_requested", [], FRESH, None),
+        ("pushed_after", [], FRESH, [STALE]),
+        ("overdue", [], ANCIENT, [STALE]),
+        # A review exists but read a DIFFERENT commit — the PR #1784 false PASS.
+        (
+            "stale review",
+            [copilot_review("Real review.", age_seconds=0, commit_id=OTHER_SHA)],
+            ANCIENT,
+            [STALE],
+        ),
+        # A review carrying head's SHA that reviewed nothing (PP-jw0s).
+        (
+            "non-review at head",
+            [copilot_review(QUOTA_BODY, age_seconds=0, commit_id=HEAD_SHA)],
+            ANCIENT,
+            [STALE],
+        ),
+    ],
+)
+def test_unreviewed_head_never_passes_the_reviewed_gate(
+    state: str, reviews: list[dict], head_age: int, request_ages: list[int] | None
+) -> None:
+    """The hard backstop stays hard. Re-keying the timer must not open a merge path.
+
+    Every state in which no reviewer has demonstrably read the head commit has to be
+    non-zero out of `check_review_happened` — that exit code is what blocks merge-pr.sh.
+    """
+    with gate_env(
+        reviews=reviews,
+        comments=[],
+        head_age_seconds=head_age,
+        request_ages=request_ages,
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert result.returncode != 0, f"{state}: {result.stdout}"
+    assert "PASS:" not in result.stdout, f"{state}: {result.stdout}"
+
+
+# --- never_requested: distinct, and no timer is waited out --------------------------
+
+
+def test_never_requested_fails_reviewed_immediately() -> None:
+    """A fresh head with no request must NOT sit in WAIT.
+
+    Nothing is coming — no push, no label and no green CI fires a review — so waiting
+    only delays the moment a human notices. The old head-push timer would have WAITed
+    here for 600s first.
+    """
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=None
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert result.returncode == 1, result.stdout
+    assert "FAIL: reviewed: no Copilot review has ever been requested" in result.stdout
+    assert REQUEST_CMD in result.stdout
+
+
+def test_never_requested_does_not_recommend_the_claude_marker() -> None:
+    """The marker is the fallback for an UNANSWERED request, not for an unasked one.
+
+    Offering it here is exactly how the marker becomes the default path and the gate
+    stops guaranteeing anything.
+    """
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=ANCIENT, request_ages=None
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert "mark-claude-review.sh" not in result.stdout, result.stdout
+
+
+def test_never_requested_warns_on_currency_without_blocking() -> None:
+    """`currency` is soft by contract — it reports, `reviewed` blocks."""
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=None
+    ) as env:
+        result = run_gate("check_copilot_currency", env)
+
+    assert result.returncode == 0, result.stdout
+    assert "WARN: currency: no Copilot review has ever been requested" in result.stdout
+    assert REQUEST_CMD in result.stdout
+
+
+# --- pushed_after: flagged loudly, never silently re-requested ----------------------
+
+
+def test_push_after_request_fails_reviewed_and_says_re_request() -> None:
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=[STALE]
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert result.returncode == 1, result.stdout
+    assert "NEWER than the last review request" in result.stdout
+    assert REQUEST_CMD in result.stdout
+    # Auto-re-requesting a 3-commit fixup would spend 3 reviews — the exact behaviour
+    # request-only Copilot exists to stop. The gate tells you; it never asks for you.
+    assert "mark-claude-review.sh" not in result.stdout
+
+
+def test_push_after_request_is_reported_distinctly_from_never_requested() -> None:
+    """Collapsing the two into one 'not reviewed yet' is the failure mode to avoid."""
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=[STALE]
+    ) as env:
+        pushed_after = run_gate("check_review_happened", env).stdout
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=None
+    ) as env:
+        never = run_gate("check_review_happened", env).stdout
+
+    assert "has ever been requested" in never
+    assert "has ever been requested" not in pushed_after
+
+
+def test_push_after_request_warns_on_currency_without_blocking() -> None:
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=[STALE]
+    ) as env:
+        result = run_gate("check_copilot_currency", env)
+
+    assert result.returncode == 0, result.stdout
+    assert "WARN: currency:" in result.stdout
+    assert "you pushed after requesting" in result.stdout
+
+
+# --- awaiting / overdue: the timer runs from the REQUEST ----------------------------
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_fresh_request_waits_even_when_the_head_is_ancient(gate: str) -> None:
+    """The re-keying, stated as a test.
+
+    Head pushed 4000s ago, review requested 60s ago. Under the old head-push timer this
+    was an immediate `reviewed` FAIL; the request is what makes waiting legitimate.
+    """
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=ANCIENT, request_ages=[FRESH]
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert result.returncode == 2, result.stdout
+    assert "WAIT:" in result.stdout
+    assert "review requested" in result.stdout
+
+
+def test_overdue_request_fails_reviewed_and_offers_both_remedies() -> None:
+    """Asked and unanswered is the ONE state where the Claude marker is the right call."""
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=ANCIENT, request_ages=[STALE]
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert result.returncode == 1, result.stdout
+    assert "FAIL: reviewed: review requested" in result.stdout
+    assert REQUEST_CMD in result.stdout
+    assert "mark-claude-review.sh" in result.stdout
+
+
+def test_overdue_request_warns_on_currency_without_blocking() -> None:
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=ANCIENT, request_ages=[STALE]
+    ) as env:
+        result = run_gate("check_copilot_currency", env)
+
+    assert result.returncode == 0, result.stdout
+    assert "WARN: currency: review requested" in result.stdout
+
+
+def test_the_newest_request_wins() -> None:
+    """A stale first request must not hold the PR in `overdue` after a fresh re-request."""
+    with gate_env(
+        reviews=[],
+        comments=[],
+        head_age_seconds=ANCIENT,
+        request_ages=[STALE, FRESH],
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert result.returncode == 2, result.stdout
+    assert "WAIT: reviewed:" in result.stdout
+
+
+def test_a_human_review_request_is_not_a_copilot_request() -> None:
+    """Only `requested_reviewer.login` starting with "copilot" starts the clock.
+
+    The gate_env stub always injects a request for a human reviewer; if that were
+    counted, this PR would read as `awaiting` instead of `never_requested`.
+    """
+    with gate_env(
+        reviews=[], comments=[], head_age_seconds=FRESH, request_ages=None
+    ) as env:
+        result = run_gate("check_review_happened", env)
+
+    assert "has ever been requested" in result.stdout
+
+
+# --- Coverage is judged by commit_id, not by timestamp ------------------------------
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_review_carrying_the_head_sha_passes(gate: str) -> None:
+    with gate_env(
+        reviews=[copilot_review("Found a null deref on line 12.", age_seconds=10)],
+        comments=[],
+        head_age_seconds=STALE,
+        request_ages=[STALE],
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert result.returncode == 0, result.stdout
+    assert "carries head SHA" in result.stdout
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_newer_review_of_an_earlier_commit_does_not_cover_head(gate: str) -> None:
+    """The PR #1784 false PASS: submitted_at is newer than head, commit_id is not head.
+
+    A review submitted after a later push can still have read the earlier tree — GitHub
+    stamps it with the commit it actually analysed. Comparing timestamps read that as
+    "covers head"; comparing SHAs does not. The request here is newer than the head, so
+    the honest answer is WAIT, not PASS.
+    """
+    with gate_env(
+        reviews=[
+            copilot_review(
+                "Reviewed the previous head.", age_seconds=0, commit_id=OTHER_SHA
+            )
+        ],
+        comments=[],
+        head_age_seconds=STALE,
+        request_ages=[FRESH],
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert result.returncode == 2, result.stdout
+    assert "PASS:" not in result.stdout
+
+
+# --- PP-jw0s: a non-review must not count as a review -------------------------------
 
 
 @pytest.mark.parametrize("body", [QUOTA_BODY, NO_FILES_BODY])
-def test_non_review_does_not_satisfy_reviewed_gate(body: str) -> None:
-    """A Copilot 'I could not review this' comment must fail the hard backstop.
+def test_non_review_at_head_does_not_satisfy_reviewed_gate(body: str) -> None:
+    """A Copilot "I could not review this" comment must fail the hard backstop.
 
-    Before the fix this returned PASS: the review object carried a Copilot login and a
-    submitted_at newer than the head, satisfying a login-only filter.
+    It now carries head's own commit_id, so only the body filter can catch it.
     """
     with gate_env(
         reviews=[copilot_review(body, age_seconds=0)],
         comments=[],
-        head_age_seconds=STALE_HEAD_AGE,
+        head_age_seconds=ANCIENT,
+        request_ages=[STALE],
     ) as env:
         result = run_gate("check_review_happened", env)
 
@@ -136,20 +433,17 @@ def test_non_review_does_not_satisfy_reviewed_gate(body: str) -> None:
 
 @pytest.mark.parametrize("body", [QUOTA_BODY, NO_FILES_BODY])
 def test_non_review_is_invisible_to_currency_gate(body: str) -> None:
-    """Currency must treat a non-review as absent, not as something to be stale about.
-
-    Counting it produced the inverted incentive: a PR Copilot never touched skipped
-    instantly, while one carrying a useless comment served the full 600s wait.
-    """
+    """Currency must treat a non-review as absent, not as coverage."""
     with gate_env(
         reviews=[copilot_review(body, age_seconds=0)],
         comments=[],
-        head_age_seconds=FRESH_HEAD_AGE,
+        head_age_seconds=STALE,
+        request_ages=[FRESH],
     ) as env:
         result = run_gate("check_copilot_currency", env)
 
-    assert result.returncode == 0, result.stdout
-    assert "SKIP: currency: no substantive Copilot review" in result.stdout
+    assert result.returncode == 2, result.stdout
+    assert "WAIT: currency:" in result.stdout
 
 
 def test_a_partial_review_is_not_mistaken_for_a_non_review() -> None:
@@ -167,12 +461,13 @@ def test_a_partial_review_is_not_mistaken_for_a_non_review() -> None:
     with gate_env(
         reviews=[copilot_review(body, age_seconds=10)],
         comments=[],
-        head_age_seconds=FRESH_HEAD_AGE,
+        head_age_seconds=STALE,
+        request_ages=[STALE],
     ) as env:
         result = run_gate("check_review_happened", env)
 
     assert result.returncode == 0, result.stdout
-    assert "PASS: reviewed: Copilot review covers head commit" in result.stdout
+    assert "PASS: reviewed: Copilot review carries head SHA" in result.stdout
 
 
 def test_non_review_alongside_real_review_keeps_the_real_one() -> None:
@@ -183,90 +478,72 @@ def test_non_review_alongside_real_review_keeps_the_real_one() -> None:
             copilot_review(QUOTA_BODY, age_seconds=0),
         ],
         comments=[],
-        head_age_seconds=FRESH_HEAD_AGE,
+        head_age_seconds=STALE,
+        request_ages=[STALE],
     ) as env:
         result = run_gate("check_review_happened", env)
 
     assert result.returncode == 0, result.stdout
-    assert "PASS: reviewed: Copilot review covers head commit" in result.stdout
+    assert "PASS: reviewed: Copilot review carries head SHA" in result.stdout
 
 
-# --- The Claude marker is honoured by both gates, not just `reviewed` ---------------
+# --- The Claude marker: honoured by both gates, but never silently ------------------
 
 
-def test_claude_marker_satisfies_currency_gate() -> None:
-    """A marker pinned to head answers currency's question directly.
-
-    Before the fix currency ignored the marker entirely and sat out its full timer
-    waiting on a reviewer that already had a documented substitute.
-    """
-    with gate_env(
-        reviews=[copilot_review("Old but real review.", age_seconds=9999)],
-        comments=[claude_marker(HEAD_SHA)],
-        head_age_seconds=FRESH_HEAD_AGE,
-    ) as env:
-        result = run_gate("check_copilot_currency", env)
-
-    assert result.returncode == 0, result.stdout
-    assert "PASS: currency: Claude review covers head commit" in result.stdout
-
-
-def test_claude_marker_satisfies_reviewed_gate() -> None:
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_claude_marker_satisfies_both_gates(gate: str) -> None:
+    """The merge bar is unchanged — a marker pinned to head is still a valid review."""
     with gate_env(
         reviews=[],
         comments=[claude_marker(HEAD_SHA)],
-        head_age_seconds=STALE_HEAD_AGE,
+        head_age_seconds=ANCIENT,
+        request_ages=[STALE],
     ) as env:
-        result = run_gate("check_review_happened", env)
+        result = run_gate(gate, env)
 
     assert result.returncode == 0, result.stdout
-    assert "PASS: reviewed: Claude review covers head commit" in result.stdout
+    assert "Claude review marker covers head commit" in result.stdout
 
 
-@pytest.mark.parametrize("gate", ["check_copilot_currency", "check_review_happened"])
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_marker_standing_in_for_an_unasked_review_says_so(gate: str) -> None:
+    """ "Do not let a Claude marker SILENTLY stand in" — it passes, but it announces."""
+    with gate_env(
+        reviews=[],
+        comments=[claude_marker(HEAD_SHA)],
+        head_age_seconds=FRESH,
+        request_ages=None,
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert result.returncode == 0, result.stdout
+    assert "no Copilot review was requested for this head" in result.stdout
+    assert REQUEST_CMD in result.stdout
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_marker_backed_by_a_current_request_needs_no_note(gate: str) -> None:
+    with gate_env(
+        reviews=[],
+        comments=[claude_marker(HEAD_SHA)],
+        head_age_seconds=STALE,
+        request_ages=[FRESH],
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert result.returncode == 0, result.stdout
+    assert "no Copilot review was requested" not in result.stdout
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
 def test_marker_for_a_different_sha_is_ignored(gate: str) -> None:
     """The SHA pin is what makes the attestation self-expiring after a new push."""
     with gate_env(
         reviews=[],
         comments=[claude_marker(OTHER_SHA)],
-        head_age_seconds=FRESH_HEAD_AGE,
+        head_age_seconds=FRESH,
+        request_ages=[FRESH],
     ) as env:
         result = run_gate(gate, env)
 
-    assert "Claude review covers head commit" not in result.stdout
-
-
-# --- Unchanged behaviour that the refactor must not have broken --------------------
-
-
-def test_stale_real_review_waits_inside_the_window() -> None:
-    with gate_env(
-        reviews=[copilot_review("Real review of the previous head.", age_seconds=9999)],
-        comments=[],
-        head_age_seconds=FRESH_HEAD_AGE,
-    ) as env:
-        result = run_gate("check_copilot_currency", env)
-
-    assert result.returncode == 2, result.stdout
-    assert "WAIT: currency:" in result.stdout
-
-
-def test_stale_real_review_warns_and_proceeds_past_the_window() -> None:
-    """Currency never hard-fails — past the threshold it degrades to WARN."""
-    with gate_env(
-        reviews=[copilot_review("Real review of the previous head.", age_seconds=9999)],
-        comments=[],
-        head_age_seconds=STALE_HEAD_AGE,
-    ) as env:
-        result = run_gate("check_copilot_currency", env)
-
-    assert result.returncode == 0, result.stdout
-    assert "WARN: currency:" in result.stdout
-
-
-def test_no_review_at_all_waits_inside_the_window() -> None:
-    with gate_env(reviews=[], comments=[], head_age_seconds=FRESH_HEAD_AGE) as env:
-        result = run_gate("check_review_happened", env)
-
-    assert result.returncode == 2, result.stdout
-    assert "WAIT: reviewed:" in result.stdout
+    assert "Claude review marker covers head commit" not in result.stdout

--- a/scripts/tests/test_pr_gates.py
+++ b/scripts/tests/test_pr_gates.py
@@ -67,6 +67,7 @@ def gate_env(
     head_age_seconds: int,
     request_ages: list[int] | None = None,
     head_sha: str = HEAD_SHA,
+    request_pending: bool = False,
 ) -> Iterator[dict]:
     """Yield an env dict wiring a fake `gh` that answers every call the gates make.
 
@@ -112,7 +113,7 @@ def gate_env(
             'args="$*"\n'
             'case "$args" in\n'
             '  *"--jq .headRefOid"*) printf "%s\\n" "$STUB_HEAD_SHA" ;;\n'
-            '  *"--json headRefOid"*) printf \'{"headRefOid":"%s"}\\n\' "$STUB_HEAD_SHA" ;;\n'
+            '  *"--json headRefOid"*) printf \'{"headRefOid":"%s","reviewRequests":%s}\\n\' "$STUB_HEAD_SHA" "$STUB_REVIEW_REQUESTS" ;;\n'
             '  *"nameWithOwner"*) printf "acme/widget\\n" ;;\n'
             '  *"/commits/"*) printf "%s\\n" "$STUB_HEAD_DATE" ;;\n'
             '  *"/issues/"*"/timeline"*) cat "$STUB_TIMELINE" ;;\n'
@@ -132,6 +133,9 @@ def gate_env(
         env["STUB_REVIEWS"] = str(tmp_path / "reviews.json")
         env["STUB_COMMENTS"] = str(tmp_path / "comments.json")
         env["STUB_TIMELINE"] = str(tmp_path / "timeline.json")
+        env["STUB_REVIEW_REQUESTS"] = (
+            '[{"__typename":"User","login":"Copilot"}]' if request_pending else "[]"
+        )
         yield env
 
 
@@ -283,6 +287,50 @@ def test_push_after_request_is_reported_distinctly_from_never_requested() -> Non
 
     assert "has ever been requested" in never
     assert "has ever been requested" not in pushed_after
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_pushed_after_flags_a_lagging_timeline_when_copilot_is_pending(
+    gate: str,
+) -> None:
+    """The trap this note exists for, hit live while writing this PR.
+
+    GitHub's issue timeline is eventually consistent — a review_requested event
+    can take up to a minute to appear. In that window the state computes to
+    `pushed_after` even though the agent just re-requested, and the printed
+    remedy is a command they already ran. `reviewRequests` updates immediately,
+    so a pending Copilot entry alongside this verdict means "re-run".
+
+    Deliberately still a FAIL: a pending request does NOT imply coverage.
+    Copilot reviews the head as of the REQUEST, so a genuinely stale pending
+    request still produces a review of the wrong tree.
+    """
+    with gate_env(
+        reviews=[],
+        comments=[],
+        head_age_seconds=FRESH,
+        request_ages=[STALE],
+        request_pending=True,
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert "Copilot IS a pending reviewer right now" in result.stdout
+    if gate == "check_review_happened":
+        assert result.returncode == 1, result.stdout
+
+
+@pytest.mark.parametrize("gate", BOTH_GATES)
+def test_pushed_after_omits_the_lag_note_when_nothing_is_pending(gate: str) -> None:
+    with gate_env(
+        reviews=[],
+        comments=[],
+        head_age_seconds=FRESH,
+        request_ages=[STALE],
+        request_pending=False,
+    ) as env:
+        result = run_gate(gate, env)
+
+    assert "pending reviewer right now" not in result.stdout
 
 
 def test_push_after_request_warns_on_currency_without_blocking() -> None:

--- a/scripts/tests/test_pr_gates.py
+++ b/scripts/tests/test_pr_gates.py
@@ -75,9 +75,9 @@ def gate_env(
     only needs to distinguish the six shapes `_pr-gates.sh` actually issues.
 
     `request_ages` is a list of "seconds ago" for Copilot `review_requested` timeline
-    events. `None` means the PR has none at all — which does not occur in practice while
-    the repo's PR-open auto-request is enabled, but is the state the gates must report
-    distinctly the moment it is switched off.
+    events. `None` means the PR has none at all — the state every PR now opens in, since
+    Copilot review became fully request-only on 2026-08-01 and nothing asks on your
+    behalf.
     """
     now = time.time()
     with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -24,6 +24,7 @@ reach GitHub (CORE-TEST-006).
 
 import importlib.util
 import json
+import re
 import sys
 import time
 from pathlib import Path
@@ -542,6 +543,41 @@ ANCIENT = 4000
 
 _MARKER = f"<!-- pinpoint-claude-review: {HEAD_SHA} -->\nreviewed by hand"
 REQUEST_CMD = f'gh pr edit {PR} --add-reviewer "@copilot"'
+
+
+GATES_PATH = Path(__file__).parent.parent / "workflow" / "_pr-gates.sh"
+
+
+@pytest.mark.unit
+def test_non_review_pattern_is_identical_to_the_bash_gate():
+    """pr-watch and _pr-gates.sh must eat exactly the same non-review bodies.
+
+    A wording added to one and not the other makes the readiness report and the
+    merge gate disagree about whether a PR has been reviewed — worse than either
+    answer alone, because whichever one you happen to read looks authoritative.
+    """
+    gates = GATES_PATH.read_text()
+    match = re.search(r"^readonly COPILOT_NON_REVIEW_BODY_RE='(.+)'$", gates, re.M)
+    assert match, "COPILOT_NON_REVIEW_BODY_RE not found in _pr-gates.sh"
+    assert match.group(1) == pr_watch.COPILOT_NON_REVIEW_BODY_RE.pattern
+
+
+@pytest.mark.unit
+def test_wait_threshold_is_identical_to_the_bash_gate():
+    gates = GATES_PATH.read_text()
+    match = re.search(r"^readonly COPILOT_REVIEW_WAIT_THRESHOLD=(\d+)$", gates, re.M)
+    assert match, "COPILOT_REVIEW_WAIT_THRESHOLD not found in _pr-gates.sh"
+    assert int(match.group(1)) == pr_watch.COPILOT_REVIEW_WAIT_THRESHOLD
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "state",
+    ["marker", "covered", "awaiting", "overdue", "pushed_after", "never_requested"],
+)
+def test_state_vocabulary_is_shared_with_the_bash_gate(state):
+    """Both implementations name the same six states, so reports are comparable."""
+    assert f"RS_STATE={state}" in GATES_PATH.read_text()
 
 
 @pytest.mark.unit

--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -19,11 +19,13 @@ reporting a failure for something that was not one.
    a healthy run whose jobs were all still pending. "We could not find out" is
    not a verdict. (PP-qkl8)
 
-Review-request state (PP-lzaw): Copilot review is request-only on this repo, so
-`--check-ready` has to say WHICH review state a PR is in. "Nobody asked",
-"asked and waiting" and "you pushed past the request" need three different
-actions and only the middle one resolves by waiting; flattening them into one
-"not reviewed yet" turns a forgotten request into a silent overnight stall.
+Review-request state (PP-lzaw): Copilot review is fully request-only on this
+repo as of 2026-08-01 — nothing asks on your behalf, so every PR opens with no
+request at all — and `--check-ready` has to say WHICH review state a PR is in.
+"Nobody asked", "asked and waiting" and "you pushed past the request" need three
+different actions and only the middle one resolves by waiting; flattening them
+into one "not reviewed yet" turns a forgotten request into a silent overnight
+stall.
 
 Everything is mocked at the `gh` CLI seam (`pr_watch.gh`) — these tests never
 reach GitHub (CORE-TEST-006).

--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -1,6 +1,6 @@
-"""Regression tests for scripts/workflow/pr-watch.py cancellation handling (PP-r63o).
+"""Regression tests for scripts/workflow/pr-watch.py.
 
-Two bugs are covered:
+Cancellation handling (PP-r63o) — two bugs:
 
 1. A `cancelled` run was classified as a failure — cancellation is routine
    (a newer commit cancels the in-flight run via concurrency groups, and the
@@ -12,6 +12,12 @@ Two bugs are covered:
    superseded CI Gate check left behind at the same commit — can't hard-exit
    the watcher. `--force` was the workaround; it should no longer be needed.
 
+Review-request state (PP-lzaw): Copilot review is request-only on this repo, so
+`--check-ready` has to say WHICH review state a PR is in. "Nobody asked",
+"asked and waiting" and "you pushed past the request" need three different
+actions and only the middle one resolves by waiting; flattening them into one
+"not reviewed yet" turns a forgotten request into a silent overnight stall.
+
 Everything is mocked at the `gh` CLI seam (`pr_watch.gh`) — these tests never
 reach GitHub (CORE-TEST-006).
 """
@@ -19,6 +25,7 @@ reach GitHub (CORE-TEST-006).
 import importlib.util
 import json
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -63,10 +70,39 @@ def _run(run_id: int, status: str, conclusion: str, name: str = "CI", sha=HEAD_S
     }
 
 
-def make_gh(*, rollup=(), runs=(), merge_state="CLEAN", threads=(), labels=()):
+def _ago(seconds: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - seconds))
+
+
+def copilot_review(commit_id=HEAD_SHA, body="Copilot reviewed 3 of 3 files."):
+    return {
+        "user": {"login": "copilot-pull-request-reviewer[bot]"},
+        "commit_id": commit_id,
+        "submitted_at": _ago(0),
+        "body": body,
+    }
+
+
+def make_gh(
+    *,
+    rollup=(),
+    runs=(),
+    merge_state="CLEAN",
+    threads=(),
+    labels=(),
+    head_age=60,
+    request_ages=(0,),
+    reviews=(),
+    issue_comments=(),
+):
     """Build a fake `gh` that answers every call pr-watch makes.
 
     Records each invocation on `.calls` so tests can assert what was queried.
+
+    The review-state args mirror `copilot_review_state`'s inputs. Defaults put the
+    PR in `awaiting` — a request 0s old against a 60s-old head, with no review yet
+    — which is a passing readiness state, so tests that don't care about the
+    review gate stay unaffected by it.
     """
 
     def fake_gh(*args: str) -> str:
@@ -84,6 +120,27 @@ def make_gh(*, rollup=(), runs=(), merge_state="CLEAN", threads=(), labels=()):
                 )
             if fields == "headRefName,headRefOid":
                 return json.dumps({"headRefName": BRANCH, "headRefOid": HEAD_SHA})
+            if fields == "headRefOid":
+                return HEAD_SHA
+        if args[0] == "api" and args[1].endswith(f"/commits/{HEAD_SHA}"):
+            return _ago(head_age)
+        if args[:2] == ("api", "--paginate"):
+            path = args[2]
+            if "/timeline" in path:
+                return json.dumps(
+                    [
+                        {
+                            "event": "review_requested",
+                            "created_at": _ago(age),
+                            "requested_reviewer": {"login": "Copilot"},
+                        }
+                        for age in request_ages
+                    ]
+                )
+            if "/comments" in path:
+                return json.dumps(list(issue_comments))
+            if "/reviews" in path:
+                return json.dumps(list(reviews))
         if args[:2] == ("api", "graphql"):
             return json.dumps(
                 {
@@ -467,3 +524,192 @@ def test_run_audit_reports_cancelled_gate_as_superseded(monkeypatch, capsys):
     monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[_gate("CANCELLED")]))
     assert pr_watch.run_audit(PR) is False
     assert "cancelled (superseded)" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# copilot_review_state — the six states, keyed to the REQUEST (PP-lzaw)
+# ---------------------------------------------------------------------------
+#
+# Copilot review is request-only on this repo. The states that matter are the
+# ones a bare "not reviewed yet" would flatten: "nobody asked", "asked and
+# waiting", and "you pushed past the request" need three different actions, and
+# only the middle one resolves by waiting. Kept in lockstep with the bash
+# implementation in _pr-gates.sh (see scripts/tests/test_pr_gates.py).
+
+FRESH = 60
+STALE = 1200
+ANCIENT = 4000
+
+_MARKER = f"<!-- pinpoint-claude-review: {HEAD_SHA} -->\nreviewed by hand"
+REQUEST_CMD = f'gh pr edit {PR} --add-reviewer "@copilot"'
+
+
+@pytest.mark.unit
+def test_review_state_never_requested(monkeypatch):
+    monkeypatch.setattr(pr_watch, "gh", make_gh(head_age=FRESH, request_ages=()))
+    state, detail = pr_watch.copilot_review_state(PR)
+    assert state == "never_requested"
+    assert REQUEST_CMD in detail
+
+
+@pytest.mark.unit
+def test_review_state_pushed_after_request(monkeypatch):
+    """Head newer than the newest request — nothing re-requests automatically."""
+    monkeypatch.setattr(pr_watch, "gh", make_gh(head_age=FRESH, request_ages=(STALE,)))
+    state, detail = pr_watch.copilot_review_state(PR)
+    assert state == "pushed_after"
+    assert "NEWER than the last request" in detail
+    assert REQUEST_CMD in detail
+
+
+@pytest.mark.unit
+def test_review_state_awaiting_survives_an_ancient_head(monkeypatch):
+    """The timer runs from the request, so an old head with a fresh ask still waits."""
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(head_age=ANCIENT, request_ages=(FRESH,))
+    )
+    assert pr_watch.copilot_review_state(PR)[0] == "awaiting"
+
+
+@pytest.mark.unit
+def test_review_state_overdue(monkeypatch):
+    monkeypatch.setattr(
+        pr_watch, "gh", make_gh(head_age=ANCIENT, request_ages=(STALE,))
+    )
+    state, detail = pr_watch.copilot_review_state(PR)
+    assert state == "overdue"
+    assert "mark-claude-review.sh" in detail
+
+
+@pytest.mark.unit
+def test_review_state_covered_is_judged_by_commit_id(monkeypatch):
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(head_age=STALE, request_ages=(STALE,), reviews=[copilot_review()]),
+    )
+    assert pr_watch.copilot_review_state(PR)[0] == "covered"
+
+
+@pytest.mark.unit
+def test_review_state_ignores_a_newer_review_of_an_earlier_commit(monkeypatch):
+    """The PR #1784 false PASS: submitted_at is newer than head, commit_id is not.
+
+    Comparing timestamps read this as "covers head"; comparing SHAs does not.
+    """
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(
+            head_age=STALE,
+            request_ages=(FRESH,),
+            reviews=[copilot_review(commit_id=OLD_SHA)],
+        ),
+    )
+    assert pr_watch.copilot_review_state(PR)[0] == "awaiting"
+
+
+@pytest.mark.unit
+def test_review_state_ignores_a_non_review_at_head(monkeypatch):
+    """A quota-limited "I could not review this" carries head's SHA but read nothing."""
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(
+            head_age=STALE,
+            request_ages=(FRESH,),
+            reviews=[
+                copilot_review(
+                    body=(
+                        "Copilot was unable to review this pull request because "
+                        "the user who requested the review has reached their "
+                        "quota limit."
+                    )
+                )
+            ],
+        ),
+    )
+    assert pr_watch.copilot_review_state(PR)[0] == "awaiting"
+
+
+@pytest.mark.unit
+def test_review_state_counts_a_partial_review(monkeypatch):
+    """A real review that merely mentions files it could not analyse still counts."""
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(
+            head_age=STALE,
+            request_ages=(STALE,),
+            reviews=[
+                copilot_review(
+                    body=(
+                        "Copilot reviewed 3 out of 5 changed files. It was unable "
+                        "to review 2 generated files."
+                    )
+                )
+            ],
+        ),
+    )
+    assert pr_watch.copilot_review_state(PR)[0] == "covered"
+
+
+@pytest.mark.unit
+def test_review_state_marker_without_a_request_says_it_is_standing_in(monkeypatch):
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(head_age=FRESH, request_ages=(), issue_comments=[{"body": _MARKER}]),
+    )
+    state, detail = pr_watch.copilot_review_state(PR)
+    assert state == "marker"
+    assert "standing in" in detail
+
+
+@pytest.mark.unit
+def test_review_state_ignores_a_marker_for_another_sha(monkeypatch):
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(
+            head_age=FRESH,
+            request_ages=(FRESH,),
+            issue_comments=[{"body": f"<!-- pinpoint-claude-review: {OLD_SHA} -->"}],
+        ),
+    )
+    assert pr_watch.copilot_review_state(PR)[0] == "awaiting"
+
+
+# ---------------------------------------------------------------------------
+# run_audit — the review state is reported distinctly, and gates readiness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "state,kwargs",
+    [
+        ("never_requested", {"head_age": FRESH, "request_ages": ()}),
+        ("pushed_after", {"head_age": FRESH, "request_ages": (STALE,)}),
+        ("overdue", {"head_age": ANCIENT, "request_ages": (STALE,)}),
+    ],
+)
+def test_run_audit_is_not_ready_without_a_live_review_path(
+    monkeypatch, capsys, state, kwargs
+):
+    """A forgotten request must be UNMISTAKABLE, not a silent overnight stall."""
+    monkeypatch.setattr(pr_watch, "gh", make_gh(rollup=[_gate("SUCCESS")], **kwargs))
+    assert pr_watch.run_audit(PR) is False
+    assert f"✗ copilot-review: {state}:" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_run_audit_passes_while_a_request_is_outstanding(monkeypatch, capsys):
+    """`awaiting` is not a failure — the ask is live and the answer is coming."""
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(rollup=[_gate("SUCCESS")], head_age=ANCIENT, request_ages=(FRESH,)),
+    )
+    assert pr_watch.run_audit(PR) is True
+    assert "✓ copilot-review: awaiting:" in capsys.readouterr().out

--- a/scripts/tests/test_pr_watch.py
+++ b/scripts/tests/test_pr_watch.py
@@ -95,6 +95,7 @@ def make_gh(
     request_ages=(0,),
     reviews=(),
     issue_comments=(),
+    request_pending=False,
 ):
     """Build a fake `gh` that answers every call pr-watch makes.
 
@@ -121,8 +122,15 @@ def make_gh(
                 )
             if fields == "headRefName,headRefOid":
                 return json.dumps({"headRefName": BRANCH, "headRefOid": HEAD_SHA})
-            if fields == "headRefOid":
-                return HEAD_SHA
+            if fields == "headRefOid,reviewRequests":
+                return json.dumps(
+                    {
+                        "headRefOid": HEAD_SHA,
+                        "reviewRequests": [{"__typename": "User", "login": "Copilot"}]
+                        if request_pending
+                        else [],
+                    }
+                )
         if args[0] == "api" and args[1].endswith(f"/commits/{HEAD_SHA}"):
             return _ago(head_age)
         if args[:2] == ("api", "--paginate"):
@@ -596,6 +604,25 @@ def test_review_state_pushed_after_request(monkeypatch):
     assert state == "pushed_after"
     assert "NEWER than the last request" in detail
     assert REQUEST_CMD in detail
+
+
+@pytest.mark.unit
+def test_review_state_pushed_after_flags_a_lagging_timeline(monkeypatch):
+    """A pending Copilot reviewer alongside `pushed_after` means "re-run".
+
+    GitHub's issue timeline lags a freshly-created review_requested event by up
+    to a minute; `reviewRequests` updates immediately. Still `pushed_after`, not
+    `awaiting`: Copilot reviews the head as of the REQUEST, so a genuinely stale
+    pending request produces a review of the wrong tree.
+    """
+    monkeypatch.setattr(
+        pr_watch,
+        "gh",
+        make_gh(head_age=FRESH, request_ages=(STALE,), request_pending=True),
+    )
+    state, detail = pr_watch.copilot_review_state(PR)
+    assert state == "pushed_after"
+    assert "pending reviewer right now" in detail
 
 
 @pytest.mark.unit

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -13,13 +13,24 @@
 
 set -euo pipefail
 
-# Canonical Copilot reviewer login allowlist. Source of truth for all PinPoint workflow scripts.
+# Canonical Copilot reviewer login allowlist. Source of truth for all PinPoint workflow
+# scripts. These are the logins Copilot posts REVIEWS under. The login it is REQUESTED
+# under on the issue timeline is different — plain "Copilot" — so request detection
+# matches a case-insensitive "copilot" prefix instead of this list (see
+# _latest_copilot_request_at).
 readonly COPILOT_LOGINS=("copilot-pull-request-reviewer" "copilot-pull-request-reviewer[bot]")
 
-# Threshold: if Copilot review is stale by more than this many seconds since head push,
-# WARN-and-proceed instead of WAIT. Covers GitHub silently-skipped review_requested events
-# (observed in PR #1342 and PR #1326).
-readonly COPILOT_CURRENCY_THRESHOLD=600
+# How long to wait for Copilot to answer a review REQUEST before escalating: `currency`
+# degrades WAIT → WARN, `reviewed` degrades WAIT → FAIL.
+#
+# Measured from the request, NOT from the head push (PP-lzaw). Copilot review is
+# request-only on this repo since 2026-08-01 — one automatic request at PR-open and
+# nothing after — so a timer keyed to the head push counts down against a review nobody
+# asked for, and every un-re-requested PR lands on the `reviewed` FAIL whose documented
+# remedy is the Claude marker. That makes the marker the DEFAULT path rather than the
+# fallback, gutting the guarantee this gate exists to provide. A timer only makes sense
+# once someone has actually asked.
+readonly COPILOT_REVIEW_WAIT_THRESHOLD=600
 
 # Copilot posts a review OBJECT even when it reviewed nothing — quota exhaustion, or
 # no files it could analyze. Those carry a real submitted_at and a Copilot login, so a
@@ -41,25 +52,82 @@ readonly COPILOT_NON_REVIEW_BODY_RE='reached their quota limit|unable to review 
 # SHA-pinned Claude review marker, posted by mark-claude-review.sh.
 readonly CLAUDE_MARKER_PREFIX="<!-- pinpoint-claude-review:"
 
-# Parse owner/repo dynamically — avoid hardcoded slug.
+# Parse owner/repo dynamically — avoid hardcoded slug. Memoized: the review-state
+# computation asks four different endpoints and pr-dashboard.sh runs it once per open
+# PR, so an unmemoized call was one wasted API round-trip per question.
+_REPO_SLUG_CACHE=""
 _repo_slug() {
-  gh repo view --json nameWithOwner --jq .nameWithOwner
+  if [ -z "$_REPO_SLUG_CACHE" ]; then
+    _REPO_SLUG_CACHE=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+  fi
+  printf '%s\n' "$_REPO_SLUG_CACHE"
 }
 
-# Latest SUBSTANTIVE Copilot review timestamp for a PR, or empty if none.
-# Shared by the currency and reviewed gates: they asked the same question with the same
-# 3-line jq, and drifted — reviewed learned about the Claude marker, currency did not.
+# jq array of the Copilot review-author logins, built once per process.
+_copilot_logins_json() {
+  printf '%s\n' "${COPILOT_LOGINS[@]}" | jq -R . | jq -s .
+}
+
+# ISO-8601 → epoch seconds. macOS ships BSD date, Linux GNU date; the gates compare
+# timestamps from three different endpoints, so this branching lived inline in two
+# functions and was about to live in a third.
+_epoch() {
+  local iso=$1
+  if date -d "$iso" +%s 2>/dev/null; then
+    return 0
+  fi
+  TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${iso%Z}Z" +%s
+}
+
+# Timestamp of the most recent Copilot review REQUEST, or empty when none exists.
+#
+# The reviews endpoint cannot answer this: it only reports whether a review exists, so
+# "nobody asked" and "asked, still waiting" are indistinguishable there — and keeping
+# those two distinct is the whole point of PP-lzaw. The issue timeline carries
+# `event == "review_requested"` with a `created_at`, which is the clock the gates key to.
+#
+# Matched on a case-insensitive "copilot" prefix rather than COPILOT_LOGINS: a request
+# names the reviewer as plain "Copilot", while the review it produces is authored by
+# "copilot-pull-request-reviewer[bot]". The actor is NOT a usable discriminator — the
+# repo owner is the actor for both the PR-open automatic request and an explicit
+# `gh pr edit --add-reviewer`.
+_latest_copilot_request_at() {
+  local pr=$1 owner_repo=$2
+  gh api --paginate "repos/${owner_repo}/issues/${pr}/timeline?per_page=100" \
+    | jq -rs '[ .[] | flatten | .[]
+                | select(.event == "review_requested")
+                | select((.requested_reviewer.login // "") | ascii_downcase | startswith("copilot"))
+              ] | sort_by(.created_at) | last | .created_at // empty'
+}
+
+# True when a SUBSTANTIVE Copilot review carries the head SHA.
+#
+# Compared by `commit_id`, not by timestamp (PP-lzaw). Copilot stamps every review with
+# the commit it actually read; comparing submitted_at against the head commit's committer
+# date instead reported "covers head" for a review of an earlier tree that happened to be
+# submitted after a later push — observed on PR #1784, where a review of 64cfebc2 was
+# submitted 3 minutes after head d7392134 was pushed. Under the old review-on-every-push
+# model that mostly self-corrected; under request-only, where a review is a scarce
+# deliberate act, it is a standing false PASS.
+#
+# ANY matching review counts, not just the newest: a review whose commit_id is head
+# demonstrably read head, whatever landed after it.
+#
 # `jq -rs` (slurp) rather than gh's `--jq`, which runs per-page under --paginate and so
 # misses reviews on page 2+ of a busy PR.
-_latest_copilot_review_at() {
-  local pr=$1 owner_repo=$2
-  gh api --paginate "repos/${owner_repo}/pulls/${pr}/reviews" \
-    | jq -rs --argjson logins "$(printf '%s\n' "${COPILOT_LOGINS[@]}" | jq -R . | jq -s .)" \
+_copilot_review_covers_head() {
+  local pr=$1 owner_repo=$2 head_sha=$3
+  local count
+  count=$(gh api --paginate "repos/${owner_repo}/pulls/${pr}/reviews" \
+    | jq -rs --argjson logins "$(_copilot_logins_json)" \
              --arg skip "$COPILOT_NON_REVIEW_BODY_RE" \
+             --arg head "$head_sha" \
         '[ .[] | flatten | .[]
            | select(.user.login as $l | $logins | index($l))
            | select(((.body // "") | test($skip; "i")) | not)
-         ] | sort_by(.submitted_at) | last | .submitted_at // empty'
+           | select(.commit_id == $head)
+         ] | length')
+  [ "${count:-0}" -gt 0 ]
 }
 
 # True when a Claude review marker pins THIS head SHA. The pin is what makes the
@@ -113,64 +181,162 @@ check_ci() {
   esac
 }
 
-# Gate 2: A reviewer has seen the current head commit. Soft by design — this gate
-# never FAILs, it only holds briefly to give Copilot a chance to catch up:
-#   - Claude marker pins head SHA                  → PASS
-#   - no substantive Copilot review on the PR      → SKIP (nothing to be stale about)
-#   - Copilot review covers head (review >= head)  → PASS
-#   - head newer, elapsed < COPILOT_CURRENCY_THRESHOLD → WAIT
-#   - head newer, elapsed >= threshold             → WARN (proceed)
-# The hard backstop is `reviewed` (gate 4), not this one.
-check_copilot_currency() {
+# ---------------------------------------------------------------------------------
+# Shared review state (PP-lzaw)
+# ---------------------------------------------------------------------------------
+#
+# `currency` and `reviewed` ask one question — "where does this PR stand with its
+# reviewer?" — and answer it with different tokens. They used to compute it twice and
+# drifted apart (reviewed learned about the Claude marker; currency did not). One
+# computation, two mappings, so they cannot disagree.
+#
+# Six states. The point of splitting them this finely is that under request-only Copilot
+# the difference between "asked, still waiting" and "nobody asked" is the difference
+# between a legitimate wait and an overnight stall nobody is coming to end:
+#
+#   marker           SHA-pinned Claude review marker covers head
+#   covered          a substantive Copilot review carries head's SHA
+#   awaiting         request is newer than head, no covering review, inside the window
+#   overdue          same, past the window — Copilot was asked and did not answer
+#   pushed_after     head is NEWER than the newest request — you pushed after asking
+#   never_requested  no Copilot review_requested event exists on this PR at all
+#
+# `never_requested` does not occur in practice while the repo's PR-open auto-request is
+# enabled (measured 2026-08-01: it fires ~1s after PR creation on every PR). It is kept
+# distinct anyway — it becomes real the moment that setting is turned off, and a gate
+# that only asked "was a review ever requested" would answer yes on every PR and catch
+# nothing. `pushed_after` is the state that actually bites today.
+#
+# Sets globals: RS_STATE RS_DETAIL RS_HEAD_SHA RS_REQUEST_AT RS_REQUEST_COVERS_HEAD
+# RS_DETAIL carries seconds — elapsed since the request (awaiting/overdue), or how far
+# head outruns the request (pushed_after).
+RS_STATE=""
+RS_DETAIL=""
+RS_HEAD_SHA=""
+RS_REQUEST_AT=""
+RS_REQUEST_COVERS_HEAD=0
+
+_compute_review_state() {
   local pr=$1
-  local owner_repo head_sha head_date latest_review elapsed
+  local owner_repo head_sha head_date request_at
   owner_repo=$(_repo_slug)
 
-  # Get head SHA and committer date in one call.
-  local pr_data
-  pr_data=$(gh pr view "$pr" --json headRefOid)
-  head_sha=$(jq -r '.headRefOid' <<< "$pr_data")
+  head_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
   head_date=$(gh api "repos/${owner_repo}/commits/${head_sha}" --jq '.commit.committer.date')
+  request_at=$(_latest_copilot_request_at "$pr" "$owner_repo")
 
-  # A Claude review pinned to this head answers currency's question — "has a reviewer
-  # seen THIS commit?" — with a stronger signal than a timestamp comparison. Without
-  # this check the gate sits out its full timer waiting on a reviewer that already has
-  # a documented substitute, which is dead time whenever Copilot is quota-limited.
-  if _claude_marker_present "$pr" "$owner_repo" "$head_sha"; then
-    echo "PASS: currency: Claude review covers head commit"
-    return 0
-  fi
+  RS_HEAD_SHA=$head_sha
+  RS_REQUEST_AT=$request_at
+  RS_DETAIL=0
+  RS_REQUEST_COVERS_HEAD=0
 
-  latest_review=$(_latest_copilot_review_at "$pr" "$owner_repo")
-
-  if [ -z "$latest_review" ]; then
-    echo "SKIP: currency: no substantive Copilot review exists for this PR"
-    return 0
-  fi
-
-  # macOS vs Linux date parsing with TZ=UTC normalization.
-  local head_epoch review_epoch now_epoch
-  if date -d "$head_date" +%s >/dev/null 2>&1; then
-    head_epoch=$(date -d "$head_date" +%s)
-    review_epoch=$(date -d "$latest_review" +%s)
-  else
-    head_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${head_date%Z}Z" +%s)
-    review_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${latest_review%Z}Z" +%s)
-  fi
+  local head_epoch request_epoch=0 now_epoch
+  head_epoch=$(_epoch "$head_date")
   now_epoch=$(date -u +%s)
+  if [ -n "$request_at" ]; then
+    request_epoch=$(_epoch "$request_at")
+    # THE question, in one comparison: is there a request newer than the head push?
+    # Not "was a review ever requested" — every PR answers yes to that.
+    if [ "$request_epoch" -ge "$head_epoch" ]; then
+      RS_REQUEST_COVERS_HEAD=1
+    fi
+  fi
 
-  if [ "$review_epoch" -ge "$head_epoch" ]; then
-    echo "PASS: currency: latest Copilot review covers head commit"
+  # A Claude marker pinned to head answers "has a reviewer seen THIS commit?" directly.
+  # It is checked first so a quota-limited or unanswered request doesn't sit out a timer
+  # against a reviewer that already has a documented substitute. It is NOT silent about
+  # standing in — see the note the gates print when no request covers head.
+  if _claude_marker_present "$pr" "$owner_repo" "$head_sha"; then
+    RS_STATE=marker
     return 0
   fi
 
-  elapsed=$((now_epoch - head_epoch))
-  if [ "$elapsed" -lt "$COPILOT_CURRENCY_THRESHOLD" ]; then
-    echo "WAIT: currency: ${elapsed}s since head push, Copilot review pending"
-    return 2
+  if _copilot_review_covers_head "$pr" "$owner_repo" "$head_sha"; then
+    RS_STATE=covered
+    return 0
   fi
-  echo "WARN: currency: head ${elapsed}s old, Copilot review ${COPILOT_CURRENCY_THRESHOLD}s+ stale"
-  return 0
+
+  if [ -z "$request_at" ]; then
+    RS_STATE=never_requested
+    return 0
+  fi
+
+  if [ "$RS_REQUEST_COVERS_HEAD" -eq 0 ]; then
+    RS_STATE=pushed_after
+    RS_DETAIL=$((head_epoch - request_epoch))
+    return 0
+  fi
+
+  # Only here does a timer apply, and it runs from the request — the moment someone
+  # actually asked — not from the push.
+  RS_DETAIL=$((now_epoch - request_epoch))
+  if [ "$RS_DETAIL" -lt "$COPILOT_REVIEW_WAIT_THRESHOLD" ]; then
+    RS_STATE=awaiting
+  else
+    RS_STATE=overdue
+  fi
+}
+
+# The one command that requests (or RE-requests) a Copilot review. `--add-reviewer`
+# re-requests when the reviewer is already assigned, so it is correct in both cases.
+_request_review_cmd() {
+  printf 'gh pr edit %s --add-reviewer "@copilot"\n' "$1"
+}
+
+# Printed whenever a Claude marker carries a head that no request covers. The marker is
+# the fallback for a request Copilot did not answer; letting it stand in silently for a
+# request nobody made is how it becomes the default path.
+_marker_without_request_note() {
+  local pr=$1
+  echo "  note: no Copilot review was requested for this head — the Claude marker is"
+  echo "        standing in. The marker is the fallback for a request Copilot did not"
+  echo "        answer, not a substitute for asking. To ask:"
+  echo "    $(_request_review_cmd "$pr")"
+}
+
+# Gate 2: where the PR stands with its reviewer. Soft by design — this gate never
+# FAILs. It holds (WAIT) only while a request is genuinely outstanding; every other
+# non-covering state is reported as a WARN with the remedy, because no amount of waiting
+# resolves them. The hard backstop is `reviewed` (gate 4), not this one.
+check_copilot_currency() {
+  local pr=$1
+  _compute_review_state "$pr"
+
+  case "$RS_STATE" in
+    marker)
+      echo "PASS: currency: Claude review marker covers head commit"
+      if [ "$RS_REQUEST_COVERS_HEAD" -eq 0 ]; then _marker_without_request_note "$pr"; fi
+      return 0
+      ;;
+    covered)
+      echo "PASS: currency: Copilot review carries head SHA ${RS_HEAD_SHA:0:7}"
+      return 0
+      ;;
+    awaiting)
+      echo "WAIT: currency: review requested ${RS_DETAIL}s ago, Copilot has not answered yet"
+      return 2
+      ;;
+    overdue)
+      echo "WARN: currency: review requested ${RS_DETAIL}s ago (>${COPILOT_REVIEW_WAIT_THRESHOLD}s), still unanswered"
+      return 0
+      ;;
+    pushed_after)
+      echo "WARN: currency: head is ${RS_DETAIL}s NEWER than the last review request — you pushed after requesting"
+      echo "  re-request once you have stopped iterating:"
+      echo "    $(_request_review_cmd "$pr")"
+      return 0
+      ;;
+    never_requested)
+      echo "WARN: currency: no Copilot review has ever been requested on this PR"
+      echo "  request one:"
+      echo "    $(_request_review_cmd "$pr")"
+      return 0
+      ;;
+    *)
+      echo "FAIL: currency: unrecognised review state '${RS_STATE}'"
+      return 1
+      ;;
+  esac
 }
 
 # Gate 3: Zero unresolved Copilot threads. Uses GraphQL with cursor pagination.
@@ -216,60 +382,74 @@ check_unresolved_threads() {
 }
 
 # Gate 4: Head commit was reviewed by *someone* — Copilot OR a SHA-pinned Claude
-# review marker. Unlike `currency` (which WARN-proceeds on a stale/absent Copilot
-# review), this gate is the hard backstop: a head commit that no one reviewed
-# cannot merge. The Claude marker is `<!-- pinpoint-claude-review: <head_sha> -->`
-# in a PR conversation comment (posted by mark-claude-review.sh); the SHA pin makes
-# it self-expiring — a later fix changes the head SHA and re-arms the gate.
-#   - Claude marker matches head SHA            → PASS
-#   - Copilot review covers head (review>=head) → PASS
-#   - no review, head age < threshold           → WAIT (still inside Copilot window)
-#   - no review, head age >= threshold          → FAIL
+# review marker. Unlike `currency` (which WARN-proceeds), this gate is the hard
+# backstop: a head commit that no one reviewed cannot merge. The Claude marker is
+# `<!-- pinpoint-claude-review: <head_sha> -->` in a PR conversation comment (posted by
+# mark-claude-review.sh); the SHA pin makes it self-expiring — a later fix changes the
+# head SHA and re-arms the gate.
+#
+# The merge bar is UNCHANGED by PP-lzaw: a review covering head is still REQUIRED. What
+# changed is WHEN the wait is spent (from the request, not the push) and how precisely
+# the non-covering states are named. Each terminal state names the ONE action that
+# clears it, and only `overdue` — asked, unanswered — offers the Claude marker, because
+# offering it on "you never asked" is what turns the fallback into the default path.
+#
+#   marker           → PASS (+ note if no request covers head)
+#   covered          → PASS
+#   awaiting         → WAIT   (the only state a timer legitimately applies to)
+#   overdue          → FAIL   remedy: re-request, or attest with mark-claude-review.sh
+#   pushed_after     → FAIL   remedy: re-request. No timer is waited out.
+#   never_requested  → FAIL   remedy: request. No timer is waited out.
 check_review_happened() {
   local pr=$1
-  local owner_repo head_sha head_date latest_review elapsed
-  owner_repo=$(_repo_slug)
+  _compute_review_state "$pr"
 
-  # Head SHA + committer date (same idiom as check_copilot_currency).
-  local pr_data
-  pr_data=$(gh pr view "$pr" --json headRefOid)
-  head_sha=$(jq -r '.headRefOid' <<< "$pr_data")
-  head_date=$(gh api "repos/${owner_repo}/commits/${head_sha}" --jq '.commit.committer.date')
-
-  if _claude_marker_present "$pr" "$owner_repo" "$head_sha"; then
-    echo "PASS: reviewed: Claude review covers head commit"
-    return 0
-  fi
-
-  latest_review=$(_latest_copilot_review_at "$pr" "$owner_repo")
-
-  # macOS vs Linux date parsing with TZ=UTC normalization (mirrors check_copilot_currency).
-  local head_epoch review_epoch=0 now_epoch
-  if date -d "$head_date" +%s >/dev/null 2>&1; then
-    head_epoch=$(date -d "$head_date" +%s)
-    [ -n "$latest_review" ] && review_epoch=$(date -d "$latest_review" +%s)
-  else
-    head_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${head_date%Z}Z" +%s)
-    [ -n "$latest_review" ] && review_epoch=$(TZ=UTC date -jf "%Y-%m-%dT%H:%M:%SZ" "${latest_review%Z}Z" +%s)
-  fi
-  now_epoch=$(date -u +%s)
-
-  if [ -n "$latest_review" ] && [ "$review_epoch" -ge "$head_epoch" ]; then
-    echo "PASS: reviewed: Copilot review covers head commit"
-    return 0
-  fi
-
-  elapsed=$((now_epoch - head_epoch))
-  if [ "$elapsed" -lt "$COPILOT_CURRENCY_THRESHOLD" ]; then
-    echo "WAIT: reviewed: ${elapsed}s since head push, awaiting review"
-    return 2
-  fi
-  echo "FAIL: reviewed: head commit has no Copilot or Claude review"
-  echo "  note: a Copilot comment saying it could not review (quota limit, nothing to"
-  echo "        analyze) does NOT count as a review — that is this gate working."
-  echo "  remedy: review the PR yourself, then attest the head commit with:"
-  echo "    bash scripts/workflow/mark-claude-review.sh $pr \"<one-line findings>\""
-  return 1
+  case "$RS_STATE" in
+    marker)
+      echo "PASS: reviewed: Claude review marker covers head commit"
+      if [ "$RS_REQUEST_COVERS_HEAD" -eq 0 ]; then _marker_without_request_note "$pr"; fi
+      return 0
+      ;;
+    covered)
+      echo "PASS: reviewed: Copilot review carries head SHA ${RS_HEAD_SHA:0:7}"
+      return 0
+      ;;
+    awaiting)
+      echo "WAIT: reviewed: review requested ${RS_DETAIL}s ago, awaiting Copilot"
+      return 2
+      ;;
+    overdue)
+      echo "FAIL: reviewed: review requested ${RS_DETAIL}s ago and Copilot has not answered"
+      echo "  note: a Copilot comment saying it could not review (quota limit, nothing to"
+      echo "        analyze) does NOT count as a review — that is this gate working."
+      echo "  remedy: ask again —"
+      echo "    $(_request_review_cmd "$pr")"
+      echo "  or, if Copilot cannot answer, review the PR yourself and attest head with:"
+      echo "    bash scripts/workflow/mark-claude-review.sh $pr \"<one-line findings>\""
+      return 1
+      ;;
+    pushed_after)
+      echo "FAIL: reviewed: head is ${RS_DETAIL}s NEWER than the last review request (${RS_REQUEST_AT})"
+      echo "  You pushed AFTER requesting the review, so the review that arrives (or"
+      echo "  already arrived) does not cover head. Nothing re-requests automatically —"
+      echo "  that is deliberate, so a 3-commit fixup does not spend 3 reviews."
+      echo "  remedy: once you have stopped iterating, re-request:"
+      echo "    $(_request_review_cmd "$pr")"
+      return 1
+      ;;
+    never_requested)
+      echo "FAIL: reviewed: no Copilot review has ever been requested on this PR"
+      echo "  Copilot review is request-only on this repo — nothing fires on a push, on"
+      echo "  the ready-for-review label, or on green CI. Nobody has asked yet."
+      echo "  remedy: request one —"
+      echo "    $(_request_review_cmd "$pr")"
+      return 1
+      ;;
+    *)
+      echo "FAIL: reviewed: unrecognised review state '${RS_STATE}'"
+      return 1
+      ;;
+  esac
 }
 
 # Gate 5: PR has no merge conflict. UNKNOWN returned once; caller may retry.

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -201,11 +201,13 @@ check_ci() {
 #   pushed_after     head is NEWER than the newest request — you pushed after asking
 #   never_requested  no Copilot review_requested event exists on this PR at all
 #
-# `never_requested` does not occur in practice while the repo's PR-open auto-request is
-# enabled (measured 2026-08-01: it fires ~1s after PR creation on every PR). It is kept
-# distinct anyway — it becomes real the moment that setting is turned off, and a gate
-# that only asked "was a review ever requested" would answer yes on every PR and catch
-# nothing. `pushed_after` is the state that actually bites today.
+# `never_requested` is now the common opening state. Copilot review is fully request-only
+# as of 2026-08-01: nothing asks on your behalf, so a PR has no request until an agent runs
+# `gh pr edit <PR> --add-reviewer "@copilot"`. (Earlier that same day a PR-open auto-request
+# still fired ~1s after creation on every PR, which made this state unreachable in practice;
+# it came from an account-level preference at github.com/settings/copilot that overrode the
+# already-disabled repo toggle. Turning that off is what made it real.) `pushed_after` — you
+# asked, then pushed past the answer — remains the subtler failure of the two.
 #
 # Sets globals: RS_STATE RS_DETAIL RS_HEAD_SHA RS_REQUEST_AT RS_REQUEST_COVERS_HEAD
 # RS_REQUEST_PENDING

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -208,6 +208,7 @@ check_ci() {
 # nothing. `pushed_after` is the state that actually bites today.
 #
 # Sets globals: RS_STATE RS_DETAIL RS_HEAD_SHA RS_REQUEST_AT RS_REQUEST_COVERS_HEAD
+# RS_REQUEST_PENDING
 # RS_DETAIL carries seconds — elapsed since the request (awaiting/overdue), or how far
 # head outruns the request (pushed_after).
 RS_STATE=""
@@ -215,13 +216,30 @@ RS_DETAIL=""
 RS_HEAD_SHA=""
 RS_REQUEST_AT=""
 RS_REQUEST_COVERS_HEAD=0
+RS_REQUEST_PENDING=0
 
 _compute_review_state() {
   local pr=$1
-  local owner_repo head_sha head_date request_at
+  local owner_repo pr_data head_sha head_date request_at
   owner_repo=$(_repo_slug)
 
-  head_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+  # headRefOid and reviewRequests in ONE call. reviewRequests is only used to
+  # explain a confusing `pushed_after`: the issue timeline is eventually
+  # consistent and can lag a freshly-created review_requested event by a minute,
+  # during which the state computes to `pushed_after` even though the agent just
+  # re-requested. reviewRequests updates immediately, so a Copilot entry there
+  # alongside a `pushed_after` verdict means "re-run, the timeline is catching
+  # up". It is NOT treated as coverage: Copilot reviews the head as of the
+  # REQUEST, not as of when it runs (measured on this PR — a request made at
+  # a4a26aad produced a review stamped a4a26aad two minutes after 7d672c4 was
+  # pushed), so a genuinely stale pending request still yields a stale review.
+  pr_data=$(gh pr view "$pr" --json headRefOid,reviewRequests)
+  head_sha=$(jq -r '.headRefOid' <<< "$pr_data")
+  if [ "$(jq -r '[.reviewRequests[]? | (.login // .name // "") | ascii_downcase | select(startswith("copilot"))] | length' <<< "$pr_data")" -gt 0 ]; then
+    RS_REQUEST_PENDING=1
+  else
+    RS_REQUEST_PENDING=0
+  fi
   head_date=$(gh api "repos/${owner_repo}/commits/${head_sha}" --jq '.commit.committer.date')
   request_at=$(_latest_copilot_request_at "$pr" "$owner_repo")
 
@@ -309,6 +327,14 @@ _marker_without_request_note() {
   echo "    $(_request_review_cmd "$pr")"
 }
 
+# Printed on `pushed_after` when Copilot is nonetheless a pending reviewer right now.
+# Almost always means the re-request has been made and the timeline has not caught up.
+_pending_request_lag_note() {
+  echo "  note: Copilot IS a pending reviewer right now, so a request has probably just"
+  echo "        been made and GitHub's issue timeline (which this gate reads) has not"
+  echo "        caught up — it lags by up to a minute. Re-run before acting."
+}
+
 # Gate 2: where the PR stands with its reviewer. Soft by design — this gate never
 # FAILs. It holds (WAIT) only while a request is genuinely outstanding; every other
 # non-covering state is reported as a WARN with the remedy, because no amount of waiting
@@ -339,6 +365,7 @@ check_copilot_currency() {
       echo "WARN: currency: head is ${RS_DETAIL}s NEWER than the last review request — you pushed after requesting"
       echo "  re-request once you have stopped iterating:"
       echo "    $(_request_review_cmd "$pr")"
+      if [ "$RS_REQUEST_PENDING" -eq 1 ]; then _pending_request_lag_note; fi
       return 0
       ;;
     never_requested)
@@ -450,6 +477,7 @@ check_review_happened() {
       echo "  that is deliberate, so a 3-commit fixup does not spend 3 reviews."
       echo "  remedy: once you have stopped iterating, re-request:"
       echo "    $(_request_review_cmd "$pr")"
+      if [ "$RS_REQUEST_PENDING" -eq 1 ]; then _pending_request_lag_note; fi
       return 1
       ;;
     never_requested)

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -235,8 +235,23 @@ _compute_review_state() {
   now_epoch=$(date -u +%s)
   if [ -n "$request_at" ]; then
     request_epoch=$(_epoch "$request_at")
-    # THE question, in one comparison: is there a request newer than the head push?
-    # Not "was a review ever requested" — every PR answers yes to that.
+    # THE question, in one comparison: is the newest request newer than the head
+    # COMMIT? Not "was a review ever requested" — every PR answers yes to that.
+    #
+    # The head commit's committer date stands in for "when head arrived on the
+    # branch". GitHub exposes no push timestamp for a PR head, and the two differ:
+    # a commit can be authored well before it is pushed, and a cherry-pick or a
+    # `git commit --date` can carry an older date still. Both endpoints agree on
+    # the substitution — see the same note in pr-watch.py.
+    #
+    # It errs in a known direction. Committer date EARLIER than the real push makes
+    # a request look like it covers a head it predates, so the gate reports
+    # `awaiting` (and after the window, `overdue`) instead of `pushed_after`: it
+    # still refuses to PASS, it just names the wrong reason for a while. The
+    # opposite skew — a committer date in the future — would read as `pushed_after`
+    # and demand a re-request that is already outstanding, which is noisy but
+    # equally cannot open a merge path. Coverage itself is decided by commit_id, so
+    # neither skew can make an unreviewed head PASS.
     if [ "$request_epoch" -ge "$head_epoch" ]; then
       RS_REQUEST_COVERS_HEAD=1
     fi

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -23,13 +23,13 @@ readonly COPILOT_LOGINS=("copilot-pull-request-reviewer" "copilot-pull-request-r
 # How long to wait for Copilot to answer a review REQUEST before escalating: `currency`
 # degrades WAIT → WARN, `reviewed` degrades WAIT → FAIL.
 #
-# Measured from the request, NOT from the head push (PP-lzaw). Copilot review is
-# request-only on this repo since 2026-08-01 — one automatic request at PR-open and
-# nothing after — so a timer keyed to the head push counts down against a review nobody
-# asked for, and every un-re-requested PR lands on the `reviewed` FAIL whose documented
-# remedy is the Claude marker. That makes the marker the DEFAULT path rather than the
-# fallback, gutting the guarantee this gate exists to provide. A timer only makes sense
-# once someone has actually asked.
+# Measured from the request, NOT from the head push (PP-lzaw). Copilot review is fully
+# request-only on this repo as of 2026-08-01 — nothing asks on your behalf — so a timer
+# keyed to the head push counts down against a review nobody asked for, and every
+# un-requested PR lands on the `reviewed` FAIL whose documented remedy is the Claude
+# marker. That makes the marker the DEFAULT path rather than the fallback, gutting the
+# guarantee this gate exists to provide. A timer only makes sense once someone has
+# actually asked.
 readonly COPILOT_REVIEW_WAIT_THRESHOLD=600
 
 # Copilot posts a review OBJECT even when it reviewed nothing — quota exhaustion, or
@@ -88,9 +88,11 @@ _epoch() {
 #
 # Matched on a case-insensitive "copilot" prefix rather than COPILOT_LOGINS: a request
 # names the reviewer as plain "Copilot", while the review it produces is authored by
-# "copilot-pull-request-reviewer[bot]". The actor is NOT a usable discriminator — the
-# repo owner is the actor for both the PR-open automatic request and an explicit
-# `gh pr edit --add-reviewer`.
+# "copilot-pull-request-reviewer[bot]". Deliberately does NOT filter on the actor. Every
+# request is an explicit `gh pr edit --add-reviewer` now, but while GitHub was still
+# auto-requesting at PR-open the actor was the repo owner for BOTH kinds — so actor never
+# discriminated anything, and re-adding it if automation returns would be a false lead.
+# Ordering against the head commit is what separates a live request from a spent one.
 _latest_copilot_request_at() {
   local pr=$1 owner_repo=$2
   gh api --paginate "repos/${owner_repo}/issues/${pr}/timeline?per_page=100" \

--- a/scripts/workflow/merge-pr.sh
+++ b/scripts/workflow/merge-pr.sh
@@ -14,20 +14,26 @@
 #   -a, --automerge               Poll the gates instead of evaluating them once, and merge
 #                                 as soon as they all pass. Fire it while CI is still
 #                                 running — that is what it is for. It does NOT wait out
-#                                 an unreviewed head: `reviewed` hard-fails 600s after a
-#                                 head push with no Copilot review and no Claude marker,
-#                                 and a hard failure ends the run. So attest the review
-#                                 first (mark-claude-review.sh) if Copilot is quota-limited
-#                                 or has already skipped. Terminates on exactly three
-#                                 outcomes, each reported on exit:
+#                                 an unreviewed head. `reviewed` only WAITs while a review
+#                                 REQUEST is outstanding, and only for 600s from that
+#                                 request; if nobody requested a review since the last
+#                                 push, it hard-fails on the FIRST poll and the run ends.
+#                                 So request the review before firing this
+#                                 (`gh pr edit <PR> --add-reviewer "@copilot"`), or attest
+#                                 head with mark-claude-review.sh if Copilot is
+#                                 quota-limited or has already skipped. Terminates on
+#                                 exactly three outcomes, each reported on exit:
 #                                   MERGED      — gates went green, PR squash-merged
 #                                   RED         — a gate hard-failed; no merge, label removed
 #                                   TIMED OUT   — still waiting when the budget ran out
-#                                 A WAIT (CI running, review pending) keeps polling; only a
-#                                 hard failure stops it. Tune with AUTOMERGE_TIMEOUT (default
-#                                 3600s) and AUTOMERGE_POLL_INTERVAL (default 30s).
+#                                 A WAIT (CI running, requested review not yet answered)
+#                                 keeps polling; only a hard failure stops it. Tune with
+#                                 AUTOMERGE_TIMEOUT (default 3600s) and
+#                                 AUTOMERGE_POLL_INTERVAL (default 30s).
 #   --dry-run                     Print would-do summary, take no action. Does not require --human.
-#   --force                       Bypass currency + threads + reviewed gates.
+#   --force                       Bypass currency + threads + reviewed gates. This is the
+#                                 ONLY way to merge a head no reviewer has seen, and it
+#                                 requires manual permission approval each time.
 #   --bypass-merge-requirements   Bypass ci gate AND pass --admin to gh pr merge
 #                                 (overrides GitHub branch-protection rules).
 #                                 Combine with --force to bypass currency + threads + reviewed + ci together.

--- a/scripts/workflow/pr-dashboard.sh
+++ b/scripts/workflow/pr-dashboard.sh
@@ -30,9 +30,13 @@ if [ -z "$PRS" ]; then
     exit 0
 fi
 
-# Header
-printf "%-6s %-40s %-12s %-10s %-10s %-8s %s\n" "PR" "Title" "CI" "Copilot" "Merge" "Draft" "Branch"
-printf "%-6s %-40s %-12s %-10s %-10s %-8s %s\n" "------" "----------------------------------------" "------------" "----------" "----------" "--------" "-------------------"
+# Header. The Copilot column reports the REVIEW state, not just a thread count:
+# a bare "0" read identically for "reviewed, everything resolved" and "no review
+# was ever requested", which under request-only Copilot (PP-lzaw) is the
+# difference between ready-to-merge and nobody-is-coming. Unresolved threads
+# still take precedence — they are the actionable state.
+printf "%-6s %-40s %-12s %-12s %-10s %-8s %s\n" "PR" "Title" "CI" "Copilot" "Merge" "Draft" "Branch"
+printf "%-6s %-40s %-12s %-12s %-10s %-8s %s\n" "------" "----------------------------------------" "------------" "------------" "----------" "--------" "-------------------"
 
 for pr in $PRS; do
     if ! [[ "$pr" =~ ^[0-9]+$ ]]; then
@@ -100,6 +104,26 @@ for pr in $PRS; do
     done
     [ "$copilot_ok" = "false" ] && copilot_count="?"
 
+    # Copilot column: unresolved threads win (they need action now); otherwise
+    # report which review state the PR is in.
+    if [ "$copilot_count" = "?" ]; then
+        copilot_str="?"
+    elif [ "$copilot_count" -gt 0 ]; then
+        copilot_str="${copilot_count} unres"
+    elif _compute_review_state "$pr" 2>/dev/null; then
+        case "$RS_STATE" in
+            marker)          copilot_str="marker" ;;
+            covered)         copilot_str="reviewed" ;;
+            awaiting)        copilot_str="awaiting" ;;
+            overdue)         copilot_str="OVERDUE" ;;
+            pushed_after)    copilot_str="RE-REQUEST" ;;
+            never_requested) copilot_str="NOT ASKED" ;;
+            *)               copilot_str="?" ;;
+        esac
+    else
+        copilot_str="?"
+    fi
+
     # Merge status
     case "$merge_state" in
         CONFLICTING) merge_str="CONFLICT" ;;
@@ -117,5 +141,5 @@ for pr in $PRS; do
         draft_str="draft"
     fi
 
-    printf "%-6s %-40s %-12s %-10s %-10s %-8s %s\n" "#${pr}" "$title" "$ci_status" "$copilot_count" "$merge_str" "$draft_str" "$branch"
+    printf "%-6s %-40s %-12s %-12s %-10s %-8s %s\n" "#${pr}" "$title" "$ci_status" "$copilot_str" "$merge_str" "$draft_str" "$branch"
 done

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -10,15 +10,20 @@ Usage: ./scripts/workflow/pr-watch.py [--check-ready | --force] [--verbose] <PR_
                  Gate absent or in-progress is NOT a blocking condition —
                  the watch loop handles those by waiting.
   --check-ready  Run the full readiness check (mergeable + CI Gate present
-                 + a review covering head + Copilot threads resolved +
-                 ready label) and exit. CI Gate absent IS a fail here —
-                 this mode answers "is this PR ready for human review
-                 right now?". The `copilot-review` line names one of six
-                 states rather than a bare yes/no: Copilot review is
-                 request-only on this repo, so "nobody asked yet",
-                 "asked, still waiting" and "you pushed past the request"
-                 need three different actions and only the middle one
-                 resolves by waiting (PP-lzaw).
+                 + a live review path + Copilot threads resolved + ready
+                 label) and exit. CI Gate absent IS a fail here — this
+                 mode answers "is this PR ready for human review right
+                 now?". "Live review path" means a review already covers
+                 head, OR a request newer than head is still outstanding
+                 — the latter passes here because it resolves by waiting,
+                 while `merge-pr.sh`'s `reviewed` gate still requires the
+                 review to have actually landed before a merge. The
+                 `copilot-review` line names one of six states rather
+                 than a bare yes/no: Copilot review is request-only on
+                 this repo, so "nobody asked yet", "asked, still waiting"
+                 and "you pushed past the request" need three different
+                 actions and only the middle one resolves by waiting
+                 (PP-lzaw).
   --force        Skip the pre-check entirely and watch unconditionally.
   --verbose      Emit per-job progressive updates ("X passed", "CI Gate
                  in_progress — continuing to wait", "Watching PR #N — N
@@ -275,7 +280,17 @@ def copilot_review_state(pr: int) -> tuple[str, str]:
     path (coverage itself is decided by commit_id).
     """
     repo = f"repos/{REPO_OWNER}/{REPO_NAME}"
-    head_sha = gh("pr", "view", str(pr), "--json", "headRefOid", "--jq", ".headRefOid")
+    pr_data = json.loads(
+        gh("pr", "view", str(pr), "--json", "headRefOid,reviewRequests")
+    )
+    head_sha = pr_data["headRefOid"]
+    # Only used to explain a confusing `pushed_after` — see the note at the same
+    # spot in _pr-gates.sh. Never treated as coverage: Copilot reviews the head
+    # as of the REQUEST, not as of when it runs.
+    request_pending = any(
+        str(r.get("login") or r.get("name") or "").lower().startswith("copilot")
+        for r in pr_data.get("reviewRequests") or []
+    )
     head_date = gh(
         "api", f"{repo}/commits/{head_sha}", "--jq", ".commit.committer.date"
     )
@@ -326,11 +341,18 @@ def copilot_review_state(pr: int) -> tuple[str, str]:
 
     if not request_covers_head:
         behind = int(head_epoch - request_epoch)
+        lag = (
+            " (Copilot IS a pending reviewer right now — a request has probably "
+            "just been made and the issue timeline has not caught up; re-run "
+            "before acting)"
+            if request_pending
+            else ""
+        )
         return (
             "pushed_after",
             f"head is {behind}s NEWER than the last request ({latest_request}) — "
             f"you pushed after requesting; nothing re-requests automatically. "
-            f"When you stop iterating, run: {hint}",
+            f"When you stop iterating, run: {hint}{lag}",
         )
 
     waited = int(time.time() - request_epoch)

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -10,9 +10,15 @@ Usage: ./scripts/workflow/pr-watch.py [--check-ready | --force] [--verbose] <PR_
                  Gate absent or in-progress is NOT a blocking condition —
                  the watch loop handles those by waiting.
   --check-ready  Run the full readiness check (mergeable + CI Gate present
-                 + Copilot resolved + ready label) and exit. CI Gate
-                 absent IS a fail here — this mode answers "is this PR
-                 ready for human review right now?".
+                 + a review covering head + Copilot threads resolved +
+                 ready label) and exit. CI Gate absent IS a fail here —
+                 this mode answers "is this PR ready for human review
+                 right now?". The `copilot-review` line names one of six
+                 states rather than a bare yes/no: Copilot review is
+                 request-only on this repo, so "nobody asked yet",
+                 "asked, still waiting" and "you pushed past the request"
+                 need three different actions and only the middle one
+                 resolves by waiting (PP-lzaw).
   --force        Skip the pre-check entirely and watch unconditionally.
   --verbose      Emit per-job progressive updates ("X passed", "CI Gate
                  in_progress — continuing to wait", "Watching PR #N — N
@@ -52,6 +58,32 @@ COPILOT_LOGINS = (
 )
 READY_LABEL = "ready-for-review"
 CI_GATE_NAME = "CI Gate"
+
+# --- Review-request state (PP-lzaw) -----------------------------------------
+# Kept deliberately in sync with scripts/workflow/_pr-gates.sh, which is the
+# canonical implementation. Duplicated rather than shelled out to because this
+# script is the read-only reporter and _pr-gates.sh is sourced by merge-pr.sh,
+# which agents may not invoke at all. scripts/tests/test_pr_watch.py pins the
+# two vocabularies together.
+
+# Copilot posts a review OBJECT even when it reviewed nothing (quota exhausted,
+# no analyzable files). Those must be treated as absent — see the long rationale
+# in _pr-gates.sh (PP-jw0s).
+# Matched on WHOLE-PR phrasings only. "t able to review any files" covers both
+# "wasn't able to..." and "not able to..." without eating a real review that
+# merely mentions files it could not analyse.
+COPILOT_NON_REVIEW_MARKERS = (
+    "reached their quota limit",
+    "unable to review this pull request",
+    "t able to review any files",
+)
+CLAUDE_MARKER_PREFIX = "<!-- pinpoint-claude-review:"
+
+# Seconds to wait for Copilot to answer a REQUEST before the wait stops being
+# legitimate. Measured from the request, not the head push.
+COPILOT_REVIEW_WAIT_THRESHOLD = 600
+
+REQUEST_REVIEW_HINT = 'gh pr edit {pr} --add-reviewer "@copilot"'
 
 REVIEW_POLL_INTERVAL = 60  # seconds — GitHub rate limit friendly
 STARTUP_RETRIES = 6  # attempts to find runs for current SHA
@@ -183,6 +215,126 @@ def get_review_threads(pr: int) -> list[dict]:
         if not rt["pageInfo"]["hasNextPage"]:
             return threads
         cursor = rt["pageInfo"]["endCursor"]
+
+
+def _gh_api_list(path: str) -> list[dict]:
+    """GET a paginated GitHub list endpoint, returning every item.
+
+    `gh api --paginate` emits ONE JSON document per page, so json.loads on the
+    whole stream fails from page 2 onward. Decode documents until the buffer is
+    exhausted and flatten.
+    """
+    raw = gh("api", "--paginate", f"{path}?per_page=100")
+    decoder = json.JSONDecoder()
+    items: list[dict] = []
+    idx = 0
+    while idx < len(raw):
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+        if idx >= len(raw):
+            break
+        doc, end = decoder.raw_decode(raw, idx)
+        if isinstance(doc, list):
+            items.extend(doc)
+        idx = end
+    return items
+
+
+def _is_substantive(review: dict) -> bool:
+    body = (review.get("body") or "").lower()
+    return not any(m in body for m in COPILOT_NON_REVIEW_MARKERS)
+
+
+def _iso_to_epoch(value: str) -> float:
+    return (
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
+    )
+
+
+def copilot_review_state(pr: int) -> tuple[str, str]:
+    """Return (state, human-readable detail) for the PR's review situation.
+
+    Mirrors `_compute_review_state` in scripts/workflow/_pr-gates.sh — same six
+    states, same ordering, same clock. States: marker, covered, awaiting,
+    overdue, pushed_after, never_requested.
+
+    The distinction that matters: a request NEWER than the head push means a
+    wait is legitimate; a head newer than the newest request means nobody is
+    coming, because nothing re-requests automatically. Collapsing those into one
+    "not reviewed yet" is what turns a forgotten request into an overnight stall.
+    """
+    repo = f"repos/{REPO_OWNER}/{REPO_NAME}"
+    head_sha = gh("pr", "view", str(pr), "--json", "headRefOid", "--jq", ".headRefOid")
+    head_date = gh(
+        "api", f"{repo}/commits/{head_sha}", "--jq", ".commit.committer.date"
+    )
+    head_epoch = _iso_to_epoch(head_date)
+
+    # The review REQUEST clock lives on the issue timeline; the reviews endpoint
+    # cannot tell "nobody asked" from "asked, still waiting". A request names the
+    # reviewer as plain "Copilot" — not the bot login its reviews are authored
+    # under — so match a case-insensitive "copilot" prefix.
+    requests = [
+        ev.get("created_at", "")
+        for ev in _gh_api_list(f"{repo}/issues/{pr}/timeline")
+        if ev.get("event") == "review_requested"
+        and ((ev.get("requested_reviewer") or {}).get("login") or "")
+        .lower()
+        .startswith("copilot")
+    ]
+    latest_request = max(requests) if requests else ""
+    request_epoch = _iso_to_epoch(latest_request) if latest_request else 0.0
+    request_covers_head = bool(latest_request) and request_epoch >= head_epoch
+
+    marker = f"{CLAUDE_MARKER_PREFIX} {head_sha} -->"
+    if any(
+        marker in (c.get("body") or "")
+        for c in _gh_api_list(f"{repo}/issues/{pr}/comments")
+    ):
+        detail = f"Claude review marker pins head {head_sha[:7]}"
+        if not request_covers_head:
+            detail += " (standing in — no Copilot review was requested for this head)"
+        return "marker", detail
+
+    # Coverage is judged by commit_id, not by timestamp: a review submitted after
+    # a later push can still have read an earlier tree.
+    if any(
+        r.get("commit_id") == head_sha
+        and (r.get("user") or {}).get("login") in COPILOT_LOGINS
+        and _is_substantive(r)
+        for r in _gh_api_list(f"{repo}/pulls/{pr}/reviews")
+    ):
+        return "covered", f"Copilot review carries head SHA {head_sha[:7]}"
+
+    hint = REQUEST_REVIEW_HINT.format(pr=pr)
+    if not latest_request:
+        return (
+            "never_requested",
+            f"no Copilot review has ever been requested — run: {hint}",
+        )
+
+    if not request_covers_head:
+        behind = int(head_epoch - request_epoch)
+        return (
+            "pushed_after",
+            f"head is {behind}s NEWER than the last request ({latest_request}) — "
+            f"you pushed after requesting; nothing re-requests automatically. "
+            f"When you stop iterating, run: {hint}",
+        )
+
+    waited = int(time.time() - request_epoch)
+    if waited < COPILOT_REVIEW_WAIT_THRESHOLD:
+        return (
+            "awaiting",
+            f"review requested {waited}s ago, Copilot has not answered yet",
+        )
+    return (
+        "overdue",
+        f"review requested {waited}s ago and still unanswered — re-request ({hint}) "
+        f"or attest head with scripts/workflow/mark-claude-review.sh",
+    )
 
 
 def _unresolved_copilot(threads: list[dict]) -> int:
@@ -356,9 +508,22 @@ def run_audit(pr: int) -> bool:
         "applied" if READY_LABEL in labels else "not applied (orchestrator applies)"
     )
 
+    # A review covering head is part of an agent's terminal state on a PR, and
+    # under request-only Copilot it does not happen unless someone asks. Report
+    # WHICH state the PR is in — "nobody asked", "asked and waiting", and "you
+    # pushed past the request" need three different actions, and only the middle
+    # one resolves by waiting. `awaiting` is not a failure: the request is
+    # outstanding and the answer is on its way.
+    try:
+        review_state, review_detail = copilot_review_state(pr)
+    except (RuntimeError, ValueError, KeyError) as exc:
+        review_state, review_detail = "unknown", f"could not determine ({exc})"
+    review_ok = review_state in ("marker", "covered", "awaiting")
+
     checks = [
         (not bad_merge, "mergeable", merge_detail),
         (ci_check[0], "ci-gate", ci_check[1]),
+        (review_ok, "copilot-review", f"{review_state}: {review_detail}"),
         (
             unresolved == 0,
             "copilot-resolved",

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -68,14 +69,17 @@ CI_GATE_NAME = "CI Gate"
 
 # Copilot posts a review OBJECT even when it reviewed nothing (quota exhausted,
 # no analyzable files). Those must be treated as absent — see the long rationale
-# in _pr-gates.sh (PP-jw0s).
-# Matched on WHOLE-PR phrasings only. "t able to review any files" covers both
-# "wasn't able to..." and "not able to..." without eating a real review that
-# merely mentions files it could not analyse.
-COPILOT_NON_REVIEW_MARKERS = (
-    "reached their quota limit",
-    "unable to review this pull request",
-    "t able to review any files",
+# in _pr-gates.sh (PP-jw0s). This pattern is a CHARACTER-FOR-CHARACTER copy of
+# COPILOT_NON_REVIEW_BODY_RE there; two hand-written variants would silently
+# diverge on the next wording added, and a body the bash eats but the Python
+# keeps (or vice versa) is exactly the kind of disagreement that makes the
+# gates untrustworthy. Change one, change both.
+COPILOT_NON_REVIEW_BODY_RE = re.compile(
+    "reached their quota limit"
+    "|unable to review this pull request"
+    "|not able to review any files"
+    "|wasn.t able to review any files",
+    re.IGNORECASE,
 )
 CLAUDE_MARKER_PREFIX = "<!-- pinpoint-claude-review:"
 
@@ -241,8 +245,7 @@ def _gh_api_list(path: str) -> list[dict]:
 
 
 def _is_substantive(review: dict) -> bool:
-    body = (review.get("body") or "").lower()
-    return not any(m in body for m in COPILOT_NON_REVIEW_MARKERS)
+    return not COPILOT_NON_REVIEW_BODY_RE.search(review.get("body") or "")
 
 
 def _iso_to_epoch(value: str) -> float:

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -263,10 +263,16 @@ def copilot_review_state(pr: int) -> tuple[str, str]:
     states, same ordering, same clock. States: marker, covered, awaiting,
     overdue, pushed_after, never_requested.
 
-    The distinction that matters: a request NEWER than the head push means a
+    The distinction that matters: a request NEWER than the head commit means a
     wait is legitimate; a head newer than the newest request means nobody is
     coming, because nothing re-requests automatically. Collapsing those into one
     "not reviewed yet" is what turns a forgotten request into an overnight stall.
+
+    "Newer than the head commit" is measured against the head commit's committer
+    date, which stands in for when head arrived on the branch — GitHub exposes no
+    push timestamp for a PR head. See the note at the comparison site in
+    _pr-gates.sh for how the two can differ and why neither skew can open a merge
+    path (coverage itself is decided by commit_id).
     """
     repo = f"repos/{REPO_OWNER}/{REPO_NAME}"
     head_sha = gh("pr", "view", str(pr), "--json", "headRefOid", "--jq", ".headRefOid")


### PR DESCRIPTION
## Problem

Copilot review is request-only on this repo since 2026-08-01, but every review gate still measured staleness from the **head push** — a clock that only made sense when Copilot arrived unprompted.

Under request-only that timer counts down against a review nobody asked for: `currency` waits 10 minutes then WARN-proceeds, and `reviewed` then hard-fails with a message whose documented remedy is `mark-claude-review.sh`. So a PR where no review was requested **always** lands on that FAIL, and the Claude marker becomes the DEFAULT path rather than the fallback — gutting the guarantee the gate exists to provide.

## The merge bar is UNCHANGED

A review covering head — Copilot, or a SHA-pinned Claude marker — with threads resolved is still **required** to merge. What changed is *when* the wait is spent and how precisely the non-covering states are named. `reviewed` still hard-fails an unreviewed head; `--force` (permission-gated) remains the only way past it.

## State machine

`currency` and `reviewed` now share one `_compute_review_state` — they asked the same question twice and had already drifted (`reviewed` learned about the Claude marker, `currency` did not).

| State | Meaning | `currency` | `reviewed` |
| --- | --- | --- | --- |
| `marker` | SHA-pinned Claude marker covers head | PASS | PASS |
| `covered` | substantive Copilot review carries head's SHA | PASS | PASS |
| `awaiting` | request newer than head, inside the 600s window | WAIT | WAIT |
| `overdue` | asked, unanswered past the window | WARN | FAIL — re-request, or attest |
| `pushed_after` | head is NEWER than the newest request | WARN | FAIL — re-request. No timer. |
| `never_requested` | no Copilot `review_requested` event at all | WARN | FAIL — request. No timer. |

Only `awaiting` waits, and it times from the **request**. `pushed_after` and `never_requested` fail immediately with the exact command — waiting there just delays the moment a human notices.

Nothing ever re-requests automatically: a 3-commit fixup would spend 3 reviews, the exact behaviour request-only exists to stop. The gates say so; they never ask for you.

`overdue` is the **only** state that offers `mark-claude-review.sh`. Offering the marker on "you never asked" is precisely how the fallback becomes the default. A marker still passes both gates in any state — but when no request covers head it prints a note saying it is standing in, so it can never do so *silently*.

## Two measurement fixes underneath

**The request clock comes from the issue timeline.** The reviews endpoint cannot tell "nobody asked" from "asked, still waiting" — only `event == "review_requested"` can. Requests name the reviewer as plain `Copilot`, not the bot login its reviews are authored under. The actor is deliberately not filtered on: while GitHub was still auto-requesting at PR-open, the repo owner was the actor for both kinds, so actor never discriminated anything. Ordering against the head commit does.

**The gate asks "is there a request newer than head", not "was one ever requested".** That distinction is why this survived the config changing underneath it mid-PR. When the work started, a PR-open auto-request fired ~1s after creation on every PR, so `never_requested` was unreachable and a gate keyed on "ever requested" would have answered yes every time and caught nothing. Tim then found the account-level preference at `github.com/settings/copilot` overriding the already-off repo toggle and disabled it — there are now **zero** automatic reviews, and `never_requested` is the state every PR opens in. Neither configuration changed a line of the logic.

**Coverage is judged by `commit_id`, not by timestamp.** On #1784, a Copilot review of `64cfebc2` was submitted 3 minutes *after* head `d7392134` was pushed; comparing `submitted_at` against the head commit date read that as "covers head" for a review that demonstrably read a different tree. Under the old review-on-every-push model that mostly self-corrected; under request-only it is a standing false PASS. **This PR reproduced it live**: a request made at `a4a26aad` produced a review stamped `a4a26aad` two minutes after `7d672c4` had been pushed, with a `submitted_at` newer than head's committer date. The old comparison would have passed it.

That same measurement establishes the fact the whole `pushed_after` state rests on: **Copilot reviews the head as of the REQUEST, not as of when it runs.** Pushing after asking genuinely spends the review on the old tree, so demanding a re-request is right rather than pedantic.

## Also

- `pr-watch.py --check-ready` reports the same six states as a `copilot-review` check. `awaiting` passes; the three dead-end states fail with the remedy inline.
- `pr-dashboard.sh`'s Copilot column now distinguishes `reviewed` / `marker` / `awaiting` from `RE-REQUEST` / `NOT ASKED`, instead of showing a bare `0` for both "everything resolved" and "nobody asked".
- `merge-pr.sh`'s `--automerge` and `--force` docs no longer state the 600s-after-head-push rule.
- A `pushed_after` verdict now says so when Copilot is *currently* a pending reviewer — GitHub's issue timeline is eventually consistent and lagged a fresh `review_requested` event by ~1 minute during this PR, during which the gate told me to run a command I had just run. `gh pr view --json reviewRequests` updates immediately, so it is folded into the existing call at no cost. Still a FAIL, and never treated as coverage: per the measurement above, a genuinely stale pending request still yields a stale review.

## Verification

`pnpm run check` green. 39 gate tests + 55 pr-watch tests, both directions covered: an unreviewed head cannot pass `reviewed` in any state (parametrised across every non-covering state), and a fresh request holds a 4000s-old head in WAIT where the old timer would have failed it outright. Three tests assert the bash and Python implementations share one non-review regex, one threshold, and one state vocabulary, so they cannot drift.

Run read-only against live PRs: all seven queued for merge (#1779, #1780, #1782–#1786) still PASS — five on Copilot coverage, two on a Claude marker with no spurious note. #1762 correctly surfaces as `RE-REQUEST` / `pushed_after`, which the old gates could not distinguish from "not reviewed yet".

Bead: PP-lzaw. The docs half (#1784) is merged; #1790 (PP-if27) documents this state machine in `scripts/workflow/AGENTS.md` and is sequenced to land after this PR.
