### PR TITLE
fix(discord): delete vault orphans with a real DELETE, not a nonexistent RPC (PP-w3d9)

### DIFF
--- a/src/app/(app)/admin/integrations/discord/actions.ts
+++ b/src/app/(app)/admin/integrations/discord/actions.ts
@@ -386,7 +386,7 @@ export async function saveDiscordConfig(
         if (!createdId) {
           // Residual we cannot compensate: if create_secret succeeded
           // server-side but this result read rejected/returned no id, we
-          // have no id to delete_secret — the orphan (if any) is
+          // have no id to delete — the orphan (if any) is
           // unrecoverable here. Throwing still routes through the catch for
           // the Sentry signal + structured error; orphanGuard.vaultId stays
           // null because there's nothing actionable to clean up.
@@ -469,12 +469,16 @@ export async function saveDiscordConfig(
     //     Hence orphanGuard.vaultId is only ever set on the create path.
     if (orphanGuard.vaultId) {
       try {
-        // vault.delete_secret is the inverse of vault.create_secret used
-        // above (pg_vault extension). Best-effort — a failure here just
-        // leaves a stray encrypted secret in vault.secrets; the singleton
-        // row already isn't pointing at it.
+        // supabase_vault (0.3.1, the version running locally and in prod)
+        // exposes exactly two public functions — create_secret and
+        // update_secret. There is NO delete_secret at any version we run, so
+        // deletion is a plain row DELETE against vault.secrets, the same form
+        // migration 0059 uses. Scoped to the single id we just created: the
+        // singleton's own (referenced) secret must never be touched.
+        // Best-effort — a failure here just leaves a stray encrypted secret
+        // in vault.secrets; the singleton row already isn't pointing at it.
         await db.execute(
-          sql`SELECT vault.delete_secret(${orphanGuard.vaultId}::uuid)`
+          sql`DELETE FROM vault.secrets WHERE id = ${orphanGuard.vaultId}::uuid`
         );
       } catch (cleanupErr) {
         log.error(

--- a/src/test/integration/admin/discord-integration-actions.test.ts
+++ b/src/test/integration/admin/discord-integration-actions.test.ts
@@ -496,58 +496,15 @@ describe("saveDiscordConfig", () => {
       ).toBe(true);
     });
 
-    it("create path: deletes the orphaned secret when the transaction fails", async () => {
-      mockHappyProbes();
-      mockFindFirst.mockResolvedValue({ botTokenVaultId: null });
-
-      // First execute = create_secret (returns id); later execute =
-      // delete_secret in the catch block.
-      mockExecute
-        .mockResolvedValueOnce([{ id: "new-vault-id" }])
-        .mockResolvedValue([]);
-
-      // Force the transaction to fail after the secret was created.
-      mockTransaction.mockImplementation(() => {
-        throw new Error("simulated transaction failure");
-      });
-
-      const fd = makeFormData({
-        enabled: "true",
-        newToken: VALID_TOKEN,
-        guildId: "123456789012345678",
-      });
-      const result = await saveDiscordConfig(fd);
-      expect(result.ok).toBe(false);
-
-      // create_secret + delete_secret both ran.
-      const calls = mockExecute.mock.calls.map((c) => JSON.stringify(c[0]));
-      expect(calls.some((c) => c.includes("create_secret"))).toBe(true);
-      expect(calls.some((c) => c.includes("delete_secret"))).toBe(true);
-    });
-
-    it("update path: does NOT delete the secret when the transaction fails (no orphan to undo)", async () => {
-      mockHappyProbes();
-      mockFindFirst.mockResolvedValue({ botTokenVaultId: "existing-vault-id" });
-      mockExecute.mockResolvedValue([]);
-
-      mockTransaction.mockImplementation(() => {
-        throw new Error("simulated transaction failure");
-      });
-
-      const fd = makeFormData({
-        enabled: "true",
-        newToken: VALID_TOKEN,
-        guildId: "123456789012345678",
-      });
-      const result = await saveDiscordConfig(fd);
-      expect(result.ok).toBe(false);
-
-      // Only update_secret ran — no delete_secret compensation on the
-      // rotate-in-place path.
-      const calls = mockExecute.mock.calls.map((c) => JSON.stringify(c[0]));
-      expect(calls.some((c) => c.includes("update_secret"))).toBe(true);
-      expect(calls.some((c) => c.includes("delete_secret"))).toBe(false);
-    });
+    // The two orphan-compensation cases (create path deletes the orphan;
+    // update path deletes nothing) deliberately do NOT live here. They used to,
+    // asserted as `JSON.stringify(sqlArg).includes("delete_secret")` — a test
+    // that inspects the SQL string the action generates without ever running
+    // it. That let a compensation calling a function supabase_vault does not
+    // ship pass review and ship (PP-w3d9). They now live in
+    // src/test/integration/admin/discord-vault-orphan-cleanup.test.ts, which
+    // executes every statement against Postgres and asserts on the surviving
+    // vault.secrets rows instead.
 
     it("vault RPC rejection returns {ok:false} and reports to Sentry instead of throwing uncaught", async () => {
       mockHappyProbes();

--- a/src/test/integration/admin/discord-vault-orphan-cleanup.test.ts
+++ b/src/test/integration/admin/discord-vault-orphan-cleanup.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Integration tests: saveDiscordConfig's create-path Vault orphan compensation,
+ * with the compensation SQL **actually executed** against Postgres (PP-w3d9).
+ *
+ * Why this file exists separately from discord-integration-actions.test.ts:
+ * that suite mocks `~/server/db` wholesale and asserted the compensation by
+ * string-matching the SQL text the action generates. That shape can only ever
+ * confirm "we still emit the same string" — it kept passing for the entire
+ * lifetime of a compensation that could never work, because the action called
+ * `vault.delete_secret()`, a function supabase_vault does not ship. Per
+ * CORE-TEST-005 a query-correctness bug belongs in integration (PGlite +
+ * direct action), so here every statement the action issues — including the
+ * compensation — is executed by a real Postgres and its effect is asserted on
+ * the resulting rows, never on the SQL string.
+ *
+ * The Vault stand-in (CORE-TEST-006): `vault` is a Postgres extension, not a
+ * network service, so the boundary we mock is its *public function surface*.
+ * supabase_vault 0.3.1 — the version installed both locally and in
+ * pinpoint-prod — exposes exactly `vault.create_secret` and
+ * `vault.update_secret` over the `vault.secrets` table. The stub below defines
+ * those two and the table, and deliberately defines **nothing else**: any call
+ * to a function the real extension lacks (`vault.delete_secret` among them)
+ * fails here exactly as it fails in production. The "harness self-check" test
+ * pins that property so the stub can't silently grow teeth-free.
+ *
+ * What this does NOT prove: that the app's database role holds DELETE on
+ * vault.secrets in production. That is a grant, not a query, and PGlite has no
+ * Supabase role model. It was verified directly against the local and prod
+ * stacks under PP-o355.23, and drizzle/0059 performs the same raw DELETE.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import { createTestUser } from "~/test/helpers/factories";
+import { discordIntegrationConfig, userProfiles } from "~/server/db/schema";
+
+// ── Test-controlled seams (hoisted so the db mock factory can close over them)
+
+const { testControl } = vi.hoisted(() => ({
+  testControl: {
+    /**
+     * Simulate the exact race the create-path guard exists for: another admin
+     * writes `bot_token_vault_id` on the singleton between the action's
+     * pre-transaction read and its first in-transaction UPDATE. Set to the
+     * vault id that competing writer installs; consumed once.
+     */
+    competingWriterVaultId: null as string | null,
+    /**
+     * Force a failure *inside* the transaction, after the action's row writes
+     * have run, so the rollback is real. Used for the update-path case, which
+     * has no in-code failure to provoke.
+     */
+    failInsideTransaction: false,
+  },
+}));
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("~/lib/logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("~/lib/observability/report-error", () => ({
+  reportError: vi.fn(),
+}));
+
+// The Vault token accessor reaches for a decrypt RPC the stub doesn't provide;
+// the tests here always type a new token, so it is never consulted.
+vi.mock("~/lib/discord/config", () => ({
+  getDiscordTokenForAdmin: vi.fn().mockResolvedValue(null),
+  getDiscordConfig: vi.fn(),
+  isDiscordIntegrationEnabled: vi.fn(),
+}));
+
+const mockGetUser = vi.fn();
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ auth: { getUser: mockGetUser } }),
+}));
+
+/**
+ * Route the production db import at the PGlite worker instance.
+ *
+ * Two adaptations, both mechanical — neither changes which SQL runs:
+ *
+ *   1. `execute` unwraps PGlite's `{ rows, fields, affectedRows }` result to
+ *      the bare rows array that postgres-js (and therefore every production
+ *      call site) returns. Same impedance mismatch `asDbOrTx` documents.
+ *   2. `transaction` is wrapped so a test can land a competing write just
+ *      before it opens, or fail from inside it after the action's writes.
+ */
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  const { discordIntegrationConfig } = await import("~/server/db/schema");
+  const { eq } = await import("drizzle-orm");
+  const testDb = await getTestDb();
+
+  const transaction: typeof testDb.transaction = async (callback, config) => {
+    const competing = testControl.competingWriterVaultId;
+    if (competing !== null) {
+      testControl.competingWriterVaultId = null;
+      await testDb
+        .update(discordIntegrationConfig)
+        .set({ botTokenVaultId: competing })
+        .where(eq(discordIntegrationConfig.id, "singleton"));
+    }
+    return testDb.transaction(async (tx) => {
+      const result = await callback(tx);
+      if (testControl.failInsideTransaction) {
+        throw new Error("simulated in-transaction failure");
+      }
+      return result;
+    }, config);
+  };
+
+  return {
+    db: {
+      query: testDb.query,
+      update: testDb.update.bind(testDb),
+      transaction,
+      execute: async (query: Parameters<typeof testDb.execute>[0]) => {
+        const result = await testDb.execute(query);
+        return result.rows;
+      },
+    },
+  };
+});
+
+// Import the action AFTER the db mock so it binds to PGlite.
+const { saveDiscordConfig } =
+  await import("~/app/(app)/admin/integrations/discord/actions");
+
+// ── Vault stand-in ───────────────────────────────────────────────────────────
+
+/**
+ * supabase_vault 0.3.1's public surface, and nothing beyond it. Deliberately
+ * omits any delete helper — the extension has none, which is the defect this
+ * file exists to catch.
+ */
+async function createVaultStub(): Promise<void> {
+  const db = await getTestDb();
+  await db.execute(sql`CREATE SCHEMA IF NOT EXISTS vault`);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS vault.secrets (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      name text,
+      description text NOT NULL DEFAULT '',
+      secret text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+  await db.execute(sql`
+    CREATE OR REPLACE FUNCTION vault.create_secret(
+      new_secret text,
+      new_name text DEFAULT NULL,
+      new_description text DEFAULT ''
+    ) RETURNS uuid LANGUAGE sql AS $$
+      INSERT INTO vault.secrets (secret, name, description)
+      VALUES (new_secret, new_name, new_description)
+      RETURNING id
+    $$
+  `);
+  await db.execute(sql`
+    CREATE OR REPLACE FUNCTION vault.update_secret(
+      secret_id uuid,
+      new_secret text DEFAULT NULL,
+      new_name text DEFAULT NULL,
+      new_description text DEFAULT NULL
+    ) RETURNS void LANGUAGE sql AS $$
+      UPDATE vault.secrets
+      SET secret = coalesce(new_secret, secret),
+          name = coalesce(new_name, name),
+          description = coalesce(new_description, description),
+          updated_at = now()
+      WHERE id = secret_id
+    $$
+  `);
+}
+
+// `db.execute<T>` constrains T to Record<string, unknown> (a raw row shape),
+// so these extend it rather than being plain interfaces.
+interface VaultRow extends Record<string, unknown> {
+  id: string;
+  secret: string;
+}
+
+interface IdRow extends Record<string, unknown> {
+  id: string;
+}
+
+async function readVaultSecrets(): Promise<VaultRow[]> {
+  const db = await getTestDb();
+  const result = await db.execute<VaultRow>(
+    sql`SELECT id::text AS id, secret FROM vault.secrets ORDER BY created_at`
+  );
+  return result.rows;
+}
+
+async function seedVaultSecret(secret: string): Promise<string> {
+  const db = await getTestDb();
+  const result = await db.execute<IdRow>(
+    sql`INSERT INTO vault.secrets (secret, name) VALUES (${secret}, ${`seed-${randomUUID()}`}) RETURNING id::text AS id`
+  );
+  const id = result.rows[0]?.id;
+  if (id === undefined) throw new Error("failed to seed vault secret");
+  return id;
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ADMIN_USER_ID = randomUUID();
+const VALID_TOKEN =
+  "Bot.Token.1234567890123456789012345678901234567890123456789012345678";
+const ROTATED_TOKEN =
+  "Bot.Rotated.12345678901234567890123456789012345678901234567890123456";
+
+/**
+ * `enabled: "false"` keeps Discord's REST probes out of the picture entirely
+ * (the action only probes when enabling), so these tests exercise nothing but
+ * the Vault + row-write path. A non-empty `newToken` still selects the
+ * create/rotate branch.
+ */
+function makeFormData(newToken: string): FormData {
+  const fd = new FormData();
+  fd.set("enabled", "false");
+  fd.set("newToken", newToken);
+  fd.set("guildId", "123456789012345678");
+  fd.set("inviteLink", "");
+  return fd;
+}
+
+async function seedSingleton(botTokenVaultId: string | null): Promise<void> {
+  const db = await getTestDb();
+  await db.insert(discordIntegrationConfig).values({
+    id: "singleton",
+    enabled: false,
+    botTokenVaultId,
+  });
+}
+
+async function readSingleton(): Promise<{ botTokenVaultId: string | null }> {
+  const db = await getTestDb();
+  const row = await db.query.discordIntegrationConfig.findFirst({
+    where: eq(discordIntegrationConfig.id, "singleton"),
+    columns: { botTokenVaultId: true },
+  });
+  if (!row) throw new Error("singleton row missing");
+  return row;
+}
+
+describe("saveDiscordConfig Vault orphan compensation (real SQL, PGlite)", () => {
+  setupTestDb();
+
+  beforeAll(async () => {
+    await createVaultStub();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    testControl.competingWriterVaultId = null;
+    testControl.failInsideTransaction = false;
+
+    const db = await getTestDb();
+    // vault.secrets lives outside the Drizzle schema, so the shared
+    // FK-graph cleanup doesn't know about it.
+    await db.execute(sql`DELETE FROM vault.secrets`);
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: ADMIN_USER_ID } } });
+    await db.insert(userProfiles).values(
+      createTestUser({
+        id: ADMIN_USER_ID,
+        role: "admin",
+        email: `admin-${ADMIN_USER_ID}@test.com`,
+      })
+    );
+  });
+
+  it("harness self-check: the Vault stand-in has no delete helper, so the old compensation SQL fails here", async () => {
+    const db = await getTestDb();
+    const id = await seedVaultSecret("some-secret");
+
+    // This is the statement that shipped and could never succeed. It must
+    // blow up against the stub exactly as it does against supabase_vault.
+    await expect(
+      db.execute(sql`SELECT vault.delete_secret(${id}::uuid)`)
+    ).rejects.toThrow(/delete_secret/);
+
+    // ...and the row is, of course, still there.
+    expect(await readVaultSecrets()).toHaveLength(1);
+  });
+
+  it("create path: a rolled-back save deletes the secret it just created, and only that one", async () => {
+    // Stand in for prod's single live secret: already stored, and about to be
+    // claimed by a competing admin write. The compensation must not touch it.
+    const referencedId = await seedVaultSecret("pre-existing-live-token");
+    await seedSingleton(null);
+    testControl.competingWriterVaultId = referencedId;
+
+    const result = await saveDiscordConfig(makeFormData(VALID_TOKEN));
+
+    // The competing write means the create-path race guard fires, the
+    // transaction rolls back, and the freshly created secret is orphaned.
+    expect(result.ok).toBe(false);
+
+    const remaining = await readVaultSecrets();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.id).toBe(referencedId);
+    expect(remaining[0]?.secret).toBe("pre-existing-live-token");
+
+    // The singleton still points at the referenced secret — the rollback held
+    // and the compensation did not strand it.
+    expect((await readSingleton()).botTokenVaultId).toBe(referencedId);
+  });
+
+  it("create path: a successful save keeps the new secret and points the singleton at it", async () => {
+    await seedSingleton(null);
+
+    const result = await saveDiscordConfig(makeFormData(VALID_TOKEN));
+    expect(result.ok).toBe(true);
+
+    const stored = await readVaultSecrets();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.secret).toBe(VALID_TOKEN);
+    expect((await readSingleton()).botTokenVaultId).toBe(stored[0]?.id);
+  });
+
+  it("update path: a rolled-back rotation deletes nothing (there is no orphan to undo)", async () => {
+    const existingId = await seedVaultSecret("original-token");
+    await seedSingleton(existingId);
+    testControl.failInsideTransaction = true;
+
+    const result = await saveDiscordConfig(makeFormData(ROTATED_TOKEN));
+    expect(result.ok).toBe(false);
+
+    // The rotation is non-transactional and intentional: the secret stays,
+    // rotated in place, and the singleton still points at it.
+    const stored = await readVaultSecrets();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.id).toBe(existingId);
+    expect(stored[0]?.secret).toBe(ROTATED_TOKEN);
+    expect((await readSingleton()).botTokenVaultId).toBe(existingId);
+  });
+});

--- a/supabase/seed-discord.mjs
+++ b/supabase/seed-discord.mjs
@@ -120,11 +120,13 @@ try {
       }
     } catch (updateError) {
       try {
-        // vault.delete_secret is the inverse of vault.create_secret used
-        // above (pg_vault extension). Best-effort cleanup so we don't leave
-        // an encrypted secret with no DB reference; failure here is logged
-        // but not re-thrown — the original UPDATE error is what matters.
-        await sql`SELECT vault.delete_secret(${vaultId}::uuid)`;
+        // supabase_vault (0.3.1) exposes only create_secret and
+        // update_secret — there is no delete_secret — so deletion is a plain
+        // row DELETE against vault.secrets, scoped to the id we just created.
+        // Best-effort cleanup so we don't leave an encrypted secret with no
+        // DB reference; failure here is logged but not re-thrown — the
+        // original UPDATE error is what matters.
+        await sql`DELETE FROM vault.secrets WHERE id = ${vaultId}::uuid`;
       } catch (cleanupError) {
         console.error(
           "⚠️  Failed to clean up orphaned vault secret",


### PR DESCRIPTION
## What

`saveDiscordConfig`'s create-path orphan compensation ran `SELECT vault.delete_secret(<uuid>)`. **supabase_vault 0.3.1** — the version installed both locally and in `pinpoint-prod` — exposes exactly `create_secret` and `update_secret`. There is no `delete_secret` at any version we run.

The call lives inside a best-effort `try/catch` that logs and swallows, so it never broke a save. It simply failed 100% of the time it fired: every rolled-back create-path save left a stray encrypted secret in `vault.secrets` forever, plus a misleading error in the logs. `supabase/seed-discord.mjs` had the same call and the same wrong "inverse of `vault.create_secret`" comment.

Both now issue `DELETE FROM vault.secrets WHERE id = <uuid>` — the form `drizzle/0059` already uses — scoped to the single id just created. The comments are corrected to say what the extension actually ships.

**Blast radius today: zero.** Prod's vault holds exactly one row (the Discord bot token, correctly referenced by `discord_integration_config.bot_token_vault_id`); the create-plus-rollback combination hasn't happened since the code shipped.

## Why it shipped: the test shape

The covering test mocked `db.execute` wholesale and asserted:

```ts
expect(calls.some((c) => c.includes("delete_secret"))).toBe(true);
```

That asserts on the SQL string *we generate* and never executes it. It could only ever confirm that we still call the nonexistent function — and it would have passed just as happily on a wrong fix. Fixing the SQL while leaving that assertion in place would reproduce the exact blind spot.

Per CORE-TEST-005 this is a query-correctness bug, so both orphan-compensation cases move out of the mock-based suite into `src/test/integration/admin/discord-vault-orphan-cleanup.test.ts`, which routes `~/server/db` at PGlite and **executes every statement for real**, asserting on the surviving `vault.secrets` rows rather than on SQL text.

The Vault stand-in defines exactly supabase_vault's public surface — `vault.secrets`, `create_secret`, `update_secret` — and deliberately nothing else, so a call to a function the real extension lacks fails there exactly as it fails in prod. A "harness self-check" test pins that property so the stub can't quietly lose its teeth.

### Proof the new suite has teeth

| Variant | Result |
| :-- | :-- |
| The fix as written | 4 passed |
| Reverted to `SELECT vault.delete_secret(...)` | ❌ orphan survives (2 rows, expected 1) |
| Unscoped `DELETE FROM vault.secrets` | ❌ the referenced secret dies |

The create-path case provokes its failure from real code — a competing admin write lands between the action's pre-transaction read and its first in-transaction UPDATE, firing the existing race guard — so the rollback and the compensation are both genuine, and the assertion is that the referenced secret survives while the orphan does not.

## Not covered

That the app's DB role holds `DELETE` on `vault.secrets` in production is a grant, not a query, and PGlite has no Supabase role model. It was verified directly against the local and prod stacks under PP-o355.23, and `drizzle/0059` performs the same raw DELETE. This is stated in the new suite's header.

## Testing

`pnpm run check` green; `next build` green; `pnpm run test:integration` green (52 files / 510 tests).

`db:fast-reset`, `test:integration:supabase`, and `smoke` could not run locally — this worktree's Supabase stack refuses to boot (`pgsodium_getkey.sh: /etc/postgresql-custom/pgsodium_root.key: Read-only file system` → `FATAL: invalid secret key`), a host-level condition unrelated to this change. Those failures are all `ECONNREFUSED`. Leaving them to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VypoeEVeXdF7Y3KfyWYeP8