### PR TITLE
feat(pinballmap): tie guard for duplicate same-title cabinets (PP-o355.15)

### DIFF
--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -1104,12 +1104,15 @@ export async function updateMachineAction(
     if (error instanceof MachineNotFoundError) {
       return err("NOT_FOUND", "Machine not found.");
     }
-    // This action cannot touch `initials`, so a duplicate-listing collision is
-    // the only unique violation it can realistically raise — and it had no
-    // catch at all, so it surfaced as a 500 (PP-o355.15). `pbmColumns` is scoped
+    // Matched on the bare code, NOT `isPbmListingConflict`, for the same reason
+    // as the listing actions: this action cannot touch `initials`, so the
+    // one-lister index is the only unique constraint it can violate, and
+    // matching the constraint NAME would put a correctable conflict back to a
+    // 500 on any driver that omits the field. It had no catch at all before, so
+    // the collision surfaced as a 500 (PP-o355.15). `pbmColumns` is scoped
     // inside the try; the submitted title id is the same value and is in scope
     // here.
-    if (isPbmListingConflict(error)) {
+    if (isPgErrorCode(error, "23505")) {
       return err(
         "VALIDATION",
         await pbmListingConflictMessage(validation.data.pinballmapMachineId)

--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -358,6 +358,9 @@ export async function createMachineAction(
         redirectTo: `/m/${machine.initials}`,
       });
     } catch (error: unknown) {
+      // Name-matched rather than bare, unlike the listing actions: create is the
+      // only write that can violate EITHER unique constraint, so it has to tell
+      // them apart. See `isPbmListingConflict` for the tradeoff that buys.
       if (isPbmListingConflict(error)) {
         return err(
           "VALIDATION",
@@ -454,6 +457,8 @@ export async function createMachineAction(
       redirectTo: `/m/${machine.initials}`,
     });
   } catch (error: unknown) {
+    // Name-matched rather than bare — see the forcePromote catch above and
+    // `isPbmListingConflict`.
     if (isPbmListingConflict(error)) {
       return err(
         "VALIDATION",
@@ -698,11 +703,16 @@ export async function updateMachineAction(
           "You do not have permission to link this machine to Pinball Map."
         );
       }
-      // `pinballmapListed` is NOT a form field — it is flipped only by
+      // `pinballmapListed` is not a user-facing field — the edit form renders no
+      // control for it, and it is meant to be flipped only by
       // `linkPinballmapEntryAction` / the verify action, which talk to PBM. The
-      // edit form therefore submits nothing for it, and without this carry-over
+      // form therefore submits nothing for it, and without this carry-over
       // `resolvePbmLinkColumns` would default it to `false` — silently unlisting
       // a listed machine on every unrelated "Save details" (PP-o355.19 review).
+      //
+      // `readPbmLinkFormFields` does still READ the raw field, so a crafted POST
+      // can set it with no PBM interaction at all — PP-o355.29, to close before
+      // PP-o355.21 wires the listing controls up for real.
       // Carry the stored value only while the link target is unchanged;
       // re-targeting the link makes the old listing meaningless, and the
       // resolver already forces `false` on the unlinked/excluded branches.
@@ -1112,10 +1122,16 @@ export async function updateMachineAction(
     // the collision surfaced as a 500 (PP-o355.15). `pbmColumns` is scoped
     // inside the try; the submitted title id is the same value and is in scope
     // here.
-    if (isPgErrorCode(error, "23505")) {
+    //
+    // Gated on `pbmFormPresent`: without the picker on this form no listing
+    // column is written, so a 23505 cannot be the one-lister index. Claiming it
+    // anyway would answer an unrelated unique violation with a confident,
+    // wrong PinballMap message AND skip `serverActionError`'s reporting,
+    // leaving no telemetry for a genuine defect.
+    if (pbmFormPresent && isPgErrorCode(error, "23505")) {
       return err(
         "VALIDATION",
-        await pbmListingConflictMessage(validation.data.pinballmapMachineId)
+        await pbmListingConflictMessage(validation.data.pinballmapMachineId, id)
       );
     }
     return serverActionError(

--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -43,7 +43,10 @@ import {
   proseMirrorDocSchema,
 } from "~/lib/tiptap/types";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
-import { isPgErrorCode } from "~/lib/db/postgres-errors";
+import {
+  isPgErrorCode,
+  getPostgresErrorConstraint,
+} from "~/lib/db/postgres-errors";
 import {
   emitMachineUpdated,
   toMachineOwnerRef,
@@ -194,6 +197,58 @@ function readPbmLinkFormFields(formData: FormData): {
 /**
  * Create Machine Action
  *
+ * Name of the partial unique index enforcing one PinballMap lister per catalog
+ * title at our location (migration 0052). PBM's `POST /location_machine_xrefs`
+ * is find-or-create on `(location_id, machine_id)`, so two cabinets of one title
+ * physically cannot hold distinct lmx rows here.
+ */
+const PBM_LISTED_UNIQUE = "machines_pinballmap_listed_unique";
+
+/**
+ * True when a failed write is specifically a duplicate-listing collision.
+ *
+ * `machines` has TWO unique constraints — `machines_initials_unique` and the
+ * partial listing index — and both raise SQLSTATE 23505. A bare code check
+ * cannot tell them apart, which is why the write paths below used to answer
+ * every 23505 with "Initials are already taken" (PP-o355.15).
+ */
+function isPbmListingConflict(error: unknown): boolean {
+  return (
+    isPgErrorCode(error, "23505") &&
+    getPostgresErrorConstraint(error) === PBM_LISTED_UNIQUE
+  );
+}
+
+/**
+ * Message for a duplicate-listing collision, naming the cabinet that already
+ * holds the listing so the fix is obvious.
+ *
+ * This is a LAST-RESORT path. The tie guard (`resolveListingHolder`) is the
+ * primary defence and stops us choosing when we cannot tell cabinets apart;
+ * this catches what a race can still slip through.
+ */
+async function pbmListingConflictMessage(
+  pinballmapMachineId: number | null | undefined
+): Promise<string> {
+  const incumbent =
+    pinballmapMachineId == null
+      ? undefined
+      : await db.query.machines.findFirst({
+          where: and(
+            eq(machines.pinballmapMachineId, pinballmapMachineId),
+            eq(machines.pinballmapListed, true)
+          ),
+          columns: { name: true, initials: true },
+        });
+
+  const holder = incumbent
+    ? `${incumbent.name} (${incumbent.initials})`
+    : "Another cabinet of this title";
+
+  return `${holder} already holds the PinballMap listing for this title at our location. Only one cabinet per title can hold it — unlist that one first.`;
+}
+
+/**
  * Creates a new machine with validation.
  * Requires authentication (CORE-SEC-001).
  * Validates input with Zod (CORE-SEC-002).
@@ -354,6 +409,12 @@ export async function createMachineAction(
         redirectTo: `/m/${machine.initials}`,
       });
     } catch (error: unknown) {
+      if (isPbmListingConflict(error)) {
+        return err(
+          "VALIDATION",
+          await pbmListingConflictMessage(pbmColumns.pinballmapMachineId)
+        );
+      }
       if (isPgErrorCode(error, "23505")) {
         return err("VALIDATION", `Initials '${initials}' are already taken.`);
       }
@@ -444,6 +505,12 @@ export async function createMachineAction(
       redirectTo: `/m/${machine.initials}`,
     });
   } catch (error: unknown) {
+    if (isPbmListingConflict(error)) {
+      return err(
+        "VALIDATION",
+        await pbmListingConflictMessage(pbmColumns.pinballmapMachineId)
+      );
+    }
     if (isPgErrorCode(error, "23505")) {
       return err("VALIDATION", `Initials '${initials}' are already taken.`);
     }
@@ -1087,6 +1154,17 @@ export async function updateMachineAction(
     }
     if (error instanceof MachineNotFoundError) {
       return err("NOT_FOUND", "Machine not found.");
+    }
+    // This action cannot touch `initials`, so a duplicate-listing collision is
+    // the only unique violation it can realistically raise — and it had no
+    // catch at all, so it surfaced as a 500 (PP-o355.15). `pbmColumns` is scoped
+    // inside the try; the submitted title id is the same value and is in scope
+    // here.
+    if (isPbmListingConflict(error)) {
+      return err(
+        "VALIDATION",
+        await pbmListingConflictMessage(validation.data.pinballmapMachineId)
+      );
     }
     return serverActionError(
       error,

--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -43,10 +43,11 @@ import {
   proseMirrorDocSchema,
 } from "~/lib/tiptap/types";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
+import { isPgErrorCode } from "~/lib/db/postgres-errors";
 import {
-  isPgErrorCode,
-  getPostgresErrorConstraint,
-} from "~/lib/db/postgres-errors";
+  isPbmListingConflict,
+  pbmListingConflictMessage,
+} from "~/lib/pinballmap/listing-conflict";
 import {
   emitMachineUpdated,
   toMachineOwnerRef,
@@ -197,58 +198,6 @@ function readPbmLinkFormFields(formData: FormData): {
 /**
  * Create Machine Action
  *
- * Name of the partial unique index enforcing one PinballMap lister per catalog
- * title at our location (migration 0052). PBM's `POST /location_machine_xrefs`
- * is find-or-create on `(location_id, machine_id)`, so two cabinets of one title
- * physically cannot hold distinct lmx rows here.
- */
-const PBM_LISTED_UNIQUE = "machines_pinballmap_listed_unique";
-
-/**
- * True when a failed write is specifically a duplicate-listing collision.
- *
- * `machines` has TWO unique constraints — `machines_initials_unique` and the
- * partial listing index — and both raise SQLSTATE 23505. A bare code check
- * cannot tell them apart, which is why the write paths below used to answer
- * every 23505 with "Initials are already taken" (PP-o355.15).
- */
-function isPbmListingConflict(error: unknown): boolean {
-  return (
-    isPgErrorCode(error, "23505") &&
-    getPostgresErrorConstraint(error) === PBM_LISTED_UNIQUE
-  );
-}
-
-/**
- * Message for a duplicate-listing collision, naming the cabinet that already
- * holds the listing so the fix is obvious.
- *
- * This is a LAST-RESORT path. The tie guard (`resolveListingHolder`) is the
- * primary defence and stops us choosing when we cannot tell cabinets apart;
- * this catches what a race can still slip through.
- */
-async function pbmListingConflictMessage(
-  pinballmapMachineId: number | null | undefined
-): Promise<string> {
-  const incumbent =
-    pinballmapMachineId == null
-      ? undefined
-      : await db.query.machines.findFirst({
-          where: and(
-            eq(machines.pinballmapMachineId, pinballmapMachineId),
-            eq(machines.pinballmapListed, true)
-          ),
-          columns: { name: true, initials: true },
-        });
-
-  const holder = incumbent
-    ? `${incumbent.name} (${incumbent.initials})`
-    : "Another cabinet of this title";
-
-  return `${holder} already holds the PinballMap listing for this title at our location. Only one cabinet per title can hold it — unlist that one first.`;
-}
-
-/**
  * Creates a new machine with validation.
  * Requires authentication (CORE-SEC-001).
  * Validates input with Zod (CORE-SEC-002).

--- a/src/app/(app)/m/pinballmap-actions.ts
+++ b/src/app/(app)/m/pinballmap-actions.ts
@@ -321,6 +321,21 @@ export async function verifyPinballmapLinkAction(
   if (machine.pinballmapMachineId === null)
     return err("VALIDATION", "Machine isn't linked to a PinballMap title yet");
 
+  // Verify re-checks a listing we HOLD, and an unlisted cabinet holds none.
+  // Without this guard, verifying one would silently LIST it: the schema CHECK
+  // `machines_pinballmap_lmx_requires_listed` forces an unlisted row's
+  // `pinballmapLmxId` to null, so the `lmx.id === machine.pinballmapLmxId`
+  // comparison below can never match and every such verify falls into the heal
+  // branch — which sets `pinballmapListed: true`. Putting a machine on Pinball
+  // Map is a human decision (see `sync.ts`), never a side effect of a
+  // spot-check. Refuse before the sync so a request we will not honour never
+  // spends a manual-refresh slot (CORE-PBM-001).
+  if (!machine.pinballmapListed)
+    return err(
+      "VALIDATION",
+      "This machine isn't listed on Pinball Map, so there's no listing to re-check."
+    );
+
   // Verify means "check right now" — force a fresh sync before resolving. Bail
   // out (rather than resolve against a stale snapshot) if the sync didn't land.
   const sync = await syncLocationSnapshot({
@@ -348,11 +363,12 @@ export async function verifyPinballmapLinkAction(
 
   // Title now maps to a different lmx (PBM re-minted it) — heal the stored handle.
   //
-  // This sets `pinballmapListed: true`, so it can collide with the one-lister
-  // partial unique index exactly like the create/update paths: cabinets A and B
-  // share a title, A is listed and holds the lmx, B is linked but unlisted, and
-  // verifying B heals it onto A's lmx. Without this catch the violation escaped
-  // as a 500 — in the very duplicate-title case PP-o355.15 exists for.
+  // This writes `pinballmapListed`, so the one-lister partial unique index
+  // applies and a violation would escape as a 500 the way it did on the
+  // create/update paths (PP-o355.15). The not-listed guard above closes the
+  // concrete duplicate-cabinet path — reaching here means this machine is
+  // already the sole listed row for its title, so it can only collide with a
+  // concurrent write. Kept as a genuine backstop, not a load-bearing catch.
   try {
     await db.transaction(async (tx) => {
       await tx

--- a/src/app/(app)/m/pinballmap-actions.ts
+++ b/src/app/(app)/m/pinballmap-actions.ts
@@ -33,7 +33,10 @@ import {
 import { findLmxForMachine } from "~/lib/pinballmap/resolve-lmx";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 import { createMachineTimelineEvent } from "~/lib/timeline/machine-events";
-import { isPgErrorCode } from "~/lib/db/postgres-errors";
+import {
+  isPbmListingConflict,
+  pbmListingConflictMessage,
+} from "~/lib/pinballmap/listing-conflict";
 import { type Result, ok, err } from "~/lib/result";
 
 export type { CatalogEdition, CatalogFamily } from "~/lib/pinballmap/catalog";
@@ -262,13 +265,15 @@ export async function linkPinballmapEntryAction(
     });
   } catch (error) {
     // Partial-unique (one lister per title at our location): a duplicate cabinet
-    // of this title is already the lister. Graceful 2nd-cabinet handling is
-    // PP-o355.15; here we surface a clear message rather than a 500.
-    if (isPgErrorCode(error, "23505"))
+    // of this title is already the lister. VALIDATION, not SERVER — the user can
+    // fix it by unlisting the other cabinet, and `SERVER` makes the UI treat a
+    // correctable condition as a crash (PP-o355.15).
+    if (isPbmListingConflict(error)) {
       return err(
-        "SERVER",
-        "Another cabinet of this title is already linked as the PinballMap lister for our location"
+        "VALIDATION",
+        await pbmListingConflictMessage(machine.pinballmapMachineId)
       );
+    }
     throw error;
   }
 
@@ -338,26 +343,42 @@ export async function verifyPinballmapLinkAction(
   if (lmx.id === machine.pinballmapLmxId) return ok({ state: "ok" });
 
   // Title now maps to a different lmx (PBM re-minted it) — heal the stored handle.
-  await db.transaction(async (tx) => {
-    await tx
-      .update(machines)
-      .set({ pinballmapLmxId: lmx.id, pinballmapListed: true })
-      .where(eq(machines.id, machine.id));
-    await createMachineTimelineEvent(
-      machine.id,
-      {
-        sourceType: "lifecycle",
-        tag: "lifecycle",
-        eventData: {
-          kind: "pinballmap_listing",
-          action: "reconnected",
-          lmxId: lmx.id,
+  //
+  // This sets `pinballmapListed: true`, so it can collide with the one-lister
+  // partial unique index exactly like the create/update paths: cabinets A and B
+  // share a title, A is listed and holds the lmx, B is linked but unlisted, and
+  // verifying B heals it onto A's lmx. Without this catch the violation escaped
+  // as a 500 — in the very duplicate-title case PP-o355.15 exists for.
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .update(machines)
+        .set({ pinballmapLmxId: lmx.id, pinballmapListed: true })
+        .where(eq(machines.id, machine.id));
+      await createMachineTimelineEvent(
+        machine.id,
+        {
+          sourceType: "lifecycle",
+          tag: "lifecycle",
+          eventData: {
+            kind: "pinballmap_listing",
+            action: "reconnected",
+            lmxId: lmx.id,
+          },
+          actorId: userId,
         },
-        actorId: userId,
-      },
-      tx
-    );
-  });
+        tx
+      );
+    });
+  } catch (error: unknown) {
+    if (isPbmListingConflict(error)) {
+      return err(
+        "VALIDATION",
+        await pbmListingConflictMessage(machine.pinballmapMachineId)
+      );
+    }
+    throw error;
+  }
 
   revalidatePath(`/m/${machine.initials}`);
   return ok({ state: "healed" });

--- a/src/app/(app)/m/pinballmap-actions.ts
+++ b/src/app/(app)/m/pinballmap-actions.ts
@@ -33,10 +33,8 @@ import {
 import { findLmxForMachine } from "~/lib/pinballmap/resolve-lmx";
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 import { createMachineTimelineEvent } from "~/lib/timeline/machine-events";
-import {
-  isPbmListingConflict,
-  pbmListingConflictMessage,
-} from "~/lib/pinballmap/listing-conflict";
+import { isPgErrorCode } from "~/lib/db/postgres-errors";
+import { pbmListingConflictMessage } from "~/lib/pinballmap/listing-conflict";
 import { type Result, ok, err } from "~/lib/result";
 
 export type { CatalogEdition, CatalogFamily } from "~/lib/pinballmap/catalog";
@@ -268,7 +266,13 @@ export async function linkPinballmapEntryAction(
     // of this title is already the lister. VALIDATION, not SERVER — the user can
     // fix it by unlisting the other cabinet, and `SERVER` makes the UI treat a
     // correctable condition as a crash (PP-o355.15).
-    if (isPbmListingConflict(error)) {
+    //
+    // Matched on the bare code, NOT `isPbmListingConflict`: this write touches
+    // only the listing columns, so the listing index is the sole unique
+    // constraint it can violate — and `getPostgresErrorConstraint` returns
+    // undefined when a driver drops the field, which would send a correctable
+    // condition back to being a 500.
+    if (isPgErrorCode(error, "23505")) {
       return err(
         "VALIDATION",
         await pbmListingConflictMessage(machine.pinballmapMachineId)
@@ -371,7 +375,9 @@ export async function verifyPinballmapLinkAction(
       );
     });
   } catch (error: unknown) {
-    if (isPbmListingConflict(error)) {
+    // Bare code for the same reason as the link path above — this transaction
+    // writes only listing columns, so any 23505 here is the one-lister index.
+    if (isPgErrorCode(error, "23505")) {
       return err(
         "VALIDATION",
         await pbmListingConflictMessage(machine.pinballmapMachineId)

--- a/src/app/(app)/m/pinballmap-actions.ts
+++ b/src/app/(app)/m/pinballmap-actions.ts
@@ -275,7 +275,7 @@ export async function linkPinballmapEntryAction(
     if (isPgErrorCode(error, "23505")) {
       return err(
         "VALIDATION",
-        await pbmListingConflictMessage(machine.pinballmapMachineId)
+        await pbmListingConflictMessage(machine.pinballmapMachineId, machine.id)
       );
     }
     throw error;
@@ -393,10 +393,13 @@ export async function verifyPinballmapLinkAction(
   } catch (error: unknown) {
     // Bare code for the same reason as the link path above — this transaction
     // writes only listing columns, so any 23505 here is the one-lister index.
+    // Exclude self from the incumbent lookup: this machine IS the listed row
+    // for its title (the guard above guarantees it), so an unfiltered lookup
+    // would name it and tell the operator to unlist what they're verifying.
     if (isPgErrorCode(error, "23505")) {
       return err(
         "VALIDATION",
-        await pbmListingConflictMessage(machine.pinballmapMachineId)
+        await pbmListingConflictMessage(machine.pinballmapMachineId, machine.id)
       );
     }
     throw error;

--- a/src/components/machines/PinballmapListingControl.test.tsx
+++ b/src/components/machines/PinballmapListingControl.test.tsx
@@ -101,10 +101,13 @@ describe("PinballmapListingControl", () => {
   });
 
   it("surfaces a failed link's message (non-ABSENT) instead of failing silently", async () => {
+    // Mirrors what the action actually returns for a duplicate-lister
+    // collision since PP-o355.15: VALIDATION (the operator can fix it by
+    // unlisting the other cabinet), naming the incumbent.
     vi.mocked(linkPinballmapEntryAction).mockResolvedValue(
       err(
-        "SERVER",
-        "Another cabinet of this title is already linked as the PinballMap lister for our location"
+        "VALIDATION",
+        "First Godzilla (GZ1) already holds the PinballMap listing for this title at our location. Only one cabinet per title can hold it — unlist that one first."
       )
     );
     render(
@@ -116,7 +119,7 @@ describe("PinballmapListingControl", () => {
     );
 
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/already linked as the pinballmap lister/i);
+    expect(alert).toHaveTextContent(/already holds the pinballmap listing/i);
   });
 
   it("keeps the friendly ABSENT copy (no duplicate alert) when the title isn't on the lineup", async () => {

--- a/src/lib/db/postgres-errors.test.ts
+++ b/src/lib/db/postgres-errors.test.ts
@@ -4,11 +4,26 @@ import {
   isPostgresError,
   getPostgresErrorCode,
   isPgErrorCode,
+  getPostgresErrorConstraint,
 } from "~/lib/db/postgres-errors";
 
 const makeBareError = (code: string): Error => {
   const e = new Error("postgres error") as Error & { code: string };
   e.code = code;
+  return e;
+};
+
+/** postgres-js shape (production): the Postgres wire field name, snake_case. */
+const makeConstraintError = (code: string, constraint: string): Error => {
+  const e = makeBareError(code) as Error & { constraint_name: string };
+  e.constraint_name = constraint;
+  return e;
+};
+
+/** PGlite shape (integration tests): pg-protocol's camelCase naming. */
+const makePgliteConstraintError = (code: string, constraint: string): Error => {
+  const e = makeBareError(code) as Error & { constraint: string };
+  e.constraint = constraint;
   return e;
 };
 
@@ -98,6 +113,67 @@ describe("postgres-errors", () => {
     it("returns false for non-Postgres errors", () => {
       expect(isPgErrorCode(new Error("plain"), "23505")).toBe(false);
       expect(isPgErrorCode(null, "23505")).toBe(false);
+    });
+  });
+
+  describe("getPostgresErrorConstraint", () => {
+    it("reads postgres-js's `constraint_name` (the production driver)", () => {
+      expect(
+        getPostgresErrorConstraint(
+          makeConstraintError("23505", "machines_initials_unique")
+        )
+      ).toBe("machines_initials_unique");
+    });
+
+    it("reads PGlite's `constraint` (every integration test)", () => {
+      // The two drivers genuinely disagree — verified 2026-08-01 against
+      // postgres/src/connection.js:46 and a live PGlite error dump. Reading only
+      // one spelling passes one environment and silently fails the other, which
+      // is exactly how the first attempt at this fix went green in unit tests
+      // and dead in the integration suite.
+      expect(
+        getPostgresErrorConstraint(
+          makePgliteConstraintError("23505", "machines_initials_unique")
+        )
+      ).toBe("machines_initials_unique");
+    });
+
+    it("finds it through the Drizzle cause chain", () => {
+      const wrapped = makeDrizzleWrap(
+        makeConstraintError("23505", "machines_pinballmap_listed_unique")
+      );
+      expect(getPostgresErrorConstraint(wrapped)).toBe(
+        "machines_pinballmap_listed_unique"
+      );
+    });
+
+    it("distinguishes two unique violations that share SQLSTATE 23505", () => {
+      // The whole point: one table, several unique constraints, one code. Code
+      // that assumes which one fired reports the wrong cause (PP-o355.15).
+      const initials = makeConstraintError("23505", "machines_initials_unique");
+      const listing = makeConstraintError(
+        "23505",
+        "machines_pinballmap_listed_unique"
+      );
+
+      expect(isPgErrorCode(initials, "23505")).toBe(true);
+      expect(isPgErrorCode(listing, "23505")).toBe(true);
+      expect(getPostgresErrorConstraint(initials)).not.toBe(
+        getPostgresErrorConstraint(listing)
+      );
+    });
+
+    it("returns undefined when the error carries no constraint name", () => {
+      // Callers must keep a general fallback — not every unique violation names
+      // its constraint.
+      expect(
+        getPostgresErrorConstraint(makeBareError("23505"))
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for non-Postgres errors", () => {
+      expect(getPostgresErrorConstraint(new Error("plain"))).toBeUndefined();
+      expect(getPostgresErrorConstraint(null)).toBeUndefined();
     });
   });
 });

--- a/src/lib/db/postgres-errors.ts
+++ b/src/lib/db/postgres-errors.ts
@@ -62,9 +62,18 @@ export const isPgErrorCode = (error: unknown, code: string): boolean =>
   getPostgresErrorCode(error) === code;
 
 /**
- * The two spellings our two drivers use for the violated constraint's name.
+ * Returns the violated constraint's name, across both driver spellings.
  *
- * **This asymmetry is a live trap, verified 2026-08-01, not a defensive guess:**
+ * **Why a bare 23505 check is not enough.** A table with several unique
+ * constraints reports the same SQLSTATE for all of them, so code that assumes
+ * *which* one fired reports the wrong cause. `machines` has both a unique
+ * `initials` and the partial `machines_pinballmap_listed_unique` (migration
+ * 0052), and the machine write paths used to answer every 23505 with "Initials
+ * are already taken" — actively misleading for a duplicate-listing collision
+ * (PP-o355.15).
+ *
+ * **The two drivers spell the field differently, and that is a live trap
+ * (verified 2026-08-01), not a defensive guess:**
  *
  * - **postgres-js** (production, `src/server/db/index.ts`) maps the Postgres wire
  *   field `n` to **`constraint_name`** — `node_modules/postgres/src/connection.js:46`.
@@ -75,17 +84,6 @@ export const isPgErrorCode = (error: unknown, code: string): boolean =>
  * production, or fails its tests while production works. Both must be read.
  * The same split applies to the other fields (`table_name`/`table`,
  * `column_name`/`column`) if anything ever needs them.
- */
-/**
- * Returns the violated constraint's name, across both driver spellings.
- *
- * **Why a bare 23505 check is not enough.** A table with several unique
- * constraints reports the same SQLSTATE for all of them, so code that assumes
- * *which* one fired reports the wrong cause. `machines` has both a unique
- * `initials` and the partial `machines_pinballmap_listed_unique` (migration
- * 0052), and the machine write paths used to answer every 23505 with "Initials
- * are already taken" — actively misleading for a duplicate-listing collision
- * (PP-o355.15).
  *
  * Returns undefined when absent, so callers must keep a general fallback: not
  * every unique violation carries a name (some arrive from `EXCLUDE` constraints

--- a/src/lib/db/postgres-errors.ts
+++ b/src/lib/db/postgres-errors.ts
@@ -60,3 +60,49 @@ export const getPostgresErrorCode = (error: unknown): string | undefined => {
  */
 export const isPgErrorCode = (error: unknown, code: string): boolean =>
   getPostgresErrorCode(error) === code;
+
+/**
+ * The two spellings our two drivers use for the violated constraint's name.
+ *
+ * **This asymmetry is a live trap, verified 2026-08-01, not a defensive guess:**
+ *
+ * - **postgres-js** (production, `src/server/db/index.ts`) maps the Postgres wire
+ *   field `n` to **`constraint_name`** — `node_modules/postgres/src/connection.js:46`.
+ * - **PGlite** (every integration test) inherits pg-protocol's camelCase naming
+ *   and exposes **`constraint`**, alongside `dataType`, `internalPosition`, etc.
+ *
+ * So a helper reading only one key passes its tests and silently fails in
+ * production, or fails its tests while production works. Both must be read.
+ * The same split applies to the other fields (`table_name`/`table`,
+ * `column_name`/`column`) if anything ever needs them.
+ */
+/**
+ * Returns the violated constraint's name, across both driver spellings.
+ *
+ * **Why a bare 23505 check is not enough.** A table with several unique
+ * constraints reports the same SQLSTATE for all of them, so code that assumes
+ * *which* one fired reports the wrong cause. `machines` has both a unique
+ * `initials` and the partial `machines_pinballmap_listed_unique` (migration
+ * 0052), and the machine write paths used to answer every 23505 with "Initials
+ * are already taken" — actively misleading for a duplicate-listing collision
+ * (PP-o355.15).
+ *
+ * Returns undefined when absent, so callers must keep a general fallback: not
+ * every unique violation carries a name (some arrive from `EXCLUDE` constraints
+ * or through drivers that drop the field).
+ */
+export const getPostgresErrorConstraint = (
+  error: unknown
+): string | undefined => {
+  for (const link of walkCauseChain(error)) {
+    // Checked separately rather than via a key list so `in` narrows each access
+    // — no cast, matching `isPostgresError` above (CORE-TS-007).
+    if ("constraint_name" in link && typeof link.constraint_name === "string") {
+      return link.constraint_name;
+    }
+    if ("constraint" in link && typeof link.constraint === "string") {
+      return link.constraint;
+    }
+  }
+  return undefined;
+};

--- a/src/lib/pinballmap/listing-conflict.ts
+++ b/src/lib/pinballmap/listing-conflict.ts
@@ -1,0 +1,71 @@
+import "server-only";
+import { and, eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { machines } from "~/server/db/schema";
+import {
+  isPgErrorCode,
+  getPostgresErrorConstraint,
+} from "~/lib/db/postgres-errors";
+
+/**
+ * Recognising and explaining a duplicate-listing collision (PP-o355.15).
+ *
+ * Shared by every path that writes `pinballmapListed` — `createMachineAction`,
+ * `updateMachineAction`, `linkPinballmapEntryAction`, and the verify/heal
+ * transaction. They previously disagreed about what the same failure meant
+ * (wrong message / no catch / `SERVER`), which is precisely the drift a single
+ * implementation prevents.
+ */
+
+/**
+ * Name of the partial unique index enforcing one PinballMap lister per catalog
+ * title at our location (migration 0052). PBM's `POST /location_machine_xrefs`
+ * is find-or-create on `(location_id, machine_id)`, so two cabinets of one title
+ * physically cannot hold distinct lmx rows here.
+ */
+const PBM_LISTED_UNIQUE = "machines_pinballmap_listed_unique";
+
+/**
+ * True when a failed write is specifically a duplicate-listing collision.
+ *
+ * `machines` has TWO unique constraints — `machines_initials_unique` and the
+ * partial listing index — and both raise SQLSTATE 23505. A bare code check
+ * cannot tell them apart, which is why the machine write paths used to answer
+ * every 23505 with "Initials are already taken".
+ */
+export function isPbmListingConflict(error: unknown): boolean {
+  return (
+    isPgErrorCode(error, "23505") &&
+    getPostgresErrorConstraint(error) === PBM_LISTED_UNIQUE
+  );
+}
+
+/**
+ * Message for a duplicate-listing collision, naming the cabinet that already
+ * holds the listing so the fix is obvious.
+ *
+ * This is a BACKSTOP. Once auto-link consumes `resolveListingHolder`
+ * (PP-o355.20), that rule is the primary guard and stops us picking when
+ * cabinets are indistinguishable; this catches what a race — or a hand-driven
+ * "list this one" on both cabinets — can still slip through.
+ */
+export async function pbmListingConflictMessage(
+  pinballmapMachineId: number | null | undefined
+): Promise<string> {
+  const incumbent =
+    pinballmapMachineId == null
+      ? undefined
+      : await db.query.machines.findFirst({
+          where: and(
+            eq(machines.pinballmapMachineId, pinballmapMachineId),
+            eq(machines.pinballmapListed, true)
+          ),
+          columns: { name: true, initials: true },
+        });
+
+  const holder = incumbent
+    ? `${incumbent.name} (${incumbent.initials})`
+    : "Another cabinet of this title";
+
+  return `${holder} already holds the PinballMap listing for this title at our location. Only one cabinet per title can hold it — unlist that one first.`;
+}

--- a/src/lib/pinballmap/listing-conflict.ts
+++ b/src/lib/pinballmap/listing-conflict.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { db } from "~/server/db";
 import { machines } from "~/server/db/schema";
 import {
@@ -32,6 +32,18 @@ const PBM_LISTED_UNIQUE = "machines_pinballmap_listed_unique";
  * partial listing index — and both raise SQLSTATE 23505. A bare code check
  * cannot tell them apart, which is why the machine write paths used to answer
  * every 23505 with "Initials are already taken".
+ *
+ * **Only the create paths use this.** They are the only writes that can violate
+ * either constraint, so they have to tell the two apart. Every other listing
+ * write touches listing columns alone, so it matches the bare `23505` instead:
+ * `getPostgresErrorConstraint` returns `undefined` on a driver exposing neither
+ * spelling, and narrowing there would put a correctable conflict back to a 500.
+ * Create pays a different price for that same gap — with no constraint name it
+ * falls through to the initials message, the very misdiagnosis this module
+ * exists to remove. Both drivers we run on supply the field, so the asymmetry is
+ * latent rather than live; closing it needs a "do these initials actually
+ * collide?" lookup to pick the message, which is more machinery than a
+ * hypothetical third driver currently justifies.
  */
 export function isPbmListingConflict(error: unknown): boolean {
   return (
@@ -48,9 +60,17 @@ export function isPbmListingConflict(error: unknown): boolean {
  * (PP-o355.20), that rule is the primary guard and stops us picking when
  * cabinets are indistinguishable; this catches what a race — or a hand-driven
  * "list this one" on both cabinets — can still slip through.
+ *
+ * `excludeMachineId` is the machine the failed write was targeting, when the
+ * caller has one. Without it the lookup can resolve the incumbent to that very
+ * machine — the verify/heal path only ever runs on a machine that already holds
+ * the listing — and the message then tells the operator to unlist the cabinet
+ * they are looking at. The conflict is always with some OTHER row, so exclude
+ * self and fall back to the generic phrasing when nothing else matches.
  */
 export async function pbmListingConflictMessage(
-  pinballmapMachineId: number | null | undefined
+  pinballmapMachineId: number | null | undefined,
+  excludeMachineId?: string
 ): Promise<string> {
   const incumbent =
     pinballmapMachineId == null
@@ -58,7 +78,10 @@ export async function pbmListingConflictMessage(
       : await db.query.machines.findFirst({
           where: and(
             eq(machines.pinballmapMachineId, pinballmapMachineId),
-            eq(machines.pinballmapListed, true)
+            eq(machines.pinballmapListed, true),
+            ...(excludeMachineId === undefined
+              ? []
+              : [ne(machines.id, excludeMachineId)])
           ),
           columns: { name: true, initials: true },
         });

--- a/src/lib/pinballmap/listing-holder.test.ts
+++ b/src/lib/pinballmap/listing-holder.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveListingHolder,
+  findListingTies,
+  type ListingHolderCandidate,
+} from "./listing-holder";
+import type { MachinePresenceStatus } from "~/lib/machines/presence";
+
+function machine(
+  id: string,
+  presenceStatus: MachinePresenceStatus,
+  opts: { listed?: boolean; titleId?: number | null } = {}
+): ListingHolderCandidate {
+  return {
+    id,
+    pinballmapMachineId: opts.titleId === undefined ? 42 : opts.titleId,
+    pinballmapListed: opts.listed ?? false,
+    presenceStatus,
+  };
+}
+
+describe("resolveListingHolder", () => {
+  describe("an existing listing is knowledge — the incumbent wins", () => {
+    it("returns the listed machine, with no tie, however many share its availability", () => {
+      // Three same-title cabinets all on the floor. Without rule 1 this is the
+      // worst possible tie; with it there is no ambiguity at all, because WE
+      // created that lmx and therefore know whose it is.
+      const holder = resolveListingHolder([
+        machine("a", "on_the_floor"),
+        machine("b", "on_the_floor", { listed: true }),
+        machine("c", "on_the_floor"),
+      ]);
+
+      expect(holder).toEqual({ kind: "incumbent", machineId: "b" });
+    });
+
+    it("keeps the incumbent even when a better-ranked cabinet appears", () => {
+      // The listed one is off the floor and an unlisted one is on it. The
+      // incumbent still holds the listing — auto-link must not migrate it.
+      const holder = resolveListingHolder([
+        machine("fresh", "on_the_floor"),
+        machine("incumbent", "off_the_floor", { listed: true }),
+      ]);
+
+      expect(holder).toEqual({ kind: "incumbent", machineId: "incumbent" });
+    });
+
+    it("keeps the incumbent even when its own availability makes Listed invalid", () => {
+      // A listed machine marked `removed` is a §6 matrix problem — a hard flag
+      // the dashboard counts — NOT a tie. It still holds the listing.
+      const holder = resolveListingHolder([
+        machine("gone", "removed", { listed: true }),
+        machine("here", "on_the_floor"),
+      ]);
+
+      expect(holder).toEqual({ kind: "incumbent", machineId: "gone" });
+    });
+  });
+
+  describe("nobody listed — we would have to pick, so the tie rule applies", () => {
+    it("picks the sole machine at the lowest presence rank", () => {
+      const holder = resolveListingHolder([
+        machine("floor", "on_the_floor"),
+        machine("off", "off_the_floor"),
+      ]);
+
+      expect(holder).toEqual({ kind: "candidate", machineId: "floor" });
+    });
+
+    it("stands down when two tie at the lowest rank", () => {
+      const holder = resolveListingHolder([
+        machine("b", "on_the_floor"),
+        machine("a", "on_the_floor"),
+        machine("c", "off_the_floor"),
+      ]);
+
+      // Ids sorted, so callers and snapshots are stable.
+      expect(holder).toEqual({ kind: "tie", machineIds: ["a", "b"] });
+    });
+
+    it("drops availabilities that make Listed invalid before ranking", () => {
+      // `removed` and `pending_arrival` are `invalid` in the §6 matrix, so they
+      // are not candidates at all — leaving one legitimate pick, not a tie.
+      const holder = resolveListingHolder([
+        machine("gone", "removed"),
+        machine("soon", "pending_arrival"),
+        machine("loaned", "on_loan"),
+      ]);
+
+      expect(holder).toEqual({ kind: "candidate", machineId: "loaned" });
+    });
+
+    it("reports none when every machine's availability makes Listed invalid", () => {
+      const holder = resolveListingHolder([
+        machine("gone", "removed"),
+        machine("soon", "pending_arrival"),
+      ]);
+
+      expect(holder).toEqual({ kind: "none" });
+    });
+
+    it("ties only among the valid ones, ignoring invalid cabinets entirely", () => {
+      const holder = resolveListingHolder([
+        machine("x", "on_loan"),
+        machine("y", "on_loan"),
+        machine("dead", "removed"),
+      ]);
+
+      expect(holder).toEqual({ kind: "tie", machineIds: ["x", "y"] });
+    });
+  });
+
+  describe("degenerate inputs", () => {
+    it("reports none for an empty group", () => {
+      expect(resolveListingHolder([])).toEqual({ kind: "none" });
+    });
+
+    it("treats a single valid machine as a candidate, not a tie", () => {
+      expect(resolveListingHolder([machine("only", "on_the_floor")])).toEqual({
+        kind: "candidate",
+        machineId: "only",
+      });
+    });
+  });
+});
+
+describe("findListingTies", () => {
+  it("groups the fleet by catalog title and reports only the tied titles", () => {
+    const ties = findListingTies([
+      // Title 1 — tied, nobody listed.
+      machine("a", "on_the_floor", { titleId: 1 }),
+      machine("b", "on_the_floor", { titleId: 1 }),
+      // Title 2 — has an incumbent, so not a tie.
+      machine("c", "on_the_floor", { titleId: 2, listed: true }),
+      machine("d", "on_the_floor", { titleId: 2 }),
+      // Title 3 — a clear single candidate.
+      machine("e", "on_the_floor", { titleId: 3 }),
+    ]);
+
+    expect(ties).toEqual([{ pinballmapMachineId: 1, machineIds: ["a", "b"] }]);
+  });
+
+  it("ignores unmatched machines, which have no title to contend over", () => {
+    expect(
+      findListingTies([
+        machine("a", "on_the_floor", { titleId: null }),
+        machine("b", "on_the_floor", { titleId: null }),
+      ])
+    ).toEqual([]);
+  });
+
+  it("returns ties ordered by title id, so the report is stable", () => {
+    const ties = findListingTies([
+      machine("c", "on_the_floor", { titleId: 9 }),
+      machine("d", "on_the_floor", { titleId: 9 }),
+      machine("a", "on_the_floor", { titleId: 4 }),
+      machine("b", "on_the_floor", { titleId: 4 }),
+    ]);
+
+    expect(ties.map((t) => t.pinballmapMachineId)).toEqual([4, 9]);
+  });
+
+  it("is empty for a fleet with no duplicate titles", () => {
+    expect(
+      findListingTies([
+        machine("a", "on_the_floor", { titleId: 1 }),
+        machine("b", "on_the_floor", { titleId: 2 }),
+      ])
+    ).toEqual([]);
+  });
+});

--- a/src/lib/pinballmap/listing-holder.test.ts
+++ b/src/lib/pinballmap/listing-holder.test.ts
@@ -22,9 +22,9 @@ function machine(
 describe("resolveListingHolder", () => {
   describe("an existing listing is knowledge — the incumbent wins", () => {
     it("returns the listed machine, with no tie, however many share its availability", () => {
-      // Three same-title cabinets all on the floor. Without rule 1 this is the
-      // worst possible tie; with it there is no ambiguity at all, because WE
-      // created that lmx and therefore know whose it is.
+      // Three same-title cabinets all on the floor. Without the incumbent
+      // branch this is the worst possible tie; with it there is no ambiguity
+      // at all, because WE created that lmx and therefore know whose it is.
       const holder = resolveListingHolder([
         machine("a", "on_the_floor"),
         machine("b", "on_the_floor", { listed: true }),

--- a/src/lib/pinballmap/listing-holder.ts
+++ b/src/lib/pinballmap/listing-holder.ts
@@ -23,9 +23,15 @@ import {
  * point (refresher §7).
  *
  * Pure: no DB, no `server-only`. Auto-link (PP-o355.20), the action layer, and
- * the dashboard all call this rather than re-deriving the rule — two
+ * the dashboard are all meant to call this rather than re-derive the rule — two
  * implementations would drift, and the partial unique index would start
  * rejecting writes one of them believed were legal.
+ *
+ * **No production caller yet.** This module lands ahead of its consumer on
+ * purpose: PP-o355.20 may not set `listed = true` until the rule deciding which
+ * cabinet may hold a listing exists, so the rule ships first. Until auto-link
+ * wires it up, the only thing actually preventing a duplicate listing at runtime
+ * is the 23505 backstop in `./listing-conflict` plus the DB index itself.
  */
 
 /** The fields the rule needs. Deliberately structural, so callers pass rows. */

--- a/src/lib/pinballmap/listing-holder.ts
+++ b/src/lib/pinballmap/listing-holder.ts
@@ -1,0 +1,143 @@
+import {
+  MACHINE_PRESENCE_RANK,
+  type MachinePresenceStatus,
+} from "~/lib/machines/presence";
+
+/**
+ * Which machine may hold a PinballMap listing when several cabinets share one
+ * catalog title (PP-o355.15).
+ *
+ * **Why the rule has to exist.** PBM's `POST /location_machine_xrefs` is
+ * find-or-create on `(location_id, machine_id)` — verified in their source at
+ * `api/v1/location_machine_xrefs_controller.rb:92`. Two PinPoint machines matched
+ * to the same catalog title therefore cannot each own a distinct lmx at our
+ * location; they collapse to a single PBM entry. Migration 0052 mirrors that with
+ * a partial UNIQUE on `pinballmap_machine_id WHERE pinballmap_listed`.
+ *
+ * **What the guard is actually for.** It exists for exactly one reason: we cannot
+ * tell which cabinet PBM's single entry belongs to. Anything that disambiguates
+ * dissolves it — *including a human clicking a button*. So a tie never hides an
+ * action, never raises an alert, and never pauses syncing. It only ever means
+ * **we** decline to choose automatically. A tie with nobody listed is
+ * indistinguishable from "not listed" in the UI, and that invisibility is the
+ * point (refresher §7).
+ *
+ * Pure: no DB, no `server-only`. Auto-link (PP-o355.20), the action layer, and
+ * the dashboard all call this rather than re-deriving the rule — two
+ * implementations would drift, and the partial unique index would start
+ * rejecting writes one of them believed were legal.
+ */
+
+/** The fields the rule needs. Deliberately structural, so callers pass rows. */
+export interface ListingHolderCandidate {
+  id: string;
+  /** Catalog title edition. `null` = unmatched, so no listing to contend over. */
+  pinballmapMachineId: number | null;
+  pinballmapListed: boolean;
+  presenceStatus: MachinePresenceStatus;
+}
+
+/**
+ * Availabilities under which being Listed is **invalid** (refresher §6 matrix).
+ *
+ * These machines are not candidates to *become* the holder. Note the asymmetry:
+ * an incumbent that drifts into one of these keeps its listing — that is a §6
+ * hard flag for the dashboard to count, not a tie (see `resolveListingHolder`).
+ */
+const INVALID_WHEN_LISTED: ReadonlySet<MachinePresenceStatus> = new Set([
+  "pending_arrival",
+  "removed",
+]);
+
+export type ListingHolder =
+  /** Already listed. We created that lmx, so we know whose it is. */
+  | { kind: "incumbent"; machineId: string }
+  /** Nobody listed, exactly one legitimate pick — auto-link may link it. */
+  | { kind: "candidate"; machineId: string }
+  /** Nobody listed, two or more equally good — auto-link stands down. */
+  | { kind: "tie"; machineIds: string[] }
+  /** Nothing eligible to hold a listing at all. */
+  | { kind: "none" };
+
+/**
+ * Decide who may hold the listing for one catalog title.
+ *
+ * Pass every machine sharing a single `pinballmapMachineId`; grouping is the
+ * caller's job (`findListingTies` does it for the whole fleet).
+ */
+export function resolveListingHolder(
+  group: readonly ListingHolderCandidate[]
+): ListingHolder {
+  // Rule 1 — an existing listing is knowledge, so the incumbent wins outright
+  // (Tim, 2026-07-25). No tie, ever, regardless of how many same-title cabinets
+  // share its availability, and regardless of whether its OWN availability has
+  // since drifted into an invalid one: a listed machine marked `removed` is a §6
+  // hard flag, not an ambiguity. The partial unique index guarantees at most one
+  // row can be listed per title, so there is no second case to handle.
+  const incumbent = group.find((m) => m.pinballmapListed);
+  if (incumbent) return { kind: "incumbent", machineId: incumbent.id };
+
+  // Rule 2 — nobody is listed, so we would have to *pick*. Drop the machines
+  // whose availability makes Listed invalid, then rank what remains.
+  const eligible = group.filter(
+    (m) => !INVALID_WHEN_LISTED.has(m.presenceStatus)
+  );
+  if (eligible.length === 0) return { kind: "none" };
+
+  const bestRank = Math.min(
+    ...eligible.map((m) => MACHINE_PRESENCE_RANK[m.presenceStatus])
+  );
+  const atBestRank = eligible.filter(
+    (m) => MACHINE_PRESENCE_RANK[m.presenceStatus] === bestRank
+  );
+
+  const [sole] = atBestRank;
+  if (atBestRank.length === 1 && sole) {
+    return { kind: "candidate", machineId: sole.id };
+  }
+
+  return {
+    kind: "tie",
+    // Sorted so the descriptor is stable across query orderings — callers
+    // compare and render these.
+    machineIds: atBestRank.map((m) => m.id).sort(),
+  };
+}
+
+/** A title where nobody holds the listing and we declined to auto-pick. */
+export interface ListingTie {
+  pinballmapMachineId: number;
+  machineIds: string[];
+}
+
+/**
+ * The reportable condition, across a whole fleet: "no machine holds this listing
+ * and we declined to choose."
+ *
+ * Informational, not urgent — the fleet still works, someone just has to pick.
+ * The admin machine dashboard (PP-o355.7) owns the presentation; this only
+ * exposes the data.
+ */
+export function findListingTies(
+  fleet: readonly ListingHolderCandidate[]
+): ListingTie[] {
+  const byTitle = new Map<number, ListingHolderCandidate[]>();
+  for (const m of fleet) {
+    // Unmatched machines have no title to contend over.
+    if (m.pinballmapMachineId === null) continue;
+    const group = byTitle.get(m.pinballmapMachineId);
+    if (group) group.push(m);
+    else byTitle.set(m.pinballmapMachineId, [m]);
+  }
+
+  const ties: ListingTie[] = [];
+  for (const [pinballmapMachineId, group] of byTitle) {
+    const holder = resolveListingHolder(group);
+    if (holder.kind === "tie") {
+      ties.push({ pinballmapMachineId, machineIds: holder.machineIds });
+    }
+  }
+
+  // Ordered by title id so the report is stable run to run.
+  return ties.sort((a, b) => a.pinballmapMachineId - b.pinballmapMachineId);
+}

--- a/src/lib/pinballmap/listing-holder.ts
+++ b/src/lib/pinballmap/listing-holder.ts
@@ -68,7 +68,7 @@ export type ListingHolder =
 export function resolveListingHolder(
   group: readonly ListingHolderCandidate[]
 ): ListingHolder {
-  // Rule 1 — an existing listing is knowledge, so the incumbent wins outright
+  // INCUMBENT — an existing listing is knowledge, so it wins outright
   // (Tim, 2026-07-25). No tie, ever, regardless of how many same-title cabinets
   // share its availability, and regardless of whether its OWN availability has
   // since drifted into an invalid one: a listed machine marked `removed` is a §6
@@ -77,7 +77,7 @@ export function resolveListingHolder(
   const incumbent = group.find((m) => m.pinballmapListed);
   if (incumbent) return { kind: "incumbent", machineId: incumbent.id };
 
-  // Rule 2 — nobody is listed, so we would have to *pick*. Drop the machines
+  // OPEN CONTEST — nobody is listed, so we would have to *pick*. Drop machines
   // whose availability makes Listed invalid, then rank what remains.
   const eligible = group.filter(
     (m) => !INVALID_WHEN_LISTED.has(m.presenceStatus)

--- a/src/test/integration/pinballmap-link-capture.test.ts
+++ b/src/test/integration/pinballmap-link-capture.test.ts
@@ -320,6 +320,39 @@ describe("verifyPinballmapLinkAction (PGlite)", () => {
     expect(events).toHaveLength(0);
   });
 
+  it("refuses (and does not list) a linked-but-unlisted machine", async () => {
+    // An unlisted row's lmx is null by schema CHECK, so it can never match the
+    // live lmx — without an explicit guard every verify here would fall into
+    // the heal branch and set `pinballmapListed`, putting the machine on
+    // Pinball Map as a side effect of a spot-check.
+    const db = await getTestDb();
+    const { verifyPinballmapLinkAction } =
+      await import("~/app/(app)/m/pinballmap-actions");
+    const admin = await createUser("admin");
+    await mockAuthAs(admin.id);
+    pbm.lineup = [{ id: 900, machineId: 42 }];
+    const machine = await seedMachine({
+      initials: "GZ",
+      pinballmapMachineId: 42,
+      pinballmapListed: false,
+    });
+
+    const res = await verifyPinballmapLinkAction(undefined, fdFor(machine.id));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe("VALIDATION");
+
+    const row = await db.query.machines.findFirst({
+      where: eq(machines.id, machine.id),
+    });
+    expect(row?.pinballmapListed).toBe(false);
+    expect(row?.pinballmapLmxId).toBeNull();
+    const events = await db
+      .select()
+      .from(timelineEvents)
+      .where(eq(timelineEvents.machineId, machine.id));
+    expect(events).toHaveLength(0);
+  });
+
   it("heals the stored lmx when the title now maps to a new id", async () => {
     const db = await getTestDb();
     const { verifyPinballmapLinkAction } =

--- a/src/test/integration/pinballmap-listing-conflict.test.ts
+++ b/src/test/integration/pinballmap-listing-conflict.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration Test: duplicate-listing unique violation backstop (PP-o355.15)
+ *
+ * The partial unique index `machines_pinballmap_listed_unique` (migration 0052)
+ * enforces one PinballMap lister per catalog title at our location, mirroring
+ * PBM's find-or-create on `(location_id, machine_id)`.
+ *
+ * The tie guard (`resolveListingHolder`) is the primary defence — it stops US
+ * choosing when cabinets are indistinguishable. This file covers the LAST-RESORT
+ * path a race can still reach: the write actually hits the index.
+ *
+ * The specific defect: `machines` has TWO unique constraints and both raise
+ * SQLSTATE 23505, so the bare code check in these actions answered a listing
+ * collision with "Initials are already taken" — an actively wrong diagnosis —
+ * while `updateMachineAction` had no catch at all and surfaced a 500.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { getTestDb, setupTestDb } from "~/test/setup/pglite";
+import {
+  machines,
+  userProfiles,
+  authUsers,
+  pinballmapCatalog,
+} from "~/server/db/schema";
+
+vi.mock("~/server/db", async () => {
+  const { getTestDb } = await import("~/test/setup/pglite");
+  return { db: await getTestDb() };
+});
+
+vi.mock("~/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+// Pin the PBM client to the in-memory mock at the seam (CORE-TEST-006).
+vi.mock("~/lib/pinballmap/client", async () => {
+  const { getMockClient } = await import("~/lib/pinballmap/client-mock");
+  return { getPinballMapClient: () => Promise.resolve(getMockClient()) };
+});
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("~/lib/notifications", () => ({
+  planNotification: vi.fn().mockResolvedValue(undefined),
+  dispatchNotification: vi.fn().mockResolvedValue(undefined),
+  getChannels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("~/lib/logger", () => ({
+  log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const TITLE_ID = 7;
+
+async function createAdmin(): Promise<{ id: string }> {
+  const db = await getTestDb();
+  const id = randomUUID();
+  await db.insert(authUsers).values({ id, email: `${id}@example.com` });
+  const [user] = await db
+    .insert(userProfiles)
+    .values({
+      id,
+      email: `${id}@example.com`,
+      firstName: "Test",
+      lastName: "Admin",
+      role: "admin",
+    })
+    .returning();
+  return user;
+}
+
+async function mockAuthAs(userId: string): Promise<void> {
+  const { createClient } = await import("~/lib/supabase/server");
+  vi.mocked(createClient).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: userId } } }),
+    },
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+}
+
+/** Seed the catalog title plus the cabinet that already holds its listing. */
+async function seedIncumbent(): Promise<void> {
+  const db = await getTestDb();
+  await db.insert(pinballmapCatalog).values({
+    pinballmapMachineId: TITLE_ID,
+    name: "Godzilla (Premium)",
+    manufacturer: "Stern",
+    year: 2021,
+  });
+  await db.insert(machines).values({
+    name: "First Godzilla",
+    initials: "GZ1",
+    pinballmapMachineId: TITLE_ID,
+    pinballmapListed: true,
+  });
+}
+
+describe("duplicate PinballMap listing — 23505 backstop (PGlite)", () => {
+  setupTestDb();
+
+  it("names the incumbent cabinet instead of blaming initials", async () => {
+    const { createMachineAction } = await import("~/app/(app)/m/actions");
+    const admin = await createAdmin();
+    await mockAuthAs(admin.id);
+    await seedIncumbent();
+
+    const fd = new FormData();
+    fd.append("name", "Second Godzilla");
+    // Initials are unique and valid — nothing about this request is an initials
+    // problem, which is exactly what the old message claimed.
+    fd.append("initials", "GZ2");
+    fd.append("pinballmapMachineId", String(TITLE_ID));
+    fd.append("pinballmapListed", "on");
+
+    const result = await createMachineAction(undefined, fd);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("VALIDATION");
+    expect(result.message).toContain("First Godzilla");
+    expect(result.message).toContain("GZ1");
+    expect(result.message).not.toContain("Initials");
+  });
+
+  it("still reports a genuine initials collision as an initials problem", async () => {
+    // Regression guard: distinguishing the two constraints must not swallow the
+    // case the original catch existed for.
+    const db = await getTestDb();
+    const { createMachineAction } = await import("~/app/(app)/m/actions");
+    const admin = await createAdmin();
+    await mockAuthAs(admin.id);
+    await db.insert(machines).values({ name: "Taken", initials: "DUP" });
+
+    const fd = new FormData();
+    fd.append("name", "Another");
+    fd.append("initials", "DUP");
+
+    const result = await createMachineAction(undefined, fd);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("VALIDATION");
+    expect(result.message).toContain("Initials");
+    expect(result.message).toContain("DUP");
+  });
+
+  it("updateMachineAction surfaces the collision as VALIDATION, not a 500", async () => {
+    const db = await getTestDb();
+    const { updateMachineAction } = await import("~/app/(app)/m/actions");
+    const admin = await createAdmin();
+    await mockAuthAs(admin.id);
+    await seedIncumbent();
+
+    const [second] = await db
+      .insert(machines)
+      .values({ name: "Second Godzilla", initials: "GZ2" })
+      .returning();
+
+    const fd = new FormData();
+    fd.append("id", second.id);
+    fd.append("name", "Second Godzilla");
+    fd.append("pbmLinkPresent", "1");
+    fd.append("pinballmapMachineId", String(TITLE_ID));
+    fd.append("pinballmapListed", "on");
+
+    const result = await updateMachineAction(undefined, fd);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // The point is that it is a handled validation failure naming the conflict,
+    // not the generic "Failed to update machine" a raw 23505 produced.
+    expect(result.code).toBe("VALIDATION");
+    expect(result.message).toContain("First Godzilla");
+  });
+});

--- a/src/test/integration/pinballmap-listing-conflict.test.ts
+++ b/src/test/integration/pinballmap-listing-conflict.test.ts
@@ -5,9 +5,10 @@
  * enforces one PinballMap lister per catalog title at our location, mirroring
  * PBM's find-or-create on `(location_id, machine_id)`.
  *
- * The tie guard (`resolveListingHolder`) is the primary defence — it stops US
- * choosing when cabinets are indistinguishable. This file covers the LAST-RESORT
- * path a race can still reach: the write actually hits the index.
+ * At head this catch is the ONLY defense. `resolveListingHolder` exists but has
+ * no production caller yet — it becomes the primary guard once auto-link
+ * consumes it (PP-o355.20). Until then, do not read these tests as covering a
+ * backstop behind something else; they cover the whole of it.
  *
  * The specific defect: `machines` has TWO unique constraints and both raise
  * SQLSTATE 23505, so the bare code check in these actions answered a listing


### PR DESCRIPTION
## Summary

Server-side only, no UI. Unblocks PP-o355.20 (auto-link), which may not set `listed = true` until the rule deciding *which* cabinet may hold a listing exists.

**`resolveListingHolder()`** is the single exported source of that rule, so auto-link consumes it rather than re-deriving it — two implementations would drift, and the partial unique index would start rejecting writes one of them believed were legal.

1. **An existing listing is knowledge, so the incumbent wins outright.** We created that lmx, so we know whose it is: no tie, however many same-title cabinets share its availability, and even if the incumbent's *own* availability has drifted into an invalid one (that's a §6 hard flag for the dashboard, not an ambiguity — deliberately kept separate).
2. **Nobody listed** → drop availabilities that make Listed invalid (`pending_arrival`, `removed`), rank the rest by `MACHINE_PRESENCE_RANK`, return either the sole best or a tie descriptor.

A tie only ever means **we** decline to choose. No banner, no hidden actions, no paused syncing — a human clicking "list *this* one" *is* the disambiguation. A tie with nobody listed renders identically to "not listed", and that invisibility is the point (refresher §7).

`findListingTies()` exposes the reportable condition for the admin dashboard (PP-o355.7) without building any page here.

## The 23505 backstop was two real defects, not one

Both reproduced by the new integration test *before* being fixed:

- `machines` has **two** unique constraints and both raise SQLSTATE 23505, so `createMachineAction` answered a duplicate-listing collision with **"Initials are already taken"** — an actively wrong diagnosis for a request whose initials were fine and unique.
- `updateMachineAction` had **no 23505 catch at all**, so the same collision surfaced as a generic 500.

Both now name the cabinet that already holds the listing.

## One thing worth a careful look

`getPostgresErrorConstraint()` reads **both** driver spellings, and that is load-bearing rather than defensive:

- **postgres-js** (production) exposes `constraint_name` — `node_modules/postgres/src/connection.js:46` maps wire field `n`.
- **PGlite** (every integration test) inherits pg-protocol's camelCase and exposes `constraint`.

Reading one spelling passes one environment and silently fails the other. The first cut of this fix did exactly that — green in unit tests, dead in the integration suite — which is how the asymmetry was found. Both are now covered by explicit unit tests.

## Test Plan

- [x] 14 unit tests on `resolveListingHolder` / `findListingTies` across the incumbent/no-incumbent × tie/no-tie matrix, plus degenerate inputs — written before the implementation.
- [x] 6 unit tests on `getPostgresErrorConstraint`, including both driver spellings and the two-constraints-one-SQLSTATE case.
- [x] 3 integration tests (PGlite): the collision names the incumbent, `updateMachineAction` returns VALIDATION not a 500, and a genuine initials collision **still** reports as an initials problem (regression guard).
- [x] `pnpm run preflight` — typecheck, lint, 2024 unit tests, build, 518 integration tests all pass.

**Note on smoke E2E:** preflight's Mobile Safari smoke reports pre-existing `responsive-overflow` failures on `/m/[initials]` tab routes. Bisected to confirm they are **not** from this branch (which touches no UI) and **not** a regression from #1762 — `87552bad`, the commit before #1762 merged, fails *worse* (3 failed vs 1 failed + 2 flaky today). Filed as **PP-h490**, including the reason nobody noticed: Mobile Safari smoke runs only in the post-merge, non-required `test-e2e-comprehensive` job.

## Related Issues

PP-o355.15 (epic PP-o355). Unblocks PP-o355.20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y39wAcWjeH7BKkB8p96eqo