### PR TITLE
fix(mcp): dedupe retried create_issue, report list_machines truncation (PP-u4ab.4)

### DIFF
--- a/src/lib/mcp/tools/create-issue.test.ts
+++ b/src/lib/mcp/tools/create-issue.test.ts
@@ -13,7 +13,14 @@ import { createIssueIdempotencyKey } from "./create-issue";
 
 const USER = "11111111-1111-4111-8111-111111111111";
 const MACHINE = "22222222-2222-4222-8222-222222222222";
-const NOW = 1_770_000_000_000;
+/**
+ * Deliberately *mid*-bucket, not on a boundary. `1_770_000_000_000` is an exact
+ * multiple of the 10-minute window, so a test anchored there always sits at the
+ * start of a bucket and the "a retry seconds later collides" assertion holds
+ * trivially — it would keep passing even if the near-boundary protection
+ * regressed to nothing.
+ */
+const NOW = 1_770_000_000_000 + 100_000;
 
 const base = {
   machine: "AFM",
@@ -72,6 +79,17 @@ describe("createIssueIdempotencyKey", () => {
     // silently resolving to the closed one.
     expect(key({}, NOW + 5_000)).toBe(key());
     expect(key({}, NOW + 30 * 24 * 60 * 60 * 1000)).not.toBe(key());
+  });
+
+  it("does not protect a retry that straddles a window boundary", () => {
+    // Pins a known limitation rather than a guarantee. The window is tumbling,
+    // not sliding, so a call late in one bucket and its retry moments later in
+    // the next produce different keys and file a duplicate. That is the safe
+    // direction to fail — a visible duplicate, honestly reported as created —
+    // and the tool description is worded to match ("usually"), but it must not
+    // silently become the common case.
+    const boundary = 1_770_000_000_000 + 600_000;
+    expect(key({}, boundary - 1_000)).not.toBe(key({}, boundary + 1_000));
   });
 
   it("does not collide when content shifts across the field boundary", () => {

--- a/src/lib/mcp/tools/create-issue.test.ts
+++ b/src/lib/mcp/tools/create-issue.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit test: create_issue idempotency key (PP-u4ab.4)
+ *
+ * The key is what makes a retried MCP call resolve to the issue already filed
+ * instead of a duplicate. It has to hold three properties at once: identical
+ * calls in one window collide, anything else does not, and the output is a
+ * valid `uuid` because that is the column type it lands in.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createIssueIdempotencyKey } from "./create-issue";
+
+const USER = "11111111-1111-4111-8111-111111111111";
+const MACHINE = "22222222-2222-4222-8222-222222222222";
+const NOW = 1_770_000_000_000;
+
+const base = {
+  machine: "AFM",
+  title: "left flipper weak",
+  description: "Barely reaches the ramp.",
+  severity: "major",
+} as const;
+
+function key(
+  overrides: Partial<Parameters<typeof createIssueIdempotencyKey>[0]> = {},
+  now = NOW
+): string {
+  return createIssueIdempotencyKey(
+    { ...base, ...overrides },
+    USER,
+    MACHINE,
+    now
+  );
+}
+
+describe("createIssueIdempotencyKey", () => {
+  it("is a well-formed v8 UUID", () => {
+    // Not cosmetic: issues.idempotency_key is a Postgres `uuid` column, so a
+    // raw hex digest is rejected outright at query time.
+    expect(key()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+  });
+
+  it("is stable for an identical call in the same window", () => {
+    expect(key()).toBe(key());
+  });
+
+  it("differs when any field of the report differs", () => {
+    const original = key();
+    expect(key({ title: "right flipper weak" })).not.toBe(original);
+    expect(key({ description: "Something else." })).not.toBe(original);
+    expect(key({ severity: "minor" })).not.toBe(original);
+    expect(key({ priority: "high" })).not.toBe(original);
+    expect(key({ frequency: "constant" })).not.toBe(original);
+  });
+
+  it("differs per user and per machine", () => {
+    const other = "33333333-3333-4333-8333-333333333333";
+    expect(
+      createIssueIdempotencyKey({ ...base }, other, MACHINE, NOW)
+    ).not.toBe(key());
+    expect(createIssueIdempotencyKey({ ...base }, USER, other, NOW)).not.toBe(
+      key()
+    );
+  });
+
+  it("holds across a retry seconds later but not weeks later", () => {
+    // The window is the whole point: a retry moments later is the same report,
+    // while the same fault re-reported later must file a new issue rather than
+    // silently resolving to the closed one.
+    expect(key({}, NOW + 5_000)).toBe(key());
+    expect(key({}, NOW + 30 * 24 * 60 * 60 * 1000)).not.toBe(key());
+  });
+
+  it("does not collide when content shifts across the field boundary", () => {
+    // NUL-joining is what stops "ab"+"c" hashing the same as "a"+"bc".
+    expect(key({ title: "ab", description: "c" })).not.toBe(
+      key({ title: "a", description: "bc" })
+    );
+  });
+});

--- a/src/lib/mcp/tools/create-issue.ts
+++ b/src/lib/mcp/tools/create-issue.ts
@@ -133,7 +133,7 @@ export async function runCreateIssue(
   // reaching the service (which would otherwise throw a generic not-found).
   const machine = await resolveMachine(args.machine);
 
-  const { issue, deliveryPlan } = await createIssue({
+  const { issue, deliveryPlan, deduped } = await createIssue({
     title: args.title,
     description: args.description ? plainTextToDoc(args.description) : null,
     machineInitials: machine.initials,
@@ -153,6 +153,12 @@ export async function runCreateIssue(
 
   return {
     result: {
+      // Whether this call actually filed something. Dedupe makes "your report
+      // was recorded" and "an identical report already existed and yours was
+      // not written" two different outcomes, and they must not look alike:
+      // reporting the pre-existing issue's number as if it were newly filed is
+      // exactly the success-for-work-not-done shape CORE-ARCH-012 forbids.
+      created: !deduped,
       number: issue.issueNumber,
       title: issue.title,
       machine: machine.initials,
@@ -171,7 +177,7 @@ export function registerCreateIssue(server: McpServer): void {
     {
       title: "Create issue",
       description:
-        "File an issue against a machine (identified by initials or UUID). Requires a title; optional plain-text description, severity (cosmetic/minor/major/unplayable), priority (low/medium/high), and frequency (intermittent/frequent/constant). Attributed to the authenticated admin. Safe to retry: repeating the identical call within a few minutes returns the issue already filed rather than a duplicate.",
+        "File an issue against a machine (identified by initials or UUID). Requires a title; optional plain-text description, severity (cosmetic/minor/major/unplayable), priority (low/medium/high), and frequency (intermittent/frequent/constant). Attributed to the authenticated admin. Retrying an identical call shortly after one usually resolves to the issue already filed instead of a duplicate — check 'created' in the response: false means nothing new was written and 'number' refers to the pre-existing issue, so report it as already filed rather than as a new one.",
       inputSchema: createIssueSchema.shape,
     },
     (args, extra) =>

--- a/src/lib/mcp/tools/create-issue.ts
+++ b/src/lib/mcp/tools/create-issue.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { after } from "next/server";
 import { z } from "zod";
@@ -53,6 +55,72 @@ const createIssueSchema = z.object({
 
 type CreateIssueArgs = z.infer<typeof createIssueSchema>;
 
+/**
+ * How long an identical `create_issue` call is treated as a retry of the same
+ * report rather than a second, deliberate one.
+ *
+ * MCP has no client-supplied idempotency token, so the key is derived from the
+ * call itself: same admin, same machine, same field-for-field content, same
+ * window. A transport-level retry resends byte-identical arguments and lands on
+ * the same key, so the service returns the original issue instead of filing a
+ * duplicate.
+ *
+ * The window is what keeps this from being wrong in the other direction — a
+ * genuine re-report of the same fault weeks later ("left flipper weak" after a
+ * repair regressed) must file a NEW issue, not silently resolve to the old one.
+ * A retry that straddles a window boundary degrades to the previous behaviour
+ * (a duplicate), which is the safe direction to fail.
+ */
+const RETRY_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Content-addressed idempotency key for one create_issue call.
+ *
+ * `issues.idempotency_key` is a Postgres `uuid` column, so the digest is
+ * rendered as a **UUIDv8** — the RFC 9562 version reserved for custom,
+ * implementation-defined layouts, which is what a hash-derived identifier is.
+ * (v4 would misrepresent these bits as random; v5 specifically means SHA-1 over
+ * a namespace.)
+ *
+ * Exported for the unit tests that pin the properties that matter: identical
+ * calls in one window collide, anything else does not, and the output is always
+ * a well-formed v8 UUID.
+ */
+export function createIssueIdempotencyKey(
+  args: CreateIssueArgs,
+  userId: string,
+  machineId: string,
+  now: number
+): string {
+  const parts = [
+    userId,
+    machineId,
+    args.title,
+    args.description ?? "",
+    args.severity ?? "",
+    args.priority ?? "",
+    args.frequency ?? "",
+    String(Math.floor(now / RETRY_WINDOW_MS)),
+  ];
+  // NUL-joined so no field's content can impersonate a boundary between two
+  // others ("ab" + "c" must not hash the same as "a" + "bc").
+  const digest = createHash("sha256").update(parts.join("\u0000")).digest();
+
+  // Take the leading 16 bytes and stamp the version (8) and RFC 4122 variant
+  // bits in place, then render the canonical 8-4-4-4-12 form.
+  const bytes = digest.subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
 export async function runCreateIssue(
   args: CreateIssueArgs,
   ctx: McpAuthContext
@@ -73,8 +141,12 @@ export async function runCreateIssue(
     priority: args.priority,
     frequency: args.frequency,
     reportedBy: ctx.userId,
-    // A fresh key per call: this is a new report, not a retried submission.
-    idempotencyKey: crypto.randomUUID(),
+    idempotencyKey: createIssueIdempotencyKey(
+      args,
+      ctx.userId,
+      machine.id,
+      Date.now()
+    ),
   });
 
   after(() => dispatchNotification(deliveryPlan));
@@ -99,7 +171,7 @@ export function registerCreateIssue(server: McpServer): void {
     {
       title: "Create issue",
       description:
-        "File an issue against a machine (identified by initials or UUID). Requires a title; optional plain-text description, severity (cosmetic/minor/major/unplayable), priority (low/medium/high), and frequency (intermittent/frequent/constant). Attributed to the authenticated admin.",
+        "File an issue against a machine (identified by initials or UUID). Requires a title; optional plain-text description, severity (cosmetic/minor/major/unplayable), priority (low/medium/high), and frequency (intermittent/frequent/constant). Attributed to the authenticated admin. Safe to retry: repeating the identical call within a few minutes returns the issue already filed rather than a duplicate.",
       inputSchema: createIssueSchema.shape,
     },
     (args, extra) =>

--- a/src/lib/mcp/tools/list-machines.ts
+++ b/src/lib/mcp/tools/list-machines.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { and, eq, ilike, or } from "drizzle-orm";
+import { and, count, eq, ilike, or } from "drizzle-orm";
 import { z } from "zod";
 
 import { checkPermission } from "~/lib/permissions/helpers";
@@ -17,6 +17,9 @@ import {
   type ToolOutcome,
 } from "./shared";
 import type { McpAuthContext } from "~/lib/mcp/verify-token";
+
+/** Page size when the caller doesn't ask for one. */
+const DEFAULT_LIMIT = 50;
 
 const listMachinesSchema = z.object({
   search: z
@@ -37,7 +40,9 @@ const listMachinesSchema = z.object({
     .min(1)
     .max(100)
     .optional()
-    .describe("Maximum machines to return (default 50)."),
+    .describe(
+      `Maximum machines to return (default ${DEFAULT_LIMIT}). The response reports the matching 'total' and 'hasMore' so you can tell a full list from a truncated page.`
+    ),
 });
 
 type ListMachinesArgs = z.infer<typeof listMachinesSchema>;
@@ -61,19 +66,30 @@ export async function runListMachines(
     );
   }
 
-  const rows = await db.query.machines.findMany({
-    where: conditions.length > 0 ? and(...conditions) : undefined,
-    columns: {
-      id: true,
-      initials: true,
-      name: true,
-      presenceStatus: true,
-      ownerId: true,
-      invitedOwnerId: true,
-    },
-    orderBy: (m, { asc }) => [asc(m.name)],
-    limit: args.limit ?? 50,
-  });
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const limit = args.limit ?? DEFAULT_LIMIT;
+
+  // Count alongside the page so the caller can tell a complete answer from a
+  // truncated one. Without this a 50-machine page of a 120-machine collection
+  // reads as "there are 50", and the model answers "how many are off the floor"
+  // wrongly with no way to know it was cut off (CORE-ARCH-012 honest failure).
+  const [rows, totalRows] = await Promise.all([
+    db.query.machines.findMany({
+      where,
+      columns: {
+        id: true,
+        initials: true,
+        name: true,
+        presenceStatus: true,
+        ownerId: true,
+        invitedOwnerId: true,
+      },
+      orderBy: (m, { asc }) => [asc(m.name)],
+      limit,
+    }),
+    db.select({ value: count() }).from(machines).where(where),
+  ]);
+  const total = totalRows[0]?.value ?? 0;
 
   const [ownerNames, openCounts] = await Promise.all([
     getOwnerNamesByMachine(rows),
@@ -88,7 +104,14 @@ export async function runListMachines(
     openIssues: openCounts.get(r.initials) ?? 0,
   }));
 
-  return { result: { count: machineList.length, machines: machineList } };
+  return {
+    result: {
+      count: machineList.length,
+      total,
+      hasMore: total > machineList.length,
+      machines: machineList,
+    },
+  };
 }
 
 export function registerListMachines(server: McpServer): void {
@@ -97,7 +120,7 @@ export function registerListMachines(server: McpServer): void {
     {
       title: "List machines",
       description:
-        "List machines with their initials, name, availability, owner name, and open-issue count. Use this to find a machine's initials before acting on it (e.g. disambiguate 'the Medieval Madness by the door'). Supports a name/initials search and a presence filter.",
+        "List machines with their initials, name, availability, owner name, and open-issue count. Use this to find a machine's initials before acting on it (e.g. disambiguate 'the Medieval Madness by the door'). Supports a name/initials search and a presence filter. Returns 'count' (this page), 'total' (all matches), and 'hasMore' — when hasMore is true the list is truncated, so narrow it with search/presence or raise limit before answering a counting question.",
       inputSchema: listMachinesSchema.shape,
     },
     (args, extra) =>

--- a/src/lib/mcp/tools/list-machines.ts
+++ b/src/lib/mcp/tools/list-machines.ts
@@ -41,7 +41,15 @@ const listMachinesSchema = z.object({
     .max(100)
     .optional()
     .describe(
-      `Maximum machines to return (default ${DEFAULT_LIMIT}). The response reports the matching 'total' and 'hasMore' so you can tell a full list from a truncated page.`
+      `Maximum machines to return (default ${DEFAULT_LIMIT}, max 100). The response reports the matching 'total' and 'hasMore' so you can tell a full list from a truncated page.`
+    ),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe(
+      "How many matches to skip, for paging past the limit. Machines are ordered by name, so a stable full listing is offset 0, then offset+limit until 'hasMore' is false."
     ),
 });
 
@@ -68,6 +76,7 @@ export async function runListMachines(
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
   const limit = args.limit ?? DEFAULT_LIMIT;
+  const offset = args.offset ?? 0;
 
   // Count alongside the page so the caller can tell a complete answer from a
   // truncated one. Without this a 50-machine page of a 120-machine collection
@@ -86,6 +95,7 @@ export async function runListMachines(
       },
       orderBy: (m, { asc }) => [asc(m.name)],
       limit,
+      offset,
     }),
     db.select({ value: count() }).from(machines).where(where),
   ]);
@@ -108,7 +118,8 @@ export async function runListMachines(
     result: {
       count: machineList.length,
       total,
-      hasMore: total > machineList.length,
+      offset,
+      hasMore: offset + machineList.length < total,
       machines: machineList,
     },
   };
@@ -120,7 +131,7 @@ export function registerListMachines(server: McpServer): void {
     {
       title: "List machines",
       description:
-        "List machines with their initials, name, availability, owner name, and open-issue count. Use this to find a machine's initials before acting on it (e.g. disambiguate 'the Medieval Madness by the door'). Supports a name/initials search and a presence filter. Returns 'count' (this page), 'total' (all matches), and 'hasMore' — when hasMore is true the list is truncated, so narrow it with search/presence or raise limit before answering a counting question.",
+        "List machines with their initials, name, availability, owner name, and open-issue count. Use this to find a machine's initials before acting on it (e.g. disambiguate 'the Medieval Madness by the door'). Supports a name/initials search and a presence filter. Returns 'count' (this page), 'total' (every match), 'offset', and 'hasMore'. Answer counting questions from 'total', never from 'count' or the array length. To enumerate a collection larger than one page, keep requesting with offset += limit until hasMore is false — raising limit alone caps at 100 and will not reach the rest.",
       inputSchema: listMachinesSchema.shape,
     },
     (args, extra) =>

--- a/src/test/integration/mcp-tools.test.ts
+++ b/src/test/integration/mcp-tools.test.ts
@@ -155,6 +155,38 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
       expect(result.hasMore).toBe(true);
     });
 
+    it("pages past the limit with offset until hasMore clears (PP-u4ab.4)", async () => {
+      const admin = await makeUser("admin");
+      for (const name of ["Page A", "Page B", "Page C"]) {
+        await seedMachine({ name });
+      }
+
+      interface Page {
+        count: number;
+        total: number;
+        hasMore: boolean;
+      }
+      const first = (
+        await runListMachines(
+          { search: "Page", limit: 2, offset: 0 },
+          ctx("admin", admin)
+        )
+      ).result as Page;
+      const second = (
+        await runListMachines(
+          { search: "Page", limit: 2, offset: 2 },
+          ctx("admin", admin)
+        )
+      ).result as Page;
+
+      expect(first.hasMore).toBe(true);
+      // The last page must report hasMore false even though total > count —
+      // otherwise an enumerating caller loops forever.
+      expect(second.count).toBe(1);
+      expect(second.total).toBe(3);
+      expect(second.hasMore).toBe(false);
+    });
+
     it("reports hasMore false when the page holds every match", async () => {
       const admin = await makeUser("admin");
       await seedMachine({ name: "Complete Alpha" });
@@ -411,6 +443,13 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
       // A transport-level retry resends identical arguments; it must resolve to
       // the issue already filed rather than a second one.
       expect(second.issueId).toBe(first.issueId);
+
+      // ...and it must SAY so. Reporting the pre-existing issue's number with
+      // no signal that nothing was written is the success-for-work-not-done
+      // shape CORE-ARCH-012 forbids — the caller would tell a member their
+      // second report was logged when it was dropped.
+      expect((first.result as { created: boolean }).created).toBe(true);
+      expect((second.result as { created: boolean }).created).toBe(false);
 
       const db = await getTestDb();
       const rows = await db

--- a/src/test/integration/mcp-tools.test.ts
+++ b/src/test/integration/mcp-tools.test.ts
@@ -131,6 +131,48 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
       expect(result.machines[0]?.owner).toBe("Pat Owner");
       expect(result.machines[0]?.openIssues).toBe(1);
     });
+
+    it("reports total and hasMore when the page is truncated (PP-u4ab.4)", async () => {
+      const admin = await makeUser("admin");
+      for (const name of ["Truncate A", "Truncate B", "Truncate C"]) {
+        await seedMachine({ name });
+      }
+
+      const outcome = await runListMachines(
+        { search: "Truncate", limit: 2 },
+        ctx("admin", admin)
+      );
+      const result = outcome.result as {
+        count: number;
+        total: number;
+        hasMore: boolean;
+      };
+
+      // The bug this pins: `count` alone reads as "there are 2", which is how a
+      // 100+ machine collection gets miscounted from a 50-row page.
+      expect(result.count).toBe(2);
+      expect(result.total).toBe(3);
+      expect(result.hasMore).toBe(true);
+    });
+
+    it("reports hasMore false when the page holds every match", async () => {
+      const admin = await makeUser("admin");
+      await seedMachine({ name: "Complete Alpha" });
+
+      const outcome = await runListMachines(
+        { search: "Complete Alpha" },
+        ctx("admin", admin)
+      );
+      const result = outcome.result as {
+        count: number;
+        total: number;
+        hasMore: boolean;
+      };
+
+      expect(result.count).toBe(1);
+      expect(result.total).toBe(1);
+      expect(result.hasMore).toBe(false);
+    });
   });
 
   describe("get_machine", () => {
@@ -351,6 +393,53 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
       await expect(
         runCreateIssue({ machine: "NOPE", title: "x" }, ctx("admin", admin))
       ).rejects.toBeInstanceOf(McpToolError);
+    });
+
+    it("returns the original issue when an identical call is retried (PP-u4ab.4)", async () => {
+      const admin = await makeUser("admin");
+      const machine = await seedMachine();
+      const args = {
+        machine: machine.initials,
+        title: "right flipper sticking",
+        description: "Sticks on multiball.",
+        severity: "major",
+      } as const;
+
+      const first = await runCreateIssue({ ...args }, ctx("admin", admin));
+      const second = await runCreateIssue({ ...args }, ctx("admin", admin));
+
+      // A transport-level retry resends identical arguments; it must resolve to
+      // the issue already filed rather than a second one.
+      expect(second.issueId).toBe(first.issueId);
+
+      const db = await getTestDb();
+      const rows = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.machineInitials, machine.initials));
+      expect(rows).toHaveLength(1);
+    });
+
+    it("files a separate issue when the content differs", async () => {
+      const admin = await makeUser("admin");
+      const machine = await seedMachine();
+
+      const first = await runCreateIssue(
+        { machine: machine.initials, title: "left flipper weak" },
+        ctx("admin", admin)
+      );
+      const second = await runCreateIssue(
+        { machine: machine.initials, title: "right flipper weak" },
+        ctx("admin", admin)
+      );
+
+      expect(second.issueId).not.toBe(first.issueId);
+      const db = await getTestDb();
+      const rows = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.machineInitials, machine.initials));
+      expect(rows).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
Closes the two real findings from the PR #1707 review of the MCP tool surface, and records the other two as non-defects rather than hardening against bugs that don't exist.

## What was actually wrong

**`create_issue` could never dedupe a retry.** It built a fresh `randomUUID()` on every call, so the service's idempotency check had nothing to match on and a transport-level retry filed a second issue. The key is now derived from the call itself — admin, machine, every content field, and a 10-minute window.

The window is what keeps this honest in both directions. A retry moments later is the same report; the same fault re-reported weeks later (a repair that regressed) must open a **new** issue rather than silently resolving to the closed one. A retry straddling a window boundary degrades to the old behaviour — a duplicate — which is the safe way to fail.

**`list_machines` answered counting questions wrongly and confidently.** `count` was the length of the page, so a 50-row page of a 120-machine collection read as "there are 50" with no signal it was truncated (CORE-ARCH-012). It now reports `total` and `hasMore` beside `count`, and the tool description tells the model to narrow the filter or raise the limit before answering a counting question.

## The thing only a real database could tell us

`issues.idempotency_key` is a Postgres `uuid` column — which is *why* the original code reached for `randomUUID()`. The first attempt passed a hex digest and failed at query time with `invalid input syntax for type uuid`. The digest is now rendered as a **UUIDv8**, the RFC 9562 version reserved for custom layouts: v4 would misrepresent these bits as random, and v5 specifically means SHA-1 over a namespace.

This surfaced only because the work was probed against a live local MCP endpoint. Unit tests alone would have sailed past it.

## Findings closed as non-defects

- **`after()` is valid inside an mcp-handler tool context.** Probing `create_issue` on local dev returned ok *and* delivered real notification emails to Mailpit (2 → 4), so the mutation commits and post-commit dispatch runs. No fix needed.
- **Audience binding** is moot after the bearer-token pivot — there is no third-party issuer to confuse — and the **cached claims client** it referenced was deleted with the OAuth code in #1727.

## Testing

- 6 new unit tests on the key builder: v8 UUID shape, stability, per-field and per-actor divergence, window behaviour, and NUL-join boundary safety.
- 4 new integration tests: truncated vs complete pages, retry-returns-original, different-content-files-new. `mcp-tools.test.ts` goes 15 → 19.
- `pnpm run check` green.
- Live-verified on a local dev MCP endpoint: identical call twice → same issue number, one row; different title → new issue. `list_machines` → `{count: 3, total: 10, hasMore: true}`.

**`pnpm run preflight` did not run locally** — the memory precheck hard-blocked it (8.5 GB swap in use from concurrent sessions, over the 6.5 GB threshold), and forcing past that gate on a 16 GB machine risks a lockup. CI runs the full suite.

Bead: PP-u4ab.4. PP-u4ab.3 (rate limiting) stays open — separate concern, deliberately not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRcP4Qx71VYNT2AtDq1fzf