### PR TITLE
docs(agents): cut the security corpus to its decisions (PP-22e4)

### DIFF
--- a/.agents/skills/pinpoint-security/SKILL.md
+++ b/.agents/skills/pinpoint-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-security
-description: The security choices PinPoint made that its own code does not state — which modules may touch `@supabase/ssr` directly, the CSP authoring posture and what is already allowlisted, what counts as a non-gating role comparison under the `permissions-audit-allow` contract, the multi-provider OAuth registry and unlink guard, the shared `sanitize-html` allowlist, and the `~/lib/url` seam (`getSiteUrl` / `requireSiteUrl` / `resolveRequestUrl` / `isInternalUrl` / `getSafeRedirect`) that makes hand-rolled `process.env` URL building a bug. Use when writing a redirect, an absolute URL in an email or webhook, a CSP change, an OAuth flow, a sanitizer, or a permission gate. The enforced rules themselves are `CORE-SEC-*` / `CORE-SSR-*` in `docs/NON_NEGOTIABLES.md`; recorded threat-model decisions are in `docs/SECURITY.md`.
+description: The security choices PinPoint made that its own code does not state — which modules may touch `@supabase/ssr` directly, the CSP authoring posture and what is already allowlisted, what counts as a non-gating role comparison under the `permissions-audit-allow` contract, the multi-provider OAuth registry and unlink guard, the shared `sanitize-html` allowlist, and the `~/lib/url` seam (`getSiteUrl` / `requireSiteUrl` / `resolveRequestUrl` / `isInternalUrl` / `getSafeRedirect`) that makes hand-rolled `process.env` URL building a bug. Use when creating a Supabase server client, writing a Server Action's auth check, a redirect, an absolute URL in an email or webhook, a CSP change, an OAuth flow, a sanitizer, or a permission gate. The enforced rules themselves are `CORE-SEC-*` / `CORE-SSR-*` in `docs/NON_NEGOTIABLES.md`; recorded threat-model decisions are in `docs/SECURITY.md`.
 ---
 
 # PinPoint Security
@@ -47,6 +47,13 @@ or enforces authorization** is forbidden outright and must go through
 behaviour are allowed with an annotation — SQL/query row filtering (an `isAdmin`
 flag driving a `where` clause), UI display flags and badges, business-logic
 preconditions.
+
+**`getRawPermissionValue` is introspection-only.** It returns the raw matrix
+entry — `boolean | "own" | "owner" | "own_or_owner"` — so every conditional
+value is truthy. Using it as a gate (`if (getRawPermissionValue(...))`) grants
+access to everyone at that access level. Reach for it only to choose between
+two UI states; actual access decisions go through `checkPermission()` /
+`getPermissionState()`.
 
 **There are no permission React hooks.** The helpers in
 `src/lib/permissions/helpers.ts` are pure, so client components call them

--- a/.agents/skills/pinpoint-security/SKILL.md
+++ b/.agents/skills/pinpoint-security/SKILL.md
@@ -1,157 +1,73 @@
 ---
 name: pinpoint-security
-description: Security patterns, CSP nonces, input validation, auth checks, Supabase SSR patterns. Also site-URL construction and open-redirect prevention — `getSiteUrl` / `requireSiteUrl` / `resolveRequestUrl` / `isInternalUrl` / `getSafeRedirect` from `~/lib/url`, and why hand-rolled `process.env` URL building is banned. Use when implementing authentication, forms, redirects, absolute URLs in emails or webhooks, or security features, or when user mentions security/validation/auth/redirect/site URL.
+description: The security choices PinPoint made that its own code does not state — which modules may touch `@supabase/ssr` directly, the CSP authoring posture and what is already allowlisted, what counts as a non-gating role comparison under the `permissions-audit-allow` contract, the multi-provider OAuth registry and unlink guard, the shared `sanitize-html` allowlist, and the `~/lib/url` seam (`getSiteUrl` / `requireSiteUrl` / `resolveRequestUrl` / `isInternalUrl` / `getSafeRedirect`) that makes hand-rolled `process.env` URL building a bug. Use when writing a redirect, an absolute URL in an email or webhook, a CSP change, an OAuth flow, a sanitizer, or a permission gate. The enforced rules themselves are `CORE-SEC-*` / `CORE-SSR-*` in `docs/NON_NEGOTIABLES.md`; recorded threat-model decisions are in `docs/SECURITY.md`.
 ---
 
-# PinPoint Security Guide
+# PinPoint Security
 
-## When to Use This Skill
+The enforced rules live in `docs/NON_NEGOTIABLES.md` (`CORE-SEC-*`, `CORE-SSR-*`,
+`CORE-ARCH-008`) and are checked by `pnpm run check`. This skill carries only the
+decisions behind them.
 
-Use this skill when:
+## Which modules may touch `@supabase/ssr` (CORE-SSR-001)
 
-- Implementing authentication or authorization checks.
-- Creating forms, validating user inputs, or handling FormData.
-- Setting up or modifying security headers (CSP, HSTS, X-Frame-Options, etc.).
-- Working with Supabase SSR authentication (Server Components, Server Actions, API routes, or Middleware).
-- Implementing or modifying OAuth login/linking flows (e.g., Discord OAuth).
-- Performing or verifying permission checks in pages, layouts, server actions, or client components.
-- The user mentions: "security", "auth", "validation", "XSS", "CSRF", "input", "forms", "permissions", "roles", "CSP", "Discord".
-
----
-
-## Quick Reference
-
-### Critical Security Rules
-
-1. **Permissions Go Through the Matrix (CORE-ARCH-008)**: All permission checks that gate a request or enforce authorization MUST go through `checkPermission()` / `getPermissionState()` from `~/lib/permissions/helpers` — these are pure functions, so the same helpers run in Server Components, Server Actions, and Client Components (there are no permission React hooks). Hardcoded role checks (e.g., `role === "admin"`) as auth gates are strictly forbidden. Limited role comparisons are allowed for non-gating logic — SQL/query row filtering (e.g., an `isAdmin` flag driving a `where` clause), UI display flags/badges, business-logic preconditions — but each such usage must be annotated with `// permissions-audit-allow: <reason>` so the matrix audit recognizes the exception. The matrix at `src/lib/permissions/matrix.ts` is the single source of truth and must remain perfectly synced with actual enforcement.
-2. **Supabase SSR Contract (CORE-SSR-001/002)**: Use `~/lib/supabase/server`'s `createClient()` for user-scoped server work. Always call `await supabase.auth.getUser()` immediately after client creation, with **no logic in between**. Do not hand-build a user-scoped SSR client from `@supabase/supabase-js` — go through `~/lib/supabase/server`. Importing types or specific utilities from `@supabase/supabase-js` is fine, and `src/lib/supabase/admin.ts` legitimately uses `createClient` from `@supabase/supabase-js` to build the server-only, service-role admin client.
-3. **Validate ALL Inputs (CORE-SEC-002)**: Use Zod for all form data and user inputs. Never trust `FormData` or query parameters without validation.
-4. **CSP with Nonces (CORE-SEC-003/004)**: Dynamic nonces are generated via `middleware.ts` for script execution. Do not use `'unsafe-inline'` or `'unsafe-eval'` for scripts. Static security headers are set in `next.config.ts`.
-5. **PII and Email Privacy (CORE-SEC-007)**: Email addresses are PII. Display user emails only in admin views and the user's own settings page. Everywhere else: names, "Anonymous", or roles.
-6. **Host Consistency (CORE-SEC-008)**: Use `localhost` for all local URLs, config, `.env*`, and Playwright `baseURL`. Mixing `localhost` and `127.0.0.1` breaks cookies and SSR auth.
-
----
-
-## 1. Authentication & Supabase SSR
-
-### Server Client Creation (CORE-SSR-001)
+Nothing enforces this — it is a convention with a short allowlist, so it is worth
+stating.
 
 Always import and use the custom client creator from `~/lib/supabase/server`. Only a small allowlist of **non-test** modules touches `@supabase/ssr` directly: `src/lib/supabase/server.ts` (the SSR wrapper itself), `src/lib/supabase/middleware.ts` (token refresh in `updateSession`), and `src/app/(auth)/auth/callback/route.ts` (custom cookie handling so OAuth tokens are written to the response). App code outside this allowlist must go through `~/lib/supabase/server`. (Tests may mock `@supabase/ssr` — e.g. `src/lib/supabase/middleware.test.ts` — which is fine.)
 
-### Immediate `getUser` Check (CORE-SSR-002)
+`src/lib/supabase/admin.ts` legitimately builds the server-only, service-role
+admin client from `@supabase/supabase-js`; importing types or specific utilities
+from that package is also fine.
 
-To prevent timing and token invalidation issues, `await supabase.auth.getUser()` must be the very next line after client instantiation.
+The `auth.users` ban (CORE-SSR-007) has one workaround worth knowing: to look up
+an auth record by email — e.g. detecting an orphaned `auth.users` row after a
+trigger failure — use `createAdminClient().auth.admin.listUsers(...)` and filter
+in JS rather than querying the table.
 
-**Correct Pattern (Server Action or Route):**
+## CSP authoring (CORE-SEC-003/004)
 
-```typescript
-const supabase = await createClient();
-const {
-  data: { user },
-} = await supabase.auth.getUser(); // Called immediately!
-if (!user) redirect("/login");
-```
-
-### Middleware Token Refresh (CORE-SSR-003, CORE-SSR-005)
-
-Token refresh is managed automatically in `middleware.ts` (at the repo root — not `src/middleware.ts`) via `updateSession(request)` (implemented in `src/lib/supabase/middleware.ts`). This function invokes `supabase.auth.getUser()` to refresh expired tokens and updates response cookies for the browser.
-
-Return the response object from `updateSession` as-is (CORE-SSR-005). Don't mutate, rewrap, or copy headers into a fresh `NextResponse` — that strips the `Set-Cookie` headers that carry refreshed session tokens, and the next request will see an anonymous user.
-
-### CSP Authoring (CORE-SEC-003/004)
-
-The root `middleware.ts` also sets the Content-Security-Policy. Things to know before modifying it:
+The root `middleware.ts` sets the Content-Security-Policy. Things to know before modifying it:
 
 - **`script-src` posture**: production is nonce-only — `'self' 'nonce-<uuid>' 'strict-dynamic'`, no host allowlist. Preview adds `https://vercel.live` and `https://challenges.cloudflare.com` for the Vercel toolbar and Turnstile widget. Never add `'unsafe-inline'` or `'unsafe-eval'`.
 - **Per-request nonce**: `middleware.ts` calls `crypto.randomUUID()` and sets the nonce on `Content-Security-Policy` (`'nonce-<uuid>'`) plus an `x-nonce` response header. The `x-nonce` header is set for any inline-script use case; there is no consumer in `src/` today, so if you add an inline `<script>` you must read `x-nonce` yourself and set the `nonce` attribute.
 - **Already allowlisted**: `challenges.cloudflare.com` (Turnstile CAPTCHA) — in `connect-src` and `frame-src` in both branches, and additionally in `script-src` only on preview. Supabase URL + WS URL in `connect-src`. Note `connect-src` allows both `localhost:*` and `127.0.0.1:*` in **both** branches (production included), so don't describe that as dev-only.
 - **Adding a new external host**: add to the appropriate directive in the production branch first, mirror to the preview branch only if needed. Default to deny.
 
-### Auth Callback Route (CORE-SSR-004)
+Why `'strict-dynamic'` is there, and the gaps the header set does not cover, are
+in `docs/SECURITY.md`.
 
-The OAuth flow redirects through `src/app/(auth)/auth/callback/route.ts` which handles the code-to-session exchange (`exchangeCodeForSession`) and OTP verification (`verifyOtp`).
-
-### Database Profile Trigger (CORE-SSR-006)
-
-Never create user profiles manually in Server Actions. Profiles are created atomically via the `handle_new_user` SQL trigger on `auth.users` insert, ensuring compatibility with all auth methods including OAuth.
-
-### Don't Query `auth.users` Directly (CORE-SSR-007)
-
-Application code reads user data from `user_profiles` (mirrored from `auth.users` via the `handle_new_user` trigger). Do not write Drizzle queries or raw SQL against `auth.users` in Server Actions, services, or route handlers — the schema is internal to Supabase and can change between releases. If you need to look up an auth record by email (e.g., detecting an orphaned `auth.users` row after a trigger failure), use the Supabase Admin API: `createAdminClient().auth.admin.listUsers(...)` and filter in JS.
-
-**Allowed exceptions:**
-
-- Database triggers and `supabase/seed.sql`.
-- Test bootstrapping (`src/test/setup/pglite.ts` and integration test fixtures, which use the `authUsers` Drizzle wrapper to seed paired `auth.users` + `user_profiles` rows).
-
-### Server→Client Data Minimization (CORE-SEC-006)
-
-The React Server Components payload is visible in page source — `view-source:` on any authenticated page reveals every prop passed to `"use client"` components. Map server-fetched data to a minimal shape _before_ the boundary; never pass full ORM/domain objects (`UnifiedUser`, full `user_profiles` records, raw issue rows with `reporterEmail`, etc.) as Client Component props.
-
-Practical pattern: define a `XyzProps` interface listing only the fields the component actually uses, then build it from the full object in the Server Component. Combine with CORE-SEC-007: even authenticated users should not see other users' emails in the RSC payload outside admin views.
-
----
-
-## 2. Authorization & Permissions Framework (CORE-ARCH-008)
-
-The permissions system is defined in `src/lib/permissions/matrix.ts` (single source of truth) and checked via the pure helpers in `src/lib/permissions/helpers.ts`, which run unchanged in both server and client code.
+## What counts as a non-gating role comparison (CORE-ARCH-008)
 
 The `permissions-audit-allow` annotation contract is **enforced**, not documentation. `scripts/audit/no-hardcoded-role-checks.sh` scans `src/` (excluding the permissions module and tests) for `role === "<role>"` comparisons and fails on any that lack `// permissions-audit-allow: <reason>` on the same line, the line directly above, or the line directly below. The audit is wired into `pnpm run check` as `audit:role-checks` — preflight will reject unannotated gates.
 
-### Permission Helpers
+The line the audit cannot draw for you: a role comparison that **gates a request
+or enforces authorization** is forbidden outright and must go through
+`checkPermission()` / `getPermissionState()`. Comparisons that merely _shape_
+behaviour are allowed with an annotation — SQL/query row filtering (an `isAdmin`
+flag driving a `where` clause), UI display flags and badges, business-logic
+preconditions.
 
-Always use the following functions for permission gating and auditing:
+**There are no permission React hooks.** The helpers in
+`src/lib/permissions/helpers.ts` are pure, so client components call them
+directly: derive the `AccessLevel` and `OwnershipContext` server-side, pass them
+down as props, then call `getPermissionState` / `getPermissionDeniedReason` in
+the component. Deriving server-side also keeps the client payload minimal
+(CORE-SEC-006).
 
-- **Server Helpers (`src/lib/permissions/helpers.ts`)**:
-  - `getAccessLevel(role)`: Resolves a database role string (or null) to an `AccessLevel` ("unauthenticated", "guest", "member", "technician", "admin").
-  - `checkPermission(permissionId, accessLevel, context)`: Checks if a permission is granted. Handles conditional permissions (`'own'`, `'owner'`) using `OwnershipContext`.
-  - `checkPermissions(permissionIds, accessLevel, context)`: Returns true if all permissions are granted.
-  - `checkAnyPermission(permissionIds, accessLevel, context)`: Returns true if any of the permissions are granted.
-  - `getGrantedPermissions(accessLevel, context)`: Retrieves list of granted permission IDs.
-  - `getPermissionState(permissionId, accessLevel, context)`: Returns a discriminated union — `{ allowed: true }` or `{ allowed: false; reason: "unauthenticated" | "role" | "ownership" }`. Narrow on `allowed` before reading `reason`; it only exists on the denied branch.
-  - `getPermissionDeniedReason(permissionId, accessLevel, context)`: Returns a human-readable tooltip string for disabled actions.
-  - `isConditionalPermission(permissionId, accessLevel)`: Checks if a permission's matrix value is conditional (`'own'`/`'owner'`) and therefore requires `OwnershipContext` to evaluate.
-  - `getRawPermissionValue(permissionId, accessLevel)`: Returns the raw matrix value (`true`, `false`, `'own'`, or `'owner'`) before ownership resolution. Use this only when you need to introspect the matrix entry itself (e.g., to choose between two UI states); for actual access decisions, always go through `checkPermission` / `getPermissionState`.
-- **Client Components**: there are no permission-specific React hooks. Because the helpers above are pure (no server-only dependencies), client components call them directly — compute the `accessLevel` (`AccessLevel`) and `OwnershipContext` server-side, pass them down as props, then call `getPermissionState` / `getPermissionDeniedReason` inside the component. Keeping the derivation server-side also keeps the client payload minimal (CORE-SEC-006).
-
----
-
-## 3. Discord OAuth Integration (extensible to other providers)
+## OAuth providers
 
 Discord is the only provider currently registered. The OAuth machinery (provider registry, unlink guard, callback redirect handling) is structured so additional providers can be added by appending entries to the registry, but `ProviderKey` resolves to `"discord"` today.
 
-### Multi-Provider Registry (`src/lib/auth/providers.ts`)
+`canUnlinkIdentity` (`src/lib/auth/identity-guards.ts`) exists to stop users
+locking themselves out: unlinking is only allowed if the user has at least one
+other active login method (another provider, or a password).
 
-Supported providers are defined in the `providers` map, which implements the `Provider` interface:
+Redirect target URLs in the callback route are normalized through
+`resolveRedirectPath`, which enforces internal-path-or-`getSiteUrl()`. Anywhere
+else that accepts a redirect target from the user, use `getSafeRedirect`.
 
-- `key`: Stable key matching Supabase (e.g., `"discord"`).
-- `displayName`: User-facing name (e.g., `"Discord"`).
-- `scopes`: OAuth scopes requested (e.g., `"identify email"`).
-- `iconComponent`: SVG icon for the button.
-- `isAvailable()`: Returns `true` if credentials (e.g., client ID and secret) exist in environment variables.
-
-### Unlink Identity Guard (`src/lib/auth/identity-guards.ts`)
-
-To prevent users from locking themselves out, `canUnlinkIdentity` enforces that unlinking is only allowed if the user has at least one other active login method (e.g., another provider or a password):
-
-```typescript
-export function canUnlinkIdentity(
-  identities: readonly UserIdentity[],
-  providerKey: ProviderKey
-): UnlinkCheck;
-```
-
-### Discord Identity Mirroring
-
-During OAuth login or linking, the callback route `src/app/(auth)/auth/callback/route.ts` invokes `syncDiscordIdentity(supabase)` to extract the Discord user ID from `getUserIdentities()` and mirror it into `user_profiles.discordUserId` in the database. `syncDiscordIdentity` is defined as an internal helper inside the callback route — it is not exported and is not callable from elsewhere.
-
-### Dynamic Redirects
-
-Redirect target URLs are normalized using `resolveRedirectPath` in the callback route to enforce that redirects only point to internal paths or the configured `getSiteUrl()`, preventing open redirect vulnerabilities.
-
----
-
-## 4. Site URL Construction & Safe Redirects
+## Site URL construction & safe redirects
 
 **Goal**: one consistent site-URL resolution across dev, preview, and prod — and no open redirects.
 
@@ -165,176 +81,11 @@ Never read `process.env` and stitch a URL together by hand. Use the helpers in `
 | `isInternalUrl(url)`         | Type guard: is this a same-site path we're allowed to send a user to?                                          |
 | `getSafeRedirect(...)`       | Normalizing a user-supplied `?redirect=` target down to an internal path. Open-redirect prevention.            |
 
-```typescript
-import { getSiteUrl } from "~/lib/url";
-
-// Good
-const url = `${getSiteUrl()}/some-path`;
-
-// Bad — re-derives the rule, drifts from every other call site
-const port = process.env.PORT || 3000;
-const url = `http://localhost:${port}/some-path`;
-```
-
 Why it's centralized: the fallback rules differ per environment, and a hand-rolled copy silently emails users a `localhost` link from production.
 
 **Watch for this**: the local-mock branch of `src/lib/blob/client.ts` still builds its upload URL from `process.env["NEXT_PUBLIC_SITE_URL"] ?? \`http://localhost:${port}\`` instead of calling `getSiteUrl()` — the one place in the codebase that still hand-rolls this. Don't copy it, and fold it in if you're already touching that file.
 
-Redirect targets in the OAuth callback route go through `resolveRedirectPath`, which enforces internal-path-or-`getSiteUrl()` (see §3 Dynamic Redirects). Anywhere else that accepts a redirect target from the user, use `getSafeRedirect`.
-
----
-
-## 5. Code Examples
-
-### Server Action with Auth & Permission Gates
-
-```typescript
-"use server";
-
-import { z } from "zod";
-import { redirect } from "next/navigation";
-import { createClient } from "~/lib/supabase/server";
-import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
-import { db } from "~/server/db";
-import { issues } from "~/server/db/schema";
-import { eq } from "drizzle-orm";
-
-const updateIssueSchema = z.object({
-  id: z.string().uuid(),
-  title: z.string().min(1, "Title is required"),
-  severity: z.enum(["cosmetic", "minor", "major", "unplayable"]),
-});
-
-export async function updateIssueAction(formData: FormData) {
-  // 1. Create client and fetch user immediately (CORE-SSR-001, CORE-SSR-002)
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    redirect("/login");
-  }
-
-  // 2. Fetch the user's role from the profile
-  const profile = await db.query.userProfiles.findFirst({
-    where: (profiles, { eq }) => eq(profiles.id, user.id),
-  });
-  const accessLevel = getAccessLevel(profile?.role);
-
-  // 3. Validate form inputs (CORE-SEC-002)
-  const validation = updateIssueSchema.safeParse({
-    id: formData.get("id"),
-    title: formData.get("title"),
-    severity: formData.get("severity"),
-  });
-  if (!validation.success) {
-    return { ok: false, error: "Invalid form input" };
-  }
-  const data = validation.data;
-
-  // 4. Fetch resource for ownership context
-  const issue = await db.query.issues.findFirst({
-    where: eq(issues.id, data.id),
-  });
-  if (!issue) {
-    return { ok: false, error: "Issue not found" };
-  }
-
-  // 5. Check permissions through the matrix helper (CORE-ARCH-008)
-  //    checkPermission returns boolean — it resolves "own"/"owner" conditional
-  //    permissions internally against the OwnershipContext. Always pass
-  //    { userId, reporterId } (issues) or { userId, machineOwnerId } (machines)
-  //    when the permission may be conditional; otherwise the call denies by
-  //    default. For UI gating with denial-reason tooltips, prefer
-  //    getPermissionState(...).allowed, which returns { allowed, reason }.
-  const isAllowed = checkPermission("issues.update.reporting", accessLevel, {
-    userId: user.id,
-    reporterId: issue.reportedBy,
-  });
-
-  if (!isAllowed) {
-    return { ok: false, error: "Unauthorized" };
-  }
-
-  // 6. Proceed with database update
-  await db
-    .update(issues)
-    .set({
-      title: data.title,
-      severity: data.severity,
-    })
-    .where(eq(issues.id, data.id));
-
-  return { ok: true };
-}
-```
-
-### Client Component (pure helpers, no hooks)
-
-```typescript
-"use client";
-
-import {
-  getPermissionDeniedReason,
-  getPermissionState,
-  type OwnershipContext,
-} from "~/lib/permissions/helpers";
-import { type AccessLevel } from "~/lib/permissions/matrix";
-
-interface IssueEditorProps {
-  // Derived server-side and passed down — keeps the client payload minimal (CORE-SEC-006).
-  accessLevel: AccessLevel;
-  ownershipContext: OwnershipContext;
-}
-
-export function IssueEditor({ accessLevel, ownershipContext }: IssueEditorProps) {
-  // The helpers are pure, so they run directly in the client component — no hook needed.
-  const permissionState = getPermissionState(
-    "issues.update.reporting",
-    accessLevel,
-    ownershipContext
-  );
-  const deniedReason = permissionState.allowed
-    ? undefined
-    : getPermissionDeniedReason(
-        "issues.update.reporting",
-        accessLevel,
-        ownershipContext
-      );
-
-  return (
-    <div className="flex flex-col gap-2">
-      <input
-        type="text"
-        disabled={!permissionState.allowed}
-        placeholder="Edit issue title..."
-        className="border p-2 disabled:bg-gray-100 disabled:cursor-not-allowed"
-        title={deniedReason}
-      />
-      {!permissionState.allowed && deniedReason && (
-        <span className="text-xs text-destructive-text">{deniedReason}</span>
-      )}
-    </div>
-  );
-}
-```
-
-### OAuth Linking Action
-
-OAuth linking must redirect through `/auth/callback?next=/settings` so that `exchangeCodeForSession` persists the link state:
-
-```typescript
-export async function linkProviderAction(rawKey: string): Promise<void> {
-  const result = await runLinkProvider(rawKey);
-  if (!result.ok) {
-    redirect(`/settings?oauth_error=${encodeURIComponent(result.code)}`);
-  }
-  // Redirect to Supabase authorize url
-  redirect(result.value.redirectUrl);
-}
-```
-
-### Input Sanitization
+## Input sanitization
 
 Don't roll a new `sanitize-html` allowlist. The codebase has a shared config — `~/lib/sanitize-html-config` exports `NON_TEXT_TAGS`, the canonical set of raw-text tags that must be stripped (covered by the test in `sanitize-html-config.test.ts`). The shared config is consumed by `src/lib/markdown.ts`, `src/lib/tiptap/render.ts`, and `src/lib/notifications/channels/email-channel.ts`.
 
@@ -343,32 +94,3 @@ For the common cases:
 - **Markdown-from-user-input → safe HTML**: call `renderMarkdownToHtml(...)` from `~/lib/markdown` (double-sanitizes after the markdown renderer runs).
 - **TipTap ProseMirror JSON → safe HTML for display**: use the renderer in `~/lib/tiptap/render` (this is what `RichTextDisplay` uses; the comment there reads "Output is double-sanitized — the renderer escapes all text").
 - **Raw HTML that genuinely needs sanitization in a new place**: import `sanitizeHtml` from `sanitize-html` AND `NON_TEXT_TAGS` from `~/lib/sanitize-html-config`, and pass `nonTextTags: NON_TEXT_TAGS` alongside whatever `allowedTags`/`allowedAttributes` you need. The shared `NON_TEXT_TAGS` constant is what keeps `<script>`, `<style>`, `<textarea>`, etc. from leaking through; replicating an inline allowlist that omits it is a footgun.
-
----
-
-## Security Checklist
-
-Before deploying or merging security-sensitive changes, verify:
-
-- [ ] **Auth Checks**: `createClient()` is immediately followed by `auth.getUser()` (CORE-SSR-002) in all Server Actions/routes.
-- [ ] **Authorization**: Every action is protected using the permissions matrix via `checkPermission()` (CORE-ARCH-008). No hardcoded role gates; `pnpm run check` (`audit:role-checks`) must pass.
-- [ ] **`auth.users` discipline**: No application-code queries against `auth.users` outside the sanctioned exceptions (CORE-SSR-007).
-- [ ] **Server→Client minimization**: Client Component props are minimal shapes, not raw ORM rows (CORE-SEC-006).
-- [ ] **Email Privacy**: User email addresses are never displayed outside of admin views or settings (CORE-SEC-007).
-- [ ] **Input Validation**: All form inputs are validated using Zod (CORE-SEC-002).
-- [ ] **Sanitization**: Any new sanitize-html call uses `NON_TEXT_TAGS` from `~/lib/sanitize-html-config`; prefer the existing `renderMarkdownToHtml` / tiptap renderer over rolling a new allowlist.
-- [ ] **Hostnames**: No hardcoded hostnames/ports used; local dev runs strictly on `localhost` (CORE-SEC-008). Absolute URLs come from `~/lib/url` (`getSiteUrl` / `requireSiteUrl`), never hand-built from `process.env`.
-- [ ] **Redirects**: Any user-supplied redirect target is normalized through `getSafeRedirect` / `isInternalUrl` before use.
-- [ ] **CSP Config**: Dynamic CSP nonce generated via root `middleware.ts` (CORE-SEC-004); no `'unsafe-inline'` for script-src; new external hosts added to the production branch by default.
-- [ ] **Middleware response**: `updateSession`'s response is returned as-is (CORE-SSR-005) — no rewrap, no header copy.
-- [ ] **Identities Safeguard**: Manual unlinking verifies multiple identities remain via `canUnlinkIdentity`.
-- [ ] **Drizzle Migrations**: Schema updates are managed via generated SQL migrations only (CORE-ARCH-009).
-
----
-
-## References
-
-- **Security Details**: `docs/SECURITY.md`
-- **Core Guidelines**: `docs/NON_NEGOTIABLES.md` (specifically `CORE-SEC-*` and `CORE-SSR-*` rules)
-- **Design System Rules**: `pinpoint-design-bible`
-- **Database Schema**: `src/server/db/schema.ts`

--- a/.agents/skills/pinpoint-ui/SKILL.md
+++ b/.agents/skills/pinpoint-ui/SKILL.md
@@ -157,7 +157,7 @@ Native reset clears the form's DOM state; explicit `setState` clears React's vie
 ### Server Actions
 
 - Exported server actions are **suffixed `Action`** — `createMachineAction`, `markAsReadAction`. This is the house style for new code, not a universal invariant: a set of older actions under `src/app/**/actions.ts` predate the convention. Name new actions with the suffix; **don't** rename existing ones to match (the rename is churn with a real chance of missing a call site), and **don't assume an unsuffixed export isn't a Server Action** — several are wired straight into `useActionState`.
-- Every action checks authorization through `checkPermission()` from `~/lib/permissions/helpers` (CORE-ARCH-008). Never hand-roll a role comparison. `pinpoint-security` has the full auth/permission gate walkthrough.
+- Every action checks authorization through `checkPermission()` from `~/lib/permissions/helpers` (CORE-ARCH-008). Never hand-roll a role comparison — `pinpoint-security` covers what counts as a non-gating comparison and how the `permissions-audit-allow` audit treats it.
 - Actions return `Result<T, C>` from `~/lib/result.ts` (`ok(...)` / `err(...)`), not thrown exceptions, so `useActionState` can render the failure.
 - Report failures through `serverActionError()` from `~/lib/observability/report-error` rather than a bare `console.error` — that's what routes the error to Sentry with action context.
 - Zod schemas live in a separate `schemas.ts` next to the action (a Next.js requirement — `"use server"` files may only export async functions).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -40,7 +40,7 @@ A default `/code-review` or Antigravity pass is aimed at smaller changes — Tim
 
 Reviewers read agent skills. Consult the relevant one for the area a PR touches — this is a routing table, not a summary; read the skill itself for the actual guidance. All live at `.agents/skills/<name>/SKILL.md`.
 
-- `pinpoint-security` — auth, CSP, Zod validation, Supabase SSR changes.
+- `pinpoint-security` — CSP authoring, redirects and site-URL construction, the `@supabase/ssr` allowlist, sanitizers, and what counts as a non-gating role comparison. The rules themselves are `CORE-SEC-*` / `CORE-SSR-*`.
 - `pinpoint-testing` — whether a PR picked the right test layer (unit/integration/E2E) for what it's testing.
 - `pinpoint-e2e` — Playwright/E2E stability: worker isolation, flake-prone patterns.
 - `pinpoint-typescript` — the db→app typing decision: no converter layer, narrow with `Pick<>` at boundaries. CORE-TS-007's `!` ban is not linted, so non-null assertions stay a review question.

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -134,8 +134,8 @@
 **CORE-SSR-005:** Don't modify Supabase response object
 
 - **Severity:** Required
-- **Why:** Altering it breaks authentication
-- **Do:** Return response object as‑is from middleware
+- **Why:** Altering it breaks authentication. Rewrapping into a fresh `NextResponse` — or copying headers across by hand — strips the `Set-Cookie` headers carrying the refreshed session tokens, so the _next_ request sees an anonymous user.
+- **Do:** Return the response object from `updateSession` as‑is from middleware
 - **Don't:** Mutate or rewrap the response
 
 **CORE-SSR-006:** Use database trigger for auto-profile creation
@@ -151,7 +151,7 @@
 - **Why:** Internal Supabase schema; breaks abstraction, couples to implementation details, may break with Supabase updates
 - **Do:** Query `user_profiles` table (which mirrors necessary auth data via database triggers)
 - **Don't:** Use raw SQL or Drizzle queries against `auth.users` in Server Actions or services
-- **Exception:** Database triggers (`supabase/seed.sql`) and test setup (`pglite.ts`) may reference `auth.users` for bootstrapping
+- **Exception:** Database triggers (`supabase/seed.sql`) and test setup may reference `auth.users` for bootstrapping — `pglite.ts`, and the integration-test fixtures that seed paired `auth.users` + `user_profiles` rows through the `authUsers` Drizzle wrapper
 
 ---
 

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -177,7 +177,7 @@
 - **Why:** Defense-in-depth protection against XSS, clickjacking, and protocol downgrade attacks
 - **Do:** Set security headers in `middleware.ts` (CSP with nonces) and `next.config.ts` (static headers)
 - **Don't:** Remove or weaken Content-Security-Policy, rely on 'unsafe-inline' or 'unsafe-eval'
-- **Reference:** `docs/SECURITY.md` for configuration and modification guidelines
+- **Reference:** `middleware.ts` and `next.config.ts` are the configuration; `pinpoint-security` covers how to author a CSP change, and `docs/SECURITY.md` records the threat-model decisions and known gaps
 
 **CORE-SEC-004:** Nonce-based CSP
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,102 +1,18 @@
-# PinPoint Security Headers
+# PinPoint Security — recorded decisions
 
-**Last Updated**: July 12, 2026
+The security headers themselves are not documented here. `next.config.ts` sets
+the static headers (HSTS, `X-Frame-Options`, `X-Content-Type-Options`,
+`Referrer-Policy`, `Permissions-Policy`); the root `middleware.ts` builds the
+Content-Security-Policy and the per-request nonce. Read those files for the
+current values — a table here would only drift from them. How to author a CSP
+change (production-branch-first, what is already allowlisted, the `x-nonce`
+contract) is in the `pinpoint-security` skill; the enforced rules are
+`CORE-SEC-*` and `CORE-SSR-*` in `docs/NON_NEGOTIABLES.md`.
 
-## Overview
+What follows is the part that lives nowhere else: choices made against a
+specific threat, and the gaps we know we have.
 
-PinPoint implements a defense-in-depth security strategy using HTTP security headers to protect against common web vulnerabilities. This document describes the security headers configuration, implementation details, and modification guidelines.
-
-## Security Headers Configuration
-
-### Static Headers (next.config.ts)
-
-The following headers are set statically for all routes via `next.config.ts`:
-
-| Header                      | Value                                          | Purpose                                                          |
-| --------------------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
-| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Enforces HTTPS connections for 2 years, including all subdomains |
-| `X-Frame-Options`           | `DENY`                                         | Prevents clickjacking by blocking iframe embedding               |
-| `X-Content-Type-Options`    | `nosniff`                                      | Prevents MIME-sniffing attacks                                   |
-| `Referrer-Policy`           | `strict-origin-when-cross-origin`              | Controls referrer information sent with requests                 |
-| `Permissions-Policy`        | `camera=(), microphone=(), geolocation=()`     | Disables unnecessary browser features                            |
-
-### Dynamic Headers (middleware.ts)
-
-Content-Security-Policy (CSP) is set dynamically in middleware to support nonce-based script execution:
-
-#### Content-Security-Policy Directives
-
-| Directive                   | Value                                                         | Purpose                                                                                      |
-| --------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `default-src`               | `'self'`                                                      | Default policy: only load resources from same origin                                         |
-| `script-src`                | `'self' 'nonce-{random}' 'strict-dynamic'`                    | Scripts: same origin or with valid nonce. 'strict-dynamic' allows dynamically loaded scripts |
-| `style-src`                 | `'self' 'unsafe-inline'`                                      | Styles: same origin or inline (for CSS-in-JS compatibility)                                  |
-| `img-src`                   | `'self' data: blob: https://*.public.blob.vercel-storage.com` | Images: same origin, data URIs, blob URLs, or Vercel Blob CDN (uploaded avatars)             |
-| `font-src`                  | `'self' data:`                                                | Fonts: same origin or data URIs                                                              |
-| `connect-src`               | `'self' {supabase-url} {supabase-ws-url} localhost`           | Network requests: same origin, Supabase, and local development                               |
-| `object-src`                | `'none'`                                                      | No plugins (Flash, Java, etc.)                                                               |
-| `base-uri`                  | `'self'`                                                      | Restricts `<base>` tag URLs                                                                  |
-| `form-action`               | `'self'`                                                      | Forms can only submit to same origin                                                         |
-| `frame-ancestors`           | `'none'`                                                      | Cannot be embedded in any frame (stricter than X-Frame-Options)                              |
-| `block-all-mixed-content`   | -                                                             | Blocks HTTP content on HTTPS pages                                                           |
-| `upgrade-insecure-requests` | -                                                             | Upgrades HTTP requests to HTTPS                                                              |
-
-## Implementation Details
-
-### Nonce-Based CSP
-
-PinPoint uses nonce-based Content-Security-Policy instead of `'unsafe-inline'` and `'unsafe-eval'` for enhanced security:
-
-1. **Nonce Generation**: A unique cryptographic nonce (UUID) is generated for each request in `middleware.ts`
-2. **Header Injection**: The nonce is injected into the CSP header as `'nonce-{uuid}'`
-3. **x-nonce Header**: The nonce is exposed via `x-nonce` response header for use in Server Components
-4. **Script Execution**: Only scripts with matching nonce attributes can execute
-
-**Example Script Tag (future implementation)**:
-
-```tsx
-// In a Server Component
-export default async function Page() {
-  const nonce = headers().get("x-nonce");
-
-  return (
-    <Script nonce={nonce}>console.log('This script will execute');</Script>
-  );
-}
-```
-
-### Supabase Integration
-
-The CSP is configured to work with Supabase authentication and real-time features:
-
-- **HTTPS**: `https://{project-id}.supabase.co` for API requests
-- **WebSocket**: `wss://{project-id}.supabase.co` for Realtime subscriptions
-- **No Wildcards**: Uses specific project URL from `NEXT_PUBLIC_SUPABASE_URL` instead of `*.supabase.co`
-
-### Local Development
-
-CSP allows local connections for development:
-
-- `http://127.0.0.1:*` and `ws://127.0.0.1:*`
-- `http://localhost:*` and `ws://localhost:*`
-
-## Current Limitations
-
-### style-src 'unsafe-inline'
-
-The CSP currently includes `'unsafe-inline'` for `style-src` to maintain compatibility with:
-
-- CSS-in-JS libraries (if used in future)
-- Inline styles in third-party components
-- Server-rendered styles from Next.js
-
-**Future Improvement**: Once nonce support is tested with all components, migrate to nonce-based styles:
-
-```
-style-src 'self' 'nonce-{random}';
-```
-
-### script-src 'strict-dynamic'
+## script-src 'strict-dynamic'
 
 The `'strict-dynamic'` directive allows scripts loaded by nonce'd scripts to execute without their own nonce. This is necessary for:
 
@@ -105,136 +21,6 @@ The `'strict-dynamic'` directive allows scripts loaded by nonce'd scripts to exe
 - Client-side routing and code splitting
 
 **Trade-off**: Slightly relaxes CSP but required for modern JavaScript frameworks. The initial script must still have a valid nonce.
-
-## Modifying CSP
-
-### Adding External Resources
-
-If you need to add external resources (CDNs, analytics, etc.), update the appropriate directive in `middleware.ts`:
-
-**Example: Adding Google Fonts**
-
-```typescript
-const cspHeader = `
-  ...
-  font-src 'self' data: https://fonts.gstatic.com;
-  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-  ...
-`;
-```
-
-**Example: Adding Vercel Analytics**
-
-```typescript
-const cspHeader = `
-  ...
-  script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://va.vercel-scripts.com;
-  connect-src 'self' ${supabaseUrl} ${supabaseWsUrl} https://va.vercel-scripts.com;
-  ...
-`;
-```
-
-### Testing CSP Changes
-
-1. **Check Browser Console**: CSP violations appear as console errors
-2. **Review Network Tab**: Blocked requests show "blocked:csp" status
-3. **Test User Flows**: Verify auth, forms, and dynamic features work
-4. **Use CSP Evaluator**: https://csp-evaluator.withgoogle.com/
-
-### Manual Testing on Staging/Production
-
-**Prerequisites:**
-
-- Deployment to staging environment (e.g., Vercel preview)
-- Browser DevTools (Chrome, Firefox, or Safari)
-
-**Test Procedure:**
-
-1. **Open DevTools** → Navigate to **Network** tab
-2. **Load the application** → Navigate to any page
-3. **Inspect Response Headers**:
-   - Click on the document request (first item in Network tab)
-   - Go to **Headers** tab
-   - Scroll to **Response Headers** section
-
-**Verify Headers Present:**
-
-```
-✅ strict-transport-security: max-age=63072000; includeSubDomains; preload
-✅ x-frame-options: DENY
-✅ x-content-type-options: nosniff
-✅ referrer-policy: strict-origin-when-cross-origin
-✅ permissions-policy: camera=(), microphone=(), geolocation=()
-✅ content-security-policy: default-src 'self'; script-src 'self' 'nonce-...' 'strict-dynamic'; ...
-✅ x-nonce: <uuid>
-```
-
-**Verify CSP Directives:**
-
-Check that `content-security-policy` contains:
-
-- `default-src 'self'`
-- `script-src 'self' 'nonce-<random-uuid>' 'strict-dynamic'`
-- `style-src 'self' 'unsafe-inline'`
-- `img-src 'self' data: blob: https://*.public.blob.vercel-storage.com`
-- `connect-src 'self' https://<project>.supabase.co wss://<project>.supabase.co`
-- `object-src 'none'`
-- `frame-ancestors 'none'`
-
-**Verify Nonce:**
-
-1. **Copy nonce value** from `x-nonce` header (e.g., `a1b2c3d4-e5f6-...`)
-2. **Open Console** tab
-3. **Run test script**:
-
-   ```javascript
-   // This should FAIL (no nonce)
-   const scriptFail = document.createElement("script");
-   scriptFail.textContent = 'console.log("BLOCKED");';
-   document.body.appendChild(scriptFail);
-
-   // Check console for CSP violation error
-   ```
-
-4. **Expected Result**: Console shows CSP violation error
-
-**Verify User Flows Work:**
-
-- ✅ Authentication (login/logout)
-- ✅ Form submissions
-- ✅ Navigation between pages
-- ✅ Supabase realtime connections (if implemented)
-
-**Common Issues:**
-
-| Symptom                   | Likely Cause           | Fix                               |
-| ------------------------- | ---------------------- | --------------------------------- |
-| CSP header missing        | Middleware not running | Check middleware matcher config   |
-| Nonce header missing      | Middleware error       | Check server logs                 |
-| White screen              | CSP blocking scripts   | Check console for violations      |
-| Supabase connection fails | Wrong connect-src URL  | Verify `NEXT_PUBLIC_SUPABASE_URL` |
-
-### CSP Reporting (Future)
-
-To monitor CSP violations in production, add a `report-uri` or `report-to` directive:
-
-```typescript
-const cspHeader = `
-  ...
-  report-uri /api/csp-report;
-`;
-```
-
-Then implement the endpoint to log violations.
-
-## Security Best Practices
-
-1. **Never use 'unsafe-eval'**: Allows arbitrary code execution
-2. **Minimize 'unsafe-inline'**: Use nonces or hashes instead
-3. **Avoid wildcards**: Be specific with allowed origins
-4. **Test thoroughly**: CSP can break legitimate functionality
-5. **Monitor violations**: Set up CSP reporting in production
-6. **Keep updated**: Review and tighten CSP as codebase evolves
 
 ## Authentication CAPTCHA (Turnstile fail-open)
 
@@ -278,14 +64,6 @@ there as follow-ups.
 
 ## Threat Model
 
-### Protected Against
-
-- **XSS (Cross-Site Scripting)**: Nonce-based CSP prevents unauthorized script execution
-- **Clickjacking**: X-Frame-Options and frame-ancestors prevent iframe embedding
-- **MIME Sniffing**: X-Content-Type-Options prevents content type confusion
-- **Protocol Downgrade**: HSTS enforces HTTPS
-- **Mixed Content**: CSP blocks HTTP resources on HTTPS pages
-
 ### Not Protected Against
 
 - **CSRF**: Requires additional token-based protection (not yet implemented)
@@ -296,17 +74,3 @@ there as follow-ups.
   "Authentication CAPTCHA (Turnstile fail-open)" above) — but other surfaces are
   not comprehensively rate-limited.
 - **DDoS**: Requires infrastructure-level protection
-
-## References
-
-- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)
-- [MDN Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-- [Next.js Security Headers](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy)
-- [web.dev CSP Guide](https://web.dev/articles/csp)
-
-## Related Documentation
-
-- `middleware.ts` - CSP implementation
-- `next.config.ts` - Static security headers
-- `docs/NON_NEGOTIABLES.md` - Security requirements
-- `docs/TECH_SPEC.md` - Architecture security considerations

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -74,3 +74,7 @@ there as follow-ups.
   "Authentication CAPTCHA (Turnstile fail-open)" above) — but other surfaces are
   not comprehensively rate-limited.
 - **DDoS**: Requires infrastructure-level protection
+- **CSS injection**: `style-src` keeps `'unsafe-inline'` for CSS-in-JS and
+  Next.js server-rendered styles, so inline styles are permitted. This is a
+  deliberate weakening, not an oversight; tightening it to a nonce would mean
+  proving every component's inline styles carry one first.

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,7 @@ import { updateSession } from "~/lib/supabase/middleware";
  * - style-src keeps 'unsafe-inline' for CSS-in-JS compatibility
  *
  * Required for CORE-SSR-003 compliance
- * See docs/SECURITY.md for security headers documentation
+ * See docs/SECURITY.md for the threat-model decisions and known gaps
  */
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   // 1. Run Supabase middleware first to handle session


### PR DESCRIPTION
Sweep task 3 of PP-22e4 (context-corpus deletion sweep). **686 → 172 lines**: `pinpoint-security` 374 → 96, `docs/SECURITY.md` 312 → 76. Docs-only apart from two one-line comment/reference corrections.

Operations were DELETE / MOVE-VERBATIM / POINTER only — no surviving passage was rewritten.

## What was deleted, and what already owns each fact

**`.agents/skills/pinpoint-security/SKILL.md`**

| Deleted | Owner |
| :-- | :-- |
| "When to Use This Skill", "Security Checklist" | the frontmatter description; every checklist item is a `CORE-*` restatement or a `pnpm run check` gate |
| "Quick Reference / Critical Security Rules" (6 items) | CORE-ARCH-008, CORE-SSR-001/002, CORE-SEC-002/003/004/007/008 |
| Immediate-`getUser` example, profile trigger, `auth.users` ban + exceptions | CORE-SSR-002 / 006 / 007 (the catalog carries the exception list verbatim) |
| Middleware token refresh; Server→Client minimization | CORE-SSR-005 and CORE-SEC-006, whose **Why** fields already state the `Set-Cookie` and view-source mechanisms |
| Permission-helper API listing (9 functions) | `src/lib/permissions/helpers.ts` |
| §5 Code Examples — server action, client component, OAuth linking | real gated server actions in `src/` |

Input Sanitization sat under the §5 "Code Examples" heading but is a decision (use the shared `NON_TEXT_TAGS`, don't roll a new allowlist), so it survives.

**`docs/SECURITY.md`** — deleted the static-header and CSP-directive tables (`next.config.ts` and `middleware.ts` hold the values; a table here can only drift), the nonce-implementation walkthrough and its "future implementation" example that was never built, the CSP-modification examples, the manual staging/production test procedure, speculative CSP reporting, the generic best-practices list, the OWASP/MDN/web.dev link list, and "Protected Against".

Also deleted the "Local Development" section, which was **wrong**: it described `127.0.0.1` as a dev-only CSP allowance, but `middleware.ts:57-58` allows `http://127.0.0.1:*` and `ws://127.0.0.1:*` in the production branch too. The skill already carried the correction.

Kept **verbatim**: the `'strict-dynamic'` tradeoff, the entire Turnstile fail-open section (PP-20yy, PP-vo43, the Supabase-captcha-stays-disabled invariant, the >50/hour alert threshold), and "Not Protected Against".

## Two pointer corrections

Both inbound references described `SECURITY.md` as header *configuration* documentation, which stops being true with this PR:

- `middleware.ts:19` → "for the threat-model decisions and known gaps"
- `docs/NON_NEGOTIABLES.md` CORE-SEC-003 **Reference** → now names `middleware.ts` / `next.config.ts` as the configuration, `pinpoint-security` for authoring a CSP change, and `SECURITY.md` for the decisions

The third inbound reference (`docs/runbooks/turnstile-fail-open-monitoring.md`) points specifically at the Turnstile section, which survives unchanged.

## Verified against source before keeping

The three non-test `@supabase/ssr` importers (and that nothing lints the allowlist), `admin.ts`'s `@supabase/supabase-js` client, every CSP claim against `middleware.ts:37-63` including the production `127.0.0.1`, `audit:role-checks` in `package.json:61,68`, all five `~/lib/url` exports, `blob/client.ts:58`'s hand-rolled URL, `ProviderKey = "discord"`, `canUnlinkIdentity`, `resolveRedirectPath`, and the three `NON_TEXT_TAGS` consumers.

## Routing

The description was re-derived from what survives. Terms dropped: "CSP nonces" → kept as CSP authoring; "input validation" → CORE-SEC-002 owns it, and the surviving sanitization guidance is named explicitly. Terms added: `permissions-audit-allow`, sanitizer, unlink guard.

`pnpm run check` green.