### PR TITLE
docs(agents): the `!` ban is linted now, unsafe `as` is the gap (PP-8k07)

### DIFF
--- a/.agents/skills/pinpoint-typescript/SKILL.md
+++ b/.agents/skills/pinpoint-typescript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-typescript
-description: The PinPoint-specific database typing decision — `InferSelectModel` yields camelCase types directly, so there is no db→app converter layer and none should be built; narrow with `Pick<>` at boundaries instead, and convert only on the reads and writes Drizzle does not map. Also carries the `exactOptionalPropertyTypes` resolution the compiler flags but does not teach, and which parts of CORE-TS-006/007 no tool enforces. Use when typing a database row on its way to a component, when tempted to write a row-mapping function, when reviewing a non-null assertion (`!`) or an `any`, or when the user mentions InferSelectModel, exactOptionalPropertyTypes, or snake_case/camelCase. General TypeScript technique is deliberately not covered.
+description: The PinPoint-specific database typing decision — `InferSelectModel` yields camelCase types directly, so there is no db→app converter layer and none should be built; narrow with `Pick<>` at boundaries instead, and convert only on the reads and writes Drizzle does not map. Also carries the `exactOptionalPropertyTypes` resolution the compiler flags but does not teach, and which parts of CORE-TS-006/007 no tool enforces. Use when typing a database row on its way to a component, when tempted to write a row-mapping function, when reviewing an `as` cast between two known types (the one third of CORE-TS-007 no tool checks), or when the user mentions InferSelectModel, exactOptionalPropertyTypes, or snake_case/camelCase. General TypeScript technique is deliberately not covered.
 ---
 
 # PinPoint TypeScript
@@ -25,7 +25,11 @@ CORE-TS-007's ban on `!` **is** linted, as of PP-8k07:
 `eslint-comments/no-restricted-disable` names it, so you cannot disable-comment
 past it in `src/`. It is off in the test and e2e blocks — a wrong assertion
 there fails the test loudly instead of 500ing a page — and that test exemption
-is meant to go away (PP-9q5k), so don't read it as blessed.
+is meant to go away (PP-9q5k), so don't read it as blessed. Note the scope
+differs from the paragraph above: `scripts/**` and `*.config.*` keep
+`no-non-null-assertion` at "error", but they switch
+`eslint-comments/no-restricted-disable` off, so a `// eslint-disable-next-line`
+does work there.
 
 The third of CORE-TS-007 that no tool checks is **unsafe `as`**. The
 `no-unsafe-*` rules target untyped values, not casts between two known types,

--- a/.agents/skills/pinpoint-typescript/SKILL.md
+++ b/.agents/skills/pinpoint-typescript/SKILL.md
@@ -20,10 +20,16 @@ in app code. `no-explicit-any` (CORE-TS-007) and `explicit-function-return-type`
 `*.config.*` / `scripts/**`. Writing `const page: any` in an e2e spec passes
 every gate.
 
-And CORE-TS-007's ban on `!` is enforced **nowhere**:
-`@typescript-eslint/no-non-null-assertion` is never enabled, and `!` is valid
-TypeScript at every strictness level. That third of a Critical rule rests
-entirely on review.
+CORE-TS-007's ban on `!` **is** linted, as of PP-8k07:
+`@typescript-eslint/no-non-null-assertion` is "error", and
+`eslint-comments/no-restricted-disable` names it, so you cannot disable-comment
+past it in `src/`. It is off in the test and e2e blocks — a wrong assertion
+there fails the test loudly instead of 500ing a page — and that test exemption
+is meant to go away (PP-9q5k), so don't read it as blessed.
+
+The third of CORE-TS-007 that no tool checks is **unsafe `as`**. The
+`no-unsafe-*` rules target untyped values, not casts between two known types,
+and `tsc` accepts the cast by construction. That one rests entirely on review.
 
 Full catalog: `CORE-TS-001..008` in `docs/NON_NEGOTIABLES.md`.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -43,7 +43,7 @@ Reviewers read agent skills. Consult the relevant one for the area a PR touches 
 - `pinpoint-security` — auth, CSP, Zod validation, Supabase SSR changes.
 - `pinpoint-testing` — whether a PR picked the right test layer (unit/integration/E2E) for what it's testing.
 - `pinpoint-e2e` — Playwright/E2E stability: worker isolation, flake-prone patterns.
-- `pinpoint-typescript` — the db→app typing decision: no converter layer, narrow with `Pick<>` at boundaries. CORE-TS-007's `!` ban is not linted, so non-null assertions stay a review question.
+- `pinpoint-typescript` — the db→app typing decision: no converter layer, narrow with `Pick<>` at boundaries. CORE-TS-007's unsafe-`as` third is not linted, so a cast between two known types stays a review question.
 - `pinpoint-ui` and `pinpoint-design-bible` — UI, component, and responsive-design changes. `pinpoint-ui` also owns Server Actions, data fetching, and the form conventions (Radix Select form-reset carve-out, CREATE form reset).
 - `pinpoint-deployment` — Drizzle migrations, DB connection/pooler config, preview deployments.
 


### PR DESCRIPTION
Two lines I wrote in #1804 went stale the same day #1808 merged. Docs-only, two files, ~10 lines.

**What was false:**

- `.agents/skills/pinpoint-typescript/SKILL.md` — "CORE-TS-007's ban on `!` is enforced **nowhere**: `@typescript-eslint/no-non-null-assertion` is never enabled … That third of a Critical rule rests entirely on review."
- `REVIEW.md:46` — "CORE-TS-007's `!` ban is not linted, so non-null assertions stay a review question."

Both were true when #1804 was reviewed and false when it merged.

**Verified against `eslint.config.mjs` on `main` rather than taken from the merge announcement:**

| | |
| :-- | :-- |
| `no-non-null-assertion` | `"error"` (line 165) |
| disable-comment escape | closed — `eslint-comments/no-restricted-disable` names it (208–211) |
| off where | the test-files block (267) and the e2e block (300) only |
| **not** off in | `*.config.*` / `scripts/**` — which is a real difference from the `no-explicit-any` sentence directly above it in the skill, so the two paragraphs can't share a scope claim |

The test exemption is temporary (PP-9q5k), so the skill says not to read it as blessed.

**What replaces it:** the third of CORE-TS-007 that genuinely has no gate is **unsafe `as`**. `no-unsafe-*` targets untyped values, not casts between two known types, and `tsc` accepts such a cast by construction. `REVIEW.md` now routes reviewers at that instead of at `!`, which lint already catches.

The frontmatter claim "which parts of CORE-TS-006/007 no tool enforces" is unchanged — still true, just a different part. `pnpm run check` green.

Credit: Claude-NonNullAssertion flagged the staleness in the huddle.