### PR TITLE
chore(deps): clear the nanoid high and the deferred hono moderates (PP-dj1w)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
   postcss: '>=8.5.23'
+  nanoid: '>=3.3.17 <4'
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
@@ -23,6 +24,7 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   sharp: '>=0.35.0'
   '@hono/node-server': '>=2.0.5'
+  hono: '>=4.12.34 <5'
   ip-address: '>=10.3.1 <11'
 
 importers:
@@ -839,7 +841,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.34 <5'
 
   '@hookform/resolvers@5.4.0':
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
@@ -4338,8 +4340,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -5130,8 +5132,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6878,9 +6880,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@hono/node-server@2.0.11(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.13.0)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.13.0
 
   '@hookform/resolvers@5.4.0(react-hook-form@7.82.0(react@19.2.7))':
     dependencies:
@@ -7086,7 +7088,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.13.0)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7096,7 +7098,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10218,7 +10220,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.31: {}
+  hono@4.13.0: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -11086,7 +11088,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -11377,7 +11379,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ overrides:
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
   postcss: '>=8.5.23'
+  nanoid: '>=3.3.17 <4'
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
@@ -33,6 +34,7 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   sharp: '>=0.35.0'
   '@hono/node-server': '>=2.0.5'
+  hono: '>=4.12.34 <5'
   ip-address: '>=10.3.1 <11'
 
 peerDependencyRules:


### PR DESCRIPTION
`pnpm audit --audit-level=high` exits 1 on main as of 2b2b557a. The `pnpm audit` job on main's CI run [31226892212](https://github.com/timothyfroehlich/PinPoint/actions/runs/31226892212) is **red**, and it will redden every open PR the moment that PR merges main in. Two override floors in `pnpm-workspace.yaml` fix it. No direct dependency changes, no source changes.

## nanoid `>=3.3.17 <4` — the new one, and why main is red

GHSA-2v37-7h3g-55p8 (**high**): a custom alphabet generator loops indefinitely when called with size zero.

Dependabot opened this alert at `2026-08-07T23:21:56Z` — the same minute #1821 merged. It is **not a regression from #1821**; it landed on top of it. It reaches us through the `postcss >=8.5.23` floor that #1821 raised: postcss 8.5.25 depends on nanoid, which resolved to 3.3.16.

Resolves to **3.3.17** (published 2026-08-03), not the newer 3.3.18 (published 2026-08-07T16:41Z, roughly 7 hours old). 3.3.18 is still inside the minimum-release-age window and pnpm's soak filter excluded it unprompted — so this floor needs no `minimumReleaseAgeExclude` entry. The soak gate working is what makes this a clean bump instead of a bypass.

## hono `>=4.12.34 <5` — the item #1821 split out on purpose

GHSA-8j4g-w8fx-2239 (moderate) plus three more; four advisories in total.

#1821 dropped this override rather than land a standing soak-bypass grant, and tracked the remainder in **PP-dj1w**. hono 4.12.34 published `2026-08-03T02:30Z`, so the 24h window closed four days ago and the override now installs with no exemption. That window was the only thing PP-dj1w was waiting on.

Resolves to **4.13.0**, which published `2026-08-03T21:54Z` and has since aged past the same soak window that filtered it out during #1821.

## Both ranges are bounded

`<4` and `<5`, per the unbounded-override finding from #1821's review: pnpm applies overrides to peer ranges too, so an open-ended `>=` deletes the upstream compatibility ceiling. Confirmed the lockfile records `hono: '>=4.12.34 <5'` against `@hono/node-server` rather than an unbounded range, and that no `minimumReleaseAgeExclude` key was added.

## Result

Advisory count **5 → 0**. `pnpm audit` is clean at `--audit-level=low`, two levels stricter than the CI gate.

## Verification

- `pnpm audit --audit-level=low` — clean, exit 0
- `pnpm run check` — all checks passed
- `next build` — success

Two gates could not produce a usable local signal, both for reasons that predate this change:

- **Unit tests.** 41 tests across 5 files fail on this host with `localStorage` undefined. I verified this against **main's own lockfile** — same failures, before this change — and the same suite passes as a required job in CI on main. That is a local vitest environment problem on this machine, not a repo regression; I'm filing it separately. CI covers unit here.
- **Supabase integration + smoke E2E.** The Supabase Postgres container will not start on this host (PP-9mg0). CI covers both.

Closes PP-dj1w.