### PR TITLE
docs: changelog week of August 4, 2026

### DIFF
--- a/content/changelog-meta.json
+++ b/content/changelog-meta.json
@@ -1,1 +1,1 @@
-{ "totalEntries": 159, "lastUpdated": "2026-08-01" }
+{ "totalEntries": 162, "lastUpdated": "2026-08-08" }

--- a/content/changelog.mdx
+++ b/content/changelog.mdx
@@ -1,5 +1,18 @@
 {/* This file is auto-updated by the weekly changelog workflow. Newest entries at top. */}
 
+## August 4, 2026
+
+### New Features
+
+- **Manage Tab** — The Edit button on machine detail pages has been replaced by a dedicated Manage tab, giving each machine its own full page for editing details, transferring ownership, and managing Pinball Map settings
+- **PinballMap Auto-Link** — Machines now automatically link to their Pinball Map entry when you match a catalog title — during the hourly sync and when saving machine details — with no separate "Connect" step required
+
+### Bug Fixes
+
+- Error messages, required-field markers, and destructive action buttons on the machine Manage tab now meet WCAG AA contrast requirements
+
+---
+
 ## July 28, 2026
 
 ### New Features


### PR DESCRIPTION
Adds the `## August 4, 2026` changelog entry covering the two user-facing features and one bug fix that landed this week.

## Changes

**`content/changelog.mdx`** — prepended new weekly entry:
- **New Features**: Manage Tab (PP-o355.19, PR #1762) — Edit button replaced by full-page Manage tab at `/m/[initials]/edit`
- **New Features**: PinballMap Auto-Link (PP-o355.20, PR #1810) — machines auto-link during hourly sync and on title-save
- **Bug Fixes**: WCAG AA contrast fix for error messages, required-field markers, and destructive buttons on the Manage tab

**`content/changelog-meta.json`** — updated `totalEntries: 159 → 162` (3 new bullets) and `lastUpdated: "2026-08-01" → "2026-08-08"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017CC7NxV9PDfYuL1hwaUG5q)_