### PR TITLE
chore(ci): bump the pinned Supabase CLI to 2.113.0 (PP-nlv6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -563,7 +563,7 @@ jobs:
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Setup Supabase
         uses: ./.github/actions/setup-supabase
@@ -619,7 +619,7 @@ jobs:
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -701,7 +701,7 @@ jobs:
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -783,7 +783,7 @@ jobs:
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0
@@ -866,7 +866,7 @@ jobs:
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # ratchet:actions/cache@v6.1.0

--- a/.github/workflows/preview-control.yaml
+++ b/.github/workflows/preview-control.yaml
@@ -115,7 +115,7 @@ jobs:
         if: steps.parse.outputs.action == 'start' || steps.parse.outputs.action == 'stop'
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061  # ratchet:pnpm/action-setup@v4.2.0
         if: steps.parse.outputs.action == 'start'

--- a/.github/workflows/preview-reaper.yaml
+++ b/.github/workflows/preview-reaper.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - name: Reap preview branches
         run: bash scripts/workflow/preview/preview-reap.sh

--- a/.github/workflows/preview-sync.yaml
+++ b/.github/workflows/preview-sync.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520  # ratchet:supabase/setup-cli@v3.0.0
         with:
           # Pinned Supabase CLI — bump deliberately (was: latest). PP-d5zn.
-          version: 2.109.1
+          version: 2.113.0
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061  # ratchet:pnpm/action-setup@v4.2.0
         with:


### PR DESCRIPTION
Weekly-chores version-drift item (PP-nlv6, chores bead PP-qehv).

## What changed

All **9** `supabase/setup-cli` pins move from `2.109.1` → `2.113.0` (the current latest stable), together:

| File | Sites |
| --- | --- |
| `.github/workflows/ci.yml` | 6 |
| `.github/workflows/preview-control.yaml` | 1 |
| `.github/workflows/preview-sync.yaml` | 1 |
| `.github/workflows/preview-reaper.yaml` | 1 |

All nine or none — a partial bump leaves jobs on mismatched CLI versions and shows up as a job-specific failure that reads like a flake.

## Version range crossed

`2.110.0` → `2.111.0` → `2.112.0` → `2.113.0`. Release notes reviewed for anything that changes `supabase start` / `db reset` / `db push` / `migration` / `branches` behavior our workflows depend on.

**The one breaking change does not apply to us.** 2.112.0 stopped forwarding `NPM_AUTH_TOKEN` into Docker bundling for `functions deploy` (restoring Go CLI behavior). PinPoint ships no edge functions and has no `.npmrc`, so nothing here touches it.

**The 2.112.0 deprecations also do not apply**: `db diff --use-pg-schema` and `db pull --experimental` are unused in this repo.

### Notable, in our favor

- **2.112.0** — `supabase start` no longer hangs when analytics migrations fail; `start` reuses existing volumes instead of failing when they already exist; Kong reloads after `db reset` so auth requests stop 502-ing when container IPs rotate. All three are exactly the class of infra flake the `setup-supabase` composite action retries around today.
- **2.112.0** — migrations now run in true version order (`db push` / `migration up` no longer misreport an already-applied migration as missing when one version string is a prefix of another).
- **2.112.0** — `-o toml/yaml/json` machine-readable output is back at Go-CLI parity. Worth naming because `.github/actions/setup-supabase/action.yml` parses `supabase status --output json` with `jq` (`API_URL`, `ANON_KEY`, `SERVICE_ROLE_KEY`, `DB_URL`, `INBUCKET_URL`) — this moves toward the shape we expect, not away from it, and CI exercises it on every job.
- **2.110.0 / 2.113.0** — TypeScript-port progress: `start`, `stop`, `status`, `db push`, `db reset` are now served by the TypeScript shell. Upstream states behavior matches the Go CLI; CI is the check.

## Verification

- `pnpm run check` green (includes actionlint, yamllint, zizmor — the real gate for workflow edits).
- `rg '2\.109\.1'` returns one remaining hit, deliberately left alone: `scripts/backup-production.sh:60` is a prose comment recording that `supabase db reset` was *verified* local-only against CLI 2.109.1. That is a historical verification record, not a pin — rewriting it to say 2.113.0 would assert a re-verification that did not happen.
- Full E2E is CI's job here, not local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRJXTCULMF915M6LN5zJgq
