### PR TITLE
chore(deps): bump pnpm corepack pin to 11.11.0 (PP-w0eq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinpoint",
   "version": "0.2.0",
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "type": "module",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"


### PR DESCRIPTION
## What

Bumps the corepack `packageManager` pin from `pnpm@11.9.0` to `pnpm@11.11.0`. Weekly-chores item (PP-w0eq).

## Why this is manual

Dependabot cannot update the `packageManager` field — [dependabot-core#4830](https://github.com/dependabot/dependabot-core/issues/4830) is an open, unimplemented feature request. Its pnpm support only updates deps *inside* the lockfile. The weekly chores check is the only watcher this field has.

## Why 11.11.0 and not newer

A 30-day supply-chain cooldown applies, same rationale as the Dependabot npm cooldown: a malicious release can be published and unpublished within hours, and the soak is the protection. **11.11.0 was published 2026-07-09** — 31 days old, the newest eligible stable. 11.20.0 exists but was published 2026-08-03 (6 days old).

## Release notes worth knowing (11.10.0 → 11.11.0)

Two stable releases between the old and new pin. Nothing touches lockfile format, `--frozen-lockfile` semantics, `overrides` resolution, or the audit endpoint — the four things PinPoint depends on.

**Security (11.11.0)** — two path-traversal fixes in the isolated linker, both reachable at install time:
- A dependency whose manifest `name` was a scoped traversal (`@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, **even with `--ignore-scripts`**. The hoisted linker already had this guard; the isolated linker (what we use) did not.
- A crafted `pnpm-lock.yaml` dependency-path key (`../../../tmp/x@1.0.0`) could write package content outside the virtual store.

**Memory (11.11.0)** — ~30% lower peak RSS during cold-cache resolution. Metadata fetch memoization was retaining each package's raw registry response body for the whole resolution phase; it now holds a body-less copy. Relevant to the 16 GB-laptop memory pressure this repo already fights.

**Behavior change worth flagging (11.11.0, `14332f0`)** — `pnpm install` and `pnpm dedupe` now **fail** instead of silently dropping an optional dependency's locked entries when registry metadata lacks a version the lockfile already pins (e.g. an unsynced mirror). Strictly safer: the old behavior emptied things like a package's platform-binary map, so the lockfile diverged between machines and frozen installs elsewhere had nothing to link.

**11.10.0** is mostly `pnpm up` / global-install / `pack-app` hardening plus a prototype-pollution fix in preferred-version seeding. The `pnpm up` preferred-versions rework (`dcabb78`) changes update resolution, not `install --frozen-lockfile`.

## Verification

| Gate | Result |
|:--|:--|
| Lockfile churn | **None** — `git diff --stat` shows `package.json` only |
| `pnpm install --frozen-lockfile` | Pass |
| `pnpm audit --audit-level=high` | `No known vulnerabilities found` |
| `pnpm run check` | Pass |
| `pnpm run test` | 223 files, 2052 tests passed |

The `packageManager` integrity hash was rewritten by `corepack use pnpm@11.11.0`, not hand-edited.

## Other pnpm-version pin sites

`rg -n '11\.9\.0' --hidden -g '!.git' -g '!pnpm-lock.yaml'` returns **only** `package.json:4`. CI uses `pnpm/action-setup@v4` with no `version:` input, so it reads the version from `packageManager` — CI and local move together automatically with this one edit. No Dockerfile, `.tool-versions`, or doc references a pnpm version.

Branch is merged up to date with `main` (includes #1832, whose `nanoid`/`hono` override floors the audit gate depends on).
