### PR TITLE
docs(skills): finish retiring the bot-review instruction (PP-f66n)

### DIFF
--- a/.agents/skills/pinpoint-memory-review/references/routing.md
+++ b/.agents/skills/pinpoint-memory-review/references/routing.md
@@ -62,7 +62,7 @@ Delete the redundant copies and keep the best-written one at the correct tier. *
 
 **Duplication where the copies are not equal — the tmux `-CC` fact.** It lives in three places: a Bazzite memory file, comments in `dotfiles/mac/.zshrc.local`, and the `bazzite` skill. The naive dedupe keeps the skill's copy and deletes the rest — which would destroy the `kill -WINCH <server-pid>` recovery procedure, the single most useful part, present only in the Bazzite memory. Correct handling: merge the recovery into the skill copy first, _then_ delete the others. This is why defect 3 says merge-before-delete rather than pick-one.
 
-**Straight duplication — `copilot-quota`.** Exists as both a beads memory and a Bazzite memory file. Same fact, no distinct detail. It is also time-boxed (the quota resets at month start), so the real verdict is neither "keep both" nor "keep one" but _expired — delete both_.
+**Straight duplication — `copilot-quota`.** It existed as both a beads memory and a Bazzite memory file: same fact, no distinct detail. It was also time-boxed — the quota reset at month start, and the bot reviewer it described was retired outright on 2026-08-02 (PP-4ric) — so the real verdict was neither "keep both" nor "keep one" but _expired — delete both_.
 
 **Demotion to mechanism — `--no-verify`.** "Never use `--no-verify`" is prose in the global `CLAUDE.md`. There is already a hook stack enforcing commit gates. If a hook can reject the flag outright, the prose is redundant and should go; if it cannot, the prose stays and the gap is worth a bead. Either way the review's job is to _ask_, not to leave a rule sitting in prose because it has always been there.
 

--- a/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
+++ b/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
@@ -64,7 +64,7 @@ If tests fail with `POSTGRES_URL is not set`:
 2. The bead is the source of truth — point the agent at `bd show`; don't restate scope/files in the prompt (two places to drift)
 3. Quality is self-enforced — explicit `pnpm run check` replaces hook enforcement
 4. Structured return format enables quick lead assessment
-5. No review fires automatically at all — the agent must request one, once, after it stops iterating (and again if it pushes past a review). The return format asks about it and the lead re-checks `commit_id` vs head at handoff (SKILL.md → "Ensure every PR is reviewed")
+5. Nothing reviews automatically and there is nothing for the agent to request — its terminal state is a PR reported as needing Tim's `/code-review`. The return format asks for exactly that, and at handoff the lead checks the marker's pinned SHA against head (SKILL.md → "Ensure every PR is reviewed")
 
 ## Follow-Up Prompt (via SendMessage)
 


### PR DESCRIPTION
Closes the last two live traces of the retired bot reviewer in the skill corpus (PP-f66n).

## What the bead expected vs. what was actually left

PP-f66n was filed on 2026-08-02, when four skills still carried `gh pr edit <PR> --add-reviewer "@copilot"` and a quota-fallback protocol keyed to it. Three of the four were swept in the interim by #1814 (`docs(agents): make the clean-review attestation an agent's job`) and #1820 (`docs(agents): cut the process corpus to what the scripts don't print`): `pinpoint-pr-workflow` Phase 3.4, `pinpoint-orchestrator`'s SKILL.md and prompt-template body, and `pinpoint-superpowers-bridge` all now read correctly, and the fallback protocol is gone rather than find-and-replaced. `pr-dashboard.sh`'s Copilot column is gone too.

Two stragglers survived those passes.

**`pinpoint-orchestrator/references/agent-prompt-template.md` — Key Points #5.** The template body was fixed; the Key Points list below it was not, and still said the agent "must request one, once, after it stops iterating (and again if it pushes past a review)" and that the lead "re-checks `commit_id` vs head at handoff". `commit_id` was the bot review API's field — the current gate is a SHA-pinned marker comment. So the file contradicted itself: the block a lead copies says review is a handoff to Tim, and the guidance underneath it says the agent requests one. Restated to match `SKILL.md` → "Ensure every PR is reviewed".

**`pinpoint-memory-review/references/routing.md` — the `copilot-quota` worked example.** Not a review instruction; it's an illustration of the dedupe-vs-expire verdict. But it described the quota in the present tense, which reads as though the integration is still live. Reworded to the past, with the retirement named. The teaching point (time-boxed facts expire, so the verdict is delete-both rather than keep-one) is unchanged — that's what the example is there for.

## `.claude/skills/` vs `.agents/skills/`

The bead asked whether these are copies needing parallel edits. They are neither copies nor a generated distribution: **`.claude/skills` is a committed symlink** (mode `120000`) to `../.agents/skills`. One source of truth, so the acceptance criterion "`.agents/skills/` and `.claude/skills/` agree" holds structurally and cannot drift.

## Surviving `copilot` references

`rg -n -i 'copilot' --hidden -g '!.git'` still returns hits, all legitimate:

- `scripts/workflow/{_pr-gates.sh,mark-claude-review.sh,AGENTS.md}`, `scripts/workflow/pr-watch.py`, `scripts/tests/test_pr_{gates,watch}.py` — comments and docstrings explaining *why* a gate is shaped the way it is (why thread counting is author-agnostic, why nothing WAITs, why coverage is SHA equality). The retired reviewer is the rationale; deleting the name would delete the reason.
- `src/services/issues.ts`, `src/components/security/useTurnstileGate.{ts,test.tsx}`, `src/test/integration/issue-comment-actions.test.ts` — attribution on past review findings ("the bug Copilot flagged"). Historical record.
- `docs/plans/**`, `docs/superpowers/**` — dated artifacts, left alone per AGENTS.md §8.
- `CLAUDE.md`, `AGENTS.md`, `REVIEW.md` — the retirement notice itself.

## Out of scope, noted

`.claude/agents/investigator.md` §"Working with PinPoint-Reviewer Agent" references a `PinPoint-Reviewer` agent that does not exist in `.claude/agents/`. A stale cross-reference, but unrelated to the bot-review retirement — not touched here.

## Testing

`pnpm run check` green. Docs-only; nothing under `scripts/` or `.claude/hooks/` touched, so `check:python` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRJXTCULMF915M6LN5zJgq
