### PR TITLE
fix(e2e): resolve @tsconfig/strictest by path so Playwright 1.62 can load it (PP-el95)

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -8,7 +8,25 @@
   // intentionally does NOT extend ../tsconfig.app.json — that project is
   // `composite`, and inheriting composite here would impose declaration-emit
   // checks + file-listing rules on the e2e sources.
-  "extends": ["../tsconfig.base.json", "@tsconfig/strictest/tsconfig.json"],
+  //
+  // The strictest entry is a RELATIVE path, not the bare `@tsconfig/strictest/
+  // tsconfig.json` specifier used by ../tsconfig.app.json, and that difference
+  // is load-bearing (PP-el95). Playwright loads this file with its own tsconfig
+  // reader, which is not a Node resolver: for a specifier containing `/` and `.`
+  // it tries exactly one node_modules location, `<dir-of-this-file>/node_modules/
+  // <specifier>`, and never walks upward. There is no e2e/node_modules, so the
+  // bare specifier has never resolved here — Playwright ≤1.61 silently treated
+  // the unresolvable extends as an empty config, and 1.62.0 turned that same
+  // miss into a hard `Failed to resolve "extends" path` error that fails every
+  // E2E job at collection time. tsc resolves either form to the same file (the
+  // root node_modules symlink for this direct devDependency), so the compiler
+  // settings e2e sources get are unchanged. ../tsconfig.app.json keeps the bare
+  // specifier: it sits at the repo root, where Playwright's single-location
+  // lookup happens to land on the real package.
+  "extends": [
+    "../tsconfig.base.json",
+    "../node_modules/@tsconfig/strictest/tsconfig.json"
+  ],
   "compilerOptions": {
     "noEmit": true,
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
Unblocks #1836 (Dependabot minor-patch group). Land this on `main` first, then rebase #1836 onto it.

## Root cause

**`@playwright/test` / `playwright` 1.62.0**, and nothing else in the 31-package group. Confirmed by installing `@playwright/test@1.62.0` alone into an otherwise-unchanged tree and reproducing the exact CI error.

Playwright loads tsconfigs with its own reader (`packages/playwright/src/transform/tsconfig-loader.ts`), which is **not a Node resolver**. For an `extends` specifier containing `/` and `.` it tries exactly one node_modules location — `<dir-of-the-tsconfig>/node_modules/<specifier>` — and never walks upward.

There is no `e2e/node_modules`, so `@tsconfig/strictest/tsconfig.json` has **never** resolved from `e2e/`. The behavior change is what happens next:

```diff
 function resolveConfigFile(baseConfigFile, referencedConfigFile, kind) {
   …
   if (referencedConfigFile.includes("/") && referencedConfigFile.includes(".") && !fs.existsSync(resolvedConfigFile))
     resolvedConfigFile = path.join(currentDir, "node_modules", referencedConfigFile);
+  if (!fs.existsSync(resolvedConfigFile))
+    throw new Error(`Failed to resolve "${kind}" path "${originalReferencedConfigFile}" referenced from ${baseConfigFile}`);
   return resolvedConfigFile;
 }
```

Through 1.61.1 the bogus path fell through to `innerLoadTsConfig`, whose first line is `if (!fs.existsSync(configFilePath)) return result` — an empty config, silently. Harmless in practice: Playwright only reads `allowJs`, `paths`, and `baseUrl` from a tsconfig, and `@tsconfig/strictest` sets none of them. 1.62.0 made the same miss fatal, so all three E2E jobs died at collection time, before any test ran.

## There is no CI-vs-local gap

The bead's "resolves fine locally" was an artifact of `main` still being on 1.61.1 — nobody had run 1.62.0 locally. With `@playwright/test@1.62.0` installed, a plain local `--list` fails byte-identically to CI. Nothing about pnpm layout, install flags, or the `node_modules` cache restore is involved.

## The fix

`e2e/tsconfig.json` points its strictest entry at `../node_modules/@tsconfig/strictest/tsconfig.json`, which Playwright's first `path.resolve(currentDir, …)` branch finds directly. `tsconfig.app.json` deliberately keeps the bare specifier: it sits at the repo root, where the single-location lookup happens to land on the real package.

The PP-4k76 comment block is preserved and extended to record why the two files now differ.

## No pin, no follow-up bead needed

Playwright 1.62.0 works as-is with this change, so no pin was required and no expiry note is owed.

## Verification

- `tsc --showConfig -p e2e/tsconfig.json` is **byte-identical** before and after — e2e sources get exactly the same compiler settings (the stated scope boundary).
- `@playwright/test@1.62.0` + this change: `playwright test e2e/smoke/auth-flows.spec.ts --list` collects 7 tests. Without the change: the CI error.
- `@playwright/test@1.61.1` (current `main`) + this change: still collects 7 tests — no regression on the version `main` is on.
- `pnpm run check`, `pnpm run test` (2052 passed), `pnpm run typecheck:e2e` all green.

Bead: PP-el95