### PR TITLE
docs(deployment): record the SELinux/pgsodium stack failure and its CLI cause (PP-9mg0)

### DIFF
--- a/.agents/skills/pinpoint-deployment/SKILL.md
+++ b/.agents/skills/pinpoint-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-deployment
-description: Deployment reference for PinPoint — Supabase/Postgres pooler and connection-string reference (Supavisor transaction vs session pooler, IPv4/IPv6, prepared statements, and the resolved PP-d8l8 silent-commit-loss incident); the day-to-day Drizzle migration loop (db:generate, db:migrate, db:reset, test:_generate-schema, the exported PGlite schema.sql, ensure-test-schema, CORE-ARCH-009 migrations-not-push); resolving drizzle/meta conflicts on merge; on-demand TTL'd Supabase preview branches, the /preview command, the sticky status comment, and the hourly reaper; and the per-PR /audit-override escape hatch for unrelated pnpm audit failures blocking CI Gate. Use when changing the Drizzle schema or generating/applying a migration; when touching src/server/db/**, scripts/migrate-production.ts, or scripts/lib/pg-client.mjs (DB connection/pooler config); when a merge or rebase produces conflicts under drizzle/meta or drizzle migration .sql/_snapshot.json files; when setting up, debugging, or explaining Vercel preview deployments or the /preview command; or when a PR's audit job goes red on a freshly-published advisory unrelated to the PR's own changes, or when explaining/debugging the /audit-override command.
+description: Deployment reference for PinPoint — Supabase/Postgres pooler and connection-string reference (Supavisor transaction vs session pooler, IPv4/IPv6, prepared statements, and the resolved PP-d8l8 silent-commit-loss incident); the day-to-day Drizzle migration loop (db:generate, db:migrate, db:reset, test:_generate-schema, the exported PGlite schema.sql, ensure-test-schema, CORE-ARCH-009 migrations-not-push); resolving drizzle/meta conflicts on merge; why `supabase start` died with "FATAL: invalid secret key" on an SELinux host under CLI 2.111.0 and why 2.112.0+ fixed it (PP-9mg0); on-demand TTL'd Supabase preview branches, the /preview command, the sticky status comment, and the hourly reaper; and the per-PR /audit-override escape hatch for unrelated pnpm audit failures blocking CI Gate. Use when changing the Drizzle schema or generating/applying a migration; when touching src/server/db/**, scripts/migrate-production.ts, or scripts/lib/pg-client.mjs (DB connection/pooler config); when a merge or rebase produces conflicts under drizzle/meta or drizzle migration .sql/_snapshot.json files; when setting up, debugging, or explaining Vercel preview deployments or the /preview command; when a PR's audit job goes red on a freshly-published advisory unrelated to the PR's own changes, or when explaining/debugging the /audit-override command; or when the local Supabase stack will not start and the db container is restart-looping.
 ---
 
 # PinPoint Deployment
@@ -64,6 +64,23 @@ PinPoint uses **Drizzle ORM** for schema definition and migrations, plus a **sep
 - **Descriptive names** — `add-notifications-table`, not `changes2`.
 - **Commit everything together**: `schema.ts`, the new `drizzle/` files (`.sql` **and** `_snapshot.json`), and the updated `src/test/setup/schema.sql`.
 - **Production and preview are `db:migrate` only.** Never `db:reset`, never `drizzle-kit push` against them. (AGENTS.md §7.)
+
+## Local stack won't start on an SELinux host (resolved, PP-9mg0)
+
+**Fixed by the CLI pin bump to 2.113.0 (#1837). Recorded because the symptom is unrecognizable from its error message, and the trigger was a CLI version — so an older CLI reintroduces it.**
+
+Symptom on Bazzite (Fedora Atomic, SELinux enforcing, `docker` is a shim over rootless podman): `supabase start` never completes, the `supabase_db_*` container restart-loops, and the log reads
+
+```
+pgsodium_getkey.sh: /etc/postgresql-custom/pgsodium_root.key: Read-only file system
+FATAL:  invalid secret key
+```
+
+Cause: **CLI 2.111.0 only**. Older CLIs wrote the pgsodium root key from _inside_ the container. 2.111.0 staged it on the host at `supabase/.temp/start-secrets/<container>/secret-0` and bind-mounted it `:ro` — with no `z`/`Z` relabel. The staged file inherits `user_home_t` from the repo, the container runs as `container_t`, so SELinux denies the `stat`. That makes `pgsodium_getkey.sh`'s `[[ ! -f "$KEY_FILE" ]]` true (`test -f` is false on `EACCES`), so it tries to _create_ the key — writing through a read-only mount. Both messages, one cause. Kong and pooler staged secrets the same way; db just failed first.
+
+Why it is gone: 2.112.0 replaced the bind mount with `docker cp` from a short-lived temp file, and the 2.113.0 `secretFiles` doc says it is never a host bind mount (supabase/cli#6022). Verified on Bazzite at 2.113.0 — the stack is healthy, `supabase/.temp/start-secrets/` is never created, and no Supabase container has any host bind mount into the repo.
+
+If it ever returns: check the CLI version first. Either bump it, or label the staging directory once — `chcon -R -t container_file_t -l s0 supabase/.temp/start-secrets` — which is enough because the directory survives a restart (the CLI removes only the per-container subdirectory) and staged files inherit the parent's label. macOS and CI have no SELinux and were never affected.
 
 ## Migration Conflicts
 


### PR DESCRIPTION
Replaces #1824, which is closed. Same bug, no code.

## What happened

`supabase start` on Bazzite (Fedora Atomic, SELinux enforcing, `docker` shimming rootless podman) never completed — the `supabase_db_*` container restart-looped on:

```
pgsodium_getkey.sh: /etc/postgresql-custom/pgsodium_root.key: Read-only file system
FATAL:  invalid secret key
```

Two messages, one cause, and neither of them says SELinux or names a CLI version. It blocked `db:fast-reset`, `test:integration:supabase`, and smoke E2E on that host, and diagnosing it took a full session.

## Why #1824 is closed instead of merged

#1824 shipped a script to label the CLI's secret-staging directory `container_file_t:s0`. A `/code-review medium` pass found that the bind mount it works around exists **only in CLI 2.111.0** — 2.112.0 replaced it with `docker cp` from a temp file, and 2.113.0's `secretFiles` doc says it is never a host bind mount ([supabase/cli#6022](https://github.com/supabase/cli/issues/6022)).

**#1837 bumped the pin to 2.113.0 earlier today**, so the bug was already gone before any of that code could land. Verified on Bazzite at 2.113.0:

| Check | Result |
| --- | --- |
| CLI version | 2.113.0 |
| Supabase stack | healthy |
| `supabase/.temp/start-secrets` | never created |
| Host bind mounts into the repo, any container | none — db has only its data volume |
| The labeling script in that worktree | absent, so nothing labeled anything |

The script would have labeled a directory nothing creates or reads. The review also found two real defects in it (unreachable in the main worktree; the AGENTS.md bullet stated two things that were no longer true), both moot once the premise went.

## What this PR keeps

The part that has ongoing value: the cause was a **CLI version**, so an older CLI brings the bug straight back, and nothing about the error message would lead anyone to this explanation a second time. A new section in `pinpoint-deployment` records the symptom, the mechanism (staged file inherits `user_home_t`, container runs as `container_t`, SELinux denies the `stat`, so `test -f` is false on `EACCES` and the keygen tries to *create* the key through a read-only mount), why 2.112.0+ ended it, and the one-line `chcon` if it ever returns.

Routed to the skill rather than AGENTS.md per §8 — actionable "what/how" in AGENTS.md, deep dives in skills — and the skill's `description` frontmatter now names the symptom so the lookup works from the error message.

Closes PP-9mg0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt1h4mHucYX7oQQyjUL4LT