### PR TITLE
docs(agents): point subagent quality gate at AGENTS.md §5, not `check` alone (PP-lql4)

### DIFF
--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -75,7 +75,7 @@ Present options to the user. Before proceeding, verify tasks are independent:
 
 1. The bead ID + "First run `bd show <id>` && `bd update <id> --claim`, then work from the bead." The bead carries scope, files, line numbers, and acceptance criteria — do NOT restate them in the prompt (two places to drift).
 2. Only context that ISN'T already in the bead — cross-bead conflicts, a reference PR, sequencing constraints. Omit when there's nothing to add.
-3. Quality gate: "Run `pnpm run check` before returning."
+3. Quality gate: point the agent at **AGENTS.md §5 "Which tests to run"** and tell it to run the tiers matching what it touched. Do **not** write "run `pnpm run check`" and stop — `check` is a static gate that runs no unit tests and no pytest (PP-4zcj), so that instruction cannot fail on a broken test and CI becomes the first thing that notices (PP-lql4).
 4. Full PR lifecycle: "Create PR, verify CI green."
 5. Structured return format: branch, PR#, CI status, blockers
 

--- a/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
+++ b/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
@@ -13,7 +13,9 @@ Work bead {beads_id}. First run `bd show {beads_id}` && `bd update {beads_id} --
 
 ### Quality Gates
 
-Run `pnpm run check` before returning. Then self-review **by hand**: read your own diff (`git diff origin/main...HEAD`) against `REVIEW.md` — the canonical rubric — plus the bead's acceptance criteria and out-of-scope list, and fix what you find. Don't reach for `/code-review` or `ultra`: both are user-triggered harness surfaces (`ultra` is also billed) and an agent cannot launch either.
+Before returning, run the gates **AGENTS.md §5 "Which tests to run"** names for the layers you touched — that tiered list is the source of truth, so read it rather than assuming. Note in particular that `pnpm run check` is a **static** gate: it runs no unit tests and no pytest, so on its own it cannot fail on a broken test.
+
+Then self-review **by hand**: read your own diff (`git diff origin/main...HEAD`) against `REVIEW.md` — the canonical rubric — plus the bead's acceptance criteria and out-of-scope list, and fix what you find. Don't reach for `/code-review` or `ultra`: both are user-triggered harness surfaces (`ultra` is also billed) and an agent cannot launch either.
 
 A review covering the head commit is **required** to merge, and **no bot reviews this repo**. The reviewer is Tim running `/code-review`, which you cannot launch — so getting reviewed is a handoff, not a command you run.
 
@@ -62,7 +64,7 @@ If tests fail with `POSTGRES_URL is not set`:
 
 1. `isolation: "worktree"` sets CWD automatically — no absolute paths needed
 2. The bead is the source of truth — point the agent at `bd show`; don't restate scope/files in the prompt (two places to drift)
-3. Quality is self-enforced — explicit `pnpm run check` replaces hook enforcement
+3. Quality is self-enforced — hooks don't fire for subagents, so the prompt IS the enforcement. Point at AGENTS.md §5's tiered list, never at `pnpm run check` alone: `check` is static and cannot fail on a broken test (PP-lql4)
 4. Structured return format enables quick lead assessment
 5. Nothing reviews automatically and there is nothing for the agent to request — its terminal state is a PR reported as needing Tim's `/code-review`. The return format asks for exactly that, and at handoff the lead checks the marker's pinned SHA against head (SKILL.md → "Ensure every PR is reviewed")
 

--- a/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
+++ b/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
@@ -71,7 +71,7 @@ Everything above happens **in a worktree** — the root checkout is read-only (A
 Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally". **In PinPoint that menu does not apply.** There is exactly one finish path:
 
 - **Never merge locally, never push/merge to `main`, and never merge the PR yourself by any path.** Ship through a PR: push the branch, open it **ready-for-review**, let **CI** run the full suite, post UI screenshots if UI-touching, then hand Tim the exact command to run himself: `! scripts/workflow/merge-pr.sh <PR> --human` (never `gh pr merge` / MCP merge / running `merge-pr.sh` yourself — all three are blocked for agents, PP-wi85). Full pipeline: `pinpoint-pr-workflow` (Phases 4-5, "landing the plane").
-- **Tests:** use PinPoint's tiered commands (`pnpm run check` floor; `pnpm run preflight` for migrations/auth/server-actions/middleware/schema; `pnpm run smoke` for UI) — **not** `npm test` / `pytest`. The full E2E suite (`e2e:full` / `e2e:all`) is CI's job by default; it peaks at several GB, so run it locally only when the host has the headroom.
+- **Tests:** use PinPoint's tiered commands, listed in **AGENTS.md §5 "Which tests to run"** (`pnpm run check` is the **static** floor and runs no tests; `pnpm run test` is the unit suite; `pnpm run check:python` covers `scripts/` and `.claude/hooks/`; `pnpm run preflight` for migrations/auth/server-actions/middleware/schema; `pnpm run smoke` for UI) — **not** `npm test` / `pytest`. The full E2E suite (`e2e:full` / `e2e:all`) is CI's job by default; it peaks at several GB, so run it locally only when the host has the headroom.
 - **Worktree cleanup is destructive → wait for explicit confirmation** (`pinpoint-pr-workflow` Phase 5.2 "Cleanup"). When confirmed, cleanup goes through the `WorktreeRemove` hook / `scripts/worktree_cleanup.py` (dealloc slot + Docker volumes) — **never raw `git worktree remove`/`rm -rf`**, which leaks the slot manifest and volumes.
 - **"Discard" is not a routine option.** Abandoning work is a deliberate, confirmed action, not a menu pick.
 - **Close the bead only after merge** (landing-the-plane) — not at push, not at PR-open.
@@ -88,7 +88,7 @@ Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally".
 | SDD dispatch             | clear the scale gate (count + cost, Tim's yes) first                                              |
 | Code review              | CI Gate + `pinpoint-pr-workflow` head-commit review; replies via MCP, signed with your agent name |
 | Finish: "merge locally"  | ❌ prohibited → PR + human-only `merge-pr.sh --human` handoff + landing-the-plane                 |
-| Finish: tests            | tiered `pnpm run check`/`preflight`/`smoke`, not `npm test`                                       |
+| Finish: tests            | AGENTS.md §5's tiered `check`/`test`/`preflight`/`smoke`, not `npm test`                          |
 | Finish: worktree cleanup | `WorktreeRemove` hook / `worktree_cleanup.py`, on confirmation                                    |
 | Close bead               | only after merge                                                                                  |
 

--- a/.claude/agents/investigator.md
+++ b/.claude/agents/investigator.md
@@ -87,10 +87,11 @@ color: blue
 
 ```bash
 # Fast Quality Check (recommended for quick feedback)
-pnpm run check  # Runs: typecheck, lint, test, format:fix in parallel (~5s)
+pnpm run check  # Static gate only: typecheck, lint, format, shell/YAML/Python linters (~9s). No unit tests, no pytest.
+pnpm run test   # Unit suite — check does NOT run it
 
 # Comprehensive Pre-Commit Check
-pnpm run preflight  # Full suite: check + build + integration + smoke tests
+pnpm run preflight  # Full suite: check + build + unit + integration
 
 # Individual Component Checks
 pnpm run typecheck       # TypeScript type checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ For multiple independent tasks, use worktree-isolated subagents.
 
 **Primary**: Standalone subagents with `isolation: "worktree"` + `run_in_background: true`. Use `SendMessage` (by agent ID or `name`) for follow-up (review comments, CI fixes). The `post-checkout` hook automatically allocates ports and generates configs.
 
-**Quality Enforcement**: Self-enforced via prompt instructions (`pnpm run check` before returning). Hooks don't fire for subagents.
+**Quality Enforcement**: Hooks don't fire for subagents, so the dispatch prompt is the enforcement. Point the agent at AGENTS.md §5 "Which tests to run" — the tiered list — not at `pnpm run check` alone, which is a static gate that runs no tests.
 
 **Anti-patterns**:
 


### PR DESCRIPTION
## Problem

PP-4zcj (#1800) made `pnpm run check` a **pure static gate** on 2026-08-02: types, lint, format, and the shell/YAML/Python linters. **It no longer runs unit tests or pytest.** AGENTS.md was updated thoroughly; the `pinpoint-orchestrator` skill and its dispatch prompt template were not — and those are what actually reach subagents.

Hooks don't fire for subagents, so the dispatch prompt IS the enforcement. A lead following the template verbatim dispatched agents whose only instructed gate cannot fail on a broken unit test: the agent returns "check green", opens a PR, and CI is the first thing that notices. Observed 2026-08-02 on PRs #1807/#1809, where both agents ran `pnpm run test` on their own initiative — diligence covering for the instruction, not the instruction working.

## Approach

Every site now **points at AGENTS.md §5 "Which tests to run"** as the single source of truth rather than restating a command list. A restated list is a second place to drift, which is the exact bug being fixed. The one fact each site does state inline is the correction itself: `check` is static and cannot fail on a broken test.

## Files changed

| File | What |
| :--- | :--- |
| `.agents/skills/pinpoint-orchestrator/SKILL.md` | Phase 3 dispatch checklist item 3 |
| `.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md` | the prompt body (Quality Gates) and the Key Points rationale |
| `CLAUDE.md` | "Quality Enforcement" under Parallel Subagent Workflow — the surviving anti-pattern site the bead placed at `SKILL.md:304` |
| `.agents/skills/pinpoint-superpowers-bridge/SKILL.md` | tiered test commands + the overrides table (found by the sweep, beyond the bead's five sites) |
| `.claude/agents/investigator.md` | command block claimed `check` runs `test`, and that `preflight` runs smoke — both wrong (sweep) |

## Notes

- **`.claude/skills` is a symlink to `.agents/skills`** (mode `120000` in git), so "the two trees agree" holds by construction — no duplicate edit needed.
- The bead named a fifth site at `SKILL.md:304` (anti-patterns). That section no longer exists in the current `SKILL.md`; the surviving equivalent is CLAUDE.md's "Quality Enforcement" line, which is fixed here. The bead's other line numbers are also stale relative to the rewritten file.
- **`AGENTS.md` and `docs/NON_NEGOTIABLES.md` deliberately untouched** — open PR #1834 rewrites both. No fix here needed them; AGENTS.md §5 is already correct and is what everything now points to.
- Dated artifacts under `docs/plans/`, `docs/superpowers/`, and `docs/testing/unit-test-audit-2026-06.md` still mention the old `check` semantics; per AGENTS.md §8 those are records, left alone.

Docs-only. `pnpm run check` green.

Closes PP-lql4.
