### PR TITLE
feat(hooks): point at the runner when an agent overrides the memory gate (PP-9ka9)

### DIFF
--- a/.claude/hooks/block-heavy-under-pressure.cjs
+++ b/.claude/hooks/block-heavy-under-pressure.cjs
@@ -150,7 +150,89 @@ function isHeavyCommand(command) {
   return segments.some(isHeavySegment);
 }
 
-module.exports = { isHeavyCommand };
+// --- Offload reminder (PP-9ka9) ----------------------------------------------
+// When an agent overrides the gate with FORCE_MEM_PRECHECK=skip, the block
+// message it already read is behind it — it is re-running the same command with
+// a prefix. The override is the moment a reminder is worth delivering, so this
+// attaches one to the tool call. It never denies: the override is a legitimate
+// escape hatch and stays one.
+//
+// A reminder is only honest when a job actually exists. `pnpm run build` is in
+// the heavy set but crabbox has no build job, so it maps to null and stays
+// silent. Anything ambiguous (bare `vitest run`, a raw `playwright test` whose
+// config we cannot infer) also maps to null rather than naming a job that might
+// run the wrong suite.
+const CRABBOX_JOB_BY_SCRIPT = new Map([
+  ["test:integration", "integration"],
+  ["test:integration:supabase", "integration-supabase"],
+  ["smoke", "smoke"],
+  ["e2e", "e2e-full"],
+  ["e2e:full", "e2e-full"],
+  ["e2e:all", "e2e-full"],
+]);
+
+/**
+ * Which crabbox job would have run this command, if any?
+ *
+ * Deliberately matches only `pnpm run <script>` shapes. The classifier above
+ * also treats `vitest run` and `playwright test` as heavy, but those carry no
+ * reliable signal about WHICH suite they are — a raw `playwright test
+ * --config=playwright.config.full.ts` is e2e-full while a bare one is not — and
+ * naming the wrong job is worse than saying nothing.
+ */
+function crabboxJobFor(command) {
+  const { segments } = resolveCommand(String(command || ""), {
+    splitNewlines: false,
+  });
+  for (const segment of segments) {
+    const argv = [segment.name, ...segment.args];
+    if (!PACKAGE_RUNNERS.has(path.basename(argv[0]))) continue;
+    let i = 1;
+    while (i < argv.length && argv[i].startsWith("-")) i++;
+    if (!RUNNER_RUN_SUBCOMMANDS.has(argv[i] || "")) continue;
+    const job = CRABBOX_JOB_BY_SCRIPT.get(argv[i + 1] || "");
+    if (job) return job;
+  }
+  return null;
+}
+
+/**
+ * Is the crabbox CLI on PATH?
+ *
+ * Checked here rather than shelling out to `command -v`, which would cost a
+ * process on a hook that runs before every Bash call. Silent when absent, so a
+ * host with no runner — Bazzite, CI, a contributor's machine — sees nothing
+ * rather than advice it cannot act on.
+ */
+function hasCrabbox(env = process.env) {
+  const dirs = String(env.PATH || "").split(path.delimiter).filter(Boolean);
+  return dirs.some((dir) => {
+    try {
+      fs.accessSync(path.join(dir, "crabbox"), fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** The reminder text, or null when there is nothing honest to say. */
+function offloadReminder(command, env = process.env) {
+  if (!hasCrabbox(env)) return null;
+  const job = crabboxJobFor(command);
+  if (!job) return null;
+  return (
+    `This host is under memory pressure and the gate was overridden, so this ` +
+    `command is about to compete for RAM that is already short.\n\n` +
+    `The same suite runs on the Bazzite runner against your uncommitted tree:\n` +
+    `  crabbox job run ${job}\n\n` +
+    `Integration and E2E belong there by default — it is the faster answer as ` +
+    `well as the safer one. Dev servers and interactive debugging stay local. ` +
+    `See the "crabbox" skill. Proceeding with the local run either way.`
+  );
+}
+
+module.exports = { isHeavyCommand, crabboxJobFor, hasCrabbox, offloadReminder };
 
 async function main() {
   let inputData = "";
@@ -196,6 +278,21 @@ async function main() {
   // hook would run the precheck and could deny a command the user explicitly
   // told us to skip. Allow immediately when the inline override is present.
   if (/(^|\s)FORCE_MEM_PRECHECK=skip(\s|$)/.test(command)) {
+    // Allowed unconditionally — but this is the one moment worth reminding the
+    // agent that the work could run on the remote runner (PP-9ka9). No
+    // permissionDecision is emitted, so the normal permission flow is untouched
+    // and the command still runs; additionalContext just rides along.
+    const reminder = offloadReminder(command);
+    if (reminder) {
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            additionalContext: reminder,
+          },
+        }),
+      );
+    }
     process.exit(0);
   }
 

--- a/src/test/unit/hooks/block-heavy-under-pressure.test.ts
+++ b/src/test/unit/hooks/block-heavy-under-pressure.test.ts
@@ -24,8 +24,18 @@ const hookPath = path.resolve(
   process.cwd(),
   ".claude/hooks/block-heavy-under-pressure.cjs"
 );
-const { isHeavyCommand } = require(hookPath) as {
+const { isHeavyCommand, crabboxJobFor, hasCrabbox, offloadReminder } = require(
+  hookPath
+) as {
   isHeavyCommand: (cmd: string) => boolean;
+  crabboxJobFor: (cmd: string) => string | null;
+  // Env is a plain record, not NodeJS.ProcessEnv: the project augments that
+  // type to require NODE_ENV, and these only ever read PATH.
+  hasCrabbox: (env?: Record<string, string | undefined>) => boolean;
+  offloadReminder: (
+    cmd: string,
+    env?: Record<string, string | undefined>
+  ) => string | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -254,16 +264,28 @@ afterAll(() => {
   fs.rmSync(stubRoot, { recursive: true, force: true });
 });
 
-/** Run the hook as a subprocess against the always-blocking stub precheck. */
-function runHook(command: string): { status: number; stdout: string } {
+/**
+ * Run the hook as a subprocess against the always-blocking stub precheck.
+ *
+ * `pathOverride` replaces $PATH so crabbox presence is decided by the test
+ * rather than by the machine. Without it these assertions would pass locally
+ * (crabbox installed) and fail in CI (crabbox absent), or the reverse.
+ */
+function runHook(
+  command: string,
+  pathOverride?: string
+): { status: number; stdout: string } {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     CLAUDE_PROJECT_DIR: stubRoot,
   };
+  if (pathOverride !== undefined) env.PATH = pathOverride;
   // The hook passes through unconditionally when $CI is set; drop it so the
   // classifier is what decides here (CI is set on GitHub Actions runners).
   delete env.CI;
-  const result = spawnSync("node", [hookPath], {
+  // Spawn via the absolute interpreter path, not "node": `pathOverride`
+  // replaces $PATH wholesale, so a bare "node" would no longer resolve.
+  const result = spawnSync(process.execPath, [hookPath], {
     env,
     input: JSON.stringify({ tool_name: "Bash", tool_input: { command } }),
     encoding: "utf8",
@@ -299,5 +321,169 @@ describe("hook subprocess — the precheck only runs for real heavy commands", (
     );
     expect(status).toBe(0);
     expect(stdout).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offload reminder (PP-9ka9)
+//
+// When the gate is overridden with FORCE_MEM_PRECHECK=skip, the hook attaches a
+// note pointing at the crabbox runner. It must never turn into a decision, must
+// only fire where a job actually exists, and must stay silent on a host with no
+// runner — so these tests control $PATH rather than trusting the machine's.
+// ---------------------------------------------------------------------------
+const crabboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-crabbox-"));
+fs.writeFileSync(path.join(crabboxDir, "crabbox"), "#!/bin/sh\nexit 0\n", {
+  mode: 0o755,
+});
+const emptyPathDir = fs.mkdtempSync(path.join(os.tmpdir(), "no-crabbox-"));
+
+// PATH shapes for the subprocess cases. The "present" one PREPENDS to the real
+// PATH because the non-override path shells out to `bash` for the precheck and
+// would otherwise fail-open on a missing interpreter — which would make the
+// test pass for the wrong reason. The "absent" one must replace PATH outright,
+// since the point is that crabbox is not reachable; that path short-circuits on
+// the override before any subprocess is needed.
+const pathWithCrabbox = [crabboxDir, process.env.PATH ?? ""].join(
+  path.delimiter
+);
+
+afterAll(() => {
+  fs.rmSync(crabboxDir, { recursive: true, force: true });
+  fs.rmSync(emptyPathDir, { recursive: true, force: true });
+});
+
+describe("crabboxJobFor — maps a command to the job that would run it", () => {
+  it.each([
+    ["pnpm run test:integration", "integration"],
+    ["pnpm run test:integration:supabase", "integration-supabase"],
+    ["pnpm run smoke", "smoke"],
+    ["pnpm run e2e", "e2e-full"],
+    ["pnpm run e2e:full", "e2e-full"],
+    ["pnpm run e2e:all", "e2e-full"],
+  ])("%s → %s", (cmd, job) => {
+    expect(crabboxJobFor(cmd)).toBe(job);
+  });
+
+  it("still maps when the override prefix is present", () => {
+    expect(crabboxJobFor("FORCE_MEM_PRECHECK=skip pnpm run smoke")).toBe(
+      "smoke"
+    );
+  });
+
+  it("maps through a shell sequence", () => {
+    expect(crabboxJobFor("cd apps/web && pnpm run test:integration")).toBe(
+      "integration"
+    );
+  });
+
+  it("returns null for build — heavy, but crabbox has no build job", () => {
+    expect(crabboxJobFor("pnpm run build")).toBeNull();
+  });
+
+  it.each(["vitest run", "playwright test", "pnpm exec playwright test"])(
+    "returns null for %s — heavy but the suite is not knowable",
+    (cmd) => {
+      expect(crabboxJobFor(cmd)).toBeNull();
+    }
+  );
+
+  it("returns null for prose that merely names a script", () => {
+    expect(crabboxJobFor('echo "try pnpm run smoke"')).toBeNull();
+  });
+});
+
+describe("hasCrabbox — presence is read from $PATH", () => {
+  it("finds an executable crabbox on PATH", () => {
+    expect(hasCrabbox({ PATH: crabboxDir })).toBe(true);
+  });
+
+  it("is false when PATH has no crabbox", () => {
+    expect(hasCrabbox({ PATH: emptyPathDir })).toBe(false);
+  });
+
+  it("is false when PATH is unset", () => {
+    expect(hasCrabbox({})).toBe(false);
+  });
+
+  it("does not mistake a non-executable file for the CLI", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "unexec-crabbox-"));
+    fs.writeFileSync(path.join(dir, "crabbox"), "not a binary", {
+      mode: 0o644,
+    });
+    expect(hasCrabbox({ PATH: dir })).toBe(false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("offloadReminder — only speaks when it has something true to say", () => {
+  it("names the job for an offloadable suite", () => {
+    const msg = offloadReminder("FORCE_MEM_PRECHECK=skip pnpm run smoke", {
+      PATH: crabboxDir,
+    });
+    expect(msg).toContain("crabbox job run smoke");
+  });
+
+  it("is silent for build even with crabbox installed", () => {
+    expect(
+      offloadReminder("FORCE_MEM_PRECHECK=skip pnpm run build", {
+        PATH: crabboxDir,
+      })
+    ).toBeNull();
+  });
+
+  it("is silent on a host with no runner", () => {
+    expect(
+      offloadReminder("FORCE_MEM_PRECHECK=skip pnpm run smoke", {
+        PATH: emptyPathDir,
+      })
+    ).toBeNull();
+  });
+});
+
+describe("hook subprocess — the override reminder rides along, never decides", () => {
+  it("attaches additionalContext naming the job", () => {
+    const { status, stdout } = runHook(
+      "FORCE_MEM_PRECHECK=skip pnpm run test:integration",
+      pathWithCrabbox
+    );
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput: Record<string, unknown>;
+    };
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(parsed.hookSpecificOutput.additionalContext).toContain(
+      "crabbox job run integration"
+    );
+  });
+
+  it("emits no permissionDecision, so the command is not gated by the reminder", () => {
+    const { stdout } = runHook(
+      "FORCE_MEM_PRECHECK=skip pnpm run smoke",
+      pathWithCrabbox
+    );
+    expect(stdout).not.toContain("permissionDecision");
+  });
+
+  it("stays silent for build under the override", () => {
+    const { stdout } = runHook(
+      "FORCE_MEM_PRECHECK=skip pnpm run build",
+      pathWithCrabbox
+    );
+    expect(stdout).toBe("");
+  });
+
+  it("stays silent when crabbox is not installed", () => {
+    const { stdout } = runHook(
+      "FORCE_MEM_PRECHECK=skip pnpm run test:integration",
+      emptyPathDir
+    );
+    expect(stdout).toBe("");
+  });
+
+  it("does not fire without the override — that path runs the precheck", () => {
+    const { stdout } = runHook("pnpm run test:integration", pathWithCrabbox);
+    expect(stdout).toContain('"permissionDecision":"deny"');
+    expect(stdout).not.toContain("crabbox job run");
   });
 });


### PR DESCRIPTION
## What

When an agent hits the memory-pressure hard block and overrides it with `FORCE_MEM_PRECHECK=skip`, the hook now attaches a note pointing at the crabbox runner. **It does not block** — the override stays a legitimate escape hatch.

The block message already names crabbox (PP-ljx7), but by the time an agent has typed the override it has stopped reading that message — it's re-running the same command with a prefix. The override is the moment the reminder is worth delivering.

## Where it lives

**Extends `block-heavy-under-pressure.cjs` rather than adding a second hook.** That hook already owns the heavy-command classifier and already detects the inline override — the early return added so it doesn't deny a command the user explicitly told it to skip. A separate hook would duplicate the classifier and cost another process on every Bash call.

## What it deliberately won't say

A reminder is only honest when a job actually exists:

| Command | Reminder |
| --- | --- |
| `pnpm run test:integration` | `crabbox job run integration` |
| `pnpm run test:integration:supabase` | `crabbox job run integration-supabase` |
| `pnpm run smoke` | `crabbox job run smoke` |
| `pnpm run e2e` / `e2e:full` / `e2e:all` | `crabbox job run e2e-full` |
| `pnpm run build` | **silent** — heavy, but crabbox has no build job |
| `vitest run`, `playwright test` | **silent** — heavy, but the suite isn't knowable from the command |

And it's guarded on the CLI being on `PATH`, so a host with no runner — CI, Bazzite, another contributor's machine — sees nothing rather than advice it can't act on.

## Mechanism

Emits `hookSpecificOutput.additionalContext` with **no `permissionDecision`**, so the permission flow is untouched and the command runs either way. `additionalContext` is injected into the agent's context at the tool call.

## Verification

- 66 tests in `block-heavy-under-pressure.test.ts` (was 45), covering the job mapping, the silent cases, PATH-based presence detection, and the subprocess contract that no `permissionDecision` is emitted
- Tests control `$PATH` rather than trusting the machine's, so they mean the same thing locally and in CI. `runHook` now spawns via `process.execPath` — a bare `"node"` stopped resolving once `$PATH` was overridable
- `pnpm run check` clean; full unit suite 2124 passed
- Hook exercised end-to-end with a real payload

Hook and tests only; no runtime code touched, nothing to screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh1h7VM9RiEnEsssCFqVex
