### PR TITLE
fix(mcp): single-source the issue enums, share the UUIDv8 key derivation (PP-brbu)

### DIFF
--- a/src/lib/mcp/tools/add-issue-comment.ts
+++ b/src/lib/mcp/tools/add-issue-comment.ts
@@ -1,7 +1,5 @@
 import "server-only";
 
-import { createHash } from "node:crypto";
-
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { after } from "next/server";
 import { z } from "zod";
@@ -12,26 +10,15 @@ import { plainTextToDoc } from "~/lib/tiptap/types";
 import { addIssueComment } from "~/services/issues";
 
 import {
+  contentAddressedUuid,
   issueUrl,
   McpToolError,
   resolveIssue,
+  retryWindowPart,
   runTool,
   type ToolOutcome,
 } from "./shared";
 import type { McpAuthContext } from "~/lib/mcp/verify-token";
-
-/** Retries inside this window resolve to the comment already posted. */
-const RETRY_WINDOW_MS = 10 * 60 * 1000;
-
-/**
- * The joiner for the idempotency key's field parts: a NUL, written as the
- * `\u0000` ESCAPE and never as a literal byte. A literal NUL in the source makes
- * the whole file binary to the toolchain — `git diff` reports "Binary files
- * differ" so the file is unreviewable, and `rg` skips it in directory searches,
- * which silently drops it out of every future codebase sweep. `create_issue`'s
- * key uses the same escape.
- */
-const KEY_SEPARATOR = "\u0000";
 
 const addIssueCommentSchema = z.object({
   machine: z
@@ -55,10 +42,14 @@ const addIssueCommentSchema = z.object({
 type AddIssueCommentArgs = z.infer<typeof addIssueCommentSchema>;
 
 /**
- * Content-addressed idempotency key, the same scheme as `create_issue`'s.
+ * Content-addressed idempotency key, the same scheme as `create_issue`'s — the
+ * digest-to-UUIDv8 rendering and the NUL joining both live in
+ * {@link contentAddressedUuid}, so the two tools cannot drift apart on the bits
+ * that decide whether a retry collides.
  *
- * NUL-joined so no field's content can impersonate a boundary between two
- * others ("ab" + "c" must not hash the same as "a" + "bc").
+ * Exported for the unit tests that pin the properties that matter: identical
+ * calls in one window collide, anything else does not, and the output is always
+ * a well-formed v8 UUID.
  */
 export function createCommentIdempotencyKey(
   issueId: string,
@@ -66,29 +57,7 @@ export function createCommentIdempotencyKey(
   userId: string,
   now: number
 ): string {
-  const parts = [
-    issueId,
-    comment,
-    userId,
-    String(Math.floor(now / RETRY_WINDOW_MS)),
-  ];
-  const digest = createHash("sha256")
-    .update(parts.join(KEY_SEPARATOR))
-    .digest();
-
-  // Take the leading 16 bytes and stamp the version (8) and RFC 4122 variant
-  // bits in place, then render the canonical 8-4-4-4-12 form.
-  const bytes = digest.subarray(0, 16);
-  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
-  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
-  const hex = bytes.toString("hex");
-  return [
-    hex.slice(0, 8),
-    hex.slice(8, 12),
-    hex.slice(12, 16),
-    hex.slice(16, 20),
-    hex.slice(20, 32),
-  ].join("-");
+  return contentAddressedUuid([issueId, comment, userId, retryWindowPart(now)]);
 }
 
 export async function runAddIssueComment(

--- a/src/lib/mcp/tools/create-issue.ts
+++ b/src/lib/mcp/tools/create-issue.ts
@@ -1,7 +1,5 @@
 import "server-only";
 
-import { createHash } from "node:crypto";
-
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { after } from "next/server";
 import { z } from "zod";
@@ -9,12 +7,19 @@ import { z } from "zod";
 import { dispatchNotification } from "~/lib/notifications";
 import { checkPermission } from "~/lib/permissions/helpers";
 import { plainTextToDoc } from "~/lib/tiptap/types";
+import {
+  ISSUE_FREQUENCY_VALUES,
+  ISSUE_PRIORITY_VALUES,
+  ISSUE_SEVERITY_VALUES,
+} from "~/lib/types";
 import { createIssue } from "~/services/issues";
 
 import {
+  contentAddressedUuid,
   issueUrl,
   McpToolError,
   resolveMachine,
+  retryWindowPart,
   runTool,
   type ToolOutcome,
 } from "./shared";
@@ -40,38 +45,20 @@ const createIssueSchema = z.object({
       "Optional plain-text detail; converted to the app's rich format."
     ),
   severity: z
-    .enum(["cosmetic", "minor", "major", "unplayable"])
+    .enum(ISSUE_SEVERITY_VALUES)
     .optional()
     .describe("How bad it is (default minor)."),
   priority: z
-    .enum(["low", "medium", "high"])
+    .enum(ISSUE_PRIORITY_VALUES)
     .optional()
     .describe("Triage priority (default medium)."),
   frequency: z
-    .enum(["intermittent", "frequent", "constant"])
+    .enum(ISSUE_FREQUENCY_VALUES)
     .optional()
     .describe("How often it happens (default intermittent)."),
 });
 
 type CreateIssueArgs = z.infer<typeof createIssueSchema>;
-
-/**
- * How long an identical `create_issue` call is treated as a retry of the same
- * report rather than a second, deliberate one.
- *
- * MCP has no client-supplied idempotency token, so the key is derived from the
- * call itself: same admin, same machine, same field-for-field content, same
- * window. A transport-level retry resends byte-identical arguments and lands on
- * the same key, so the service returns the original issue instead of filing a
- * duplicate.
- *
- * The window is what keeps this from being wrong in the other direction — a
- * genuine re-report of the same fault weeks later ("left flipper weak" after a
- * repair regressed) must file a NEW issue, not silently resolve to the old one.
- * A retry that straddles a window boundary degrades to the previous behaviour
- * (a duplicate), which is the safe direction to fail.
- */
-const RETRY_WINDOW_MS = 10 * 60 * 1000;
 
 /**
  * Content-addressed idempotency key for one create_issue call.
@@ -92,7 +79,7 @@ export function createIssueIdempotencyKey(
   machineId: string,
   now: number
 ): string {
-  const parts = [
+  return contentAddressedUuid([
     userId,
     machineId,
     args.title,
@@ -100,25 +87,8 @@ export function createIssueIdempotencyKey(
     args.severity ?? "",
     args.priority ?? "",
     args.frequency ?? "",
-    String(Math.floor(now / RETRY_WINDOW_MS)),
-  ];
-  // NUL-joined so no field's content can impersonate a boundary between two
-  // others ("ab" + "c" must not hash the same as "a" + "bc").
-  const digest = createHash("sha256").update(parts.join("\u0000")).digest();
-
-  // Take the leading 16 bytes and stamp the version (8) and RFC 4122 variant
-  // bits in place, then render the canonical 8-4-4-4-12 form.
-  const bytes = digest.subarray(0, 16);
-  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
-  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
-  const hex = bytes.toString("hex");
-  return [
-    hex.slice(0, 8),
-    hex.slice(8, 12),
-    hex.slice(12, 16),
-    hex.slice(16, 20),
-    hex.slice(20, 32),
-  ].join("-");
+    retryWindowPart(now),
+  ]);
 }
 
 export async function runCreateIssue(

--- a/src/lib/mcp/tools/get-issue.ts
+++ b/src/lib/mcp/tools/get-issue.ts
@@ -18,7 +18,7 @@ import {
 } from "./shared";
 import type { McpAuthContext } from "~/lib/mcp/verify-token";
 
-/** Comments returned when the caller doesn't ask for a count. */
+/** Comments returned when the caller doesn't ask for a specific limit. */
 const DEFAULT_COMMENT_LIMIT = 20;
 
 /** The comment slice returned to the caller, plus the full thread length. */
@@ -114,7 +114,13 @@ export async function runGetIssue(
         where: commentWhere,
         columns: { content: true, createdAt: true },
         with: { author: { columns: { name: true } } },
-        orderBy: (c, { desc }) => [desc(c.createdAt)],
+        // `id` breaks ties on `createdAt` for the same reason `list_issues`
+        // orders on a total key: with `createdAt` alone, two comments sharing a
+        // timestamp sit in an order Postgres is free to vary, and the LIMIT
+        // falls between them — so the window can drop one comment and the next
+        // call can show a different one, from a tool whose job is to be read
+        // before acting (CORE-ARCH-012).
+        orderBy: (c, { desc }) => [desc(c.createdAt), desc(c.id)],
         limit: commentLimit,
       }),
       db.select({ value: count() }).from(issueComments).where(commentWhere),

--- a/src/lib/mcp/tools/list-issues.ts
+++ b/src/lib/mcp/tools/list-issues.ts
@@ -13,6 +13,7 @@ import {
 import { checkPermission } from "~/lib/permissions/helpers";
 import { db } from "~/server/db";
 import { issues } from "~/server/db/schema";
+import { ISSUE_SEVERITY_VALUES } from "~/lib/types";
 
 import {
   issueUrl,
@@ -66,7 +67,7 @@ const listIssuesSchema = z.object({
       "Which statuses to include: 'open' (the default), 'closed', one status, or an array of statuses. Open statuses are new, confirmed, wait_owner, in_progress, need_parts, need_help. Closed are fixed, wont_fix, wai, no_repro, duplicate."
     ),
   severity: z
-    .enum(["cosmetic", "minor", "major", "unplayable"])
+    .enum(ISSUE_SEVERITY_VALUES)
     .optional()
     .describe("Only issues at this severity."),
   assignee: z

--- a/src/lib/mcp/tools/shared.ts
+++ b/src/lib/mcp/tools/shared.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { and, count, eq, inArray, sql } from "drizzle-orm";
@@ -14,7 +16,12 @@ import { OPEN_STATUSES, type IssueStatus } from "~/lib/issues/status";
 import type { MachinePresenceStatus } from "~/lib/machines/presence";
 import { reportError } from "~/lib/observability/report-error";
 import type { ProseMirrorDoc } from "~/lib/tiptap/types";
-import type { IssueFrequency, IssuePriority, IssueSeverity } from "~/lib/types";
+import type {
+  IssueFrequency,
+  IssuePriority,
+  IssueSeverity,
+  UserRole,
+} from "~/lib/types";
 import { getSiteUrl } from "~/lib/url";
 import type { MachinePbmColumns } from "~/services/machines";
 import { db } from "~/server/db";
@@ -183,12 +190,19 @@ function fullName(user: { firstName: string; lastName: string }): string {
   return `${user.firstName} ${user.lastName}`;
 }
 
-/** A profile matched by name, with the role its caller may or may not gate on. */
+/**
+ * A profile matched by name, with the role its caller may or may not gate on.
+ *
+ * `role` carries the column's own union rather than `string`: this interface is
+ * the declared return type of {@link findProfilesByFullName}, so widening it
+ * here would widen what Drizzle inferred and let a misspelled comparison
+ * (`m.role !== "guests"`) compile into a filter that excludes nobody.
+ */
 interface NamedProfile {
   id: string;
   firstName: string;
   lastName: string;
-  role: string;
+  role: UserRole;
 }
 
 /**
@@ -440,6 +454,76 @@ export async function resolveAssigneeFilter(ref: string): Promise<string> {
     throw ambiguousName(ref, matches);
   }
   return first.id;
+}
+
+/**
+ * How long an identical mutating call is treated as a retry of the same request
+ * rather than a second, deliberate one.
+ *
+ * MCP has no client-supplied idempotency token, so the key is derived from the
+ * call itself: same admin, same target, same field-for-field content, same
+ * window. A transport-level retry resends byte-identical arguments and lands on
+ * the same key, so the service returns the original row instead of writing a
+ * duplicate.
+ *
+ * The window is what keeps this from being wrong in the other direction — a
+ * genuine re-report of the same fault weeks later ("left flipper weak" after a
+ * repair regressed) must file a NEW row, not silently resolve to the old one. A
+ * retry that straddles a window boundary degrades to the previous behaviour (a
+ * duplicate), which is the safe direction to fail.
+ */
+const RETRY_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * The joiner for an idempotency key's field parts: a NUL, written as the
+ * `\u0000` ESCAPE and never as a literal byte. A literal NUL in the source makes
+ * the whole file binary to the toolchain — `git diff` reports "Binary files
+ * differ" so the file is unreviewable, and `rg` skips it in directory searches,
+ * which silently drops it out of every future codebase sweep.
+ */
+const KEY_SEPARATOR = "\u0000";
+
+/**
+ * Render `parts` as a content-addressed **UUIDv8**, the shared derivation behind
+ * every MCP tool's idempotency key.
+ *
+ * The `idempotency_key` columns are Postgres `uuid`, so the SHA-256 digest is
+ * rendered as v8 — the RFC 9562 version reserved for custom,
+ * implementation-defined layouts, which is what a hash-derived identifier is.
+ * (v4 would misrepresent these bits as random; v5 specifically means SHA-1 over
+ * a namespace.)
+ *
+ * Parts are NUL-joined so no field's content can impersonate a boundary between
+ * two others ("ab" + "c" must not hash the same as "a" + "bc"). Callers append
+ * `String(Math.floor(now / RETRY_WINDOW_MS))` as the window part.
+ *
+ * One implementation rather than one per tool: the bit-stamping is the part that
+ * has to be identical everywhere, and a second copy is a second chance to get
+ * the version or variant nibble wrong in a way no caller would notice.
+ */
+export function contentAddressedUuid(parts: readonly string[]): string {
+  const digest = createHash("sha256")
+    .update(parts.join(KEY_SEPARATOR))
+    .digest();
+
+  // Take the leading 16 bytes and stamp the version (8) and RFC 4122 variant
+  // bits in place, then render the canonical 8-4-4-4-12 form.
+  const bytes = digest.subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x80;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+/** The current retry window, as the trailing part of an idempotency key. */
+export function retryWindowPart(now: number): string {
+  return String(Math.floor(now / RETRY_WINDOW_MS));
 }
 
 /** Absolute URL for a machine's detail page. */

--- a/src/lib/mcp/tools/update-issue.ts
+++ b/src/lib/mcp/tools/update-issue.ts
@@ -16,6 +16,11 @@ import {
   updateIssueStatus,
   updateIssueTitle,
 } from "~/services/issues";
+import {
+  ISSUE_FREQUENCY_VALUES,
+  ISSUE_PRIORITY_VALUES,
+  ISSUE_SEVERITY_VALUES,
+} from "~/lib/types";
 
 import {
   issueUrl,
@@ -98,17 +103,17 @@ const updateIssueSchema = z.object({
       "New status. Open: new, confirmed, wait_owner, in_progress, need_parts, need_help. Closed: fixed, wont_fix, wai, no_repro, duplicate."
     ),
   severity: z
-    .enum(["cosmetic", "minor", "major", "unplayable"])
+    .enum(ISSUE_SEVERITY_VALUES)
     .optional()
     .describe(
       "How much it affects play: cosmetic, minor, major, or unplayable."
     ),
   frequency: z
-    .enum(["intermittent", "frequent", "constant"])
+    .enum(ISSUE_FREQUENCY_VALUES)
     .optional()
     .describe("How often it happens: intermittent, frequent, or constant."),
   priority: z
-    .enum(["low", "medium", "high"])
+    .enum(ISSUE_PRIORITY_VALUES)
     .optional()
     .describe("Work priority: low, medium, or high."),
   assignee: z

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -28,9 +28,38 @@ import type { IssueStatus } from "~/lib/issues/status";
 // Re-export types (IssueStatus comes from single source of truth)
 export type { UserRole, IssueStatus };
 
-export type IssueSeverity = "cosmetic" | "minor" | "major" | "unplayable";
-export type IssuePriority = "low" | "medium" | "high";
-export type IssueFrequency = "intermittent" | "frequent" | "constant";
+/**
+ * The severity/priority/frequency vocabularies as VALUE arrays, with the types
+ * derived from them — the same array-is-the-source-of-truth shape
+ * `ISSUE_STATUS_VALUES` uses in `~/lib/issues/status`.
+ *
+ * Runtime validators (Zod schemas, MCP tool inputs, URL filter parsers) need the
+ * list of values, not just the type. When the type is hand-written each of those
+ * sites re-types the literals, and adding a value to the type leaves every one
+ * of them silently rejecting it — a valid severity the API refuses, with nothing
+ * failing to compile. Spreading these arrays into `z.enum` instead makes the
+ * type and the accepted set the same object.
+ *
+ * Severity uses the player-centric vocabulary (`pinpoint-design-bible`): never
+ * low/medium/high, never "critical".
+ */
+export const ISSUE_SEVERITY_VALUES = [
+  "cosmetic",
+  "minor",
+  "major",
+  "unplayable",
+] as const;
+export type IssueSeverity = (typeof ISSUE_SEVERITY_VALUES)[number];
+
+export const ISSUE_PRIORITY_VALUES = ["low", "medium", "high"] as const;
+export type IssuePriority = (typeof ISSUE_PRIORITY_VALUES)[number];
+
+export const ISSUE_FREQUENCY_VALUES = [
+  "intermittent",
+  "frequent",
+  "constant",
+] as const;
+export type IssueFrequency = (typeof ISSUE_FREQUENCY_VALUES)[number];
 
 // Select types (full row from database)
 export type UserProfile = InferSelectModel<typeof userProfiles>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -16,6 +16,12 @@ export type {
   IssueFrequency,
 } from "./database";
 
+export {
+  ISSUE_SEVERITY_VALUES,
+  ISSUE_PRIORITY_VALUES,
+  ISSUE_FREQUENCY_VALUES,
+} from "./database";
+
 export type { UserContext, UserRole } from "./user";
 export { USER_ROLES } from "./user";
 


### PR DESCRIPTION
Hardening follow-ups on the MCP issue tools from #1851. **No correctness bugs were found in #1851** — the honest-reporting concerns there (`deduped`, `changed`, `partial`, `total` vs `count`, total-order pagination) are all handled and documented. These four changes make latent failure modes impossible rather than merely absent today.

## Where this came from

A `/code-review medium --fix` pass was launched against PR #1852 but resolved its target to `main`'s tip instead — commit `05e56e7d` (#1851), already merged. The findings are real, so rather than discard them they get their own branch. **#1852 is still unreviewed.**

## Changes

**`NamedProfile.role`: `string` → `UserRole`.** The declared return type of `findProfilesByFullName` was widening what Drizzle inferred from the column enum. A misspelled comparison in `resolveOwner` / `resolveAssignee` — `m.role !== "guests"` for `"guest"` — would have compiled into a guest filter matching nobody, letting a guest be assigned an issue. Now it fails to compile.

**Extracted `contentAddressedUuid()` and `retryWindowPart()` into `shared.ts`.** The UUIDv8 derivation — NUL join, version/variant bit stamping, 8-4-4-4-12 rendering — plus `RETRY_WINDOW_MS` and `KEY_SEPARATOR` were duplicated verbatim between `create-issue.ts` and `add-issue-comment.ts`. Two copies of hand-rolled bit stamping is two chances to get a nibble wrong, and it is load-bearing for idempotency. Both key builders now sit on the shared helpers (~50 lines of duplication removed).

**Added `ISSUE_SEVERITY_VALUES` / `ISSUE_PRIORITY_VALUES` / `ISSUE_FREQUENCY_VALUES`.** The zod schemas in `list-issues.ts` and `update-issue.ts` re-typed their literals rather than deriving from `IssueSeverity` / `IssuePriority` / `IssueFrequency`. Adding a value to those unions would leave every MCP schema silently rejecting it, with nothing failing to compile. The arrays are now the source and the types derive from them — the pattern `ISSUE_STATUS_VALUES` already used.

**Added `desc(c.id)` to the `get-issue.ts` comment window.** It ordered on `createdAt` alone under a `LIMIT`, which is not a total order. Two comments sharing a timestamp at the limit boundary sit in an order Postgres may vary, so the window can drop one and a repeat call surface a different one. This is the same reasoning `list-issues.ts:563` already applies to its own ordering, not carried over.

Plus one jsdoc fix in `get-issue.ts` — it said "when the caller doesn't ask for a count"; it's a limit, not a count.

## Deliberately not fixed

Both are behavior decisions rather than bug fixes, so they are left for a call rather than folded in here:

- **`update-issue.ts:1188`** — the `assignee` entry in `applied` reports `from`/`to` as raw UUIDs while every other field reports a human-readable value, so a caller that passed a name gets back an opaque id it cannot map to a person. Fixing means an extra name lookup and a response-payload change.
- **`get-issue.ts:329`** — when `commentsWithheld` is set, `commentCount` reports `0`, contradicting its documented meaning ("full thread length"). `commentsWithheld` saves the caller, but the count field itself lies. The branch is unreachable today because the permission matrix grants `comments.view` at every level, and fixing it means running a count query on a path that currently runs none.

## Testing

`pnpm run check` clean, `pnpm run typecheck` clean, 2072 unit tests pass — including the idempotency-key tests, which is what confirms the `contentAddressedUuid()` extraction is behavior-identical rather than merely compiling.

Closes PP-brbu.
