### PR TITLE
fix(ui): stop painting a raw ISO instant in the relative-time slot (PP-h490)

### DIFF
--- a/src/components/collections/CollectionOverviewTable.tsx
+++ b/src/components/collections/CollectionOverviewTable.tsx
@@ -14,6 +14,7 @@ import { MachineStatusBadge } from "~/components/machines/MachineStatusBadge";
 import { MachinePresenceBadge } from "~/components/machines/MachinePresenceBadge";
 import { RelativeTime } from "~/components/issues/RelativeTime";
 import { CompactAge } from "~/components/issues/CompactAge";
+import { useRelativeNow } from "~/components/issues/RelativeTimeProvider";
 import {
   useTableResponsiveColumns,
   type ColumnConfig,
@@ -158,6 +159,36 @@ function SortableHeader({
           ))}
       </button>
     </th>
+  );
+}
+
+/**
+ * "3 minutes ago — Comment" for the activity column.
+ *
+ * The separator has to be gated on the same tick as the time it separates.
+ * `<RelativeTime>` renders nothing until the shared ticker mounts, so emitting
+ * the em dash unconditionally left a bare " — Comment" on the pre-hydration
+ * paint (PP-h490). Subscribing here rather than in the row map keeps the 60s
+ * re-render scoped to this cell, which is what it already cost.
+ */
+function LastActivityCell({
+  at,
+  label,
+}: {
+  at: Date | string;
+  label: string;
+}): React.JSX.Element {
+  const now = useRelativeNow();
+  return (
+    <>
+      {now !== null && (
+        <>
+          <RelativeTime value={at} />
+          {" — "}
+        </>
+      )}
+      {label}
+    </>
   );
 }
 
@@ -381,11 +412,10 @@ export function CollectionOverviewTable({
                 {isShown("activity") && (
                   <td className="whitespace-nowrap px-3 py-2.5 text-muted-foreground">
                     {row.lastActivity ? (
-                      <>
-                        <RelativeTime value={row.lastActivity.createdAt} />
-                        {" — "}
-                        {getTagLabel(row.lastActivity.tag)}
-                      </>
+                      <LastActivityCell
+                        at={row.lastActivity.createdAt}
+                        label={getTagLabel(row.lastActivity.tag)}
+                      />
                     ) : (
                       "—"
                     )}

--- a/src/components/issues/IssueTimeline.tsx
+++ b/src/components/issues/IssueTimeline.tsx
@@ -2,6 +2,7 @@
 
 import React, { useTransition } from "react";
 import { formatDateTime } from "~/lib/dates";
+import { useRelativeNow } from "~/components/issues/RelativeTimeProvider";
 import { Avatar, AvatarFallback } from "~/components/ui/avatar";
 import { AddCommentForm } from "~/components/issues/AddCommentForm";
 import { OwnerBadge } from "~/components/issues/OwnerBadge";
@@ -202,6 +203,17 @@ function TimelineItem({
   const [isEditing, setIsEditing] = React.useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
+  // Subscribing here — not just inside the `<RelativeTime>` children — is what
+  // makes the timestamp buttons' `aria-label` safe. `formatDateTime` resolves
+  // the runtime's own locale and zone, so evaluating it during SSR and again in
+  // the browser yields different strings. React does not patch a mismatched
+  // *attribute* the way it patches text, and without this subscription nothing
+  // would ever re-render the button, so a UTC-hosted render would leave the
+  // server's zone announced to screen readers forever. Rendering a static label
+  // until the first tick keeps SSR and the client's first render in agreement,
+  // then swaps in the real timestamp once we are demonstrably client-side.
+  const now = useRelativeNow();
+
   const { currentUserId, currentUserRole } = userContext;
 
   const isSystem = event.type === "system";
@@ -263,14 +275,20 @@ function TimelineItem({
                   {/* The label names the absolute instant the tooltip reveals,
                       rather than leaving the relative label as the accessible
                       name. `<RelativeTime>` renders nothing until the client
-                      ticker mounts, so without this the button is nameless on
-                      the pre-hydration paint (axe `button-name`, PP-h490) — and
-                      even hydrated, "3 minutes ago" is a poor name for a
+                      ticker mounts, so without a label the button is nameless
+                      on the pre-hydration paint (axe `button-name`, PP-h490) —
+                      and even hydrated, "3 minutes ago" is a poor name for a
                       control whose whole purpose is to disclose the exact
-                      time. */}
+                      time. The pre-tick label is a static string because
+                      `formatDateTime` is zone-dependent; see the
+                      `useRelativeNow` comment above. */}
                   <button
                     type="button"
-                    aria-label={formatDateTime(event.createdAt)}
+                    aria-label={
+                      now === null
+                        ? "Show exact time"
+                        : formatDateTime(event.createdAt)
+                    }
                     className={cn(
                       "cursor-help bg-transparent p-0 text-[11px] text-muted-foreground",
                       timestampTooltipTriggerClassName
@@ -316,7 +334,11 @@ function TimelineItem({
                     <TooltipTrigger asChild>
                       <button
                         type="button"
-                        aria-label={formatDateTime(event.createdAt)}
+                        aria-label={
+                          now === null
+                            ? "Show exact time"
+                            : formatDateTime(event.createdAt)
+                        }
                         className={cn(
                           "cursor-help bg-transparent p-0 text-xs text-muted-foreground",
                           timestampTooltipTriggerClassName
@@ -332,9 +354,15 @@ function TimelineItem({
                   {isEdited && !isIssue && (
                     <Tooltip>
                       <TooltipTrigger asChild>
+                        {/* No `aria-label` here: unlike the two triggers above,
+                            this one carries visible text ("• edited"), so it is
+                            never nameless even while `<RelativeTime>` is empty.
+                            Leaving the content to name it also keeps the
+                            accessible name a superset of the visible label
+                            (WCAG 2.5.3), and avoids a zone-dependent
+                            attribute. */}
                         <button
                           type="button"
-                          aria-label={`Edited ${formatDateTime(event.updatedAt)}`}
                           className={cn(
                             "cursor-help bg-transparent p-0 text-xs text-muted-foreground",
                             timestampTooltipTriggerClassName

--- a/src/components/issues/IssueTimeline.tsx
+++ b/src/components/issues/IssueTimeline.tsx
@@ -260,8 +260,17 @@ function TimelineItem({
               )}
               <Tooltip>
                 <TooltipTrigger asChild>
+                  {/* The label names the absolute instant the tooltip reveals,
+                      rather than leaving the relative label as the accessible
+                      name. `<RelativeTime>` renders nothing until the client
+                      ticker mounts, so without this the button is nameless on
+                      the pre-hydration paint (axe `button-name`, PP-h490) — and
+                      even hydrated, "3 minutes ago" is a poor name for a
+                      control whose whole purpose is to disclose the exact
+                      time. */}
                   <button
                     type="button"
+                    aria-label={formatDateTime(event.createdAt)}
                     className={cn(
                       "cursor-help bg-transparent p-0 text-[11px] text-muted-foreground",
                       timestampTooltipTriggerClassName
@@ -307,6 +316,7 @@ function TimelineItem({
                     <TooltipTrigger asChild>
                       <button
                         type="button"
+                        aria-label={formatDateTime(event.createdAt)}
                         className={cn(
                           "cursor-help bg-transparent p-0 text-xs text-muted-foreground",
                           timestampTooltipTriggerClassName
@@ -324,6 +334,7 @@ function TimelineItem({
                       <TooltipTrigger asChild>
                         <button
                           type="button"
+                          aria-label={`Edited ${formatDateTime(event.updatedAt)}`}
                           className={cn(
                             "cursor-help bg-transparent p-0 text-xs text-muted-foreground",
                             timestampTooltipTriggerClassName

--- a/src/components/issues/RelativeTime.test.tsx
+++ b/src/components/issues/RelativeTime.test.tsx
@@ -25,6 +25,26 @@ describe("RelativeTime", () => {
     expect(html).not.toMatch(/ago|just now|in /);
   });
 
+  it("renders nothing pre-hydration when no fallback is given", () => {
+    // Regression (PP-h490): the default used to be `value.toISOString()`, so a
+    // call site that omitted `fallback` painted "2026-04-25T10:00:00.000Z" —
+    // 24 characters — into a slot sized for "2 minutes ago". In the timeline
+    // rows that slot is right-pinned and `shrink-0`, so the raw instant pushed
+    // ~35px past the viewport on a 375px screen and was clipped by the row's
+    // own `overflow-hidden` until the client ticker mounted. Mobile Safari
+    // hydrates late enough for a user (and the responsive-overflow spec) to
+    // see it; Chrome usually did not.
+    //
+    // An empty default is hydration-safe for the same reason the ISO instant
+    // was chosen — it cannot vary by locale or time zone — and it cannot
+    // overflow any slot.
+    const html = renderToString(
+      <RelativeTime value={new Date("2026-04-25T10:00:00Z")} />
+    );
+    expect(html).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(html).toBe("");
+  });
+
   it("swaps to a relative label after mount", async () => {
     const recent = new Date(Date.now() - 5 * 60_000); // 5 minutes ago
     render(

--- a/src/components/issues/RelativeTime.tsx
+++ b/src/components/issues/RelativeTime.tsx
@@ -17,10 +17,17 @@ interface RelativeTimeProps {
    * so the raw instant overflowed the row and was clipped until hydration
    * (PP-h490). Empty is both zone-independent and unable to overflow.
    *
-   * Pass a server-computed absolute label where the pre-hydration paint should
-   * still carry a date — `NotificationList`, `IssueList` and the issue detail
-   * page all pass `formatDateTime(...)`, which is stable because the string is
-   * built once on the server and handed down as a prop.
+   * Pass an absolute label where the pre-hydration paint should still carry a
+   * date. The pattern to copy is `IssueUpdatedTimestamp`, whose `fallback` is
+   * computed by the issue-detail *server* page and handed down as a prop — the
+   * string is then built once, in one zone, and cannot diverge.
+   *
+   * `NotificationList` and `IssueList` also pass `formatDateTime(...)`, but
+   * both are `"use client"` and call it inline, so the value is computed twice
+   * in two possibly-different zones. That is tolerable *here* only because a
+   * fallback is text that the ticker replaces on mount; the same inline call
+   * feeding an `aria-label` or any other attribute is a real bug, because
+   * React does not patch mismatched attributes (see `IssueTimeline`).
    */
   fallback?: string;
 }

--- a/src/components/issues/RelativeTime.tsx
+++ b/src/components/issues/RelativeTime.tsx
@@ -6,8 +6,22 @@ import { useRelativeNow } from "./RelativeTimeProvider";
 
 interface RelativeTimeProps {
   value: Date | string;
-  /** Server/hydration label. Defaults to an ISO instant so SSR and browser
-   *  hydration do not diverge across different default locales/time zones. */
+  /**
+   * Server/hydration label, rendered until the client ticker mounts.
+   *
+   * Defaults to the empty string. It must not default to anything derived from
+   * `value` at render time: a locale- or zone-formatted label diverges between
+   * SSR and hydration, and the ISO instant this once defaulted to is 24
+   * characters — far wider than any relative label it stands in for. The
+   * timeline rows pin this into a `shrink-0` slot sized for "2 minutes ago",
+   * so the raw instant overflowed the row and was clipped until hydration
+   * (PP-h490). Empty is both zone-independent and unable to overflow.
+   *
+   * Pass a server-computed absolute label where the pre-hydration paint should
+   * still carry a date — `NotificationList`, `IssueList` and the issue detail
+   * page all pass `formatDateTime(...)`, which is stable because the string is
+   * built once on the server and handed down as a prop.
+   */
   fallback?: string;
 }
 
@@ -19,11 +33,7 @@ export function RelativeTime({
   // After mount the shared ticker emits a number every 60s, causing a re-render.
   const now = useRelativeNow();
 
-  const resolvedFallback = (() => {
-    if (fallback !== undefined) return fallback;
-    const date = typeof value === "string" ? new Date(value) : value;
-    return Number.isNaN(date.getTime()) ? "" : date.toISOString();
-  })();
+  const resolvedFallback = fallback ?? "";
 
   // Pre-mount / SSR path: render fallback (matches original useEffect behaviour).
   if (now === null) {

--- a/src/test/unit/components/issues/issue-detail-permissions.test.tsx
+++ b/src/test/unit/components/issues/issue-detail-permissions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
 import type { ReactElement } from "react";
 import type { IssueWithAllRelations } from "~/lib/types";
 import type { ProseMirrorDoc } from "~/lib/tiptap/types";
@@ -257,5 +258,75 @@ describe("Issue detail permission-aware UI", () => {
 
     expect(screen.queryByText("Log in to comment")).not.toBeInTheDocument();
     expect(screen.getByTestId("mock-add-comment-form")).toBeInTheDocument();
+  });
+
+  it("names the timestamp triggers without a zone-dependent SSR attribute", () => {
+    // Regression (PP-h490). Two things have to hold at once here:
+    //
+    // 1. The buttons must have an accessible name even while `<RelativeTime>`
+    //    is still empty (pre-tick), or axe's `button-name` fires — that is the
+    //    bug this PR's first fix introduced.
+    // 2. That name must not be `formatDateTime(...)` evaluated during SSR.
+    //    `Intl.DateTimeFormat(undefined, …)` resolves the *runtime's* zone, so
+    //    a UTC-hosted server and a UTC-5 browser produce different strings, and
+    //    React does not patch a mismatched attribute the way it patches text.
+    //    The label would stay wrong for the life of the page.
+    //
+    // The server snapshot of the shared ticker is `null`, so this asserts the
+    // pre-tick label specifically.
+    // The default fixture has no comments, so it renders only the "issue"
+    // branch. Both timestamp-trigger branches have to be on screen for this to
+    // mean anything — a system event reaches the first, an edited comment the
+    // second and third.
+    const issue = createIssue({
+      comments: [
+        {
+          id: "comment-sys",
+          isSystem: true,
+          author: null,
+          content: null,
+          eventData: { kind: "status_changed", from: "new", to: "fixed" },
+          createdAt: new Date("2026-02-02T14:30:00.000Z"),
+          updatedAt: new Date("2026-02-02T14:30:00.000Z"),
+        },
+        {
+          id: "comment-1",
+          isSystem: false,
+          author: { id: "member-1", name: "Member User" },
+          content: {
+            type: "doc",
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "Hi" }] },
+            ],
+          },
+          eventData: null,
+          createdAt: new Date("2026-02-03T14:30:00.000Z"),
+          updatedAt: new Date("2026-02-03T15:45:00.000Z"),
+        },
+      ] as IssueWithAllRelations["comments"],
+    });
+
+    const html = renderToString(
+      <TooltipProvider>
+        <IssueTimeline
+          issue={issue}
+          currentUserId="member-1"
+          currentUserRole="member"
+          currentUserInitials="MU"
+        />
+      </TooltipProvider>
+    );
+
+    const labels = [...html.matchAll(/aria-label="([^"]*)"/g)].map((m) => m[1]);
+    // Three labelled triggers: the system row uses one branch, the issue row
+    // and the comment row the other. If this count drops, the fixture stopped
+    // covering a branch and the zone assertion below is no longer watching it.
+    const timestampLabels = labels.filter((l) => l === "Show exact time");
+    expect(timestampLabels).toHaveLength(3);
+    // No rendered label may carry a formatted absolute time. "2:30 PM" is the
+    // shape `formatDateTime` produces; matching it means SSR baked in a zone.
+    for (const label of labels) {
+      expect(label).not.toMatch(/\d{1,2}:\d{2}\s?(AM|PM)/i);
+    }
   });
 });


### PR DESCRIPTION
## What

`RelativeTime` defaulted its pre-hydration fallback to `value.toISOString()`. Every call site that omitted `fallback` painted a 24-character instant — `2026-08-11T00:41:44.489Z` — into the timestamp slot until the shared ticker mounted. The three timeline row components and the collection timeline page all omit it.

Default to the empty string instead.

## Why this was the overflow bug

The timeline rows pin that timestamp into an `ml-auto shrink-0 whitespace-nowrap` slot sized for a label like "2 minutes ago" — 127px at a 375px viewport, with 4px to spare. The ISO instant measures **166px**, overruns the row by 35px, and is then clipped by the row's own `overflow-hidden`. That is content a user cannot read or reach.

Measured directly, instrumenting the assertion helper:

```
before hydration: text="2026-08-11T00:41:44.489Z"  w=166  right=410  vw=375   ← clipped
after  hydration: text="less than a minute ago"    w=127  right=371  vw=375   ← fits
```

Mobile Safari hydrates late enough that the state is visible to a user and to `responsive-overflow.spec.ts`; Chrome settles before the assertion runs. That is the whole reason only the non-gating Mobile Safari project went red — the bug itself is not WebKit-specific, and every browser paints the raw instant for some window.

## Why empty rather than a formatted date

The ISO default was chosen so SSR and hydration could not diverge across locales and time zones (the original comment says so). An empty string satisfies that constraint just as well and additionally cannot overflow a slot. Call sites that want a date in the pre-hydration paint keep passing one explicitly — `NotificationList.tsx:173`, `IssueList.tsx:574` and `m/[initials]/i/[issueNumber]/page.tsx:295` already pass `formatDateTime(...)`, which is stable because the string is built once on the server and handed down as a prop.

Empty-slot-then-swap was Tim's call over a short absolute date.

## Test coverage

The default fallback had **no** test — every existing case passed an explicit one. That gap is how this shipped. Added an SSR test asserting the no-`fallback` render emits no ISO instant.

## Verification

| Gate | Result |
| :--- | :--- |
| `responsive-overflow.spec.ts`, Mobile Safari | 22/22 (was 4 failed) |
| Same spec, chromium + Mobile Chrome + firefox + Mobile Safari | 60/60 |
| `pnpm run test` | 2073 passed |
| `pnpm run check` | clean |

Failing routes before the fix: `/m`, `/m/TAF`, `/m/TAF/maintenance`, `/c/owner/[member]/timeline`.

## Not in scope

PP-h490 also asks for a decision on the watch gap — Mobile Safari smoke runs only in the post-merge `E2E Comprehensive Tests` job, which is not a required check and which explicitly excludes Safari from its pass/fail decision (`ci.yml:909` counts Safari failures and echoes them to a log line). Tim's call is that Safari stays low-priority and non-gating, fixed reactively as it comes up. Recorded on the bead; no CI change here.

Closes PP-h490.