### PR TITLE
fix(perms): allow the review-marker script so the attestation step is deterministic (PP-yx97)

### DIFF
--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -130,6 +130,23 @@ This is a narrow exception and it is self-policing. "It's only a small change" i
 
 **The marker attests that a review actually happened.** Posting it otherwise is a false attestation, not a shortcut — the same honesty model as `merge-pr.sh --force`.
 
+#### Why the marker command carries a permission allow rule
+
+`.claude/settings.json` has one `permissions.allow` entry, and it is this script:
+
+```json
+"allow": ["Bash(bash scripts/workflow/mark-claude-review.sh *)"]
+```
+
+It is there because the command was intermittently denied. On 2026-08-03 an auto-mode session was refused with `Blocked by classifier` on PR #1815, while the same command succeeded four times across 2026-08-09/10 (PRs #1832, #1828, #1829, #1848). The block was contextual, not a standing rule — which is the worst shape for a required step, because it fails only sometimes and leaves the PR sitting at `unreviewed` with no path forward. A background subagent has no human to hand the command to at all. Rules are evaluated deny → ask → allow, and an explicit allow resolves the call before the classifier is consulted, so the entry makes the step deterministic. (PP-yx97. A new tool permission needs Tim's explicit approval each time; he gave it on 2026-08-11. This is not a CORE-SEC-010 surface — that rule governs prod-mutating Supabase tools, and its ban on `allow` applies to those.)
+
+**What the rule does not do is make the attestation true.** It removes the harness's opinion about whether you earned the marker, which means your own judgement is now the only thing standing between a false attestation and the merge gate. The honesty model above is not softened by the allow rule; it is the entire remaining check. Merging stays human-only regardless (PP-wi85), so a marker you should not have posted misleads Tim rather than merging anything by itself — that is a smaller failure, not a harmless one.
+
+Two limits worth knowing:
+
+- The rule matches the documented invocation, `bash scripts/workflow/mark-claude-review.sh …`. An absolute path is rewritten to a relative one by the `normalize-workspace-paths.cjs` hook, so that form works too. Chaining (`… && something-else`) does not inherit the allow — each subcommand is matched on its own.
+- A summary string containing an unbalanced quote makes the whole command unresolvable to `block-direct-merge.cjs`, which then scans the raw text and blocks on `merge-pr.sh` or `pr merge`. Rare, and it fails closed. Fix the quoting rather than working around it.
+
 #### Readiness is not review
 
 `pr-watch.py --check-ready` reports review state but does **not** gate on it. That check answers "is this PR worth Tim's `/code-review` right now?", and the review is what happens after that answer is yes — gating on it would be circular. Check-ready green means "hand it to Tim", not "will merge".

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -144,7 +144,7 @@ It is there because the command was intermittently denied. On 2026-08-03 an auto
 
 Two limits worth knowing:
 
-- The rule matches the documented invocation, `bash scripts/workflow/mark-claude-review.sh …`. An absolute path is rewritten to a relative one by the `normalize-workspace-paths.cjs` hook, so that form works too. Chaining (`… && something-else`) does not inherit the allow — each subcommand is matched on its own.
+- The rule matches the documented invocation, `bash scripts/workflow/mark-claude-review.sh …`, and only that shape. **Use the relative path** — an absolute one does not match and falls through to the classifier. Don't count on `normalize-workspace-paths.cjs` to rescue it: its rewrite regex is hardcoded to `/home/froeht/Code/…`, so it never fires on this Mac (`/Users/froeht/Code/PinPoint`), and its `pinpoint-worktrees/` alternative predates the current `.claude/worktrees/<branch>/` layout. Chaining (`… && something-else`) does not inherit the allow either — each subcommand is matched on its own.
 - A summary string containing an unbalanced quote makes the whole command unresolvable to `block-direct-merge.cjs`, which then scans the raw text and blocks on `merge-pr.sh` or `pr merge`. Rare, and it fails closed. Fix the quoting rather than working around it.
 
 #### Readiness is not review

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "permissions": {
+    "allow": ["Bash(bash scripts/workflow/mark-claude-review.sh *)"],
     "deny": [
       "Bash(supabase db push:*)",
       "Bash(supabase projects delete:*)",


### PR DESCRIPTION
## What

Adds the repo's first `permissions.allow` entry to `.claude/settings.json`, scoped to one script:

```json
"allow": ["Bash(bash scripts/workflow/mark-claude-review.sh *)"]
```

## Why

`mark-claude-review.sh` is the only thing that satisfies `merge-pr.sh`'s `reviewed` gate. It was **intermittently** denied by the auto-mode classifier:

| Date | PR | Outcome |
| :--- | :--- | :--- |
| 2026-08-03 | #1815 | denied — `Blocked by classifier` |
| 2026-08-09 | #1832, #1828, #1829 | succeeded |
| 2026-08-10 | #1848 | succeeded |

Contextual, not a standing rule — the worst shape for a required step, because it fails only sometimes and leaves the PR at `unreviewed` with no path forward. A background subagent has no human to hand the command to at all.

Permission rules evaluate **deny → ask → allow**, so an explicit allow resolves the call before the classifier is consulted. No existing deny or ask rule matches this command.

## The tradeoff, stated plainly

The allow rule removes the harness's opinion about whether the attestation was *earned*. One of the datapoints suggests the classifier may have been reasoning about exactly that — the 2026-08-10 success came in a session where Tim had just run `/code-review` and the review was in the agent's context.

So this deliberately trades a possibly-correct safeguard for determinism, and the docs say so rather than pretending the rule fixes the honesty problem. **Merging stays human-only (PP-wi85)**, so a marker posted in bad faith misleads Tim rather than merging anything by itself.

Tim approved this permission explicitly on 2026-08-11.

## Docs

`pinpoint-pr-workflow` Phase 3.4 gains a subsection covering why the rule exists, what it does not do, and two limits: chained subcommands don't inherit the allow, and an unbalanced quote in the summary makes the command unresolvable to `block-direct-merge.cjs` (which then fails closed).

## Verification

- `pnpm run check` green.
- Guard-stack + merge-guard unit tests: 112 passed.
- `verify-guard-stack.cjs` canary reports healthy — `deny` (11) and `ask` (41) intact.
- Probed `block-direct-merge.cjs` directly: it allows the marker command even when the free-text summary contains `merge-pr.sh` or `pr merge`, because a statically resolvable command returns before the raw indicator scan.

Not a CORE-SEC-010 surface — that rule's ban on `allow` governs prod-mutating Supabase tools.

Closes PP-yx97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVzZ53uh3y5X1vUUxyEbVc