### PR TITLE
fix(permissions): route collection view through the matrix (PP-vdz6)

### DIFF
--- a/.agents/skills/pinpoint-security/SKILL.md
+++ b/.agents/skills/pinpoint-security/SKILL.md
@@ -39,7 +39,9 @@ in `docs/SECURITY.md`.
 
 ## What counts as a non-gating role comparison (CORE-ARCH-008)
 
-The `permissions-audit-allow` annotation contract is **enforced**, not documentation. `scripts/audit/no-hardcoded-role-checks.sh` scans `src/` (excluding the permissions module and tests) for `role === "<role>"` comparisons and fails on any that lack `// permissions-audit-allow: <reason>` on the same line, the line directly above, or the line directly below. The audit is wired into `pnpm run check` as `audit:role-checks` — preflight will reject unannotated gates.
+The `permissions-audit-allow` annotation contract is **enforced**, not documentation. `scripts/audit/no-hardcoded-role-checks.sh` scans `src/` for `role === "<role>"` comparisons and fails on any that lack `// permissions-audit-allow: <reason>` on the same line, the line directly above, or the line directly below. The audit is wired into `pnpm run check` as `audit:role-checks` — preflight will reject unannotated gates.
+
+**The exemption is two files, not the permissions directory.** Only `src/lib/permissions/matrix.ts` and `helpers.ts` are skipped (plus tests and `src/test/`), because a role comparison in those two _is_ the matrix implementation. Everything else under `src/lib/permissions/` is audited like any other caller — including `collections.ts`, which holds the collection access predicates. PP-vdz6 narrowed this: the glob used to be `src/lib/permissions/**`, so moving a permission helper into the directory silently bought it an exemption, which is the same blind spot that let a `viewer.role === "admin"` gate sit un-audited in the first place.
 
 The line the audit cannot draw for you: a role comparison that **gates a request
 or enforces authorization** is forbidden outright and must go through

--- a/scripts/audit/no-hardcoded-role-checks.sh
+++ b/scripts/audit/no-hardcoded-role-checks.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Find all hardcoded role comparisons outside the permissions module + tests.
+# Find all hardcoded role comparisons outside the matrix implementation + tests.
+#
+# The exemption is deliberately two FILES, not the whole `src/lib/permissions/`
+# directory. `matrix.ts` and `helpers.ts` ARE the matrix — a role comparison
+# there is the implementation of the rule, not a bypass of it. Every other file
+# in that directory is ordinary caller code and stays audited, including
+# `collections.ts` (PP-vdz6): a permission helper does not stop needing an
+# annotation just because it now sits next to the matrix. Exempting the
+# directory wholesale would let a future `viewer.role === "admin"` land in
+# `canManageCollection` with no marker and no audit failure — the exact defect
+# PP-vdz6 exists to close.
+#
 # Opt out by adding `// permissions-audit-allow: <reason>` on the same line
 # OR on the line immediately above OR the line immediately below (prettier may
 # wrap inline comments off the role-check line when they exceed printWidth,
@@ -15,7 +26,8 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 2
 fi
 raw=$(rg -n -B1 -A1 '\brole\s*(===|!==)\s*"(admin|technician|member|guest)"' src \
-  --glob '!src/lib/permissions/**' \
+  --glob '!src/lib/permissions/matrix.ts' \
+  --glob '!src/lib/permissions/helpers.ts' \
   --glob '!**/*.test.*' \
   --glob '!src/test/**' \
   || true)
@@ -72,7 +84,7 @@ matches=$(echo "$raw" | awk '
   }
 ' | sort -u)
 if [[ -n "$matches" ]]; then
-  echo "ERROR: hardcoded role checks outside src/lib/permissions/:" >&2
+  echo "ERROR: hardcoded role checks outside matrix.ts / helpers.ts:" >&2
   echo "$matches" >&2
   echo "" >&2
   echo "Use checkPermission() from ~/lib/permissions/helpers." >&2

--- a/src/app/(app)/c/[id]/_data.ts
+++ b/src/app/(app)/c/[id]/_data.ts
@@ -10,8 +10,9 @@ import {
   canEditCollection,
   canManageCollection,
   canViewCollection,
-} from "~/lib/collections/access";
+} from "~/lib/permissions/collections";
 import { isEditorCollaborator } from "~/lib/collections/collaborators";
+import type { UserRole } from "~/lib/types";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
 import { machines as machinesTable, userProfiles } from "~/server/db/schema";
@@ -42,7 +43,7 @@ export interface CollectionForLayout {
 /** The current viewer: their id (undefined if unauthenticated) and role. */
 export interface Viewer {
   userId: string | undefined;
-  role: string | null;
+  role: UserRole | null;
 }
 
 const uuidSchema = z.uuid();
@@ -57,7 +58,7 @@ export const getViewer = cache(async (): Promise<Viewer> => {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  let role: string | null = null;
+  let role: UserRole | null = null;
   if (user) {
     const profile = await db.query.userProfiles.findFirst({
       where: eq(userProfiles.id, user.id),

--- a/src/app/(app)/c/collections/actions.ts
+++ b/src/app/(app)/c/collections/actions.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 import { checkPermission, getAccessLevel } from "~/lib/permissions/helpers";
 import type { UserRole } from "~/lib/types";
-import { canManageCollection } from "~/lib/collections/access";
+import { canManageCollection } from "~/lib/permissions/collections";
 import { isEditorCollaborator } from "~/lib/collections/collaborators";
 import { generateViewToken } from "~/lib/collections/tokens";
 import { createClient } from "~/lib/supabase/server";

--- a/src/lib/permissions/collections.test.ts
+++ b/src/lib/permissions/collections.test.ts
@@ -3,11 +3,11 @@ import {
   canEditCollection,
   canManageCollection,
   canViewCollection,
-} from "./access";
+} from "./collections";
 
 const collection = { owner: { id: "owner-1" } };
 
-describe("canViewCollection (Wave 0a: owner or admin)", () => {
+describe("canViewCollection (Wave 0a: owner, or collections.view.private)", () => {
   it("allows the owner", () => {
     expect(
       canViewCollection(collection, { userId: "owner-1", role: "member" })
@@ -23,8 +23,23 @@ describe("canViewCollection (Wave 0a: owner or admin)", () => {
       canViewCollection(collection, { userId: "someone", role: "member" })
     ).toBe(false);
   });
+  it("denies a non-owner technician", () => {
+    expect(
+      canViewCollection(collection, { userId: "someone", role: "technician" })
+    ).toBe(false);
+  });
+  it("denies a non-owner guest", () => {
+    expect(
+      canViewCollection(collection, { userId: "someone", role: "guest" })
+    ).toBe(false);
+  });
   it("denies anonymous", () => {
     expect(canViewCollection(collection, {})).toBe(false);
+  });
+  it("denies a signed-in user with no role row", () => {
+    expect(
+      canViewCollection(collection, { userId: "someone", role: null })
+    ).toBe(false);
   });
 });
 

--- a/src/lib/permissions/collections.ts
+++ b/src/lib/permissions/collections.ts
@@ -1,12 +1,27 @@
+/**
+ * Collection access predicates.
+ *
+ * These live inside `src/lib/permissions/` because CORE-ARCH-008 puts them
+ * here: a permission helper outside this module is invisible to the
+ * auto-generated `/help/permissions` page. The *role* half of "who may view a
+ * collection" is a matrix lookup (`collections.view.private`); the ownership
+ * and collaborator halves are identity comparisons against a specific
+ * collection, which the matrix has no context for and so stay explicit here.
+ */
+
+import type { UserRole } from "~/lib/types";
+import { checkPermission, getAccessLevel } from "./helpers";
+
 export interface CollectionViewer {
   /** Current user's id (undefined if unauthenticated). */
   userId?: string | undefined;
   /** Current user's role (undefined/null if unauthenticated). */
-  role?: string | null | undefined;
+  role?: UserRole | null | undefined;
 }
 
 /**
- * Wave 0a: a collection is private to its owner; admins may also view.
+ * Wave 0a: a collection is private to its owner; `collections.view.private`
+ * widens that to whoever the matrix grants it (admins today).
  * Wave 0b extends this with view/edit link tokens.
  */
 export function canViewCollection(
@@ -16,10 +31,10 @@ export function canViewCollection(
   if (viewer.userId !== undefined && viewer.userId === collection.owner.id) {
     return true;
   }
-  // Wave 0a private-collection view invariant: admins may view any collection
-  // (spec §Wave 0a). This is a data-visibility rule, not a role-gated toggle.
-  // permissions-audit-allow: admin-may-view invariant
-  return viewer.role === "admin";
+  return checkPermission(
+    "collections.view.private",
+    getAccessLevel(viewer.role)
+  );
 }
 
 /**

--- a/src/lib/permissions/matrix.ts
+++ b/src/lib/permissions/matrix.ts
@@ -578,12 +578,29 @@ export const PERMISSIONS_MATRIX: PermissionCategory[] = [
         id: "collections.view",
         label: "View collections",
         description:
-          "View a collection's Overview, Issues, and Timeline. Private collections are additionally restricted to their owner (and admins); link-based sharing is handled outside the role matrix.",
+          "View a collection's Overview, Issues, and Timeline. Collections are private to their owner — reaching someone else's also needs the permission below, an editor grant on that collection, or its share link (a per-collection capability URL, not a role).",
         access: {
           unauthenticated: true,
           guest: true,
           member: true,
           technician: true,
+          admin: true,
+        },
+      },
+      // The Wave 0a private-collection invariant ("admins may view any
+      // collection"), stated as a matrix entry so /help/permissions shows it
+      // instead of it living in a role comparison. `canViewCollection` in
+      // ./collections.ts is the only reader (CORE-ARCH-008).
+      {
+        id: "collections.view.private",
+        label: "View anyone's collection",
+        description:
+          "Open any member's collection from its /c/<id> URL without an owner grant or a share link. Owners always see their own.",
+        access: {
+          unauthenticated: false,
+          guest: false,
+          member: false,
+          technician: false,
           admin: true,
         },
       },

--- a/src/lib/permissions/matrix.ts
+++ b/src/lib/permissions/matrix.ts
@@ -578,7 +578,7 @@ export const PERMISSIONS_MATRIX: PermissionCategory[] = [
         id: "collections.view",
         label: "View collections",
         description:
-          "View a collection's Overview, Issues, and Timeline. Collections are private to their owner — reaching someone else's also needs the permission below, an editor grant on that collection, or its share link (a per-collection capability URL, not a role).",
+          "View a collection's Overview, Issues, and Timeline. Collections are private to their owner — reaching someone else's also needs \"View anyone's collection\", an editor grant on that collection, or its share link (a per-collection capability URL, not a role).",
         access: {
           unauthenticated: true,
           guest: true,

--- a/src/test/unit/permissions-matrix.test.ts
+++ b/src/test/unit/permissions-matrix.test.ts
@@ -627,3 +627,21 @@ describe("issues.report.quick", () => {
     expect(PERMISSIONS_BY_ID["issues.report.quick"]).toBeDefined();
   });
 });
+
+describe("collections.view.private", () => {
+  it("grants only admin access", () => {
+    expect(checkPermission("collections.view.private", "admin")).toBe(true);
+    expect(checkPermission("collections.view.private", "technician")).toBe(
+      false
+    );
+    expect(checkPermission("collections.view.private", "member")).toBe(false);
+    expect(checkPermission("collections.view.private", "guest")).toBe(false);
+    expect(checkPermission("collections.view.private", "unauthenticated")).toBe(
+      false
+    );
+  });
+
+  it("is registered in PERMISSIONS_BY_ID", () => {
+    expect(PERMISSIONS_BY_ID["collections.view.private"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes PP-vdz6.

## The bug

`canViewCollection` lived in `src/lib/collections/access.ts` and decided collection visibility with a raw `viewer.role === "admin"` comparison. CORE-ARCH-008 forbids both halves of that: no permission helpers outside `src/lib/permissions/`, and all permission checks through `checkPermission()`.

The line carried `// permissions-audit-allow: admin-may-view invariant`, so `scripts/audit/no-hardcoded-role-checks.sh` passed. The opt-out was well-written and defended the *role comparison* — the narrow thing the script asks about — while the structural violation it sat inside went unexamined. A reason-required escape hatch defends against a *missing* justification, not against a justification that answers a narrower question than the rule asks.

## Route chosen: the matrix, not a recorded exception

The bead offered either. Two things settled it on routing:

1. **`pinpoint-security` draws the line the audit can't.** A role comparison that *gates a request or enforces authorization* is forbidden outright; only comparisons that *shape* behaviour (SQL row filters, UI badges) get an annotation. `canViewCollection` decides whether `getCollectionForLayout` returns `null` → `notFound()`. That is a request gate, so the annotation was answering the wrong question and an "exception" would have codified that.
2. **The capability was invisible on `/help/permissions`.** "Admins may open any member's private collection" is a real user-facing privilege. Before this PR it existed only as prose inside another row's description — no column, no checkmark. Recording an exception would have left it that way.

## What changed

- **New matrix entry `collections.view.private`** ("View anyone's collection"), admin-only. It renders as its own row in the Collections table (screenshot below).
- **`canViewCollection` reads it via `checkPermission()`.** The *ownership* half stays an explicit identity comparison: the matrix has no per-collection ownership context (`OwnershipContext` carries `reporterId` / `machineOwnerId` only), and `userId === owner.id` is not a role check. Extending `PermissionValue` with a collection-owner variant would have been a much larger change to shared semantics for one call site.
- **Moved `src/lib/collections/access.ts` → `src/lib/permissions/collections.ts`** (test alongside), so all three predicates — `canViewCollection`, `canManageCollection`, `canEditCollection` — live inside the permissions module. `canEditCollection` calls `canManageCollection`, so splitting them would have been arbitrary. Dropped the `permissions-audit-allow` comment; no role comparison remains in the file.
- **Tightened `CollectionViewer.role` and `Viewer.role` from `string` to `UserRole`** — `userProfiles.role` is already that enum, so this removes a widening, not adds a cast.
- **Rewrote `collections.view`'s description** to point at the new row instead of restating it.

## Behavior: unchanged

`collections.view.private` is `false` for unauthenticated / guest / member / technician and `true` for admin — exactly what `viewer.role === "admin"` evaluated to. Owner access is byte-for-byte the same code path. This is a refactor of *where the decision lives*, not of the decision.

Verified by:

- `pnpm run test` — 2093 passed. Extended `canViewCollection`'s unit tests with the two roles the old `=== "admin"` never covered explicitly (technician, guest) plus a null-role case; added `collections.view.private` matrix tests.
- `pnpm run test:integration` — 57 files / 635 passed (includes `collections-actions`, `collections-user`, `collections-collaborators`).
- `pnpm exec playwright test e2e/smoke --project=chromium` — 68 passed (mirrors CI's required smoke job).
- Targeted specs on chromium: `e2e/smoke/collection-view.spec.ts`, `e2e/smoke/collections.spec.ts` (8 passed, including the anonymous share-link path) and `e2e/full/collection-edit-sharing.spec.ts` (4 passed).
- `pnpm run check` clean, including `audit:role-checks`.

## Help page

Verified by rendering `/help/permissions` against a local dev server and reading the Collections section back:

```
Permission                   Not Logged In  Guest  Member  Technician  Admin
View collections                   ✓          ✓       ✓        ✓         ✓
View anyone's collection           —          —       —        —         ✓
Create collections                 —          —       ✓        ✓         ✓
```

The middle row is new. `groupPermissions` in `PermissionsTable.tsx` merges *adjacent* rows with identical access patterns; this row's pattern differs from both neighbours, so it stays a distinct row.

## Review findings addressed (`/code-review high`, commit `ef26d857`)

**The move re-opened the hole this PR closes.** `scripts/audit/no-hardcoded-role-checks.sh` exempted `src/lib/permissions/**` wholesale, so relocating the collection predicates into that directory silently bought them an exemption. Nothing was wrong today — no role comparison remains — but a future `viewer.role === "admin"` in `canManageCollection` ("admins may delete any collection") would have landed with no marker and no audit failure, in a file that is not the matrix. That is the exact defect class PP-vdz6 exists to close, so leaving it would have made the PR partly self-defeating.

Narrowed the glob from the directory to the two files that *are* the matrix implementation — `matrix.ts` and `helpers.ts`. A role comparison in those two is the rule, not a bypass of it; everything else under `src/lib/permissions/` is now audited like any other caller, `collections.ts` included.

The narrowing surfaced **nothing** — there are no role comparisons anywhere under `src/lib/permissions/`, so the audit stays green with no pre-existing violations exposed. Verified in both directions, since "quiet" alone would not prove the glob bites:

```
$ bash scripts/audit/no-hardcoded-role-checks.sh          # as-is
AUDIT GREEN

# with `if (viewer.role === "admin") return true;` injected into canManageCollection:
ERROR: hardcoded role checks outside matrix.ts / helpers.ts:
src/lib/permissions/collections.ts:48:  if (viewer.role === "admin") return true;
```

**Positional reference removed.** `collections.view`'s description said "the permission below", which would silently point at the wrong row if any future collections permission were inserted between the two. It now names the row — "View anyone's collection".

Also updated `pinpoint-security` §"What counts as a non-gating role comparison", which described the exemption as "the permissions module".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SiKCrRTM5G6Ca8ydw3Qzt

