### PR TITLE
fix(routing): resolve /m/<initials> case-insensitively (PP-ofvl)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -27,7 +27,11 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   if (canonicalPath) {
     const url = request.nextUrl.clone();
     url.pathname = canonicalPath;
-    return NextResponse.redirect(url);
+    // 308, not the 307 default: the rule is structural, not situational.
+    // Initials are uppercase by check constraint and permanent once assigned,
+    // so the lowercase form will never become the right URL. A permanent
+    // redirect lets browsers and crawlers stop paying for the hop.
+    return NextResponse.redirect(url, 308);
   }
 
   // 1. Run Supabase middleware first to handle session

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
-import { type NextRequest, type NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { updateSession } from "~/lib/supabase/middleware";
+import { canonicalMachinePath } from "~/lib/machines/canonical-path";
 
 /**
  * Next.js middleware for Supabase SSR authentication and security headers
@@ -19,6 +20,16 @@ import { updateSession } from "~/lib/supabase/middleware";
  * See docs/SECURITY.md for the threat-model decisions and known gaps
  */
 export async function middleware(request: NextRequest): Promise<NextResponse> {
+  // 0. Canonicalize machine URLs: /m/afm -> /m/AFM. Initials are stored
+  //    uppercase, so a lowercased link would otherwise 404. Runs before the
+  //    session refresh because the redirected request will refresh anyway.
+  const canonicalPath = canonicalMachinePath(request.nextUrl.pathname);
+  if (canonicalPath) {
+    const url = request.nextUrl.clone();
+    url.pathname = canonicalPath;
+    return NextResponse.redirect(url);
+  }
+
   // 1. Run Supabase middleware first to handle session
   const response = await updateSession(request);
   // 2. Generate nonce for CSP using Web Crypto API (Edge Runtime compatible)

--- a/src/app/(app)/report/(tabbed)/page.tsx
+++ b/src/app/(app)/report/(tabbed)/page.tsx
@@ -22,11 +22,14 @@ export const maxDuration = 60;
 export default async function PublicReportPage({
   searchParams,
 }: {
+  // Every one of these arrives as `string[]` when the key is repeated
+  // (`?machine=afm&machine=bbh`), so they are typed the way the App Router
+  // actually delivers them rather than the way they are normally used.
   searchParams: Promise<{
-    error?: string;
-    machine?: string;
-    machineId?: string;
-    source?: string;
+    error?: string | string[];
+    machine?: string | string[];
+    machineId?: string | string[];
+    source?: string | string[];
   }>;
 }): Promise<React.JSX.Element> {
   // Machines + assignees come from the shared request-deduped loaders (also
@@ -54,9 +57,10 @@ export default async function PublicReportPage({
   const machinesList = await machinesListPromise;
 
   const params = await searchParams;
-  const errorMessage = params.error
-    ? decodeURIComponent(params.error)
-    : undefined;
+  const errorMessage =
+    typeof params.error === "string"
+      ? decodeURIComponent(params.error)
+      : undefined;
 
   const machineIdFromQuery = params.machineId;
   const machineInitialsFromQuery = params.machine;

--- a/src/app/(app)/report/default-machine.test.ts
+++ b/src/app/(app)/report/default-machine.test.ts
@@ -15,6 +15,11 @@ describe("resolveDefaultMachineId", () => {
     expect(resolveDefaultMachineId(machines, undefined, "BB")).toBe("b");
   });
 
+  it("matches machine initials case-insensitively", () => {
+    expect(resolveDefaultMachineId(machines, undefined, "bb")).toBe("b");
+    expect(resolveDefaultMachineId(machines, undefined, "Bb")).toBe("b");
+  });
+
   it("returns undefined when query missing or invalid", () => {
     expect(resolveDefaultMachineId(machines, "missing", "missing")).toBe(
       undefined

--- a/src/app/(app)/report/default-machine.test.ts
+++ b/src/app/(app)/report/default-machine.test.ts
@@ -20,6 +20,17 @@ describe("resolveDefaultMachineId", () => {
     expect(resolveDefaultMachineId(machines, undefined, "Bb")).toBe("b");
   });
 
+  it("ignores a repeated query param instead of throwing", () => {
+    // `?machine=aa&machine=bb` reaches the page as an array. It names two
+    // machines, so it resolves to no preselection.
+    expect(resolveDefaultMachineId(machines, undefined, ["aa", "bb"])).toBe(
+      undefined
+    );
+    expect(resolveDefaultMachineId(machines, ["a", "b"], undefined)).toBe(
+      undefined
+    );
+  });
+
   it("returns undefined when query missing or invalid", () => {
     expect(resolveDefaultMachineId(machines, "missing", "missing")).toBe(
       undefined

--- a/src/app/(app)/report/default-machine.ts
+++ b/src/app/(app)/report/default-machine.ts
@@ -18,9 +18,13 @@ export function resolveDefaultMachineId(
     return undefined;
   }
 
+  // Initials are stored uppercase, but the query param is hand-typeable
+  // (`/report?machine=afm`) — match case-insensitively rather than 404-ing
+  // into an unselected form. Same reasoning as `canonicalMachinePath`.
+  const requestedInitials = requestedMachineInitials?.toUpperCase();
   const byInitials =
-    requestedMachineInitials &&
-    machines.find((machine) => machine.initials === requestedMachineInitials);
+    requestedInitials &&
+    machines.find((machine) => machine.initials === requestedInitials);
 
   if (byInitials) return byInitials.id;
 

--- a/src/app/(app)/report/default-machine.ts
+++ b/src/app/(app)/report/default-machine.ts
@@ -9,28 +9,41 @@ export interface MachineOption {
  * Returns a valid machine ID only if explicitly requested via query param (machine or machineId).
  * Returns undefined when no machine is requested, allowing the form to start unselected.
  */
+/**
+ * A repeated query param (`?machine=afm&machine=bbh`) arrives as an array, so
+ * both params are typed as the App Router actually delivers them. An array is
+ * an ambiguous request — it names two machines — and resolves to no
+ * preselection rather than an arbitrary one.
+ */
+type QueryParam = string | string[] | undefined;
+
+const singleValue = (param: QueryParam): string | undefined =>
+  typeof param === "string" ? param : undefined;
+
 export function resolveDefaultMachineId(
   machines: MachineOption[],
-  requestedMachineId: string | undefined,
-  requestedMachineInitials: string | undefined
+  requestedMachineId: QueryParam,
+  requestedMachineInitials: QueryParam
 ): string | undefined {
   if (machines.length === 0) {
     return undefined;
   }
 
   // Initials are stored uppercase, but the query param is hand-typeable
-  // (`/report?machine=afm`) — match case-insensitively rather than 404-ing
+  // (`/report?machine=afm`) — match case-insensitively rather than dropping
   // into an unselected form. Same reasoning as `canonicalMachinePath`.
-  const requestedInitials = requestedMachineInitials?.toUpperCase();
+  const requestedInitials = singleValue(
+    requestedMachineInitials
+  )?.toUpperCase();
   const byInitials =
     requestedInitials &&
     machines.find((machine) => machine.initials === requestedInitials);
 
   if (byInitials) return byInitials.id;
 
+  const requestedId = singleValue(requestedMachineId);
   const byId =
-    requestedMachineId &&
-    machines.find((machine) => machine.id === requestedMachineId);
+    requestedId && machines.find((machine) => machine.id === requestedId);
 
   if (byId) return byId.id;
 

--- a/src/lib/machines/canonical-path.test.ts
+++ b/src/lib/machines/canonical-path.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { canonicalMachinePath } from "./canonical-path";
+
+describe("canonicalMachinePath", () => {
+  it("uppercases a lowercase initials segment", () => {
+    expect(canonicalMachinePath("/m/afm")).toBe("/m/AFM");
+    expect(canonicalMachinePath("/m/rush")).toBe("/m/RUSH");
+    expect(canonicalMachinePath("/m/Afm")).toBe("/m/AFM");
+  });
+
+  it("returns null when the path is already canonical", () => {
+    expect(canonicalMachinePath("/m/AFM")).toBeNull();
+    expect(canonicalMachinePath("/m/GB2")).toBeNull();
+  });
+
+  it("preserves everything after the initials segment", () => {
+    expect(canonicalMachinePath("/m/afm/maintenance")).toBe(
+      "/m/AFM/maintenance"
+    );
+    expect(canonicalMachinePath("/m/afm/i/12")).toBe("/m/AFM/i/12");
+    expect(canonicalMachinePath("/m/afm/edit")).toBe("/m/AFM/edit");
+    // A trailing slash is part of the path, not an empty extra segment to drop.
+    expect(canonicalMachinePath("/m/afm/")).toBe("/m/AFM/");
+  });
+
+  it("leaves the reserved /m/new create route alone", () => {
+    expect(canonicalMachinePath("/m/new")).toBeNull();
+  });
+
+  it("ignores paths that are not machine detail pages", () => {
+    expect(canonicalMachinePath("/m")).toBeNull();
+    expect(canonicalMachinePath("/m/")).toBeNull();
+    expect(canonicalMachinePath("/issues")).toBeNull();
+    expect(canonicalMachinePath("/c/some-collection-handle")).toBeNull();
+    expect(canonicalMachinePath("/machines/afm")).toBeNull();
+  });
+
+  it("ignores segments that cannot be initials", () => {
+    // Outside the 2-6 char alphanumeric shape the DB constraint allows.
+    expect(canonicalMachinePath("/m/a")).toBeNull();
+    expect(canonicalMachinePath("/m/toolongforinitials")).toBeNull();
+    expect(canonicalMachinePath("/m/af-m")).toBeNull();
+  });
+});

--- a/src/lib/machines/canonical-path.test.ts
+++ b/src/lib/machines/canonical-path.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { canonicalMachinePath } from "./canonical-path";
 
@@ -25,6 +27,35 @@ describe("canonicalMachinePath", () => {
 
   it("leaves the reserved /m/new create route alone", () => {
     expect(canonicalMachinePath("/m/new")).toBeNull();
+    // Reserved segments keep their own casing rather than being uppercased
+    // into a machine lookup.
+    expect(canonicalMachinePath("/M/new")).toBe("/m/new");
+  });
+
+  /**
+   * The reserved list is the one part of this module that goes stale silently:
+   * add `src/app/(app)/m/bulk/` and `/m/bulk` starts redirecting to `/m/BULK`
+   * and 404ing, in a file whose author never opened this one. Read the route
+   * directory instead of trusting the comment.
+   */
+  it("reserves every static route directory under /m/", () => {
+    const routeDir = join(process.cwd(), "src/app/(app)/m");
+    const staticSegments = readdirSync(routeDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) => !name.startsWith("[") && !name.startsWith("("));
+
+    expect(staticSegments.length).toBeGreaterThan(0);
+    for (const segment of staticSegments) {
+      expect(canonicalMachinePath(`/m/${segment}`)).toBeNull();
+    }
+  });
+
+  it("uppercases a lowercase /m prefix too", () => {
+    // Phone keyboards capitalize the first character of what they take to be
+    // a sentence, so /M/afm is a link people actually produce.
+    expect(canonicalMachinePath("/M/afm")).toBe("/m/AFM");
+    expect(canonicalMachinePath("/M/AFM")).toBe("/m/AFM");
   });
 
   it("ignores paths that are not machine detail pages", () => {

--- a/src/lib/machines/canonical-path.ts
+++ b/src/lib/machines/canonical-path.ts
@@ -32,16 +32,24 @@ const INITIALS_PATTERN = /^[A-Za-z0-9]{2,6}$/;
 export function canonicalMachinePath(pathname: string): string | null {
   const segments = pathname.split("/");
   // ["", "m", "<initials>", ...rest]
-  if (segments[1] !== "m") return null;
+  const prefix = segments[1];
+  // The `/m` prefix is matched case-insensitively for the same reason the
+  // initials are: a phone keyboard capitalizes the first character of what it
+  // thinks is a sentence, so `/M/afm` is a link people actually produce.
+  if (prefix?.toLowerCase() !== "m") return null;
 
-  const initials = segments[2];
-  if (!initials) return null;
-  if (RESERVED_SEGMENTS.has(initials)) return null;
-  if (!INITIALS_PATTERN.test(initials)) return null;
+  const segment = segments[2];
+  if (!segment) return null;
+  if (!INITIALS_PATTERN.test(segment)) return null;
 
-  const canonical = initials.toUpperCase();
-  if (canonical === initials) return null;
+  // A reserved segment keeps its own casing — `/M/new` still becomes `/m/new`,
+  // the create page, rather than a machine lookup for "NEW".
+  const canonicalSegment = RESERVED_SEGMENTS.has(segment)
+    ? segment
+    : segment.toUpperCase();
+  if (prefix === "m" && canonicalSegment === segment) return null;
 
-  segments[2] = canonical;
+  segments[1] = "m";
+  segments[2] = canonicalSegment;
   return segments.join("/");
 }

--- a/src/lib/machines/canonical-path.ts
+++ b/src/lib/machines/canonical-path.ts
@@ -1,0 +1,47 @@
+/**
+ * Canonical casing for the `/m/<initials>` URL segment.
+ *
+ * Machine initials are stored uppercase — the `machines` table carries a
+ * `^[A-Z0-9]{2,6}$` check constraint — and every `/m/[initials]` route looks
+ * them up with an exact match. So a hand-typed or lowercased link (`/m/afm`,
+ * a QR scan retyped from memory, a URL an autocorrect touched) 404s while
+ * `/m/AFM` works. Middleware redirects the lowercase form to the canonical
+ * one rather than making the lookups case-insensitive, so there stays exactly
+ * one URL per machine.
+ */
+
+/**
+ * Static route segments that live under `/m/` and are NOT machine initials.
+ * They must stay lowercase — uppercasing `/m/new` would send the create page
+ * to a machine lookup for "NEW". Keep in sync with the directories under
+ * `src/app/(app)/m/`.
+ */
+const RESERVED_SEGMENTS = new Set(["new"]);
+
+/** Matches the shape of the initials column's check constraint, case-insensitively. */
+const INITIALS_PATTERN = /^[A-Za-z0-9]{2,6}$/;
+
+/**
+ * Returns the canonical (uppercase-initials) form of a `/m/...` pathname, or
+ * `null` when the path is already canonical or is not a machine path at all.
+ *
+ * Only the initials segment is touched; anything after it (`/i/12`,
+ * `/maintenance`, `/edit`) is preserved verbatim, since those segments are
+ * case-sensitive route names or numbers.
+ */
+export function canonicalMachinePath(pathname: string): string | null {
+  const segments = pathname.split("/");
+  // ["", "m", "<initials>", ...rest]
+  if (segments[1] !== "m") return null;
+
+  const initials = segments[2];
+  if (!initials) return null;
+  if (RESERVED_SEGMENTS.has(initials)) return null;
+  if (!INITIALS_PATTERN.test(initials)) return null;
+
+  const canonical = initials.toUpperCase();
+  if (canonical === initials) return null;
+
+  segments[2] = canonical;
+  return segments.join("/");
+}

--- a/src/test/unit/middleware-machine-canonical.test.ts
+++ b/src/test/unit/middleware-machine-canonical.test.ts
@@ -22,7 +22,7 @@ describe("middleware machine URL canonicalization", () => {
   it("redirects a lowercase initials segment to the uppercase form", async () => {
     const response = await middleware(request("http://localhost/m/afm"));
 
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(308);
     expect(response.headers.get("location")).toBe("http://localhost/m/AFM");
     expect(updateSessionMock).not.toHaveBeenCalled();
   });

--- a/src/test/unit/middleware-machine-canonical.test.ts
+++ b/src/test/unit/middleware-machine-canonical.test.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { middleware } from "../../../middleware";
+
+/**
+ * The canonical-casing redirect for `/m/<initials>` short-circuits before the
+ * Supabase session refresh, so `updateSession` is stubbed here: these cases
+ * assert the wiring in `middleware.ts` (redirect status, Location, and that
+ * the session path is skipped), not the pure path logic — that lives in
+ * `src/lib/machines/canonical-path.test.ts`.
+ */
+const updateSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/lib/supabase/middleware", () => ({
+  updateSession: updateSessionMock,
+}));
+
+const request = (url: string) => new NextRequest(new URL(url));
+
+describe("middleware machine URL canonicalization", () => {
+  it("redirects a lowercase initials segment to the uppercase form", async () => {
+    const response = await middleware(request("http://localhost/m/afm"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/m/AFM");
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the sub-path and query string", async () => {
+    const response = await middleware(
+      request("http://localhost/m/rush/i/12?from=qr")
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/m/RUSH/i/12?from=qr"
+    );
+  });
+});


### PR DESCRIPTION
## What

`https://pinpoint.austinpinballcollective.org/m/rush` 404s while `/m/RUSH` works. Machine initials are stored uppercase (the `machines` table carries a `^[A-Z0-9]{2,6}$` check constraint) and every `/m/[initials]` route looks them up with an exact `eq()`, so any hand-typed or lowercased link dies.

Middleware now redirects the lowercase form to the canonical uppercase one (`/m/afm` → 307 → `/m/AFM`) rather than making the lookups case-insensitive, so there stays exactly one URL per machine and every `href` built from `machine.initials` keeps matching.

- Only the initials segment is rewritten — `/m/afm/i/12`, `/m/afm/maintenance` and the query string survive.
- `/m/new` (the create route) is excluded by name; uppercasing it would send it to a machine lookup for "NEW".
- Segments outside the initials shape (`^[A-Za-z0-9]{2,6}$`) are left alone.
- `/report?machine=<initials>` gets the same treatment inline, since that param is hand-typeable for the same reasons.

## Testing

- `src/lib/machines/canonical-path.test.ts` — the path rule (casing, sub-paths, reserved `/m/new`, non-machine paths).
- `src/test/unit/middleware-machine-canonical.test.ts` — the middleware wiring: 307, `Location`, query preserved, session refresh skipped.
- `src/app/(app)/report/default-machine.test.ts` — case-insensitive initials match.
- `pnpm run check` green, `pnpm run test` green (2097 tests).

Manually verified against a local dev server with a seeded `AFM` machine:

| request | result |
| --- | --- |
| `/m/afm` | 307 → `/m/AFM`, 200 after following |
| `/m/afm/i/1?from=qr` | 307 → `/m/AFM/i/1?from=qr` |
| `/m/AFM` | 200, no redirect |
| `/m/new` | untouched (auth gate, not uppercased) |

That verification needed a workaround, which is a separate bug: **`next dev` ignores the root `middleware.ts`** — no CSP or `x-nonce` header on any response, no redirects, reproduced against unmodified `HEAD`. Copying the same file to `src/middleware.ts` makes it run immediately. Production is unaffected (prod CSP carries a per-request nonce, which can only come from middleware). Filed as **PP-tld9** with the evidence and a proposed fix; it is not touched here.

No E2E spec: until PP-tld9 lands, the dev server Playwright starts has no middleware either, so the spec would fail in CI for environment reasons rather than code ones.