### PR TITLE
feat(huddle): derive session names from the herdr workspace label (PP-355h)

### DIFF
--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-huddle
-description: The conventions behind the inter-session coordination channel that the huddle hooks inject but do not state — which events are auto-posted versus the judgment calls only you can post (added scope is the most-skipped and most-needed), peer-response etiquette, the em-dash self-filter signature, why a session_id belongs to whoever registered it first, why a dispatched subagent is refused registration outright, and the rotation subagent dispatch the session-start notice routes here for. Also how to read the work digest, the env knobs that quiet the nudge and the poll (`HUDDLE_NUDGE_SECONDS`, `HUDDLE_THROTTLE_SECONDS`), and the multi-machine setup — one shared Dolt server, `config.json` as a rebuildable cache rather than a source of truth, `today_bead.id` as a hint that gets verified. Use when you see a rotation-needed notice, when deciding whether something is worth posting to the daily bead, when your own posts start re-injecting, when a peer's update scrolls by, when the huddle is too noisy, or when a huddle lookup returns null on a machine.
+description: The conventions behind the inter-session coordination channel that the huddle hooks inject but do not state — which events are auto-posted versus the judgment calls only you can post (added scope is the most-skipped and most-needed), peer-response etiquette, the em-dash self-filter signature, where a session's name comes from (the herdr workspace label, falling back to the bead) and why setting the matching harness display name means asking Tim to run `/rename`, why a session_id belongs to whoever registered it first, why a dispatched subagent is refused registration outright, and the rotation subagent dispatch the session-start notice routes here for. Also how to read the work digest, the env knobs that quiet the nudge and the poll (`HUDDLE_NUDGE_SECONDS`, `HUDDLE_THROTTLE_SECONDS`), and the multi-machine setup — one shared Dolt server, `config.json` as a rebuildable cache rather than a source of truth, `today_bead.id` as a hint that gets verified. Use when you see a rotation-needed notice, when deciding whether something is worth posting to the daily bead, when your own posts start re-injecting, when a peer's update scrolls by, when the huddle is too noisy, or when a huddle lookup returns null on a machine.
 ---
 
 # pinpoint-huddle
@@ -18,6 +18,43 @@ Read it as orientation, not as instructions: it tells you what kind of work this
 ## Identity
 
 Sign your huddle comments with `—<YourFullRegisteredName>` (em-dash + your full registered name). The self-filter matches this suffix to suppress your own echoes.
+
+### Where the name comes from
+
+A session carries three names, and they are set by three different things. The
+huddle name is the only one you control; keeping the other two in step is a
+handoff, not an API call.
+
+| Name                  | Set by                             | Seen in                            |
+| --------------------- | ---------------------------------- | ---------------------------------- |
+| Huddle name           | `huddle-whoami.sh register` — you  | Bead signatures, self-filter       |
+| Display name          | `/rename` — Tim only               | `ListAgents` peers, terminal title |
+| herdr workspace label | Tim, when he creates the workspace | herdr sidebar                      |
+
+**Derive the huddle name from the workspace label.** Tim already typed a name for
+this session when he made its workspace, so it says what the session is for
+without you guessing. The registration notice reads it and prints a CamelCased
+candidate. When the label is generic — `PinPoint`, `Orchestrating`, `Busywork`,
+`main`, a bare number — name yourself after the bead Tim pointed you at instead;
+fall back to the task only when there is neither.
+
+**Then ask Tim to run `/rename <YourName>`,** one line at the end of your next
+response. That is the only way the display name gets set: `/rename` is a
+user-typed command, no tool writes it, and `--name` at launch is too early to
+know the task. Don't block on the answer.
+
+The notice reads the label from **`$HERDR_WORKSPACE_ID`**, not by matching panes.
+Hooks inherit the environment herdr launched the agent in, so the variable is
+right there and names the workspace directly. Both alternatives are traps:
+`herdr pane list`'s `agent_session.value` has been measured pointing at a
+_different live session_ (see the `herdr` skill), and `terminal_title` carries
+Claude Code's animating activity glyph, which `terminal_title_stripped` only
+partly removes — `✳` and the braille frames yes, `◐`/`◑` no. A forked session
+inherits a stale `$HERDR_WORKSPACE_ID`, which is tolerable here only because the
+result is a _suggestion_ you and Tim both read before it is registered.
+
+No herdr — a bare terminal, Bazzite, another harness — and the notice silently
+drops to bead-then-task. Nothing errors.
 
 **A session_id belongs to whoever registered it first.** `register` refuses to
 rebind a session_id that already holds a different name — no silent overwrite,

--- a/.agents/skills/pinpoint-huddle/SKILL.md
+++ b/.agents/skills/pinpoint-huddle/SKILL.md
@@ -39,9 +39,13 @@ candidate. When the label is generic — `PinPoint`, `Orchestrating`, `Busywork`
 fall back to the task only when there is neither.
 
 **Then ask Tim to run `/rename <YourName>`,** one line at the end of your next
-response. That is the only way the display name gets set: `/rename` is a
-user-typed command, no tool writes it, and `--name` at launch is too early to
-know the task. Don't block on the answer.
+response. In Claude Code that is the only way the display name gets set, and you
+cannot do it yourself: `/rename` is registered `type: local-jsx` with
+`requires: {ink: true}`, so it needs the interactive terminal UI and no tool
+reaches it. (`--name` at launch would work but fires before the task is known.)
+Don't block on the answer. Confirmed to propagate to both surfaces: a peer that
+listed as `pinpoint-11 [a8cc65]` listed as `crabbox-lease-staleness-fix [a8cc65]`
+after its rename, and the terminal title changes in the same instant.
 
 The notice reads the label from **`$HERDR_WORKSPACE_ID`**, not by matching panes.
 Hooks inherit the environment herdr launched the agent in, so the variable is
@@ -49,12 +53,28 @@ right there and names the workspace directly. Both alternatives are traps:
 `herdr pane list`'s `agent_session.value` has been measured pointing at a
 _different live session_ (see the `herdr` skill), and `terminal_title` carries
 Claude Code's animating activity glyph, which `terminal_title_stripped` only
-partly removes — `✳` and the braille frames yes, `◐`/`◑` no. A forked session
-inherits a stale `$HERDR_WORKSPACE_ID`, which is tolerable here only because the
-result is a _suggestion_ you and Tim both read before it is registered.
+partly removes — `✳` and the braille frames yes, `◐`/`◑` no.
+
+`$HERDR_WORKSPACE_ID` goes stale in a forked session, after a handoff, and on a
+**moved pane**. The moved pane is the one that misleads: the lookup is
+live-by-id, so it returns the _current_ label of a _different_ workspace and the
+notice offers a plausible name belonging to someone else's task. Tolerable here
+and nowhere else in the huddle, because the result is a _suggestion_ you and Tim
+both read before it is registered — never a signature attributed silently.
+
+**Any hook that reads herdr needs a hard timeout.** `.claude/settings.json` caps
+this hook at 5000ms and it already runs ~4s. Exceeding the cap is not a degraded
+notice: Claude Code kills the hook and discards **all** of its stdout, so the
+session learns no session_id, never registers, and re-injects its own posts —
+the PP-2m3l breakage. The lookup is wrapped in `timeout 1` (the call itself
+measures ~9ms), and with neither `timeout` nor `gtimeout` present it is skipped
+rather than run unbounded.
 
 No herdr — a bare terminal, Bazzite, another harness — and the notice silently
-drops to bead-then-task. Nothing errors.
+drops to bead-then-task. Nothing errors. The notice is harness-neutral: it says
+`<Harness>-` rather than `Claude-`, and makes the rename step conditional on the
+harness having such a command, because Antigravity and Codex run this same hook
+through `.agents/hooks/antigravity-bootstrap.cjs`.
 
 **A session_id belongs to whoever registered it first.** `register` refuses to
 rebind a session_id that already holds a different name — no silent overwrite,

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -80,18 +80,35 @@ emit_work_digest() {
 # animating spinner glyph that terminal_title_stripped does not fully remove
 # (✳ and the braille frames yes, ◐/◑ no).
 #
-# A forked or handed-off session inherits a stale value, same caveat as
-# $HERDR_PANE_ID. That is tolerable here and nowhere else in the huddle: this
-# produces a *suggested* name that both the agent and Tim read before it is
-# registered, not a signature attributed silently.
+# $HERDR_WORKSPACE_ID goes stale in three ways, all inherited from
+# $HERDR_PANE_ID: a forked session, a handoff, and a **moved pane**. The moved
+# pane is the one that misleads, because the lookup is live-by-id: it returns the
+# *current* label of a *different* workspace, so the notice offers a perfectly
+# plausible name belonging to someone else's task rather than an obviously stale
+# one. Tolerable here and nowhere else in the huddle, because the output is a
+# *suggestion* the agent and Tim both read before it is registered — not a
+# signature attributed silently.
 #
-# Fail-open at every step — no herdr, a bare terminal, Bazzite, a non-herdr
-# harness: print nothing and the caller falls back to task-derived naming.
+# HARD TIMEOUT, and this is not optional. `.claude/settings.json` gives this hook
+# 5000ms and it already runs ~4s; `herdr workspace list` is a socket read against
+# a server that can wedge. Blowing the budget is not "no label" — Claude Code
+# kills the hook and discards ALL of its stdout, so the session gets no
+# session_id and no registration prompt and never registers, which is the
+# PP-2m3l self-filter breakage. The call measures ~9ms, so 1s is generous.
+# With neither timeout binary present we skip the lookup rather than run it
+# unbounded: a missing suggestion costs a nicer name, a hung hook costs identity.
 herdr_workspace_label() {
-  local out
+  local out timeout_bin
   [[ -n "${HERDR_WORKSPACE_ID:-}" ]] || return 0
   command -v herdr >/dev/null 2>&1 || return 0
-  out=$(herdr workspace list 2>/dev/null) || return 0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_bin=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin=gtimeout
+  else
+    return 0
+  fi
+  out=$("$timeout_bin" 1 herdr workspace list 2>/dev/null) || return 0
   [[ -n "$out" ]] || return 0
   printf '%s' "$out" | jq -r --arg ws "$HERDR_WORKSPACE_ID" '
     .result.workspaces[]? | select(.workspace_id == $ws) | .label // empty
@@ -387,21 +404,29 @@ else
   printf 'Your session_id: `%s`\n\n' "$SESSION_ID"
   printf 'You are not yet registered in the huddle self-filter map.\n\n'
   printf 'When you receive your first user prompt, pick a name in this order:\n\n'
+  # The label only earns first place if it survives CamelCasing into something
+  # usable. A label with no ASCII alphanumerics ("🔥") camelizes to the empty
+  # string, which rendered "becomes something like <Harness>-" — and
+  # huddle-whoami.sh's ^[A-Za-z0-9_-]+$ validator accepts a bare "Claude-", so an
+  # agent following that text could register a truncated name. Treat an empty
+  # camelization as no label at all.
   _WS_LABEL=$(herdr_workspace_label 2>/dev/null) || _WS_LABEL=""
-  if [[ -n "$_WS_LABEL" ]]; then
+  _WS_CAMEL=""
+  [[ -n "$_WS_LABEL" ]] && _WS_CAMEL=$(huddle_camelize "$_WS_LABEL")
+  if [[ -n "$_WS_CAMEL" ]]; then
     printf '1. **Your herdr workspace label, which is "%s".** Tim typed it for this\n' "$_WS_LABEL"
     printf '   session, so it already says what the session is for. CamelCase it and add\n'
-    printf '   your harness prefix — "%s" becomes something like Claude-%s.\n' "$_WS_LABEL" "$(huddle_camelize "$_WS_LABEL")"
+    printf '   your harness prefix — "%s" becomes <Harness>-%s.\n' "$_WS_LABEL" "$_WS_CAMEL"
     printf '2. **If that label is generic, use the bead instead.** Labels like "PinPoint",\n'
     printf '   "Orchestrating", "Busywork", "main", or a bare number say nothing about the\n'
     printf '   work. When Tim has pointed you at a bead, name yourself after the bead'\''s\n'
     printf '   subject (PP-355h "Derive huddle names from the workspace label" →\n'
-    printf '   Claude-HuddleNameSource).\n'
+    printf '   <Harness>-HuddleNameSource).\n'
     printf '3. **Otherwise** derive it from what you are being asked to do.\n\n'
   else
     printf '1. **Your bead, when Tim has pointed you at one** — name yourself after its\n'
     printf '   subject (PP-355h "Derive huddle names from the workspace label" →\n'
-    printf '   Claude-HuddleNameSource).\n'
+    printf '   <Harness>-HuddleNameSource).\n'
     printf '2. **Otherwise** derive it from what you are being asked to do.\n\n'
     printf '(No herdr workspace label available for this session — normally that label is\n'
     printf 'the first choice. Expected outside herdr: a bare terminal, Bazzite, a non-herdr\n'
@@ -417,12 +442,15 @@ else
   printf 'Register with:\n'
   printf '    bash scripts/hooks/huddle-whoami.sh register <YourName> %s\n\n' "$SESSION_ID"
   printf 'If the name is taken, the helper suggests variations.\n\n'
+  printf 'THEN, IF YOUR HARNESS HAS A SESSION-RENAME COMMAND, ask Tim to run it with this\n'
   # shellcheck disable=SC2016  # backticks are literal Markdown
-  printf 'THEN ASK TIM TO RUN `/rename <YourName>` in your next response. That sets the\n'
-  printf 'harness display name — the one peer sessions see in ListAgents and the one on\n'
-  printf 'the terminal title — so all three identities match. You cannot do this yourself:\n'
-  printf '/rename is user-typed only, and no tool sets it. One line at the end of your\n'
-  printf 'reply is enough; do not stop work waiting for it.\n\n'
+  printf 'name — in Claude Code that is `/rename <YourName>`. It sets the harness display\n'
+  printf 'name, which is both what peer sessions see when they list agents and what shows\n'
+  printf 'on the terminal title, so all three identities match. You cannot do it yourself\n'
+  # shellcheck disable=SC2016  # backticks are literal Markdown
+  printf 'in Claude Code: /rename is registered `type: local-jsx` with `requires: {ink}`,\n'
+  printf 'so it needs the interactive terminal UI and no tool can invoke it. One line at\n'
+  printf 'the end of your reply is enough; do not stop work waiting for it.\n\n'
   printf 'After registering, post a one-line kickoff to today'\''s bead describing what this\n'
   printf 'session is tackling (skip it for trivial questions or one-line fixes).\n'
   # shellcheck disable=SC2016  # backticks are literal Markdown

--- a/scripts/hooks/huddle-session-start.sh
+++ b/scripts/hooks/huddle-session-start.sh
@@ -66,6 +66,48 @@ emit_work_digest() {
   printf '%s\n' "$digest_out"
 }
 
+# --- herdr workspace label (PP-355h) ---
+# The human-meaningful name for a session already exists: the label Tim typed on
+# its herdr workspace. Deriving the huddle name from it is what keeps the huddle
+# name, the Claude Code display name, and the sidebar entry recognizably the same
+# session instead of three unrelated strings.
+#
+# Read it from $HERDR_WORKSPACE_ID, NOT by matching panes. Hooks inherit the
+# environment of the shell herdr launched the agent in, so this variable is
+# present and identifies the workspace directly. The alternatives are both worse:
+# `herdr pane list`'s agent_session.value has been measured pointing at a
+# different live session (see the herdr skill), and terminal_title carries an
+# animating spinner glyph that terminal_title_stripped does not fully remove
+# (✳ and the braille frames yes, ◐/◑ no).
+#
+# A forked or handed-off session inherits a stale value, same caveat as
+# $HERDR_PANE_ID. That is tolerable here and nowhere else in the huddle: this
+# produces a *suggested* name that both the agent and Tim read before it is
+# registered, not a signature attributed silently.
+#
+# Fail-open at every step — no herdr, a bare terminal, Bazzite, a non-herdr
+# harness: print nothing and the caller falls back to task-derived naming.
+herdr_workspace_label() {
+  local out
+  [[ -n "${HERDR_WORKSPACE_ID:-}" ]] || return 0
+  command -v herdr >/dev/null 2>&1 || return 0
+  out=$(herdr workspace list 2>/dev/null) || return 0
+  [[ -n "$out" ]] || return 0
+  printf '%s' "$out" | jq -r --arg ws "$HERDR_WORKSPACE_ID" '
+    .result.workspaces[]? | select(.workspace_id == $ws) | .label // empty
+  ' 2>/dev/null || return 0
+}
+
+# CamelCase a workspace label for use as a name suffix ("main e2e failures" →
+# "MainE2eFailures"). Done in jq, not sed: BSD sed has no `\u`, so the obvious
+# `s/(^| )([a-z])/\1\u\2/g` emits a literal "u" on this Mac ("Agentunaming").
+huddle_camelize() {
+  jq -rn --arg s "$1" '
+    $s | [splits("[^A-Za-z0-9]+")] | map(select(length > 0))
+       | map((.[0:1] | ascii_upcase) + .[1:]) | join("")
+  ' 2>/dev/null || printf ''
+}
+
 # --- Per-machine Dolt sync (throttled, fail-open) ---
 # Pull peer machines' huddle updates (and push ours) before reading root notes,
 # so this session opens with the freshest cross-machine state. Throttled
@@ -344,10 +386,27 @@ else
   # shellcheck disable=SC2016  # backticks are literal Markdown, not command substitution
   printf 'Your session_id: `%s`\n\n' "$SESSION_ID"
   printf 'You are not yet registered in the huddle self-filter map.\n\n'
-  printf 'When you receive your first user prompt, derive a short descriptive name\n'
-  printf 'for yourself from what you'\''re being asked to do, prefixed with your\n'
-  printf 'harness name so Tim can recognize at a glance which agent stack each\n'
-  printf 'parallel session belongs to.\n\n'
+  printf 'When you receive your first user prompt, pick a name in this order:\n\n'
+  _WS_LABEL=$(herdr_workspace_label 2>/dev/null) || _WS_LABEL=""
+  if [[ -n "$_WS_LABEL" ]]; then
+    printf '1. **Your herdr workspace label, which is "%s".** Tim typed it for this\n' "$_WS_LABEL"
+    printf '   session, so it already says what the session is for. CamelCase it and add\n'
+    printf '   your harness prefix — "%s" becomes something like Claude-%s.\n' "$_WS_LABEL" "$(huddle_camelize "$_WS_LABEL")"
+    printf '2. **If that label is generic, use the bead instead.** Labels like "PinPoint",\n'
+    printf '   "Orchestrating", "Busywork", "main", or a bare number say nothing about the\n'
+    printf '   work. When Tim has pointed you at a bead, name yourself after the bead'\''s\n'
+    printf '   subject (PP-355h "Derive huddle names from the workspace label" →\n'
+    printf '   Claude-HuddleNameSource).\n'
+    printf '3. **Otherwise** derive it from what you are being asked to do.\n\n'
+  else
+    printf '1. **Your bead, when Tim has pointed you at one** — name yourself after its\n'
+    printf '   subject (PP-355h "Derive huddle names from the workspace label" →\n'
+    printf '   Claude-HuddleNameSource).\n'
+    printf '2. **Otherwise** derive it from what you are being asked to do.\n\n'
+    printf '(No herdr workspace label available for this session — normally that label is\n'
+    printf 'the first choice. Expected outside herdr: a bare terminal, Bazzite, a non-herdr\n'
+    printf 'harness.)\n\n'
+  fi
   printf 'Examples:\n'
   printf '  Claude-WorktreeHookFix       fixing a worktree hook in Claude Code\n'
   printf '  Antigravity-AgentsMdCleanup  cleaning up AGENTS.md in Antigravity\n'
@@ -358,6 +417,12 @@ else
   printf 'Register with:\n'
   printf '    bash scripts/hooks/huddle-whoami.sh register <YourName> %s\n\n' "$SESSION_ID"
   printf 'If the name is taken, the helper suggests variations.\n\n'
+  # shellcheck disable=SC2016  # backticks are literal Markdown
+  printf 'THEN ASK TIM TO RUN `/rename <YourName>` in your next response. That sets the\n'
+  printf 'harness display name — the one peer sessions see in ListAgents and the one on\n'
+  printf 'the terminal title — so all three identities match. You cannot do this yourself:\n'
+  printf '/rename is user-typed only, and no tool sets it. One line at the end of your\n'
+  printf 'reply is enough; do not stop work waiting for it.\n\n'
   printf 'After registering, post a one-line kickoff to today'\''s bead describing what this\n'
   printf 'session is tackling (skip it for trivial questions or one-line fixes).\n'
   # shellcheck disable=SC2016  # backticks are literal Markdown

--- a/scripts/tests/test_huddle_session_start.py
+++ b/scripts/tests/test_huddle_session_start.py
@@ -21,6 +21,7 @@ import os
 import stat
 import subprocess
 import tempfile
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -53,6 +54,16 @@ case "$1" in
     exit 0
     ;;
 esac
+exit 0
+"""
+
+
+# Stub `herdr`: serve `herdr workspace list` from $HERDR_STUB_JSON. With
+# $HERDR_STUB_HANG set it sleeps instead, standing in for a wedged herdr server
+# so the `timeout 1` guard is exercised rather than assumed.
+HERDR_STUB = r"""#!/usr/bin/env bash
+if [[ -n "${HERDR_STUB_HANG:-}" ]]; then sleep 30; exit 0; fi
+[[ -n "${HERDR_STUB_JSON:-}" ]] && cat "$HERDR_STUB_JSON"
 exit 0
 """
 
@@ -176,7 +187,32 @@ def register(repo: Path, name: str, session_id: str = SESSION_ID) -> None:
     )
 
 
-def run_hook_payload(repo: Path, payload: dict[str, object]) -> tuple[int, str, str]:
+def stub_herdr(repo: Path, label: str | None, *, hang: bool = False) -> dict[str, str]:
+    """Install a `herdr` stub and return the env vars that activate it.
+
+    `label` is the workspace label the stub reports for workspace "wX"; None
+    installs a stub that reports a *different* workspace, which is the moved-pane
+    / stale-id case. `hang` makes it sleep, for the timeout guard.
+    """
+    stub = repo / "bin" / "herdr"
+    stub.write_text(HERDR_STUB)
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    workspaces = [{"workspace_id": "wOTHER", "label": "somebody else"}]
+    if label is not None:
+        workspaces.append({"workspace_id": "wX", "label": label})
+    payload = repo / "herdr-workspaces.json"
+    _write_json(payload, {"result": {"workspaces": workspaces}})
+    env = {"HERDR_WORKSPACE_ID": "wX", "HERDR_STUB_JSON": str(payload)}
+    if hang:
+        env["HERDR_STUB_HANG"] = "1"
+    return env
+
+
+def run_hook_payload(
+    repo: Path,
+    payload: dict[str, object],
+    extra_env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
     """Run the hook with an arbitrary stdin payload. Returns (rc, out, err).
 
     Takes the payload dict verbatim so a test can omit a key or vary the key
@@ -188,6 +224,14 @@ def run_hook_payload(repo: Path, payload: dict[str, object]) -> tuple[int, str, 
     env["BD_LOG"] = str(repo / "bd.log")
     env["BD_SHOW_DIR"] = str(repo / "shows")
     env["BD_CHILDREN_JSON"] = str(repo / "children.json")
+    # Drop the inherited herdr identity. Without this the hook reaches the real
+    # herdr server whenever pytest runs from a herdr pane, so the naming block
+    # takes the label branch locally and the no-label branch in CI with nothing
+    # pinning either — the next assertion anyone adds on that text would pass
+    # here and fail in CI. Tests that want the label branch stub `herdr` on PATH
+    # and set HERDR_WORKSPACE_ID themselves.
+    env.pop("HERDR_WORKSPACE_ID", None)
+    env.update(extra_env or {})
     proc = subprocess.run(
         ["bash", str(HOOK_PATH)],
         cwd=repo,
@@ -204,6 +248,7 @@ def run_hook(
     session_id: str = SESSION_ID,
     source: str = "startup",
     transcript_path: str = "/tmp/transcripts/abc.jsonl",
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[int, str, str]:
     """Run the hook with a well-formed SessionStart payload on stdin."""
     return run_hook_payload(
@@ -215,6 +260,7 @@ def run_hook(
             "hook_event_name": "SessionStart",
             "source": source,
         },
+        extra_env=extra_env,
     )
 
 
@@ -554,3 +600,66 @@ def test_subagent_transcript_emits_nothing(repo: Path) -> None:
     )
     assert rc == 0, err
     assert out == ""
+
+
+# --- PP-355h: name derivation from the herdr workspace label -----------------
+
+
+def test_workspace_label_is_offered_as_the_first_naming_choice(repo: Path) -> None:
+    """The label branch renders the label and its CamelCased form."""
+    rc, out, err = run_hook(repo, extra_env=stub_herdr(repo, "main e2e failures"))
+    assert rc == 0, err
+    assert REGISTRATION_MARKER in out
+    assert 'workspace label, which is "main e2e failures"' in out
+    assert "becomes <Harness>-MainE2eFailures" in out
+
+
+def test_no_herdr_env_falls_back_to_bead_then_task(repo: Path) -> None:
+    """Absent HERDR_WORKSPACE_ID, naming drops to bead-then-task and says why."""
+    rc, out, err = run_hook(repo)
+    assert rc == 0, err
+    assert REGISTRATION_MARKER in out
+    assert "No herdr workspace label available" in out
+    assert "workspace label, which is" not in out
+
+
+def test_unknown_workspace_id_falls_back(repo: Path) -> None:
+    """A stale/moved id resolves to no label rather than a peer's label.
+
+    The stub reports only "wOTHER" while the hook asks for "wX".
+    """
+    rc, out, err = run_hook(repo, extra_env=stub_herdr(repo, None))
+    assert rc == 0, err
+    assert "No herdr workspace label available" in out
+    assert "somebody else" not in out
+
+
+def test_label_without_alphanumerics_does_not_render_a_bare_prefix(
+    repo: Path,
+) -> None:
+    """A label that camelizes to "" must not yield "<Harness>-".
+
+    huddle-whoami.sh's ^[A-Za-z0-9_-]+$ validator accepts a bare "Claude-", so
+    offering it invites a truncated registration.
+    """
+    rc, out, err = run_hook(repo, extra_env=stub_herdr(repo, "🔥"))
+    assert rc == 0, err
+    assert "becomes <Harness>-\n" not in out
+    assert "becomes <Harness>-." not in out
+    assert "No herdr workspace label available" in out
+
+
+def test_wedged_herdr_does_not_consume_the_hook_budget(repo: Path) -> None:
+    """A hung herdr must cost ~1s, not the hook's whole 5000ms budget.
+
+    Blowing the budget makes Claude Code discard ALL stdout, so the session gets
+    no session_id and never registers — the PP-2m3l breakage this file guards.
+    """
+    start = time.monotonic()
+    rc, out, err = run_hook(repo, extra_env=stub_herdr(repo, "whatever", hang=True))
+    elapsed = time.monotonic() - start
+    assert rc == 0, err
+    assert elapsed < 4.0, f"herdr timeout guard did not fire (took {elapsed:.1f}s)"
+    assert REGISTRATION_MARKER in out
+    assert f"`{SESSION_ID}`" in out
+    assert "No herdr workspace label available" in out


### PR DESCRIPTION
## What

A session carried three unrelated names:

| Name | Was set by | Example |
| --- | --- | --- |
| Huddle name | model invents it from the task | `Claude-HuddleNaming` |
| Display name | `<dir>-<hash>` fallback | `pinpoint-97` |
| Terminal title | drifting conversation summary | `Messaging system and name selection…` |

Nothing tied them together. This derives the huddle name from the **herdr workspace label** — which Tim already types when he creates the workspace — and then asks him to run `/rename <name>` so the display name matches.

Naming order in the registration notice:

1. Workspace label, CamelCased (`Agent naming` → `Claude-AgentNaming`)
2. The assigned bead, when the label is generic (`PinPoint`, `Orchestrating`, `Busywork`, `main`, a bare number)
3. The task, when there is neither

## Why `$HERDR_WORKSPACE_ID`

Hooks inherit the environment herdr launched the agent in, so the variable names the workspace directly — no pane matching. Both alternatives misidentify the session:

- `herdr pane list`'s `agent_session.value` has been measured pointing at a **different live session** (documented in the `herdr` skill). That is PP-788v's failure mode — signing as someone else, silently.
- `terminal_title` carries Claude Code's animating activity glyph, and `terminal_title_stripped` only partly removes it: `✳` and the braille frames yes, `◐`/`◑` no.

A forked session inherits a stale `$HERDR_WORKSPACE_ID`. Tolerable here and nowhere else in the huddle, because the output is a *suggestion* both the agent and Tim read before it is registered.

## Note for the reviewer

`/rename` exists and I initially reported it did not — I searched the compiled binary's strings and concluded from a null result. It is user-typed only, so an agent still cannot self-name, but it does mean the name can be set *after* the task is known, which is why this lands as a notice change rather than a launcher wrapper.

CamelCasing goes through `jq`, not `sed`: BSD sed has no `\u`, so `s/(^| )([a-z])/\1\u\2/g` emits a literal "u" on this Mac — `Agent naming` became `Agentunaming`.

## Testing

`pnpm run check` and `pnpm run check:python` (530 passed) both green.

Hook output verified in three states:

- **label present** → `1. Your herdr workspace label, which is "Agent naming"… Claude-AgentNaming`
- **`$HERDR_WORKSPACE_ID` unset** → drops to bead-then-task, prints why
- **unknown workspace id** → same fallback, no error

Fails open at every step: no herdr, a bare terminal, Bazzite, another harness.