### PR TITLE
fix(hooks): anchor node hook commands to CLAUDE_PROJECT_DIR (PP-iapy)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,12 +66,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/normalize-workspace-paths.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/normalize-workspace-paths.cjs",
             "timeout": 5000
           },
           {
             "type": "command",
-            "command": "node .claude/hooks/inject-beads-actor.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/inject-beads-actor.cjs",
             "timeout": 5000
           }
         ]
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/block-direct-merge.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/block-direct-merge.cjs",
             "timeout": 5000
           }
         ]
@@ -91,7 +91,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/block-main-worktree-branch-switch.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/block-main-worktree-branch-switch.cjs",
             "timeout": 5000
           }
         ]
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/block-worktree-dispatch-from-linked.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/block-worktree-dispatch-from-linked.cjs",
             "timeout": 5000
           }
         ]
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/ui-screenshot-reminder.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/ui-screenshot-reminder.cjs",
             "timeout": 5000
           }
         ]
@@ -207,7 +207,7 @@
           },
           {
             "type": "command",
-            "command": "node .claude/hooks/verify-guard-stack.cjs",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/verify-guard-stack.cjs",
             "timeout": 5000
           },
           {

--- a/scripts/tests/test_node_hook_paths.py
+++ b/scripts/tests/test_node_hook_paths.py
@@ -1,0 +1,179 @@
+"""Tests that every node-invoked hook command in .claude/settings.json
+resolves and runs when the session cwd is unrelated to the repo (PP-iapy).
+
+Every node hook used to be invoked by a bare relative path
+(`node .claude/hooks/x.cjs`), while every bash hook was already anchored to
+${CLAUDE_PROJECT_DIR:-.}. When the session cwd moved off a directory that
+happens to contain .claude/hooks -- a worktree removed, cwd changed mid-
+session -- Node exited with MODULE_NOT_FOUND and Claude Code reported a
+"Failed with non-blocking status code" -- so the tool call PROCEEDED and the
+guard hooks (block-direct-merge, block-main-worktree-branch-switch,
+block-worktree-dispatch-from-linked) went silently inert.
+
+These tests read the real settings.json rather than a fixture copy, so a
+future edit that re-introduces a bare relative path is caught here instead of
+only in production use.
+"""
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SETTINGS_PATH = REPO_ROOT / ".claude" / "settings.json"
+
+# Matches `node "${CLAUDE_PROJECT_DIR:-.}"/.claude/hooks/<name>.cjs` -- the
+# same anchoring form the bash hooks in this file already use.
+ANCHORED_NODE_HOOK_RE = re.compile(
+    r'node\s+"\$\{CLAUDE_PROJECT_DIR:-\.\}"/\.claude/hooks/[\w./-]+\.cjs'
+)
+
+# A node invocation of a .claude/hooks/*.cjs script that is NOT anchored via
+# ${CLAUDE_PROJECT_DIR:-.} -- i.e. the bare-relative-path bug shape.
+BARE_NODE_HOOK_RE = re.compile(
+    r"(?<!\$\{CLAUDE_PROJECT_DIR:-\.\}\"/)\bnode\s+\.claude/hooks/"
+)
+
+
+def _collect_commands(event_entries: object) -> list[str]:
+    """Every `command` string wired under one hook-event array."""
+    commands: list[str] = []
+    if not isinstance(event_entries, list):
+        return commands
+    for entry in event_entries:
+        if not isinstance(entry, dict):
+            continue
+        inner = entry.get("hooks")
+        if not isinstance(inner, list):
+            continue
+        for h in inner:
+            if isinstance(h, dict) and isinstance(h.get("command"), str):
+                commands.append(h["command"])
+    return commands
+
+
+def _all_hook_commands() -> list[str]:
+    settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+    commands: list[str] = []
+    for event_entries in settings.get("hooks", {}).values():
+        commands.extend(_collect_commands(event_entries))
+    return commands
+
+
+def _node_hook_commands() -> list[str]:
+    """Every wired command that invokes a .claude/hooks/*.cjs script via node."""
+    return [
+        cmd
+        for cmd in _all_hook_commands()
+        if re.search(r"\bnode\b.*\.claude/hooks/[\w./-]+\.cjs", cmd)
+    ]
+
+
+NODE_HOOK_COMMANDS = _node_hook_commands()
+
+# The seven hooks named in PP-iapy. Kept as an explicit list so a future
+# settings.json edit that silently drops one is caught rather than the
+# parametrized tests just running over a shorter list.
+EXPECTED_NODE_HOOK_BASENAMES = [
+    "normalize-workspace-paths.cjs",
+    "inject-beads-actor.cjs",
+    "block-direct-merge.cjs",
+    "block-main-worktree-branch-switch.cjs",
+    "block-worktree-dispatch-from-linked.cjs",
+    "ui-screenshot-reminder.cjs",
+    "verify-guard-stack.cjs",
+]
+
+
+def test_settings_json_exists() -> None:
+    assert SETTINGS_PATH.is_file(), f"expected {SETTINGS_PATH} to exist"
+
+
+def test_all_seven_node_hooks_are_wired() -> None:
+    """Sanity check the fixture reflects the real settings.json -- a
+    regression that deletes a hook's registration entirely should fail here,
+    not pass silently because the parametrized tests below had nothing to
+    iterate over."""
+    joined = "\n".join(NODE_HOOK_COMMANDS)
+    missing = [b for b in EXPECTED_NODE_HOOK_BASENAMES if b not in joined]
+    assert not missing, f"expected node hook(s) not found in settings.json: {missing}"
+
+
+@pytest.mark.parametrize("command", NODE_HOOK_COMMANDS, ids=lambda c: c.split("/")[-1])
+def test_node_hook_command_is_anchored_to_project_dir(command: str) -> None:
+    """Every node hook command must resolve its script path via
+    ${CLAUDE_PROJECT_DIR:-.}, matching the form the bash hooks in the same
+    file already use -- not a bare relative path that only resolves when the
+    session cwd happens to contain .claude/hooks."""
+    assert ANCHORED_NODE_HOOK_RE.search(command), (
+        f"node hook command is not CLAUDE_PROJECT_DIR-anchored: {command!r}"
+    )
+    assert not BARE_NODE_HOOK_RE.search(command), (
+        f"node hook command still uses a bare relative path: {command!r}"
+    )
+
+
+@pytest.mark.parametrize("command", NODE_HOOK_COMMANDS, ids=lambda c: c.split("/")[-1])
+def test_node_hook_resolves_and_runs_from_unrelated_cwd(
+    command: str, tmp_path: Path
+) -> None:
+    """Reproduces the PP-iapy failure mode directly: run the exact command
+    string wired in settings.json, with cwd set somewhere far from the repo
+    and CLAUDE_PROJECT_DIR set to the real repo root -- the way Claude Code
+    invokes hooks. Must NOT fail with node's MODULE_NOT_FOUND."""
+    unrelated_cwd = tmp_path / "unrelated"
+    unrelated_cwd.mkdir()
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "-c", command],
+        cwd=unrelated_cwd,
+        env=env,
+        input="{}",
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert "MODULE_NOT_FOUND" not in result.stderr, (
+        f"hook failed to resolve from an unrelated cwd: {command!r}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "Cannot find module" not in result.stderr, (
+        f"hook failed to resolve from an unrelated cwd: {command!r}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_bare_relative_path_form_actually_fails_from_unrelated_cwd(
+    tmp_path: Path,
+) -> None:
+    """Proves the assertions above test something real: the OLD bare-
+    relative-path form does fail from an unrelated cwd even with
+    CLAUDE_PROJECT_DIR set (it never consulted that variable), which is
+    exactly the PP-iapy bug. If this stops failing, node's module resolution
+    changed underneath us and the regression test above needs revisiting."""
+    unrelated_cwd = tmp_path / "unrelated"
+    unrelated_cwd.mkdir()
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        ["bash", "-c", "node .claude/hooks/verify-guard-stack.cjs"],
+        cwd=unrelated_cwd,
+        env=env,
+        input="{}",
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "MODULE_NOT_FOUND" in result.stderr


### PR DESCRIPTION
## Summary

Every **node** hook command in `.claude/settings.json` was invoked by a bare relative path (`node .claude/hooks/x.cjs`), while every **bash** hook was already anchored to `${CLAUDE_PROJECT_DIR:-.}`. When the session cwd moved off a directory that happens to contain `.claude/hooks` (a removed worktree, a mid-session cwd change), node exited `MODULE_NOT_FOUND`, Claude Code reported a non-blocking hook failure, and **the tool call proceeded anyway** — taking the guard hooks (`block-direct-merge`, `block-main-worktree-branch-switch`, `block-worktree-dispatch-from-linked`) silently inert with them. Full repro and incident notes: PP-iapy.

- Anchors all seven node hook commands (`normalize-workspace-paths`, `inject-beads-actor`, `block-direct-merge`, `block-main-worktree-branch-switch`, `block-worktree-dispatch-from-linked`, `ui-screenshot-reminder`, `verify-guard-stack`) to `${CLAUDE_PROJECT_DIR:-.}`, matching the exact quoting the bash hooks in the same file already use.
- `verify-guard-stack.cjs`'s `extractScriptPaths()` already special-cased the `${CLAUDE_PROJECT_DIR:-.}` substitution pattern, so its own reverse dead-registration check needed no code change — it was written anticipating this fix.
- Grepped the repo (`rg --hidden 'node \.claude/hooks'`) for the same bare-relative-path shape elsewhere. Found only historical/inert references, left untouched: a comment illustrating the *old* form in `verify-guard-stack.cjs` (still valid as documentation), a dated planning doc under `docs/plans/` and `docs/superpowers/plans/`, and test fixtures in `src/test/unit/hooks/verify-guard-stack.test.ts` that construct synthetic settings objects (not the real settings.json, so not affected by this bug). No `.claude/settings.local.json` exists in this repo. Nothing outside `.claude/settings.json` needed a functional fix.

## Out of scope

The bead's DESIGN section also floats making the guard hooks fail **closed** when a hook can't load (rather than warn/proceed). That is an open design decision left for Tim — not implemented here.

## Verification

`pnpm run check` (static gate) — passed:
```
$ npm-run-all --silent --parallel typecheck typecheck:tests typecheck:e2e lint:local format:fix check:linters check:rule-ids audit:role-checks audit:sm-structural check:behind-main
All checks passed!
37 files already formatted
No findings to report. Good job! (1 ignored, 10 suppressed)
```

`pnpm run check:python` (ruff + pytest scripts/tests/) — passed, 547 tests:
```
======================= 547 passed in 111.26s (0:01:51) ========================
```

Manual reproduction — anchored form resolves from an unrelated cwd with `CLAUDE_PROJECT_DIR` set (as Claude Code sets it); the old bare form still fails the same way described in the bead:
```
$ cd /tmp/unrelated-cwd
$ CLAUDE_PROJECT_DIR=<worktree-root> bash -c 'echo "{}" | node "${CLAUDE_PROJECT_DIR:-.}"/.claude/hooks/verify-guard-stack.cjs'
exit=0

$ CLAUDE_PROJECT_DIR=<worktree-root> bash -c 'echo "{}" | node .claude/hooks/verify-guard-stack.cjs'
node:internal/modules/cjs/loader:1503
  throw err;
Error: Cannot find module '/tmp/unrelated-cwd/.claude/hooks/verify-guard-stack.cjs'
  code: 'MODULE_NOT_FOUND'
exit=1
```

## New test coverage

`scripts/tests/test_node_hook_paths.py` (17 tests):
- Reads the real `.claude/settings.json` (not a fixture copy) and asserts every wired node-hook command is `${CLAUDE_PROJECT_DIR:-.}`-anchored, one test per hook.
- For each of the seven hooks, actually runs the exact command string from `settings.json` with cwd set to an unrelated tmp dir and `CLAUDE_PROJECT_DIR` set to the repo root — asserts no `MODULE_NOT_FOUND` / "Cannot find module" in stderr. This is the direct regression catch: reintroducing a bare relative path fails this test.
- A control test proves the bare-relative-path form genuinely does fail under the same conditions, so the regression assertions aren't vacuous.
- A sanity test asserts all seven expected hook basenames are still wired at all.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm run check:python`
- [x] Manual repro: anchored form resolves from unrelated cwd, bare form fails the same way as the bead's reported banner
- [ ] CI green (watching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj5S3d6aaKfxqCtcBqeVwn
