### PR TITLE
fix(e2e): wait for React hydration after navigation (PP-kz47)

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -17,7 +17,7 @@
 
 import { mkdirSync } from "fs";
 import { dirname } from "path";
-import { expect, type Page, test as setup } from "@playwright/test";
+import { expect, type Page, test as setup } from "./support/fixtures.js";
 
 import { TEST_USERS } from "./support/constants.js";
 import { STORAGE_STATE } from "./support/auth-state.js";

--- a/e2e/full/about-page.spec.ts
+++ b/e2e/full/about-page.spec.ts
@@ -4,7 +4,7 @@
  * Tests that the About page is accessible and renders correctly.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("About Page - Authenticated", () => {

--- a/e2e/full/admin-help.spec.ts
+++ b/e2e/full/admin-help.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import { TEST_USERS } from "../support/constants.js";
 

--- a/e2e/full/admin-remove-invited-user.spec.ts
+++ b/e2e/full/admin-remove-invited-user.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import {
   createTestUser,

--- a/e2e/full/admin-users.spec.ts
+++ b/e2e/full/admin-users.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import {
   createTestUser,

--- a/e2e/full/change-password.spec.ts
+++ b/e2e/full/change-password.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs, logout } from "../support/actions.js";
 import { createTestUser, deleteTestUser } from "../support/supabase-admin.js";
 

--- a/e2e/full/collection-edit-sharing.spec.ts
+++ b/e2e/full/collection-edit-sharing.spec.ts
@@ -9,7 +9,7 @@
  * `member` storageState; the editor runs in a second `technician` context.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, attachHydrationWait } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { getTestPrefix } from "../support/test-isolation.js";
 
@@ -53,7 +53,7 @@ test.describe("Collection edit sharing (PP-wqit.7)", () => {
       storageState: STORAGE_STATE.technician,
     });
     try {
-      const ed = await editorCtx.newPage();
+      const ed = attachHydrationWait(await editorCtx.newPage());
       await ed.goto("/c/collections");
       await expect(
         ed.getByRole("heading", { name: "Shared with you" })
@@ -99,7 +99,7 @@ test.describe("Collection edit sharing (PP-wqit.7)", () => {
       storageState: STORAGE_STATE.technician,
     });
     try {
-      const rv = await revokedCtx.newPage();
+      const rv = attachHydrationWait(await revokedCtx.newPage());
       await rv.goto("/c/collections");
       await expect(
         rv.getByRole("link", { name: new RegExp(name) })

--- a/e2e/full/cookie-consent.spec.ts
+++ b/e2e/full/cookie-consent.spec.ts
@@ -8,7 +8,7 @@
  * more reliable hydration on mobile viewports in CI.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { DEV_SHOW_COOKIE_BANNER_KEY } from "~/lib/cookies/constants.js";
 
 test.describe("Cookie Consent Banner", () => {

--- a/e2e/full/dashboard.spec.ts
+++ b/e2e/full/dashboard.spec.ts
@@ -5,7 +5,7 @@
  * newest games, recently fixed games, and quick stats after login.
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "../support/fixtures.js";
 import { getTestPrefix } from "../support/test-isolation.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 

--- a/e2e/full/discord-dm-preferences.spec.ts
+++ b/e2e/full/discord-dm-preferences.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import {
   createTestUser,

--- a/e2e/full/email-and-notifications.spec.ts
+++ b/e2e/full/email-and-notifications.spec.ts
@@ -5,7 +5,7 @@
  * and password reset test from auth-flows-extended.spec.ts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, attachHydrationWait } from "../support/fixtures.js";
 import { MailpitClient } from "../support/mailpit.js";
 import {
   ensureLoggedIn,
@@ -65,7 +65,7 @@ test.describe("Notifications", () => {
 
     // Login as owner
     const ownerContext = await browser.newContext();
-    const ownerPage = await ownerContext.newPage();
+    const ownerPage = attachHydrationWait(await ownerContext.newPage());
 
     await ownerPage.goto("/login");
     await ownerPage.getByLabel("Email").fill(ownerEmail);
@@ -75,7 +75,7 @@ test.describe("Notifications", () => {
 
     // 2. Action: Anonymous user reports issue on THIS machine
     const publicContext = await browser.newContext();
-    const publicPage = await publicContext.newPage();
+    const publicPage = attachHydrationWait(await publicContext.newPage());
 
     await publicPage.goto("/report");
     await selectMachine(publicPage, machine.id);
@@ -243,7 +243,7 @@ test.describe("Notifications", () => {
 
     // 2. Action: Admin (Owner) changes status
     const adminContext = await browser.newContext();
-    const adminPage = await adminContext.newPage();
+    const adminPage = attachHydrationWait(await adminContext.newPage());
 
     await adminPage.goto("/login");
     await adminPage.getByLabel("Email").fill(adminEmail);
@@ -280,7 +280,7 @@ test.describe("Notifications", () => {
     cleanupUserIds.push(watcher.id);
 
     const watcherContext = await browser.newContext();
-    const watcherPage = await watcherContext.newPage();
+    const watcherPage = attachHydrationWait(await watcherContext.newPage());
 
     await watcherPage.goto("/login");
     await watcherPage.getByLabel("Email").fill(globalWatcherEmail);
@@ -298,7 +298,7 @@ test.describe("Notifications", () => {
 
     // 2. Action: Anonymous user reports issue on ANY machine
     const publicContext = await browser.newContext();
-    const publicPage = await publicContext.newPage();
+    const publicPage = attachHydrationWait(await publicContext.newPage());
     await publicPage.goto("/report");
 
     // Use a seeded machine for convenience, or create one.
@@ -363,7 +363,7 @@ test.describe("Notifications", () => {
     // 2. Create notification via public report (as Anonymous/Other)
     // We need a separate context to avoid "actor == recipient" filter
     const publicContext = await browser.newContext();
-    const publicPage = await publicContext.newPage();
+    const publicPage = attachHydrationWait(await publicContext.newPage());
     await publicPage.goto("/report");
     // Select machine and verify state (Mobile Chrome hardening)
     await selectMachine(publicPage, machine.id);
@@ -421,7 +421,7 @@ test.describe("Notifications", () => {
     const member = await createTestUser(memberEmail);
     cleanupUserIds.push(member.id);
     const memberContext = await browser.newContext();
-    const memberPage = await memberContext.newPage();
+    const memberPage = attachHydrationWait(await memberContext.newPage());
     await ensureLoggedIn(memberPage, testInfo, {
       email: memberEmail,
       password: "TestPassword123",

--- a/e2e/full/form-resets.spec.ts
+++ b/e2e/full/form-resets.spec.ts
@@ -12,7 +12,7 @@
  * - Admin user invite dialog (InviteUserDialog)
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import {
   ensureLoggedIn,
   loginAs,
@@ -25,6 +25,7 @@ import { cleanupTestEntities } from "../support/cleanup.js";
 import { seededMachines, TEST_USERS } from "../support/constants.js";
 import {
   fillReportForm,
+  openIssueCommentForm,
   submitFormAndWaitForRedirect,
 } from "../support/page-helpers.js";
 import {
@@ -217,27 +218,9 @@ test.describe("CREATE form resets", () => {
       timeout: 30000,
     });
 
-    // On mobile (md: breakpoint hidden), AddCommentForm lives inside the
-    // StickyCommentComposer Sheet — open it before interacting with the editor.
-    // The inline form is hidden (hidden md:flex) on mobile; scope locators to
-    // the open dialog to avoid resolving to the hidden inline ProseMirror.
-    // Wait for the page to settle after redirect before checking visibility.
     await page.waitForLoadState("domcontentloaded");
-    const sheetTrigger = page.getByRole("button", { name: "Add a comment" });
-    const isOnMobile = await sheetTrigger
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    if (isOnMobile) {
-      await sheetTrigger.click();
-      // Wait for the Sheet to fully animate open before interacting.
-      await page
-        .getByRole("dialog", { name: "Add a comment" })
-        .waitFor({ state: "visible", timeout: 10000 });
-    }
-
-    const commentForm = isOnMobile
-      ? page.getByRole("dialog", { name: "Add a comment" })
-      : page.getByTestId("issue-comment-form");
+    const { form: commentForm, isSheet: isOnMobile } =
+      await openIssueCommentForm(page);
     const editor = commentForm.locator(".ProseMirror");
     await editor.waitFor({ state: "visible", timeout: 15000 });
     await editor.click();

--- a/e2e/full/invite-signup.spec.ts
+++ b/e2e/full/invite-signup.spec.ts
@@ -9,7 +9,7 @@
  * 5. User is redirected to dashboard.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { ensureLoggedIn, logout } from "../support/actions.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { seededMachines, TEST_USERS } from "../support/constants.js";

--- a/e2e/full/issue-detail-sticky-composer.spec.ts
+++ b/e2e/full/issue-detail-sticky-composer.spec.ts
@@ -9,7 +9,7 @@
  * 3. Is visible for authenticated (signed-in) members on mobile viewports.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import { seededIssue } from "../support/constants.js";
 

--- a/e2e/full/issue-list-extended.spec.ts
+++ b/e2e/full/issue-list-extended.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import {
   TEST_USERS,

--- a/e2e/full/issues-reassign-machine.spec.ts
+++ b/e2e/full/issues-reassign-machine.spec.ts
@@ -5,7 +5,7 @@
  * page. NN #11 — every clickable element gets clicked in an E2E test.
  */
 
-import { test, expect, type Page, type TestInfo } from "@playwright/test";
+import { test, expect, type Page, type TestInfo } from "../support/fixtures.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { seededMachines } from "../support/constants.js";
 import {

--- a/e2e/full/machine-details-extended.spec.ts
+++ b/e2e/full/machine-details-extended.spec.ts
@@ -16,7 +16,7 @@
  * Layout and expando tests are in e2e/smoke/machine-details-redesign.spec.ts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { ensureLoggedIn, logout, loginAs } from "../support/actions.js";
 import { seededMachines, TEST_USERS } from "../support/constants.js";
 import { clearMachineField } from "../support/supabase-admin.js";

--- a/e2e/full/machine-info.spec.ts
+++ b/e2e/full/machine-info.spec.ts
@@ -8,7 +8,7 @@
  * machine-details-extended.spec.ts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { seededMachines } from "../support/constants.js";
 

--- a/e2e/full/machine-owner-picker.spec.ts
+++ b/e2e/full/machine-owner-picker.spec.ts
@@ -17,7 +17,7 @@
  * `src/components/users/InviteUserDialog.test.tsx`.
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "../support/fixtures.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { createTestUser, deleteTestUser } from "../support/supabase-admin.js";

--- a/e2e/full/machine-pinballmap-abandoned-notice.spec.ts
+++ b/e2e/full/machine-pinballmap-abandoned-notice.spec.ts
@@ -23,7 +23,7 @@
  * the picker searches against in production too.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import {
   getTestPrefix,

--- a/e2e/full/machine-settings.spec.ts
+++ b/e2e/full/machine-settings.spec.ts
@@ -19,7 +19,7 @@
  * that CREATES a set seeds its own machine (see the editor-journey block).
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { seededMachines } from "../support/constants.js";
 import {

--- a/e2e/full/machine-timeline.spec.ts
+++ b/e2e/full/machine-timeline.spec.ts
@@ -24,7 +24,7 @@
  * Reassign-flow selectors are stable per PP-3hb (issues-reassign-machine.spec.ts).
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { openDropdownMenu } from "../support/actions.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { cleanupTestEntities } from "../support/cleanup.js";

--- a/e2e/full/machine-with-invite.spec.ts
+++ b/e2e/full/machine-with-invite.spec.ts
@@ -5,7 +5,7 @@
  * from within the creation dialog, and that the new owner is auto-selected.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 

--- a/e2e/full/machines-public-access.spec.ts
+++ b/e2e/full/machines-public-access.spec.ts
@@ -8,7 +8,7 @@
  * per the permission model: machines.view is public, machines.create is admin-only.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { seededMachines } from "../support/constants.js";
 
 test.describe("Machines Public Access", () => {

--- a/e2e/full/privilege-reset.spec.ts
+++ b/e2e/full/privilege-reset.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs, logout } from "../support/actions.js";
 import {
   createTestUser,

--- a/e2e/full/profile-edit.spec.ts
+++ b/e2e/full/profile-edit.spec.ts
@@ -10,7 +10,7 @@
  * NOTE: Hover-card reveal is intentionally NOT asserted — hover is flaky in E2E.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("Profile edit", () => {

--- a/e2e/full/public-reporting-extended.spec.ts
+++ b/e2e/full/public-reporting-extended.spec.ts
@@ -5,7 +5,7 @@
  * Core reporting tests are in e2e/smoke/public-reporting.spec.ts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs, selectMachine } from "../support/actions.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import { TEST_USERS } from "../support/constants.js";

--- a/e2e/full/public-routes-audit.spec.ts
+++ b/e2e/full/public-routes-audit.spec.ts
@@ -26,7 +26,7 @@
  * covers /about, /privacy, /terms as public routes.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { seededMachines } from "../support/constants.js";
 
 test.describe("Public Routes — Class-A Residuals", () => {

--- a/e2e/full/quick-report.spec.ts
+++ b/e2e/full/quick-report.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import { TEST_USERS, seededMachines } from "../support/constants.js";
 

--- a/e2e/full/report-stale-machine.spec.ts
+++ b/e2e/full/report-stale-machine.spec.ts
@@ -26,7 +26,7 @@
  *     so the button is gated on a selection instead).
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { ensureLoggedIn, machineSelectValue } from "../support/actions.js";
 import { TEST_USERS } from "../support/constants.js";
 
@@ -41,32 +41,36 @@ test.describe("UnifiedReportForm — stale localStorage machineId (PP-lql)", () 
       password: TEST_USERS.admin.password,
     });
 
-    // Visit /report once so we are on the right origin to set localStorage.
+    // Seed the stale draft as an init script, so it is in localStorage before
+    // any app code runs on the next navigation.
+    //
+    // This used to be a `goto` + `evaluate` + `reload`, which raced the draft
+    // store: once it has restored, its persist effect rewrites the key with the
+    // current (empty) state, so a draft written after navigation only survived
+    // if it landed after that effect. The spec won that race by luck rather
+    // than by construction — it started failing deterministically the moment
+    // anything shifted navigation timing. Seeding pre-navigation removes the
+    // window, and drops the reload with it. (PP-jxhy.)
+    //
+    // The legacy key is deliberate: this exercises the migration path, and the
+    // store reads `report_draft` first and falls back to `report_form_state`.
+    await page.addInitScript((staleId: string) => {
+      window.localStorage.setItem(
+        "report_form_state",
+        JSON.stringify({
+          machineId: staleId,
+          title: "PP-lql stale draft restoration",
+          description: null,
+          severity: "minor",
+          priority: "medium",
+          frequency: "constant",
+          watchIssue: true,
+        })
+      );
+    }, STALE_UUID);
+
+    // The machine select must NOT silently land on machinesList[0].
     await page.goto("/report");
-
-    // Seed localStorage with a stale draft. The machineId UUID does not
-    // correspond to any machine in the seeded data set.
-    await page.evaluate(
-      ([staleId]) => {
-        window.localStorage.setItem(
-          "report_form_state",
-          JSON.stringify({
-            machineId: staleId,
-            title: "PP-lql stale draft restoration",
-            description: null,
-            severity: "minor",
-            priority: "medium",
-            frequency: "constant",
-            watchIssue: true,
-          })
-        );
-      },
-      [STALE_UUID]
-    );
-
-    // Reload so the form re-mounts and restoration runs against the seeded
-    // localStorage. The machine select must NOT silently land on machinesList[0].
-    await page.reload();
 
     const machineSelect = page.getByTestId("machine-select");
     await expect(machineSelect).toBeVisible();

--- a/e2e/full/report-tabbed.spec.ts
+++ b/e2e/full/report-tabbed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import { TEST_USERS, seededMachines } from "../support/constants.js";
 

--- a/e2e/full/rich-text.spec.ts
+++ b/e2e/full/rich-text.spec.ts
@@ -1,10 +1,11 @@
 // e2e/full/rich-text.spec.ts
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import {
   createTestUser,
   createTestMachine,
 } from "../support/supabase-admin.js";
+import { openIssueCommentForm } from "../support/page-helpers.js";
 import { getTestPrefix } from "../support/test-isolation.js";
 
 /**
@@ -121,25 +122,8 @@ test.describe("Rich Text and Mentions", () => {
 
     await expect(page).toHaveURL(new RegExp(`/m/${machine.initials}/i/1`));
 
-    // On mobile (md: breakpoint hidden), AddCommentForm lives inside the
-    // StickyCommentComposer Sheet — open it before interacting with the editor.
-    // The inline form is hidden (hidden md:flex) on mobile; scope locators to
-    // the open dialog to avoid resolving to the hidden inline ProseMirror.
     await page.waitForLoadState("domcontentloaded");
-    const sheetTrigger = page.getByRole("button", { name: "Add a comment" });
-    const isOnMobile = await sheetTrigger
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    if (isOnMobile) {
-      await sheetTrigger.click();
-      await page
-        .getByRole("dialog", { name: "Add a comment" })
-        .waitFor({ state: "visible", timeout: 10000 });
-    }
-
-    const commentForm = isOnMobile
-      ? page.getByRole("dialog", { name: "Add a comment" })
-      : page.getByTestId("issue-comment-form");
+    const { form: commentForm } = await openIssueCommentForm(page);
 
     // Add rich text comment
     const editor = commentForm.locator(".ProseMirror");

--- a/e2e/full/soft-keyboard-reflow.spec.ts
+++ b/e2e/full/soft-keyboard-reflow.spec.ts
@@ -24,7 +24,7 @@
  * and therefore exercises the cross-browser `scrollIntoView`-on-focus floor.
  */
 
-import { test, expect, type Locator } from "@playwright/test";
+import { test, expect, type Locator } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { seededMachines } from "../support/constants.js";
 import {

--- a/e2e/full/status-overhaul.spec.ts
+++ b/e2e/full/status-overhaul.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import {
   updateIssueField,
   visibleIssueFieldControl,

--- a/e2e/full/technician-role.spec.ts
+++ b/e2e/full/technician-role.spec.ts
@@ -7,7 +7,7 @@
  * - CANNOT access admin panel
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { seededMachines } from "../support/constants.js";
 
@@ -20,7 +20,15 @@ test.describe("Technician Role Permissions", () => {
     const heading = page.getByRole("heading", {
       name: seededMachines.addamsFamily.name,
     });
-    if (await heading.isVisible()) {
+    // Waited for, not sampled: `isVisible()` never retries, so a heading that
+    // had merely not painted yet read as "name was changed" and sent this
+    // afterEach down the restore branch — an unnecessary DB write on every
+    // slow render.
+    const nameIsCorrect = await heading
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
+    if (nameIsCorrect) {
       // Name is already correct — nothing to do
       return;
     }

--- a/e2e/full/technician-role.spec.ts
+++ b/e2e/full/technician-role.spec.ts
@@ -23,9 +23,11 @@ test.describe("Technician Role Permissions", () => {
     // Waited for, not sampled: `isVisible()` never retries, so a heading that
     // had merely not painted yet read as "name was changed" and sent this
     // afterEach down the restore branch — an unnecessary DB write on every
-    // slow render.
+    // slow render. CI-aware because a flat 5s reopens the same hole under the
+    // conditions this suite actually fails in (Mobile Chrome, three workers, a
+    // dev server compiling routes for the other two).
     const nameIsCorrect = await heading
-      .waitFor({ state: "visible", timeout: 5000 })
+      .waitFor({ state: "visible", timeout: process.env["CI"] ? 15_000 : 5000 })
       .then(() => true)
       .catch(() => false);
     if (nameIsCorrect) {

--- a/e2e/full/username-account-settings.spec.ts
+++ b/e2e/full/username-account-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 
 test.describe("Username Account Settings", () => {

--- a/e2e/smoke/admin-discord-integration.spec.ts
+++ b/e2e/smoke/admin-discord-integration.spec.ts
@@ -11,7 +11,7 @@
  * is covered by `src/test/integration/admin/discord-integration-actions.test.ts`.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { assertNoA11yViolations } from "../support/actions.js";
 

--- a/e2e/smoke/auth-flows.spec.ts
+++ b/e2e/smoke/auth-flows.spec.ts
@@ -6,7 +6,7 @@
  * Password reset email test is in e2e/full/email-and-notifications.spec.ts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs, logout, assertNoA11yViolations } from "../support/actions.js";
 import { TEST_USERS } from "../support/constants.js";
 

--- a/e2e/smoke/collection-view.spec.ts
+++ b/e2e/smoke/collection-view.spec.ts
@@ -9,7 +9,7 @@
  * supabase/seed-users.mjs ownerMap), so "My Machines" is non-empty.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import {
   assertNoA11yViolations,

--- a/e2e/smoke/collections.spec.ts
+++ b/e2e/smoke/collections.spec.ts
@@ -12,7 +12,7 @@
  * spec — so it's a stable choice for the add-machine step.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, attachHydrationWait } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { getTestPrefix } from "../support/test-isolation.js";
 
@@ -97,7 +97,7 @@ test.describe("Personal collections (PP-wqit.1)", () => {
       storageState: { cookies: [], origins: [] },
     });
     try {
-      const anonPage = await anon.newPage();
+      const anonPage = attachHydrationWait(await anon.newPage());
       await anonPage.goto(shareUrl);
       await expect(
         anonPage.getByTestId("collection-overview-body")

--- a/e2e/smoke/image-upload.spec.ts
+++ b/e2e/smoke/image-upload.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanupTestEntities } from "../support/cleanup.js";

--- a/e2e/smoke/issue-detail-permissions.spec.ts
+++ b/e2e/smoke/issue-detail-permissions.spec.ts
@@ -9,7 +9,7 @@
  * All UI-state assertions (H-class) live in:
  *   src/test/unit/components/issues/issue-detail-permissions.test.tsx
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { assertNoA11yViolations } from "../support/actions.js";
 import { seededIssue } from "../support/constants.js";
 

--- a/e2e/smoke/issue-list.spec.ts
+++ b/e2e/smoke/issue-list.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import {
   assertNoHorizontalOverflow,
   assertNoA11yViolations,

--- a/e2e/smoke/issues-crud.spec.ts
+++ b/e2e/smoke/issues-crud.spec.ts
@@ -5,7 +5,7 @@
  * Requires Supabase to be running.
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "../support/fixtures.js";
 import {
   assertNoHorizontalOverflow,
   updateIssueField,

--- a/e2e/smoke/landing-page.spec.ts
+++ b/e2e/smoke/landing-page.spec.ts
@@ -8,7 +8,7 @@
  * The middleware task (PinPoint-nm6) will update routing to allow public access.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { assertNoA11yViolations } from "../support/actions.js";
 
 test.describe("Landing Page", () => {

--- a/e2e/smoke/machine-details-redesign.spec.ts
+++ b/e2e/smoke/machine-details-redesign.spec.ts
@@ -30,7 +30,7 @@
  *   as a standalone button (design §4, PP-5sgt.3).
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import {
   assertNoHorizontalOverflow,

--- a/e2e/smoke/navigation.spec.ts
+++ b/e2e/smoke/navigation.spec.ts
@@ -4,7 +4,7 @@
  * Tests navigation bar behavior for authenticated and unauthenticated states.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import {
   assertNoHorizontalOverflow,
   loginAs,

--- a/e2e/smoke/profile.spec.ts
+++ b/e2e/smoke/profile.spec.ts
@@ -6,7 +6,7 @@
  * Full edit-journey coverage is in e2e/full/profile-edit.spec.ts.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 
 test.describe("Profile smoke", () => {

--- a/e2e/smoke/public-reporting.spec.ts
+++ b/e2e/smoke/public-reporting.spec.ts
@@ -4,7 +4,7 @@
  * Covers anonymous reporting workflow.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import {
   assertNoHorizontalOverflow,
   assertNoA11yViolations,

--- a/e2e/smoke/quick-report.spec.ts
+++ b/e2e/smoke/quick-report.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { loginAs } from "../support/actions.js";
 import { TEST_USERS } from "../support/constants.js";
 

--- a/e2e/smoke/report-form-clear.spec.ts
+++ b/e2e/smoke/report-form-clear.spec.ts
@@ -6,7 +6,7 @@
  * returns, so the client-side localStorage cleanup never fires.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { cleanupTestEntities } from "../support/cleanup.js";
 import {

--- a/e2e/smoke/responsive-overflow.spec.ts
+++ b/e2e/smoke/responsive-overflow.spec.ts
@@ -6,7 +6,7 @@
  * project matrix — catches overflow at both desktop and mobile viewports.
  */
 
-import { test } from "@playwright/test";
+import { test } from "../support/fixtures.js";
 import {
   assertNoHorizontalOverflow,
   ensureLoggedIn,

--- a/e2e/smoke/settings-loads.spec.ts
+++ b/e2e/smoke/settings-loads.spec.ts
@@ -6,7 +6,7 @@
  * tests (oauth-actions.test.ts, connected-accounts-section.test.tsx).
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../support/fixtures.js";
 import { STORAGE_STATE } from "../support/auth-state.js";
 import { assertNoA11yViolations } from "../support/actions.js";
 

--- a/e2e/support/actions.ts
+++ b/e2e/support/actions.ts
@@ -164,6 +164,65 @@ export async function logout(page: Page, _testInfo: TestInfo): Promise<void> {
 }
 
 /**
+ * Budget for a portal, drawer, or dropdown to mount once its trigger is clicked.
+ *
+ * These helpers hard-coded 5s (3s in the retrying dropdown loop), which silently
+ * opted out of the config's CI-aware `expect.timeout` — an explicit `{ timeout }`
+ * always beats `expect: { timeout }`, so the 30s CI budget never applied here.
+ * A shared helper quietly capping every caller below the environment's own
+ * setting is a defect on its own terms, whatever it happens to be masking.
+ *
+ * 5s is also thin for this suite specifically: the E2E `webServer` runs
+ * `pnpm run dev`, so a route pays an on-demand Next compile on its first
+ * request, and mobile viewports render component trees a chromium run never
+ * compiles (`MetadataDrawer`, `StickyCommentComposer`, `RowEditSheet`).
+ *
+ * **This is a latent-defect fix, not the cause of anything observed.** The
+ * Mobile Chrome full-suite failures were dropped clicks, fixed by the hydration
+ * wait in `support/fixtures.ts`.
+ *
+ * A caveat on how that was established, because it is easy to repeat the
+ * mistake: the crabbox runner does **not** set `CI`, so on it these constants
+ * evaluate to the local 5s/3s and `playwright.config.ts` uses `actionTimeout`
+ * 5s and an `expect` timeout of 10s rather than CI's 30s. Any conclusion of the
+ * form "widening the timeout did not help" drawn from a runner session is
+ * therefore worthless — the widening never applied. Check `echo $CI` on the
+ * host before reading anything into a timeout experiment. (PP-jxhy.)
+ *
+ * Local keeps the short budget: that dev server is usually warm, and a
+ * genuinely missing selector should still fail fast.
+ */
+const PORTAL_MOUNT_TIMEOUT = process.env["CI"] ? 20_000 : 5_000;
+
+/**
+ * Same idea, halved, for `openDropdownMenu` — it clicks twice, so this budget
+ * is spent twice before the test gives up, and the CI test timeout is 60s.
+ */
+const DROPDOWN_OPEN_TIMEOUT = process.env["CI"] ? 10_000 : 3_000;
+
+/**
+ * The clicks inside `openDropdownMenu` are bounded explicitly rather than
+ * inheriting `use.actionTimeout` (30s in CI, `playwright.config.ts`).
+ *
+ * Without this the worst case is click(30) + assert(10) + click(30) +
+ * assert(10) = 80s against a 60s CI test timeout, so a genuinely stuck trigger
+ * would die as a bare "Test timeout of 60000ms exceeded" and the authored
+ * "dropdown never opened" message below — the whole point of the helper —
+ * would never print.
+ *
+ * The two clicks get different budgets because they are doing different jobs.
+ * The FIRST has to absorb a trigger that is still becoming actionable — under
+ * `--workers=3` the Mobile Chrome sticky-composer trigger genuinely needs more
+ * than 10s while the dev server compiles for other spec files, and bounding it
+ * at 10s turned `form-resets:190` and `rich-text:105` red. The RETRY only has
+ * to re-hit a control already proven actionable, so it can be tight.
+ *
+ * Worst case 20 + 10 + 10 + 10 = 50s, inside the 60s CI test timeout.
+ */
+const DROPDOWN_FIRST_CLICK_TIMEOUT = process.env["CI"] ? 20_000 : 5_000;
+const DROPDOWN_RETRY_CLICK_TIMEOUT = process.env["CI"] ? 10_000 : 3_000;
+
+/**
  * Click a Radix dropdown trigger and confirm it actually opened. Retries once
  * if the first click loses to a focus/overlay race.
  *
@@ -173,20 +232,24 @@ export async function logout(page: Page, _testInfo: TestInfo): Promise<void> {
  * opened" failure rather than a missing-item failure downstream.
  */
 export async function openDropdownMenu(trigger: Locator): Promise<void> {
-  await trigger.click();
   try {
+    // The click sits inside the try so a trigger that never becomes actionable
+    // in time gets the retry too, instead of throwing straight past it.
+    await trigger.click({ timeout: DROPDOWN_FIRST_CLICK_TIMEOUT });
     await expect(trigger).toHaveAttribute("aria-expanded", "true", {
-      timeout: 3000,
+      timeout: DROPDOWN_OPEN_TIMEOUT,
     });
     return;
   } catch {
     // One retry — the first click sometimes loses to a focus race (e.g. a
     // ProseMirror editor still holding focus right after a form submit).
-    await trigger.click();
+    await trigger.click({ timeout: DROPDOWN_RETRY_CLICK_TIMEOUT });
     await expect(
       trigger,
       "Dropdown trigger did not open after two click attempts. aria-expanded never became 'true' — the click is likely being intercepted by an overlay (modal, editor focus trap, etc.)."
-    ).toHaveAttribute("aria-expanded", "true", { timeout: 3000 });
+    ).toHaveAttribute("aria-expanded", "true", {
+      timeout: DROPDOWN_OPEN_TIMEOUT,
+    });
   }
 }
 
@@ -249,10 +312,24 @@ export async function selectOption(
     throw new Error(`Unknown select trigger: ${triggerTestId}`);
   }
 
-  // Click the select trigger
+  // Open via openDropdownMenu, which confirms the trigger actually opened and
+  // clicks a second time if it didn't.
+  //
+  // A bare `trigger.click()` here is what made the Mobile Chrome full suite fail
+  // about once per run. The button paints before React attaches Radix's
+  // handlers, and under `--workers=3` the dev server is compiling routes for two
+  // other spec files, so hydration lags behind paint by enough that a click
+  // lands on an inert button and is simply dropped. Nothing is pending
+  // afterwards, which is why raising the option-visible timeout to 20s did not
+  // help — the wait was never the problem, the lost click was. Serial runs pass
+  // (92/92) because hydration wins the race every time when the dev server has
+  // nothing else to compile.
+  //
+  // PP-168u killed the same class in `machine-timeline` by routing through this
+  // helper; `selectOption` had simply never been given it. (PP-jxhy.)
   const trigger = page.getByTestId(triggerTestId);
   await expect(trigger).toBeVisible();
-  await trigger.click();
+  await openDropdownMenu(trigger);
 
   // Wait for the option to be visible in the popover
   const optionTestId = getOptionTestId(optionValue);
@@ -260,19 +337,19 @@ export async function selectOption(
   if (triggerTestId.endsWith("-trigger")) {
     // Drawer items use dispatchEvent — they respond to synthetic clicks.
     // Wait for visibility first so the drawer open animation has completed.
-    await expect(option).toBeVisible({ timeout: 5000 });
+    await expect(option).toBeVisible({ timeout: PORTAL_MOUNT_TIMEOUT });
     await option.dispatchEvent("click");
   } else {
     // Wait for the Radix Select portal to mount — options aren't in the DOM until the portal
     // opens (async portal render), so clicking without waiting causes a 30s timeout race.
     // force:true is still needed because shadcn/ui Select options can be positioned outside
     // the visible viewport but are still technically "visible" per Playwright's CSS check.
-    await expect(option).toBeVisible({ timeout: 5000 });
+    await expect(option).toBeVisible({ timeout: PORTAL_MOUNT_TIMEOUT });
     await option.click({ force: true });
   }
 
   // Wait for dropdown to close
-  await expect(option).toBeHidden({ timeout: 5000 });
+  await expect(option).toBeHidden({ timeout: PORTAL_MOUNT_TIMEOUT });
 }
 
 /**
@@ -290,16 +367,18 @@ export async function selectMachine(
 ): Promise<void> {
   const trigger = page.getByTestId("machine-select");
   await expect(trigger).toBeVisible();
-  await trigger.click();
+  // Same lost-click exposure as selectOption above — the Popover trigger also
+  // flips aria-expanded, so the same confirm-and-retry applies. (PP-jxhy.)
+  await openDropdownMenu(trigger);
 
   const option = machineId
     ? page.getByTestId(`machine-option-${machineId}`)
     : page.locator('[data-testid^="machine-option-"]').first();
-  await expect(option).toBeVisible({ timeout: 5000 });
+  await expect(option).toBeVisible({ timeout: PORTAL_MOUNT_TIMEOUT });
   await option.click();
 
   // Selecting closes the popover, so the option unmounts.
-  await expect(option).toBeHidden({ timeout: 5000 });
+  await expect(option).toBeHidden({ timeout: PORTAL_MOUNT_TIMEOUT });
 }
 
 /** The hidden input carrying the report form's selected machine id. */

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -35,7 +35,7 @@
  *
  * ## What it does not cover
  *
- * Two real gaps, both narrower than "it's handled":
+ * Four real gaps, all narrower than "it's handled":
  *
  * 1. **Pages this fixture never sees.** A page from
  *    `browser.newContext().newPage()` is constructed by the spec, not by the
@@ -47,7 +47,14 @@
  * 2. **Route handlers.** `/api/*` renders outside the root layout and has no
  *    React root, so it is excluded rather than waited for — see `isAppPage`.
  *
- * 3. **Subtrees that hydrate after the root.** The beacon fires from an effect
+ * 3. **Navigations that are not `goto`/`reload`.** A form submit that redirects
+ *    is a real document navigation this fixture never sees, and
+ *    `submitFormAndWaitForRedirect` resolves at `waitUntil: "commit"` —
+ *    earlier still. That helper therefore calls {@link waitForHydration}
+ *    itself. Any future helper that resolves on a navigation must do the same;
+ *    a link click followed by `waitForURL` has the identical hole.
+ *
+ * 4. **Subtrees that hydrate after the root.** The beacon fires from an effect
  *    in the root layout, so it reports that the root commit landed — not that
  *    every interactive descendant has handlers. Anything inside a Suspense
  *    boundary (any segment with a `loading.tsx`, plus streamed segments) is
@@ -101,7 +108,27 @@ function isAppPage(page: Page): boolean {
   }
 }
 
-async function waitForHydration(page: Page, target: string): Promise<void> {
+/**
+ * Thrown when the beacon never appears. Named so that callers which catch
+ * broadly — `submitFormAndWaitForRedirect`'s branch races treat a `goto` throw
+ * as "a sibling branch got there first" — can re-throw this one instead of
+ * swallowing it into a bare test timeout.
+ */
+export class HydrationTimeoutError extends Error {
+  override readonly name = "HydrationTimeoutError";
+}
+
+/**
+ * Wait until React has hydrated the current document.
+ *
+ * Exported because navigation does not only happen through `goto`:
+ * `submitFormAndWaitForRedirect` resolves on a URL commit, which this fixture
+ * cannot see, so that helper calls this itself.
+ */
+export async function waitForHydration(
+  page: Page,
+  target: string
+): Promise<void> {
   if (!isAppPage(page)) return;
 
   try {
@@ -115,7 +142,7 @@ async function waitForHydration(page: Page, target: string): Promise<void> {
     // during mount, say. Swallowing it would spend HYDRATION_TIMEOUT on every
     // navigation and then fail later at whatever got clicked next, pointing at
     // the wrong thing.
-    throw new Error(
+    throw new HydrationTimeoutError(
       `React never hydrated within ${String(HYDRATION_TIMEOUT)}ms after navigating to ${target}. ` +
         `Expected \`${HYDRATED_SELECTOR}\` (set by HydrationBeacon in ClientProviders). ` +
         `A client component most likely threw during mount — check the browser console in the trace.`
@@ -124,13 +151,24 @@ async function waitForHydration(page: Page, target: string): Promise<void> {
 }
 
 /**
+ * Pages already wrapped. Wrapping twice nests the wrappers, so a single `goto`
+ * would wait for hydration twice — and on a genuinely broken page would burn
+ * `2 × HYDRATION_TIMEOUT` (60s in CI) against a 60s test timeout, replacing the
+ * authored diagnostic with a bare "Test timeout exceeded".
+ */
+const wrapped = new WeakSet<Page>();
+
+/**
  * Make `goto` and `reload` on this page wait for hydration before returning.
  *
  * The `page` fixture below applies this for you. Call it directly on pages you
  * construct yourself — `browser.newContext()` then `newPage()` — which the
- * fixture never sees.
+ * fixture never sees. Idempotent, so passing an already-wrapped page is safe.
  */
 export function attachHydrationWait(page: Page): Page {
+  if (wrapped.has(page)) return page;
+  wrapped.add(page);
+
   const originalGoto = page.goto.bind(page);
   const originalReload = page.reload.bind(page);
 

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -1,0 +1,159 @@
+/**
+ * Project-local `test` — identical to Playwright's, except that a navigation
+ * does not return until React has hydrated.
+ *
+ * ## Why this exists
+ *
+ * Playwright's actionability checks are visible, stable, enabled, and receives-
+ * events. None of them know whether React has attached a handler yet, so
+ * "clickable" and "does something" are different facts and only the first is
+ * checked. A click in that window lands on a live-looking control and is
+ * silently discarded — no error, nothing pending afterwards.
+ *
+ * The spec then fails wherever it next asserts the consequence, which is why
+ * the symptom looked like unrelated bugs: a Radix Select portal that never
+ * opened (`status-overhaul:25`), a comment Sheet that never appeared
+ * (`form-resets:190`, `rich-text:105`), a tab-strip navigation that never
+ * happened (`technician-role:89`). It is also why raising timeouts did nothing:
+ * a slow mount is rescued by a longer wait, a dropped click is not.
+ *
+ * Evidence it is one mechanism and not four bugs, from the Mobile Chrome full
+ * suite on the Bazzite runner: serial `--workers=1` passes 92/92,
+ * `--workers=3` fails about one spec per run, every victim passes in isolation,
+ * and the victim rotates. Mobile Chrome is the only project affected because
+ * the E2E `webServer` runs `pnpm run dev` — routes compile on first request —
+ * and mobile renders component trees chromium never compiles
+ * (`MetadataDrawer`, `StickyCommentComposer`, `RowEditSheet`), so it pays extra
+ * compiles while two other workers keep the server busy. (PP-jxhy.)
+ *
+ * ## Why a fixture rather than per-site retries
+ *
+ * The victims span three unrelated surfaces and rotate by scheduling luck, so
+ * guarding call sites means guarding every click in the suite — including ones
+ * nobody has written yet. Waiting once per navigation covers the specs that
+ * navigate through the `page` fixture.
+ *
+ * ## What it does not cover
+ *
+ * Two real gaps, both narrower than "it's handled":
+ *
+ * 1. **Pages this fixture never sees.** A page from
+ *    `browser.newContext().newPage()` is constructed by the spec, not by the
+ *    fixture, so it gets the stock `goto`/`reload`. Eleven such pages exist
+ *    (`email-and-notifications`, `collection-edit-sharing`, `collections`) and
+ *    several of them drive the very helpers this fixture was written for. Call
+ *    {@link attachHydrationWait} on them — see those specs for the pattern.
+ *
+ * 2. **Route handlers.** `/api/*` renders outside the root layout and has no
+ *    React root, so it is excluded rather than waited for — see `isAppPage`.
+ *
+ * 3. **Subtrees that hydrate after the root.** The beacon fires from an effect
+ *    in the root layout, so it reports that the root commit landed — not that
+ *    every interactive descendant has handlers. Anything inside a Suspense
+ *    boundary (any segment with a `loading.tsx`, plus streamed segments) is
+ *    still dehydrated at that moment, as is a `ssr: false` dynamic import such
+ *    as `RichTextEditor`. For those, keep waiting on something the subtree
+ *    itself produces — specs already wait for `.ProseMirror` to be visible,
+ *    which is the right shape of check.
+ *
+ * So this narrows the window; it does not close it. A dropped click on a
+ * Suspense-boundary child is still possible and is not evidence the fixture
+ * regressed.
+ */
+import { test as base, expect, type Page } from "@playwright/test";
+
+export { expect };
+
+// Re-exported so a spec needs exactly one import line from here, rather than
+// splitting values and types across two modules.
+export type {
+  APIRequestContext,
+  BrowserContext,
+  Locator,
+  Page,
+  TestInfo,
+} from "@playwright/test";
+
+/** Matches the attribute `HydrationBeacon` sets in `ClientProviders`. */
+const HYDRATED_SELECTOR = "html[data-hydrated]";
+
+/**
+ * Generous on purpose: this replaces a race, so it should only ever fail when
+ * hydration genuinely never happened — a broken page, not a slow one.
+ */
+const HYDRATION_TIMEOUT = process.env["CI"] ? 30_000 : 15_000;
+
+/**
+ * Route handlers render their own HTML without the root layout, so they have
+ * no React root and never set the beacon.
+ *
+ * Checked against the URL the browser actually landed on rather than the one
+ * passed in, so a redirect into or out of `/api` is classified by where it
+ * ended up. `/api/unsubscribe` is the live example: it returns
+ * `text/html; charset=utf-8` from a hand-rendered template, which is why
+ * content-type cannot be the discriminator here.
+ */
+function isAppPage(page: Page): boolean {
+  try {
+    return !new URL(page.url()).pathname.startsWith("/api/");
+  } catch {
+    return true;
+  }
+}
+
+async function waitForHydration(page: Page, target: string): Promise<void> {
+  if (!isAppPage(page)) return;
+
+  try {
+    await page
+      .locator(HYDRATED_SELECTOR)
+      .waitFor({ state: "attached", timeout: HYDRATION_TIMEOUT });
+  } catch {
+    // Deliberately NOT swallowed. Every page rendered through the root layout
+    // carries the beacon, and the one surface that does not is excluded above.
+    // So a miss here is a real hydration break — a client component throwing
+    // during mount, say. Swallowing it would spend HYDRATION_TIMEOUT on every
+    // navigation and then fail later at whatever got clicked next, pointing at
+    // the wrong thing.
+    throw new Error(
+      `React never hydrated within ${String(HYDRATION_TIMEOUT)}ms after navigating to ${target}. ` +
+        `Expected \`${HYDRATED_SELECTOR}\` (set by HydrationBeacon in ClientProviders). ` +
+        `A client component most likely threw during mount — check the browser console in the trace.`
+    );
+  }
+}
+
+/**
+ * Make `goto` and `reload` on this page wait for hydration before returning.
+ *
+ * The `page` fixture below applies this for you. Call it directly on pages you
+ * construct yourself — `browser.newContext()` then `newPage()` — which the
+ * fixture never sees.
+ */
+export function attachHydrationWait(page: Page): Page {
+  const originalGoto = page.goto.bind(page);
+  const originalReload = page.reload.bind(page);
+
+  page.goto = async (url, options) => {
+    const response = await originalGoto(url, options);
+    await waitForHydration(page, url);
+    return response;
+  };
+
+  // A reload discards the document and with it `data-hydrated`, so the new
+  // page races hydration exactly as a fresh `goto` would. Eleven specs reload
+  // and then immediately interact.
+  page.reload = async (options) => {
+    const response = await originalReload(options);
+    await waitForHydration(page, `${page.url()} (reload)`);
+    return response;
+  };
+
+  return page;
+}
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await use(attachHydrationWait(page));
+  },
+});

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -314,8 +314,17 @@ export async function fillReportForm(
   await selectOption(page, "issue-severity-select", severity);
 
   if (includePriority) {
+    // `isVisible()` samples; it never retries. Waiting first makes this an
+    // actual wait, so a priority select that is merely slow to render is set
+    // rather than silently skipped — which would leave the caller asserting
+    // against a default it believes it chose. The `catch` keeps the field
+    // genuinely optional (some report forms omit it).
     const prioritySelect = page.getByTestId("issue-priority-select");
-    if (await prioritySelect.isVisible()) {
+    const priorityRendered = await prioritySelect
+      .waitFor({ state: "visible", timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
+    if (priorityRendered) {
       await selectOption(page, "issue-priority-select", priority);
     }
   }
@@ -326,4 +335,91 @@ export async function fillReportForm(
   if ((await watchToggle.count()) > 0) {
     await watchToggle.setChecked(watchIssue);
   }
+}
+
+/** The Tailwind `md` breakpoint, which is what decides the layout below. */
+const MD_BREAKPOINT_PX = 768;
+
+// Budgets for the comment Sheet, bounded rather than inheriting the 30s CI
+// `actionTimeout`, so the worst path (click + wait + click + wait) stays inside
+// the 60s CI test timeout. The first click absorbs a trigger still becoming
+// actionable while the dev server compiles for other workers; the retry only
+// has to re-hit a control already proven actionable.
+const SHEET_FIRST_CLICK_TIMEOUT = process.env["CI"] ? 20_000 : 5_000;
+const SHEET_RETRY_CLICK_TIMEOUT = process.env["CI"] ? 10_000 : 3_000;
+const SHEET_OPEN_TIMEOUT = process.env["CI"] ? 10_000 : 3_000;
+
+/**
+ * Resolves the issue-detail comment form for the current viewport, opening the
+ * mobile sheet when that is the branch in play.
+ *
+ * Both branches are in the DOM at once: the inline `issue-comment-form` carries
+ * `hidden md:flex`, and below `md` a StickyCommentComposer button opens the same
+ * form inside a Sheet. So a test has to work out which one is live.
+ *
+ * It has to *know*, not sample. Two specs used to decide with
+ * `sheetTrigger.isVisible({ timeout: 3000 })`, which reads like a 3s wait and is
+ * not one — `isVisible()` never retries, and its `timeout` option is deprecated
+ * and ignored. The check therefore fired at whatever instant the Server Action
+ * redirect happened to land on, so a sticky composer that had not hydrated yet
+ * would read as "desktop" and send the test at the inline form that is
+ * `display: none` on mobile. Deciding on viewport width removes the sampling:
+ * it is the same input the CSS uses, and it cannot be raced.
+ *
+ * **This did not fix the Mobile Chrome full-suite failures.** It was written to,
+ * and it didn't: `form-resets:190` still failed after the change. Both specs
+ * also pass in isolation, which rules out a per-spec defect and points at
+ * cross-spec interference instead. So read this as a latent-defect fix — a wait
+ * that never waited — not as the cause of anything observed. (PP-jxhy.)
+ */
+export async function openIssueCommentForm(
+  page: Page
+): Promise<{ form: Locator; isSheet: boolean }> {
+  const viewportWidth = page.viewportSize()?.width ?? MD_BREAKPOINT_PX;
+  const isSheet = viewportWidth < MD_BREAKPOINT_PX;
+
+  if (!isSheet) {
+    return { form: page.getByTestId("issue-comment-form"), isSheet: false };
+  }
+
+  const sheetTrigger = page.getByRole("button", { name: "Add a comment" });
+  await sheetTrigger.waitFor({ state: "visible", timeout: 15000 });
+
+  const dialog = page.getByRole("dialog", { name: "Add a comment" });
+
+  // The composer paints before React attaches its handler, and under
+  // `--workers=3` the dev server is busy compiling for other spec files, so a
+  // click can land on an inert button and vanish. Waiting longer cannot
+  // recover that, because nothing is pending — it needs another click.
+  //
+  // But a BLIND second click is actively harmful: if the first one worked and
+  // the Sheet is merely slow, Radix has already marked the outside content
+  // `aria-hidden` and laid an overlay over it, so re-clicking either toggles
+  // the Sheet shut or is intercepted — turning a recoverable slow mount into a
+  // hard failure. So the retry is conditional on evidence the click did NOT
+  // register: the dialog is absent from the DOM entirely. If it is mounted but
+  // not yet visible, the click landed and the right move is to keep waiting.
+  //
+  // Note this deliberately does NOT go through `openDropdownMenu`. That helper
+  // decides on `aria-expanded`, and this trigger does not report it reliably —
+  // routing through it made the first click open the Sheet, the attribute stay
+  // "false", and the retry get eaten by the overlay. Verified on Mobile Chrome:
+  // `form-resets:190` and `rich-text:105` failed exactly that way.
+  await sheetTrigger.click({ timeout: SHEET_FIRST_CLICK_TIMEOUT });
+  const openedFirstTry = await dialog
+    .waitFor({ state: "visible", timeout: SHEET_OPEN_TIMEOUT })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!openedFirstTry) {
+    if ((await dialog.count()) > 0) {
+      // Mounted but slow — the click registered. Re-clicking here is what
+      // would close it, so wait instead.
+      await dialog.waitFor({ state: "visible", timeout: SHEET_OPEN_TIMEOUT });
+    } else {
+      await sheetTrigger.click({ timeout: SHEET_RETRY_CLICK_TIMEOUT });
+      await dialog.waitFor({ state: "visible", timeout: SHEET_OPEN_TIMEOUT });
+    }
+  }
+  return { form: dialog, isSheet: true };
 }

--- a/e2e/support/page-helpers.ts
+++ b/e2e/support/page-helpers.ts
@@ -12,6 +12,7 @@
 
 import type { Page, Locator } from "@playwright/test";
 import { selectOption } from "./actions.js";
+import { HydrationTimeoutError, waitForHydration } from "./fixtures.js";
 
 declare global {
   interface Window {
@@ -167,7 +168,12 @@ export async function submitFormAndWaitForRedirect(
           try {
             await page.goto(target, { waitUntil: "domcontentloaded" });
             return;
-          } catch {
+          } catch (error: unknown) {
+            // A page from the `test` fixture has a `goto` that also waits for
+            // hydration, and that failure is a real broken page, not a race.
+            // Swallowing it here would strand the branch on the never-resolving
+            // promise below and surface as a bare test timeout.
+            if (error instanceof HydrationTimeoutError) throw error;
             // page.goto can race with sibling branches and throw (frame
             // detached, navigation already in progress). Release the claim
             // so Branch A's natural-nav or Branch C can still succeed.
@@ -192,34 +198,43 @@ export async function submitFormAndWaitForRedirect(
   // prefix (e.g., /m vs /m/whatever). waitForResponse() buffers the full body
   // before resolving, which is essential in WebKit (page.on('response') with
   // async .text() loses the body to a closed stream).
-  const responseNavPromise: Promise<void> = new Promise<void>((resolve) => {
-    void page
-      .waitForResponse(
-        (r) =>
-          r.request().method() === "POST" &&
-          new URL(r.url()).pathname === awayFrom,
-        { timeout }
-      )
-      .then(async (response) => {
-        const body = await response.text();
-        const match =
-          /"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/.exec(body) ??
-          /\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/.exec(body);
-        if (match?.[1] && claimNavigation()) {
-          try {
-            await page.goto(match[1], { waitUntil: "domcontentloaded" });
-            resolve();
-          } catch {
-            // Same race-with-sibling-branch handling as Branch B.
-            releaseClaim();
+  const responseNavPromise: Promise<void> = new Promise<void>(
+    (resolve, reject) => {
+      void page
+        .waitForResponse(
+          (r) =>
+            r.request().method() === "POST" &&
+            new URL(r.url()).pathname === awayFrom,
+          { timeout }
+        )
+        .then(async (response) => {
+          const body = await response.text();
+          const match =
+            /"redirectTo":"(\/m\/[^/"\\]+\/i\/\d+)"/.exec(body) ??
+            /\\"redirectTo\\":\\"(\/m\/[^/"\\]+\/i\/\d+)\\"/.exec(body);
+          if (match?.[1] && claimNavigation()) {
+            try {
+              await page.goto(match[1], { waitUntil: "domcontentloaded" });
+              resolve();
+            } catch (error: unknown) {
+              // Same reasoning as Branch B: a hydration failure is a broken
+              // page, not a lost race, and this branch is the only one that can
+              // report it.
+              if (error instanceof HydrationTimeoutError) {
+                reject(error);
+                return;
+              }
+              // Same race-with-sibling-branch handling as Branch B.
+              releaseClaim();
+            }
           }
-        }
-        // No match (or already claimed, or page.goto threw): stay quiet.
-      })
-      .catch(() => {
-        // waitForResponse timed out: stay quiet.
-      });
-  });
+          // No match (or already claimed, or page.goto threw): stay quiet.
+        })
+        .catch(() => {
+          // waitForResponse timed out: stay quiet.
+        });
+    }
+  );
 
   await submitButton.click();
 
@@ -252,6 +267,14 @@ export async function submitFormAndWaitForRedirect(
     interceptorNavPromise,
     responseNavPromise,
   ]);
+
+  // The `page` fixture only wraps `goto`/`reload`, and the branch that usually
+  // wins here is A — a natural navigation the fixture cannot observe, resolved
+  // at `waitUntil: "commit"`, which is earlier than `domcontentloaded`, let
+  // alone hydration. So callers of this helper would otherwise land on a fresh
+  // document and start clicking in exactly the window the fixture exists to
+  // close. Wait here instead, once, for whichever branch won.
+  await waitForHydration(page, `${page.url()} (after form submit)`);
 }
 
 /**
@@ -387,6 +410,18 @@ export async function openIssueCommentForm(
 
   const dialog = page.getByRole("dialog", { name: "Add a comment" });
 
+  // Same dialog, matched even while it is still ARIA-hidden. `getByRole`
+  // defaults to `includeHidden: false`, so the plain `dialog` locator above
+  // reports 0 both when the Sheet was never opened AND when it is mounted but
+  // not yet in the accessibility tree — which would make the "did the click
+  // register?" test below unable to tell those two apart, the one distinction
+  // it exists to make. Radix unmounts closed Sheet content outright, so with
+  // hidden elements included a non-zero count does mean "the click registered".
+  const mountedDialog = page.getByRole("dialog", {
+    name: "Add a comment",
+    includeHidden: true,
+  });
+
   // The composer paints before React attaches its handler, and under
   // `--workers=3` the dev server is busy compiling for other spec files, so a
   // click can land on an inert button and vanish. Waiting longer cannot
@@ -401,10 +436,17 @@ export async function openIssueCommentForm(
   // not yet visible, the click landed and the right move is to keep waiting.
   //
   // Note this deliberately does NOT go through `openDropdownMenu`. That helper
-  // decides on `aria-expanded`, and this trigger does not report it reliably —
-  // routing through it made the first click open the Sheet, the attribute stay
-  // "false", and the retry get eaten by the overlay. Verified on Mobile Chrome:
-  // `form-resets:190` and `rich-text:105` failed exactly that way.
+  // asserts `aria-expanded` on the trigger, and that assertion cannot pass for
+  // THIS trigger — not because the attribute is missing (Radix's dialog Trigger
+  // does set it, which is why the MetadataDrawer `-trigger` path in
+  // `selectOption` works through the same helper) but because opening a Radix
+  // dialog calls `hideOthers()`, which marks everything outside the content
+  // `aria-hidden`. The trigger is outside the content, so once the Sheet opens
+  // the `getByRole("button")` locator stops matching it altogether and the
+  // assertion fails as "no elements" — after which the retry click has nothing
+  // to click either. Verified on Mobile Chrome: routing through the helper made
+  // `form-resets:190` and `rich-text:105` fail exactly that way. The general
+  // rule: never assert on a role locator for a control an open modal aria-hides.
   await sheetTrigger.click({ timeout: SHEET_FIRST_CLICK_TIMEOUT });
   const openedFirstTry = await dialog
     .waitFor({ state: "visible", timeout: SHEET_OPEN_TIMEOUT })
@@ -412,7 +454,7 @@ export async function openIssueCommentForm(
     .catch(() => false);
 
   if (!openedFirstTry) {
-    if ((await dialog.count()) > 0) {
+    if ((await mountedDialog.count()) > 0) {
       // Mounted but slow — the click registered. Re-clicking here is what
       // would close it, so wait instead.
       await dialog.waitFor({ state: "visible", timeout: SHEET_OPEN_TIMEOUT });

--- a/src/components/layout/ClientProviders.tsx
+++ b/src/components/layout/ClientProviders.tsx
@@ -1,8 +1,40 @@
 "use client";
 
 import type React from "react";
+import { useEffect } from "react";
 import { TooltipProvider } from "~/components/ui/tooltip";
 import { RelativeTimeProvider } from "~/components/issues/RelativeTimeProvider";
+
+/**
+ * Marks the document once React has hydrated, so tests can tell "painted" from
+ * "interactive".
+ *
+ * Playwright's actionability checks cover visible, stable, enabled and receives-
+ * events — none of which know whether React has attached a handler yet. A click
+ * in that window hits a live-looking control and is silently discarded, and the
+ * spec then fails wherever it next asserts the consequence: a Radix portal that
+ * never opened, a Sheet that never appeared, a navigation that never happened.
+ * Raising timeouts cannot help, because after a dropped click nothing is
+ * pending. (PP-jxhy.)
+ *
+ * This ships in production too. It is one attribute set once, and an attribute
+ * that exists only under test is an attribute whose absence nobody notices when
+ * it breaks.
+ *
+ * **What it actually asserts.** This effect runs when the ROOT layout's commit
+ * lands — not when every interactive descendant has handlers. Content inside a
+ * Suspense boundary (any segment with a `loading.tsx`, plus streamed segments)
+ * is still dehydrated at that moment, and an `ssr: false` dynamic import such
+ * as `RichTextEditor` has not started. So `data-hydrated` narrows the
+ * dropped-click window to the root commit; it does not close it for deeper
+ * subtrees. Waits for those belong on something the subtree itself renders.
+ */
+function HydrationBeacon(): null {
+  useEffect(() => {
+    document.documentElement.dataset["hydrated"] = "1";
+  }, []);
+  return null;
+}
 
 /**
  * Global client-side providers wrapper.
@@ -24,6 +56,7 @@ export function ClientProviders({
 }): React.JSX.Element {
   return (
     <TooltipProvider delayDuration={300}>
+      <HydrationBeacon />
       <RelativeTimeProvider>{children}</RelativeTimeProvider>
     </TooltipProvider>
   );


### PR DESCRIPTION
Split out of #1861 at Tim's direction, so that PR stays a self-contained CI-gate fix. This is the other half — the reason the Mobile Chrome full suite was failing.

## The mechanism

Playwright's actionability checks are visible, stable, enabled and receives-events. None of them know whether React has attached a handler, so "clickable" and "does something" are different facts and only the first is checked. A click in that window lands on a live-looking control and is silently discarded — nothing errors, nothing is pending afterwards — and the spec fails wherever it next asserts the consequence.

That is why one mechanism looked like four unrelated bugs: a Radix Select portal that never opened (`status-overhaul:25`), a comment Sheet that never appeared (`form-resets:190`, `rich-text:105`), a tab navigation that never happened (`technician-role:89`). It is also why raising timeouts did nothing — a slow mount is rescued by a longer wait, a dropped click is not.

**Evidence it is one mechanism and not four bugs**, from the Mobile Chrome full suite on the Bazzite runner: serial `--workers=1` passes 92/92, `--workers=3` fails about one spec per run, every victim passes in isolation, and the victim rotates.

Mobile Chrome is the only project affected because the E2E `webServer` runs `pnpm run dev` — routes compile on first request — and mobile renders component trees chromium never compiles (`MetadataDrawer`, `StickyCommentComposer`, `RowEditSheet`), so it pays extra compiles while two other workers keep the server busy.

## What this does

- `HydrationBeacon` in `ClientProviders` sets `data-hydrated` on `<html>`. Ships in production deliberately: an attribute that exists only under test is one whose absence nobody notices when it breaks.
- `e2e/support/fixtures.ts` exports a project-local `test` whose `page` waits for that attribute after `goto` **and** `reload`. 52 specs swept onto it.
- `attachHydrationWait` is exported for the 11 pages built via `browser.newContext().newPage()`, which the fixture never sees.
- `/api/*` is excluded rather than waited for — those render outside the root layout and have no React root. `/api/unsubscribe` returns hand-rendered `text/html`, so content-type could not be the discriminator.
- The wait does not swallow its own timeout. That would hide a real hydration break behind 30s per navigation and then fail at whatever got clicked next, pointing at the wrong thing.

## Latent defects fixed along the way — none of which caused this

- `openDropdownMenu` clicks are bounded (20s first, 10s retry) so the worst path is 50s and its authored diagnostic can print inside the 60s CI test timeout, instead of dying as a bare "Test timeout exceeded".
- `openIssueCommentForm` decides by viewport width rather than sampling with `isVisible()` (which never retries, and whose `timeout` option is deprecated and ignored), and retries only when the dialog is absent from the DOM — a blind second click gets eaten by Radix's overlay.
- Two more `isVisible()` samples became real waits.

## Known incomplete

Stated rather than papered over: the beacon fires from an effect in the **root** layout, so it reports the root commit — not that every interactive descendant has handlers. Suspense-boundary children (any segment with a `loading.tsx`) and `ssr: false` imports are still dehydrated when the wait returns. The client-side-navigation half of the same class is **PP-2b3r**, still open.

This narrows the window. It does not close it.

## Verification

Bazzite runner with `CI=1` (crabbox leaves `$CI` unset, which is how a timeout conclusion got written wrong earlier in this work): 33/33, 50/50 and 26/26 across the touched specs on chromium + Mobile Chrome.

Bead: PP-kz47. Sequencing: independent of #1861, but #1861 should land first.


## Review round (`/code-review high`, c3d79eb4)

Six findings, all addressed. Two were substantive:

- **`submitFormAndWaitForRedirect` returned before hydration.** It resolves on `waitForURL(…, { waitUntil: "commit" })` — a full document navigation the fixture cannot see. Eight specs reach the issue page through it, including `form-resets` and `rich-text`, so for the two victims this PR names, the fixture never actually covered the navigation that produced the failure. `waitForHydration` is now exported and awaited once at the end of that helper.
- **A hydration failure was swallowed as a lost race.** Branches B/C catch any `goto` throw as "a sibling branch won", release the claim and park on a never-resolving promise — turning the authored diagnostic into a bare 60s timeout. It is now a named `HydrationTimeoutError` that both branches re-throw; Branch C had no reject path and got one.

Four smaller: `dialog.count()` couldn't distinguish "never opened" from "mounted but not yet in the a11y tree" (`includeHidden: true`); the comment blaming a missing `aria-expanded` was wrong (Radix sets it — the cause is `hideOthers()` aria-hiding the trigger); `attachHydrationWait` wasn't idempotent; `technician-role`'s 5s wait wasn't CI-aware.

Re-validated on the Bazzite runner after the fixes: smoke 201 passed / 1 flaky (`collections`, unrelated), e2e-full 276 passed / 0 flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TZGgLY8eiTJy72XeESpQX
