### PR TITLE
fix(notifications): build Discord links from initials, not resource ids (PP-gzq2)

### DIFF
--- a/e2e/smoke/legacy-resource-redirects.spec.ts
+++ b/e2e/smoke/legacy-resource-redirects.spec.ts
@@ -44,4 +44,20 @@ test.describe("Legacy resource-id redirects", () => {
 
     expect(response?.status()).toBe(404);
   });
+
+  // A non-UUID segment reaches a `uuid` column, where Postgres raises 22P02
+  // instead of returning no rows — so without a shape check these 500 through
+  // the error boundary and report to Sentry. Crawlers and truncated pastes hit
+  // this far more often than a well-formed but unknown id.
+  for (const path of [
+    "/issues/not-a-uuid",
+    "/issues/robots.txt",
+    "/machines/not-a-uuid",
+  ]) {
+    test(`${path} 404s instead of erroring`, async ({ page }) => {
+      const response = await page.goto(path);
+
+      expect(response?.status()).toBe(404);
+    });
+  }
 });

--- a/e2e/smoke/legacy-resource-redirects.spec.ts
+++ b/e2e/smoke/legacy-resource-redirects.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Smoke: legacy id-addressed links redirect to the canonical routes.
+ *
+ * Coverage goal: D-class — `/issues/<uuid>` and `/machines/<uuid>` were the URL
+ * shapes Discord notifications shipped until PP-gzq2, and neither was ever a
+ * route. Discord DMs can't be edited, so those links live forever and the app
+ * has to resolve them. E2E is the cheapest honest layer here: the thing under
+ * test is Next's routing + redirect, not a function's return value (the URL
+ * builder itself is unit-tested in src/lib/notifications/resource-url.test.ts).
+ */
+import { test, expect } from "@playwright/test";
+import { seededIssue, seededMachines } from "../support/constants.js";
+
+test.describe("Legacy resource-id redirects", () => {
+  test("/issues/<uuid> lands on the canonical issue page", async ({ page }) => {
+    const issue = seededIssue("HD");
+
+    const response = await page.goto(`/issues/${issue.id}`);
+
+    expect(response?.ok(), "redirect target should respond 2xx").toBe(true);
+    await expect(page).toHaveURL(`/m/HD/i/${issue.num}`);
+    await expect(
+      page.getByRole("heading", { level: 1, name: issue.title })
+    ).toBeVisible();
+  });
+
+  test("/machines/<uuid> lands on the canonical machine page", async ({
+    page,
+  }) => {
+    const machine = seededMachines.humptyDumpty;
+
+    const response = await page.goto(`/machines/${machine.id}`);
+
+    expect(response?.ok(), "redirect target should respond 2xx").toBe(true);
+    await expect(page).toHaveURL(`/m/${machine.initials}`);
+  });
+
+  test("an unknown id 404s rather than redirecting somewhere wrong", async ({
+    page,
+  }) => {
+    const response = await page.goto(
+      "/issues/00000000-0000-4000-8000-999999999999"
+    );
+
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/src/app/(app)/issues/[id]/page.tsx
+++ b/src/app/(app)/issues/[id]/page.tsx
@@ -1,7 +1,10 @@
 import { notFound, redirect } from "next/navigation";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 import { db } from "~/server/db";
 import { issues } from "~/server/db/schema";
+
+const uuidSchema = z.uuid();
 
 /**
  * Legacy id-addressed issue link → canonical `/m/<INITIALS>/i/<number>`.
@@ -21,6 +24,11 @@ export default async function LegacyIssueRedirectPage({
   params: Promise<{ id: string }>;
 }): Promise<never> {
   const { id } = await params;
+
+  // `issues.id` is a uuid column, so a non-UUID segment makes Postgres raise
+  // 22P02 rather than returning no rows — crawlers and truncated pastes would
+  // hit the error boundary and report to Sentry instead of 404ing.
+  if (!uuidSchema.safeParse(id).success) notFound();
 
   const issue = await db.query.issues.findFirst({
     where: eq(issues.id, id),

--- a/src/app/(app)/issues/[id]/page.tsx
+++ b/src/app/(app)/issues/[id]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound, redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { issues } from "~/server/db/schema";
+
+/**
+ * Legacy id-addressed issue link → canonical `/m/<INITIALS>/i/<number>`.
+ *
+ * Discord notifications shipped `/issues/<uuid>` links for every issue event
+ * until PP-gzq2. That route never existed, so all of them 404'd — and a Discord
+ * DM can't be edited after delivery, so the only way to make those links work is
+ * to make the URL resolve. This stub does that and nothing else.
+ *
+ * No permission check here (CORE-ARCH-008 is about surfacing data): the page
+ * renders nothing and leaks nothing — the redirect target runs the real
+ * `checkPermission()` gate before showing the issue.
+ */
+export default async function LegacyIssueRedirectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<never> {
+  const { id } = await params;
+
+  const issue = await db.query.issues.findFirst({
+    where: eq(issues.id, id),
+    columns: { machineInitials: true, issueNumber: true },
+  });
+
+  if (!issue) notFound();
+
+  redirect(
+    `/m/${encodeURIComponent(issue.machineInitials)}/i/${issue.issueNumber}`
+  );
+}

--- a/src/app/(app)/machines/[id]/page.tsx
+++ b/src/app/(app)/machines/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound, redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { machines } from "~/server/db/schema";
+
+/**
+ * Legacy id-addressed machine link → canonical `/m/<INITIALS>`.
+ *
+ * Counterpart to `/issues/[id]`: Discord's machine-ownership notifications
+ * linked to `/machines/<uuid>` until PP-gzq2, and `/machines` is not a route at
+ * all. Same reasoning — DMs are immutable, so the URL has to resolve.
+ *
+ * No permission check (CORE-ARCH-008 is about surfacing data): nothing is
+ * rendered, and the redirect target gates the machine page itself.
+ */
+export default async function LegacyMachineRedirectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<never> {
+  const { id } = await params;
+
+  const machine = await db.query.machines.findFirst({
+    where: eq(machines.id, id),
+    columns: { initials: true },
+  });
+
+  if (!machine) notFound();
+
+  redirect(`/m/${encodeURIComponent(machine.initials)}`);
+}

--- a/src/app/(app)/machines/[id]/page.tsx
+++ b/src/app/(app)/machines/[id]/page.tsx
@@ -1,7 +1,10 @@
 import { notFound, redirect } from "next/navigation";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 import { db } from "~/server/db";
 import { machines } from "~/server/db/schema";
+
+const uuidSchema = z.uuid();
 
 /**
  * Legacy id-addressed machine link → canonical `/m/<INITIALS>`.
@@ -19,6 +22,10 @@ export default async function LegacyMachineRedirectPage({
   params: Promise<{ id: string }>;
 }): Promise<never> {
   const { id } = await params;
+
+  // See the `/issues/[id]` counterpart: a non-UUID segment against a uuid
+  // column is a 22P02 error, not an empty result.
+  if (!uuidSchema.safeParse(id).success) notFound();
 
   const machine = await db.query.machines.findFirst({
     where: eq(machines.id, id),

--- a/src/lib/discord/messages.test.ts
+++ b/src/lib/discord/messages.test.ts
@@ -9,8 +9,8 @@ describe("formatDiscordMessage", () => {
       issueTitle: "Pop bumper not working",
       formattedIssueId: "AFM-07",
       resourceType: "issue",
-      resourceId: "issue-uuid-1",
       machineName: "Attack From Mars",
+      machineInitials: undefined,
       newStatus: undefined,
       commentContent: undefined,
     });
@@ -18,7 +18,7 @@ describe("formatDiscordMessage", () => {
     expect(out).toContain("AFM-07");
     expect(out).toContain("Pop bumper not working");
     expect(out).toContain("assigned");
-    expect(out).toContain("https://app.example.com/issues/issue-uuid-1");
+    expect(out).toContain("https://app.example.com/m/AFM/i/7");
     expect(out).toMatch(/Manage notifications.*\/settings\/notifications/i);
   });
 
@@ -29,14 +29,47 @@ describe("formatDiscordMessage", () => {
       issueTitle: undefined,
       formattedIssueId: undefined,
       resourceType: "machine",
-      resourceId: "machine-uuid-1",
       machineName: "Medieval Madness",
+      machineInitials: "MM",
       newStatus: undefined,
       commentContent: undefined,
     });
 
     expect(out).toContain("Medieval Madness");
-    expect(out).toContain("https://app.example.com/machines/machine-uuid-1");
+    expect(out).toContain("https://app.example.com/m/MM");
+  });
+
+  it("falls back to the machine list when initials are missing", () => {
+    const out = formatDiscordMessage({
+      type: "machine_ownership_changed",
+      siteUrl: "https://app.example.com",
+      issueTitle: undefined,
+      formattedIssueId: undefined,
+      resourceType: "machine",
+      machineName: "Medieval Madness",
+      machineInitials: undefined,
+      newStatus: undefined,
+      commentContent: undefined,
+    });
+
+    expect(out).toContain("https://app.example.com/m\n");
+  });
+
+  it("falls back to the issue list when the formatted id is unparseable", () => {
+    const out = formatDiscordMessage({
+      type: "new_comment",
+      siteUrl: "https://app.example.com",
+      issueTitle: "Broken flipper",
+      // Single-character initials violate the 2-6 char DB constraint.
+      formattedIssueId: "X-1",
+      resourceType: "issue",
+      machineName: undefined,
+      machineInitials: undefined,
+      newStatus: undefined,
+      commentContent: undefined,
+    });
+
+    expect(out).toContain("https://app.example.com/issues\n");
   });
 
   it("includes new status when issue_status_changed", () => {
@@ -46,8 +79,8 @@ describe("formatDiscordMessage", () => {
       issueTitle: "Flippers weak",
       formattedIssueId: "TWD-03",
       resourceType: "issue",
-      resourceId: "issue-2",
       machineName: "Walking Dead",
+      machineInitials: undefined,
       newStatus: "Resolved",
       commentContent: undefined,
     });
@@ -63,8 +96,8 @@ describe("formatDiscordMessage", () => {
       issueTitle: "@everyone please look at this @here",
       formattedIssueId: "X-1",
       resourceType: "issue",
-      resourceId: "i1",
       machineName: undefined,
+      machineInitials: undefined,
       newStatus: undefined,
       commentContent: undefined,
     });
@@ -87,8 +120,8 @@ describe("formatDiscordMessage", () => {
       issueTitle: "Hi <@123456> see <#7890> via <@&5555> role",
       formattedIssueId: "X-1",
       resourceType: "issue",
-      resourceId: "i1",
       machineName: undefined,
+      machineInitials: undefined,
       newStatus: undefined,
       commentContent: undefined,
     });
@@ -109,8 +142,8 @@ describe("formatDiscordMessage", () => {
       issueTitle: "**bold** _italic_ `code` ~strike~ |spoiler| > quote \\back",
       formattedIssueId: "X-1",
       resourceType: "issue",
-      resourceId: "i1",
       machineName: undefined,
+      machineInitials: undefined,
       newStatus: undefined,
       commentContent: undefined,
     });
@@ -135,15 +168,15 @@ describe("formatDiscordMessage", () => {
       type: "new_issue",
       siteUrl: "https://app.example.com",
       issueTitle: "ok",
-      formattedIssueId: "X-1",
+      formattedIssueId: "WW-01",
       resourceType: "issue",
-      resourceId: "i1",
       machineName: "Whitewater",
+      machineInitials: undefined,
       newStatus: undefined,
       commentContent: undefined,
     });
 
-    expect(out).toContain("https://app.example.com/issues/i1");
+    expect(out).toContain("https://app.example.com/m/WW/i/1");
     expect(out).toContain(
       "Manage notifications: https://app.example.com/settings/notifications"
     );
@@ -154,20 +187,20 @@ describe("formatDiscordMessage", () => {
       type: "new_comment",
       siteUrl: "https://app.example.com",
       issueTitle: "x".repeat(5000),
-      formattedIssueId: "X-1",
+      formattedIssueId: "XX-12",
       resourceType: "issue",
-      resourceId: "i1",
       machineName: undefined,
+      machineInitials: undefined,
       newStatus: undefined,
       commentContent: undefined,
     });
 
     expect(out.length).toBeLessThanOrEqual(2000);
     // Link and footer both preserved.
-    expect(out).toContain("https://app.example.com/issues/i1");
+    expect(out).toContain("https://app.example.com/m/XX/i/12");
     expect(out).toContain("/settings/notifications");
     // Body was truncated — should end the body section with an ellipsis
     // before the link starts.
-    expect(out).toMatch(/…\nhttps:\/\/app\.example\.com\/issues\/i1/);
+    expect(out).toMatch(/…\nhttps:\/\/app\.example\.com\/m\/XX\/i\/12/);
   });
 });

--- a/src/lib/discord/messages.ts
+++ b/src/lib/discord/messages.ts
@@ -1,4 +1,5 @@
 import type { NotificationType } from "~/lib/notifications/dispatch";
+import { buildResourceUrl } from "~/lib/notifications/resource-url";
 
 const DISCORD_MAX_MESSAGE_LENGTH = 2000;
 
@@ -6,10 +7,10 @@ export interface DiscordMessageInput {
   type: NotificationType;
   siteUrl: string;
   resourceType: "issue" | "machine";
-  resourceId: string;
   issueTitle: string | undefined;
   formattedIssueId: string | undefined;
   machineName: string | undefined;
+  machineInitials: string | undefined;
   newStatus: string | undefined;
   /**
    * Comment text passed through from the dispatcher but intentionally NOT
@@ -23,7 +24,7 @@ export interface DiscordMessageInput {
 }
 
 export function formatDiscordMessage(input: DiscordMessageInput): string {
-  const link = buildResourceLink(input);
+  const link = buildResourceUrl(input);
   const body = buildBody(input);
   const footer = `Manage notifications: ${input.siteUrl}/settings/notifications`;
   const suffix = `\n${link}\n\n${footer}`;
@@ -44,13 +45,6 @@ export function formatDiscordMessage(input: DiscordMessageInput): string {
   return assembled.length > DISCORD_MAX_MESSAGE_LENGTH
     ? assembled.slice(0, DISCORD_MAX_MESSAGE_LENGTH - 1) + "…"
     : assembled;
-}
-
-function buildResourceLink(input: DiscordMessageInput): string {
-  if (input.resourceType === "issue") {
-    return `${input.siteUrl}/issues/${input.resourceId}`;
-  }
-  return `${input.siteUrl}/machines/${input.resourceId}`;
 }
 
 function buildBody(input: DiscordMessageInput): string {

--- a/src/lib/notifications/channels/discord-channel.ts
+++ b/src/lib/notifications/channels/discord-channel.ts
@@ -52,10 +52,10 @@ export function createDiscordChannel(config: DiscordConfig): DeliveryChannel {
         type: ctx.type,
         siteUrl: getSiteUrl(),
         resourceType: ctx.resourceType,
-        resourceId: ctx.resourceId,
         issueTitle: ctx.issueTitle,
         formattedIssueId: ctx.formattedIssueId,
         machineName: ctx.machineName,
+        machineInitials: ctx.machineInitials,
         newStatus: ctx.newStatus,
         commentContent: ctx.commentContent,
       });

--- a/src/lib/notifications/channels/email-channel.ts
+++ b/src/lib/notifications/channels/email-channel.ts
@@ -7,6 +7,7 @@ import { NON_TEXT_TAGS } from "~/lib/sanitize-html-config";
 import { isInternalAccount } from "~/lib/auth/internal-accounts";
 import { getSiteUrl } from "~/lib/url";
 import { getThreadingHeaders } from "~/lib/notifications/email-threading";
+import { buildResourceUrl } from "~/lib/notifications/resource-url";
 import { reportError } from "~/lib/observability/report-error";
 import type {
   DeliveryChannel,
@@ -262,25 +263,11 @@ export function getEmailHtml({
     ? sanitizeHtml(formattedIssueId, EMAIL_SANITIZE_OPTIONS)
     : "";
 
-  let issueUrl = `${siteUrl}/issues`;
-  if (formattedIssueId) {
-    // Format is [INITIALS]-[NUMBER]; initials are 2-6 alphanumeric chars (no hyphens)
-    const parts = formattedIssueId.split("-");
-    if (parts.length >= 2) {
-      const numberPart = parts.pop();
-      const initialsPart = parts.join("-");
-      // Validate initialsPart matches schema: exactly 2-6 uppercase letters or digits
-      if (
-        numberPart &&
-        /^\d+$/.test(numberPart) &&
-        /^[A-Z0-9]{2,6}$/.test(initialsPart)
-      ) {
-        const issueNumber = parseInt(numberPart, 10);
-        // URL encode for defense-in-depth, even though validation ensures only safe characters
-        issueUrl = `${siteUrl}/m/${encodeURIComponent(initialsPart)}/i/${issueNumber}`;
-      }
-    }
-  }
+  const issueUrl = buildResourceUrl({
+    siteUrl,
+    resourceType: "issue",
+    formattedIssueId,
+  });
 
   const sanitizedDescription =
     (type === "new_issue" || type === "issue_assigned") && issueDescription

--- a/src/lib/notifications/channels/email-channel.ts
+++ b/src/lib/notifications/channels/email-channel.ts
@@ -169,6 +169,7 @@ export interface EmailHtmlOptions {
   type: NotificationType;
   issueTitle?: string | undefined;
   machineName?: string | undefined;
+  machineInitials?: string | undefined;
   formattedIssueId?: string | undefined;
   commentContent?: string | undefined;
   newStatus?: string | undefined;
@@ -207,6 +208,7 @@ export function getEmailHtml({
   type,
   issueTitle,
   machineName,
+  machineInitials,
   formattedIssueId,
   commentContent,
   newStatus,
@@ -263,11 +265,17 @@ export function getEmailHtml({
     ? sanitizeHtml(formattedIssueId, EMAIL_SANITIZE_OPTIONS)
     : "";
 
-  const issueUrl = buildResourceUrl({
+  // Machine-ownership emails are about a machine, not an issue — pointing them
+  // at the global issue list under a "View Issue" label was the email half of
+  // PP-gzq2. Every other type is issue-tied.
+  const isMachineResource = type === "machine_ownership_changed";
+  const resourceUrl = buildResourceUrl({
     siteUrl,
-    resourceType: "issue",
+    resourceType: isMachineResource ? "machine" : "issue",
     formattedIssueId,
+    machineInitials,
   });
+  const resourceLinkLabel = isMachineResource ? "View Machine" : "View Issue";
 
   const sanitizedDescription =
     (type === "new_issue" || type === "issue_assigned") && issueDescription
@@ -280,7 +288,7 @@ export function getEmailHtml({
       ${eventLabel ? `<h3 style="color: #555; font-weight: 600; margin-bottom: 8px;">${eventLabel}</h3>` : ""}
       <div>${body}</div>
       ${showDescription ? `<blockquote>${sanitizedDescription}</blockquote>` : ""}
-      <p><a href="${issueUrl}">View Issue</a></p>
+      <p><a href="${resourceUrl}">${resourceLinkLabel}</a></p>
       ${getEmailFooter(userId)}
     `;
 }
@@ -352,6 +360,7 @@ export const emailChannel: DeliveryChannel = {
           type: ctx.type,
           issueTitle: ctx.issueTitle,
           machineName: ctx.machineName,
+          machineInitials: ctx.machineInitials,
           formattedIssueId: ctx.formattedIssueId,
           commentContent: ctx.commentContent,
           newStatus: ctx.newStatus,

--- a/src/lib/notifications/channels/types.ts
+++ b/src/lib/notifications/channels/types.ts
@@ -28,6 +28,13 @@ export interface ChannelContext {
   // Resolved at the top of planNotification before the fan-out
   issueTitle?: string | undefined;
   machineName?: string | undefined;
+  /**
+   * The machine's 2-6 char initials — the only handle that addresses a machine
+   * in a URL (`/m/<INITIALS>`); `resourceId` names no route. Resolved only for
+   * machine-resource notifications; issue links derive their initials from
+   * `formattedIssueId` instead. (PP-gzq2)
+   */
+  machineInitials?: string | undefined;
   formattedIssueId?: string | undefined;
   commentContent?: string | undefined;
   newStatus?: string | undefined;

--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -77,6 +77,12 @@ export interface CreateNotificationProps {
   includeActor?: boolean | undefined;
   issueTitle?: string | undefined;
   machineName?: string | undefined;
+  /**
+   * Machine initials, used to build the `/m/<INITIALS>` link in machine-resource
+   * notifications. Optional: `planNotification` resolves it from the machine row
+   * when a caller doesn't pass it. (PP-gzq2)
+   */
+  machineInitials?: string | undefined;
   formattedIssueId?: string | undefined;
   commentContent?: string | undefined;
   newStatus?: string | undefined;
@@ -98,6 +104,7 @@ export async function planNotification(
     includeActor = true,
     issueTitle,
     machineName,
+    machineInitials,
     formattedIssueId,
     commentContent,
     newStatus,
@@ -126,6 +133,7 @@ export async function planNotification(
 
   let resolvedIssueTitle = issueTitle;
   let resolvedMachineName = machineName;
+  let resolvedMachineInitials = machineInitials;
   let resolvedFormattedIssueId = formattedIssueId;
 
   if (type === "new_issue") {
@@ -151,11 +159,12 @@ export async function planNotification(
     } else {
       const machine = await tx.query.machines.findFirst({
         where: eq(machines.id, resourceId),
-        columns: { id: true, name: true, ownerId: true },
+        columns: { id: true, name: true, ownerId: true, initials: true },
       });
       machineId = machine?.id ?? null;
       machineOwnerId = machine?.ownerId ?? null;
       resolvedMachineName = resolvedMachineName ?? machine?.name;
+      resolvedMachineInitials = resolvedMachineInitials ?? machine?.initials;
     }
 
     const globalSubscribers = await tx.query.notificationPreferences.findMany({
@@ -219,6 +228,29 @@ export async function planNotification(
 
   if (recipientIds.size === 0) return { deliveries: [] };
 
+  // Notification links are built from initials + issue number, never from
+  // `resourceId` — no route addresses a resource by id (PP-gzq2). Every current
+  // caller passes what its link needs; these are the backstops, so a caller that
+  // forgets degrades to a list page rather than an unusable link. Placed after
+  // the empty-recipient early return so they cost nothing when nobody is being
+  // notified, and guarded so they cost nothing when the caller did pass them.
+  if (resourceType === "machine" && !resolvedMachineInitials) {
+    const machine = await tx.query.machines.findFirst({
+      where: eq(machines.id, resourceId),
+      columns: { initials: true },
+    });
+    resolvedMachineInitials = machine?.initials;
+  }
+  if (resourceType === "issue" && !resolvedFormattedIssueId) {
+    const issue = await tx.query.issues.findFirst({
+      where: eq(issues.id, resourceId),
+      columns: { machineInitials: true, issueNumber: true },
+    });
+    if (issue) {
+      resolvedFormattedIssueId = `${issue.machineInitials}-${String(issue.issueNumber).padStart(2, "0")}`;
+    }
+  }
+
   // 2. Fetch preferences
   const preferences = await tx.query.notificationPreferences.findMany({
     where: inArray(notificationPreferences.userId, [...recipientIds]),
@@ -277,6 +309,7 @@ export async function planNotification(
       discordUserId: discordUserIdMap.get(userId) ?? null,
       issueTitle: resolvedIssueTitle,
       machineName: resolvedMachineName,
+      machineInitials: resolvedMachineInitials,
       formattedIssueId: resolvedFormattedIssueId,
       commentContent,
       newStatus,

--- a/src/lib/notifications/resource-url.test.ts
+++ b/src/lib/notifications/resource-url.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { buildResourceUrl } from "./resource-url";
+
+const siteUrl = "https://app.example.com";
+
+describe("buildResourceUrl", () => {
+  describe("issues", () => {
+    it("builds the canonical /m/<INITIALS>/i/<number> URL", () => {
+      expect(
+        buildResourceUrl({
+          siteUrl,
+          resourceType: "issue",
+          formattedIssueId: "RUSH-01",
+        })
+      ).toBe("https://app.example.com/m/RUSH/i/1");
+    });
+
+    it("strips leading zeros from the issue number", () => {
+      expect(
+        buildResourceUrl({
+          siteUrl,
+          resourceType: "issue",
+          formattedIssueId: "AFM-007",
+        })
+      ).toBe("https://app.example.com/m/AFM/i/7");
+    });
+
+    it("handles multi-digit issue numbers", () => {
+      expect(
+        buildResourceUrl({
+          siteUrl,
+          resourceType: "issue",
+          formattedIssueId: "TWD-1234",
+        })
+      ).toBe("https://app.example.com/m/TWD/i/1234");
+    });
+
+    it("accepts digits in the initials", () => {
+      expect(
+        buildResourceUrl({
+          siteUrl,
+          resourceType: "issue",
+          formattedIssueId: "T2-05",
+        })
+      ).toBe("https://app.example.com/m/T2/i/5");
+    });
+
+    it.each([
+      ["absent", undefined],
+      ["no separator", "RUSH01"],
+      ["non-numeric suffix", "RUSH-XX"],
+      ["initials too short", "R-01"],
+      ["initials too long", "ABCDEFG-01"],
+      ["lowercase initials", "rush-01"],
+      ["empty", ""],
+    ])(
+      "falls back to /issues when the id is %s",
+      (_label, formattedIssueId) => {
+        expect(
+          buildResourceUrl({ siteUrl, resourceType: "issue", formattedIssueId })
+        ).toBe("https://app.example.com/issues");
+      }
+    );
+
+    it("never emits the id-addressed shape that 404'd (PP-gzq2)", () => {
+      const url = buildResourceUrl({
+        siteUrl,
+        resourceType: "issue",
+        formattedIssueId: "RUSH-01",
+      });
+      expect(url).not.toMatch(/\/issues\//);
+    });
+  });
+
+  describe("machines", () => {
+    it("builds the canonical /m/<INITIALS> URL", () => {
+      expect(
+        buildResourceUrl({
+          siteUrl,
+          resourceType: "machine",
+          machineInitials: "MM",
+        })
+      ).toBe("https://app.example.com/m/MM");
+    });
+
+    it.each([
+      ["absent", undefined],
+      ["too short", "M"],
+      ["too long", "ABCDEFG"],
+      ["lowercase", "mm"],
+      ["containing a slash", "M/M"],
+    ])(
+      "falls back to /m when the initials are %s",
+      (_label, machineInitials) => {
+        expect(
+          buildResourceUrl({
+            siteUrl,
+            resourceType: "machine",
+            machineInitials,
+          })
+        ).toBe("https://app.example.com/m");
+      }
+    );
+
+    it("ignores formattedIssueId for machine resources", () => {
+      expect(
+        buildResourceUrl({
+          siteUrl,
+          resourceType: "machine",
+          machineInitials: "WW",
+          formattedIssueId: "AFM-07",
+        })
+      ).toBe("https://app.example.com/m/WW");
+    });
+  });
+});

--- a/src/lib/notifications/resource-url.ts
+++ b/src/lib/notifications/resource-url.ts
@@ -1,0 +1,71 @@
+/**
+ * Canonical in-app URLs for notification resources.
+ *
+ * Every notification channel that renders a link (email, Discord) must build it
+ * here. PinPoint has no id-addressed routes: an issue lives at
+ * `/m/<INITIALS>/i/<issueNumber>` and a machine at `/m/<INITIALS>`. Channels
+ * that interpolated `resourceId` directly produced permanent 404s (PP-gzq2) —
+ * and Discord DMs can't be edited after the fact, so a bad link there is
+ * forever.
+ *
+ * Pure by design: `siteUrl` is passed in rather than read from `~/lib/url` so
+ * the Discord message builder stays a pure formatter and the unit tests don't
+ * need env stubbing.
+ */
+
+/** Matches the `initials_check` DB constraint: 2-6 uppercase alphanumerics. */
+const INITIALS_PATTERN = /^[A-Z0-9]{2,6}$/;
+
+export interface ResourceUrlInput {
+  siteUrl: string;
+  resourceType: "issue" | "machine";
+  /** `[INITIALS]-[NUMBER]`, e.g. `RUSH-01`. */
+  formattedIssueId?: string | undefined;
+  machineInitials?: string | undefined;
+}
+
+/**
+ * Absolute URL for the resource a notification is about.
+ *
+ * Falls back to the relevant list page (`/issues`, `/m`) when the identifying
+ * parts are missing or malformed — a list page is a worse landing spot than the
+ * resource, but it is a page that exists.
+ */
+export function buildResourceUrl(input: ResourceUrlInput): string {
+  const { siteUrl, resourceType, formattedIssueId, machineInitials } = input;
+
+  if (resourceType === "machine") {
+    return machineInitials && INITIALS_PATTERN.test(machineInitials)
+      ? `${siteUrl}/m/${encodeURIComponent(machineInitials)}`
+      : `${siteUrl}/m`;
+  }
+
+  const parsed = parseFormattedIssueId(formattedIssueId);
+  if (!parsed) return `${siteUrl}/issues`;
+  // URL-encode for defense in depth, even though the pattern above already
+  // restricts initials to characters that need no escaping.
+  return `${siteUrl}/m/${encodeURIComponent(parsed.initials)}/i/${parsed.issueNumber}`;
+}
+
+/**
+ * Split `RUSH-01` into `{ initials: "RUSH", issueNumber: 1 }`.
+ *
+ * Returns null when the input is absent or doesn't match the format. Initials
+ * themselves never contain a hyphen (the DB constraint allows only `[A-Z0-9]`),
+ * but splitting from the right is still the safer parse.
+ */
+function parseFormattedIssueId(
+  formattedIssueId: string | undefined
+): { initials: string; issueNumber: number } | null {
+  if (!formattedIssueId) return null;
+
+  const parts = formattedIssueId.split("-");
+  if (parts.length < 2) return null;
+
+  const numberPart = parts.pop();
+  const initials = parts.join("-");
+  if (!numberPart || !/^\d+$/.test(numberPart)) return null;
+  if (!INITIALS_PATTERN.test(initials)) return null;
+
+  return { initials, issueNumber: parseInt(numberPart, 10) };
+}

--- a/src/test/unit/notification-formatting.test.ts
+++ b/src/test/unit/notification-formatting.test.ts
@@ -141,6 +141,29 @@ describe("Notification Formatting", () => {
       expect(html).toContain('href="http://test.com/m/TZ/i/42"');
     });
 
+    it("should link a machine-ownership email to the machine, not the issue list", () => {
+      const html = getEmailHtml({
+        type: "machine_ownership_changed",
+        machineName: "Medieval Madness",
+        machineInitials: "MM",
+        newStatus: "added",
+      });
+
+      expect(html).toContain('href="http://test.com/m/MM"');
+      expect(html).toContain("View Machine");
+      expect(html).not.toContain("View Issue");
+    });
+
+    it("should fallback to the machine list when ownership email lacks initials", () => {
+      const html = getEmailHtml({
+        type: "machine_ownership_changed",
+        machineName: "Medieval Madness",
+        newStatus: "added",
+      });
+
+      expect(html).toContain('href="http://test.com/m"');
+    });
+
     it("should fallback to generic link if ID is missing", () => {
       const html = getEmailHtml({
         type: "new_issue",


### PR DESCRIPTION
Discord notification DMs linked to `${siteUrl}/issues/<uuid>` and `${siteUrl}/machines/<uuid>`. Neither is a route — PinPoint addresses issues as `/m/<INITIALS>/i/<number>` and machines as `/m/<INITIALS>`, and `/machines` is not a path segment at all. **Every Discord notification link since the channel shipped has 404'd.**

Reported by Tim from a live DM:

```
New comment on RUSH-01 — Right Pop Bumper need rebuild
https://pinpoint.austinpinballcollective.org/issues/8da49c82-…
```

Email was never affected: `email-channel.ts` parses `RUSH-01` into initials + number and builds the canonical URL itself. Discord simply never got that logic.

## Approach

**One URL builder, two channels.** Copying email's parse into `messages.ts` would have made two places to get this wrong. It moves to `buildResourceUrl()` in `src/lib/notifications/resource-url.ts`; email now calls it too, so its inline version is deleted rather than duplicated.

**The dispatcher resolves what the link needs.** `machineInitials` is new on `ChannelContext` — it is the only handle that addresses a machine in a URL. `planNotification` resolves it (and backstops `formattedIssueId`) from the row when a caller doesn't pass it, so a future caller that forgets a field degrades to a list page instead of emitting another dead deep link. Both lookups are guarded and sit after the empty-recipient early return, so they cost nothing in the common path.

**Redirect stubs rescue the links already sent.** Discord messages can't be edited after delivery, so every DM in members' history keeps its dead URL forever unless the URL starts resolving. `/issues/[id]` and `/machines/[id]` look up the row and redirect to the canonical page. They render nothing and gate nothing — the redirect target runs the real `checkPermission()`.

## Judgment calls worth a look

- **Fallback is a list page, not a 404.** Unparseable initials → `/issues` or `/m` rather than a hard failure. Debatable; a 404 would be louder but strictly worse for the recipient.
- **The 7 machine-notification call sites still don't pass `machineInitials`.** The dispatcher's fallback covers them uniformly with one indexed PK lookup on a rare event. Passing it at each site would save that query at the cost of 7 chances for the `machine` select to lack the column.

## Verification

| Check | Result |
| :--- | :--- |
| `pnpm run check` | clean |
| `pnpm run test` | 2128 passed (230 files) |
| Smoke E2E (Bazzite runner) | 210 passed, 8 skipped, 1 flaky (`collections.spec.ts`, unrelated) |
| `legacy-resource-redirects.spec.ts` targeted | 3/3 green against a real server |
| Integration (Bazzite runner) | see comment below |

New coverage: 15 unit cases on the URL helper (both resource types, every malformed-input path, and an explicit assertion that the id-addressed shape is never emitted), updated Discord/email channel suites, and a smoke spec asserting both redirects land and an unknown id 404s.

No migration. No UI surface, so no screenshots.

Closes PP-gzq2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXnCRVPp4xCxXL6FFeaVg9
