### PR TITLE
feat(mcp): set a machine's Pinball Map title (PP-u4ab.12)

### DIFF
--- a/src/app/(app)/m/actions.ts
+++ b/src/app/(app)/m/actions.ts
@@ -11,9 +11,12 @@ import { after } from "next/server";
 import { createClient } from "~/lib/supabase/server";
 import { db } from "~/server/db";
 import {
+  applyMachinePbmLink,
+  captureMachineAutoLink,
   createMachine,
+  planMachinePbmLink,
   updateMachinePresence,
-  type MachinePbmColumns,
+  type MachinePbmLinkPlan,
 } from "~/services/machines";
 import {
   machines,
@@ -22,16 +25,7 @@ import {
   invitedUsers,
 } from "~/server/db/schema";
 import { createMachineSchema, updateMachineSchema } from "./schemas";
-import {
-  resolvePbmLinkColumnsForCreate,
-  resolvePbmLinkColumnsForUpdate,
-  type AbandonedListing,
-} from "~/lib/pinballmap/link-columns";
-import { recordAbandonedListing } from "~/lib/pinballmap/abandoned-listings";
-import {
-  captureAutoLink,
-  resolveAutoLinkForMachine,
-} from "~/lib/pinballmap/sync";
+import { resolvePbmLinkColumnsForCreate } from "~/lib/pinballmap/link-columns";
 import { type Result, ok, err } from "~/lib/result";
 import { z } from "zod";
 import { eq, and } from "drizzle-orm";
@@ -200,33 +194,6 @@ function readPbmLinkFormFields(formData: FormData): {
         ? reasonRaw
         : undefined,
   };
-}
-
-/**
- * Apply a listing this save decided to auto-capture (PP-o355.20), best-effort.
- *
- * Runs AFTER the details transaction has committed, and swallows everything.
- * `captureAutoLink` already stands down on the one collision that is expected,
- * but a deadlock, a dropped connection, or a failure writing the receipt would
- * otherwise reach `updateMachineAction`'s catch and report "Failed to update
- * machine" for an edit that is already saved — sending the user to redo work
- * that landed. Auto-link is derived bookkeeping: it is allowed to not happen,
- * and the hourly reconcile pass picks it up next time round.
- */
-async function captureAutoLinkBestEffort(
-  machineId: string,
-  lmxId: number,
-  actorId: string
-): Promise<void> {
-  try {
-    await captureAutoLink({ machineId, lmxId, action: "linked" }, actorId);
-  } catch (autoLinkError: unknown) {
-    reportError(autoLinkError, {
-      action: "updateMachineAutoLink",
-      bestEffort: true,
-      machineId,
-    });
-  }
 }
 
 /**
@@ -673,11 +640,6 @@ export async function updateMachineAction(
   const { id, name, ownerId, presenceStatus, forcePromoteUserId } =
     validation.data;
 
-  // The listing this save decided to auto-capture (PP-o355.20), or null.
-  // Declared out here because it is decided in the PBM block and applied after
-  // whichever of the two update transactions ran.
-  let autoLink: { lmxId: number } | null = null;
-
   try {
     // Load current machine by id — permission check is authoritative.
     // Pre-load presenceStatus and the joined active-owner display name so
@@ -717,16 +679,16 @@ export async function updateMachineAction(
       );
     }
 
-    // Resolve PinballMap link columns when the picker is on this form. The
+    // Plan the PinballMap link change when the picker is on this form. The
     // submitted state is authoritative (clearing it unlinks), so it requires the
-    // link permission and derives metadata from the catalog mirror. When the
+    // link permission; the plan derives metadata from the catalog mirror, owns
+    // the listing carry-over, and decides any auto-link (PP-o355.20). When the
     // marker is absent, link columns are left untouched.
-    let pbmColumns: MachinePbmColumns | null = null;
-    // A live PinballMap entry this save walks away from (PP-l81u), or null.
-    // Set alongside `pbmColumns` below and written in the same transaction as
-    // the columns — a retitle whose record does not land leaves a public
-    // listing nobody can find.
-    let abandonedListing: AbandonedListing | null = null;
+    //
+    // Same seam as the MCP `set_machine_pinballmap` tool — the carry-over rule,
+    // the abandonment record and the auto-link choice exist once, in
+    // `~/services/machines` (PP-u4ab.12).
+    let pbmPlan: MachinePbmLinkPlan | null = null;
     if (pbmFormPresent) {
       if (
         !checkPermission("machines.pinballmap.link", accessLevel, {
@@ -741,44 +703,23 @@ export async function updateMachineAction(
       }
       // `pinballmapListed` is not an input to this action at all: the edit form
       // renders no control for it, `readPbmLinkFormFields` does not read it, and
-      // `updateMachineSchema` does not accept it (PP-o355.29). The resolver
-      // takes the STORED row and owns the carry-over decision, so no caller can
-      // unlist a machine by leaving an argument out (PP-l81u).
-      const pbm = await resolvePbmLinkColumnsForUpdate(validation.data, {
-        pinballmapMachineId: currentMachine.pinballmapMachineId,
-        pinballmapListed: currentMachine.pinballmapListed,
-        pinballmapLmxId: currentMachine.pinballmapLmxId,
+      // `updateMachineSchema` does not accept it (PP-o355.29). The planner takes
+      // the STORED row and owns the carry-over decision, so no caller can unlist
+      // a machine by leaving an argument out (PP-l81u).
+      const planned = await planMachinePbmLink({
+        machineId: id,
+        selection: validation.data,
+        stored: {
+          pinballmapMachineId: currentMachine.pinballmapMachineId,
+          pinballmapListed: currentMachine.pinballmapListed,
+          pinballmapLmxId: currentMachine.pinballmapLmxId,
+        },
+        // The prospective row: an edit can change availability in the same
+        // submit, and availability is what the tie guard ranks on.
+        presenceStatus: presenceStatus ?? currentMachine.presenceStatus,
       });
-      if (!pbm.ok) return err("VALIDATION", pbm.message);
-      pbmColumns = pbm.columns;
-      abandonedListing = pbm.abandoned;
-
-      // Auto-link (PP-o355.20): the moment a cabinet is matched to a title that
-      // is already on Pinball Map's lineup, capture that listing alongside the
-      // save. Matching is the human judgment; attaching the lmx is bookkeeping
-      // that mirrors what PBM already shows, so it is not a second button.
-      //
-      // DECIDED here, APPLIED after the details transaction commits (see
-      // `captureAutoLink` below). Keeping it out of that transaction is the
-      // point: the one-lister index makes the listing write the only statement
-      // here that can collide, and derived bookkeeping must never be able to
-      // discard the edit the human actually asked for.
-      //
-      // Only from unlisted → listed. A row the carry-over above kept listed is
-      // skipped entirely, which is also why this can never produce a heal: lmx
-      // drift belongs to the hourly pass, not to whoever happened to hit Save.
-      if (
-        pbmColumns.pinballmapMachineId !== null &&
-        !pbmColumns.pinballmapListed
-      ) {
-        autoLink = await resolveAutoLinkForMachine({
-          machineId: id,
-          pinballmapMachineId: pbmColumns.pinballmapMachineId,
-          // The prospective row: an edit can change availability in the same
-          // submit, and availability is what the tie guard ranks on.
-          presenceStatus: presenceStatus ?? currentMachine.presenceStatus,
-        });
-      }
+      if (!planned.ok) return err("VALIDATION", planned.message);
+      pbmPlan = planned.plan;
     }
 
     // Handle forcePromoteUserId path
@@ -841,7 +782,6 @@ export async function updateMachineAction(
             ...(presenceStatus !== undefined && { presenceStatus }),
             ownerId: machineOwnerId ?? null,
             invitedOwnerId: machineInvitedOwnerId ?? null,
-            ...(pbmColumns ?? {}),
             ...(descriptionColumn !== undefined && {
               description: descriptionColumn,
             }),
@@ -853,8 +793,8 @@ export async function updateMachineAction(
           throw new Error("Machine update failed");
         }
 
-        if (abandonedListing) {
-          await recordAbandonedListing(tx, id, abandonedListing, user.id);
+        if (pbmPlan) {
+          await applyMachinePbmLink(tx, id, pbmPlan, user.id);
         }
 
         // Add new owner as watcher if active user
@@ -897,8 +837,8 @@ export async function updateMachineAction(
         return [updatedMachine];
       });
 
-      if (autoLink) {
-        await captureAutoLinkBestEffort(id, autoLink.lmxId, user.id);
+      if (pbmPlan?.autoLink) {
+        await captureMachineAutoLink(id, pbmPlan.autoLink.lmxId, user.id);
       }
 
       // Post-commit side effects — best-effort: do not fail the action on notification errors
@@ -1027,32 +967,48 @@ export async function updateMachineAction(
 
     const oldOwnerId = currentMachine.ownerId;
 
+    // Every non-PinballMap column this submit touches. Each edit surface posts
+    // only the fields it renders, so this is routinely a subset — and on the PBM
+    // picker's own save it is EMPTY, which is why it cannot go straight into a
+    // `.set()`: Drizzle rejects an update with no values, and the link columns
+    // now travel separately (`applyMachinePbmLink`).
+    const detailValues = {
+      ...(name !== undefined && { name }),
+      ...(presenceStatus !== undefined && { presenceStatus }),
+      ...(shouldUpdateOwner && {
+        ownerId: finalOwnerId,
+        invitedOwnerId: finalInvitedOwnerId,
+      }),
+      ...(descriptionColumn !== undefined && {
+        description: descriptionColumn,
+      }),
+    };
+
     // Atomic: update machine + reconcile watcher rows + emit lifecycle events.
     // Notifications stay outside the tx as best-effort side effects.
     const [machine] = await db.transaction(async (tx) => {
-      const [updatedMachine] = await tx
-        .update(machines)
-        .set({
-          ...(name !== undefined && { name }),
-          ...(presenceStatus !== undefined && { presenceStatus }),
-          ...(shouldUpdateOwner && {
-            ownerId: finalOwnerId,
-            invitedOwnerId: finalInvitedOwnerId,
-          }),
-          ...(pbmColumns ?? {}),
-          ...(descriptionColumn !== undefined && {
-            description: descriptionColumn,
-          }),
-        })
-        .where(eq(machines.id, id))
-        .returning();
+      const [updatedMachine] =
+        Object.keys(detailValues).length > 0
+          ? await tx
+              .update(machines)
+              .set(detailValues)
+              .where(eq(machines.id, id))
+              .returning()
+          : // Nothing outside the PBM block changed. Read the row instead of
+            // writing it, so the NOT_FOUND check below still runs and the
+            // caller still gets a machine back.
+            await tx
+              .select()
+              .from(machines)
+              .where(eq(machines.id, id))
+              .limit(1);
 
       if (!updatedMachine) {
         throw new MachineNotFoundError();
       }
 
-      if (abandonedListing) {
-        await recordAbandonedListing(tx, id, abandonedListing, user.id);
+      if (pbmPlan) {
+        await applyMachinePbmLink(tx, id, pbmPlan, user.id);
       }
 
       // Handle owner changes in machine_watchers (inside tx so they roll back
@@ -1111,8 +1067,8 @@ export async function updateMachineAction(
       return [updatedMachine];
     });
 
-    if (autoLink) {
-      await captureAutoLinkBestEffort(id, autoLink.lmxId, user.id);
+    if (pbmPlan?.autoLink) {
+      await captureMachineAutoLink(id, pbmPlan.autoLink.lmxId, user.id);
     }
 
     // Post-commit side effects — best-effort: do not fail the action on notification errors
@@ -1181,7 +1137,7 @@ export async function updateMachineAction(
     // reach this point. Auto-link (PP-o355.20) made this action a writer of
     // `pinballmapListed` again, so the one-lister index
     // `machines_pinballmap_listed_unique` is reachable — but that write lives
-    // outside the details transaction and behind `captureAutoLinkBestEffort`,
+    // outside the details transaction and behind `captureMachineAutoLink`,
     // which stands down on a collision and reports anything else without
     // rethrowing. A save that reaches this catch therefore failed on its own
     // merits; derived bookkeeping is never allowed to discard a good edit.

--- a/src/lib/mcp/tools/index.ts
+++ b/src/lib/mcp/tools/index.ts
@@ -13,6 +13,7 @@ import { registerSearchPinballmapCatalog } from "./search-pinballmap-catalog";
 import { registerSetMachineAvailability } from "./set-machine-availability";
 import { registerSetMachineName } from "./set-machine-name";
 import { registerSetMachineOwner } from "./set-machine-owner";
+import { registerSetMachinePinballmap } from "./set-machine-pinballmap";
 import { registerUpdateIssue } from "./update-issue";
 
 /**
@@ -21,8 +22,9 @@ import { registerUpdateIssue } from "./update-issue";
  * `checkPermission`-gated per call.
  *
  * Two entities, each covered end to end: machines (list, read, add, rename,
- * set availability, set owner) and issues (list, read, file, comment, update),
- * plus the PinballMap catalog lookup that identifies a machine's title.
+ * set availability, set owner, set PinballMap title) and issues (list, read,
+ * file, comment, update), plus the PinballMap catalog lookup that identifies a
+ * machine's title.
  *
  * This function is the catalog — a tool that ships without a call here is
  * unreachable no matter how complete its handler is, which is what the
@@ -38,6 +40,7 @@ export function registerPinpointTools(server: McpServer): void {
   registerSetMachineName(server);
   registerAddMachine(server);
   registerSetMachineOwner(server);
+  registerSetMachinePinballmap(server);
   registerCreateIssue(server);
   registerAddIssueComment(server);
   registerUpdateIssue(server);

--- a/src/lib/mcp/tools/list-machines.ts
+++ b/src/lib/mcp/tools/list-machines.ts
@@ -214,17 +214,11 @@ export async function runListMachines(
  * warning. It is stated once, there, for the model that has to follow it; this
  * comment is the rationale, not a second copy.
  *
- * `pinballmap` is the exception TODAY, and only by accident of what is not built
- * yet: no tool links or excludes an existing machine (`add_machine` takes the
- * link columns at creation only), and auto-link (PP-o355.20) considers only rows
- * that already carry a `pinballmapMachineId` — its query filters on
- * `isNotNull(pinballmapMachineId)`, and the CHECK
- * `machines_pinballmap_listed_requires_link` means anything setting `listed`
- * already implies a link. `add_machine` can still INSERT straight into the
- * `unlinked` bucket mid-sweep, which re-reads a machine rather than skipping one.
- * PP-u4ab.12 ships the link verb and makes link state mutable like the rest —
- * at which point `pinballmap` stops being an exception and the drain procedure
- * covers it unchanged, with no edit needed here.
+ * `pinballmap` used to be the exception, by accident of what was not built yet.
+ * `set_machine_pinballmap` (PP-u4ab.12) ships the link verb, so link state is
+ * now mutable like the rest and the fleet linking pass moves rows out of the
+ * `unlinked` bucket as it goes — exactly the shape the drain procedure exists
+ * for. No edit to the description was needed: it was written to cover this.
  */
 export function registerListMachines(server: McpServer): void {
   server.registerTool(

--- a/src/lib/mcp/tools/set-machine-pinballmap.ts
+++ b/src/lib/mcp/tools/set-machine-pinballmap.ts
@@ -45,6 +45,14 @@ export const setMachinePinballmapSchema = z.object({
   pinballmapExcludedReason: z
     .string()
     .trim()
+    // Rejecting the empty string is narrower than the edit form, deliberately.
+    // The form has to accept it — an emptied input IS how a human clears a
+    // reason — but here an empty string can only be a caller filling a field it
+    // had nothing to put in, and the service reads "no reason supplied" as
+    // "keep the stored one". Accepting it would make that carry-over depend on
+    // whether the caller sent "" or nothing, which is not a distinction any
+    // caller is making on purpose.
+    .min(1)
     // 200 to match the edit form's shared schema (`m/schemas.ts`), NOT a looser
     // MCP-only cap. The two write the same column and the form prefills it: a
     // 201–500 char reason written here would render into an input that then
@@ -53,7 +61,7 @@ export const setMachinePinballmapSchema = z.object({
     .max(200)
     .optional()
     .describe(
-      "Why the machine is excluded (max 200 characters). Only meaningful alongside pinballmapExcluded: true."
+      "Why the machine is excluded (max 200 characters). Only meaningful alongside pinballmapExcluded: true. Leaving it out when the machine is ALREADY excluded keeps the reason already stored — re-confirming an exclusion never erases someone else's note. This tool cannot clear a stored reason; use the machine's edit page."
     ),
 });
 
@@ -136,10 +144,7 @@ export async function runSetMachinePinballmap(
   });
 
   if (!updated.ok) {
-    throw new McpToolError(
-      updated.reason === "not_found" ? "not_found" : "invalid",
-      updated.message
-    );
+    throw new McpToolError(updated.reason, updated.message);
   }
 
   // Same block `get_machine` returns, built from the STORED columns — a read

--- a/src/lib/mcp/tools/set-machine-pinballmap.ts
+++ b/src/lib/mcp/tools/set-machine-pinballmap.ts
@@ -22,7 +22,7 @@ import type { McpAuthContext } from "~/lib/mcp/verify-token";
  * The fleet linking pass (PP-h059) drives both tools in one session, and two
  * spellings of one concept is a mistake waiting to be made.
  */
-const setMachinePinballmapSchema = z.object({
+export const setMachinePinballmapSchema = z.object({
   machine: z
     .string()
     .trim()
@@ -45,10 +45,15 @@ const setMachinePinballmapSchema = z.object({
   pinballmapExcludedReason: z
     .string()
     .trim()
-    .max(500)
+    // 200 to match the edit form's shared schema (`m/schemas.ts`), NOT a looser
+    // MCP-only cap. The two write the same column and the form prefills it: a
+    // 201–500 char reason written here would render into an input that then
+    // fails validation on every later save from that page, wedging the picker
+    // behind text the user never typed.
+    .max(200)
     .optional()
     .describe(
-      "Why the machine is excluded. Only meaningful alongside pinballmapExcluded: true."
+      "Why the machine is excluded (max 200 characters). Only meaningful alongside pinballmapExcluded: true."
     ),
 });
 
@@ -124,22 +129,25 @@ export async function runSetMachinePinballmap(
       pinballmapExcluded: args.pinballmapExcluded,
       pinballmapExcludedReason: args.pinballmapExcludedReason,
     },
-    current: {
-      pinballmapMachineId: machine.pinballmapMachineId,
-      pinballmapListed: machine.pinballmapListed,
-      pinballmapLmxId: machine.pinballmapLmxId,
-      presenceStatus: machine.presenceStatus,
-    },
+    // The stored PBM state is NOT passed either. The service re-reads it under
+    // the row lock it writes through, so the snapshot resolved above cannot go
+    // stale between here and the write — the hourly reconcile pass is a real
+    // concurrent writer of these exact columns.
   });
 
   if (!updated.ok) {
-    throw new McpToolError("invalid", updated.message);
+    throw new McpToolError(
+      updated.reason === "not_found" ? "not_found" : "invalid",
+      updated.message
+    );
   }
 
   // Same block `get_machine` returns, built from the STORED columns — a read
   // and the write that followed it never describe one machine differently.
+  // `previous` comes from the locked read inside the write, not from the
+  // `resolveMachine` snapshot above, so it names the state actually replaced.
   const [previous, pinballmap] = await Promise.all([
-    buildMachinePinballmap(machine),
+    buildMachinePinballmap(updated.previous),
     buildMachinePinballmap(updated.columns),
   ]);
 

--- a/src/lib/mcp/tools/set-machine-pinballmap.ts
+++ b/src/lib/mcp/tools/set-machine-pinballmap.ts
@@ -1,0 +1,172 @@
+import "server-only";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { checkPermission } from "~/lib/permissions/helpers";
+import { updateMachinePbmLink } from "~/services/machines";
+
+import { buildMachinePinballmap } from "./pinballmap-block";
+import {
+  machineUrl,
+  McpToolError,
+  resolveMachine,
+  runTool,
+  type ToolOutcome,
+} from "./shared";
+import type { McpAuthContext } from "~/lib/mcp/verify-token";
+
+/**
+ * Argument names deliberately match `add_machine`'s
+ * (`pinballmapMachineId` / `pinballmapExcluded` / `pinballmapExcludedReason`).
+ * The fleet linking pass (PP-h059) drives both tools in one session, and two
+ * spellings of one concept is a mistake waiting to be made.
+ */
+const setMachinePinballmapSchema = z.object({
+  machine: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Machine initials (case-insensitive) or UUID."),
+  pinballmapMachineId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "The Pinball Map catalog id of the title/edition this machine IS. Must be a `pinballmapMachineId` from search_pinballmap_catalog — never a `machineGroupId`, which identifies an edition family."
+    ),
+  pinballmapExcluded: z
+    .boolean()
+    .optional()
+    .describe(
+      "Pass true to record that this machine is deliberately NOT on Pinball Map (homebrew, a one-off, a title the catalog doesn't carry). Mutually exclusive with pinballmapMachineId."
+    ),
+  pinballmapExcludedReason: z
+    .string()
+    .trim()
+    .max(500)
+    .optional()
+    .describe(
+      "Why the machine is excluded. Only meaningful alongside pinballmapExcluded: true."
+    ),
+});
+
+type SetMachinePinballmapArgs = z.infer<typeof setMachinePinballmapSchema>;
+
+/**
+ * Set (or re-target) a machine's PinballMap catalog link, or mark it as not on
+ * Pinball Map.
+ *
+ * The write half of the walk-the-floor flow (PP-u4ab.12), sharing one seam with
+ * the machine edit page: `updateMachinePbmLink` owns the listing carry-over, the
+ * abandoned-listing record, and the auto-link decision, so this tool cannot
+ * disagree with the form about any of them.
+ *
+ * Three things this tool deliberately cannot do:
+ *
+ *  - **Set listing state from its arguments.** `pinballmapListed` is not an
+ *    input here any more than it is on the edit form (PP-o355.29). It moves only
+ *    via the carry-over (same target kept ⇒ keep the listing) and via auto-link,
+ *    which reads the STORED PinballMap snapshot — never a caller's claim.
+ *  - **List or unlist a machine on pinballmap.com.** That is an outbound write
+ *    gated on `machines.pinballmap.push` and owned by the web UI (PP-o355.21).
+ *  - **Clear a link back to "nothing recorded".** Every accepted call states a
+ *    fact — this title, or not on Pinball Map. Silence is not one of the two, so
+ *    a call carrying neither is rejected rather than read as "unlink".
+ */
+export async function runSetMachinePinballmap(
+  args: SetMachinePinballmapArgs,
+  ctx: McpAuthContext
+): Promise<ToolOutcome> {
+  const machine = await resolveMachine(args.machine);
+
+  if (
+    !checkPermission("machines.pinballmap.link", ctx.accessLevel, {
+      userId: ctx.userId,
+      machineOwnerId: machine.ownerId,
+    })
+  ) {
+    throw new McpToolError(
+      "denied",
+      "Only the machine owner, technicians, or admins can change this machine's Pinball Map link."
+    );
+  }
+
+  const linking = args.pinballmapMachineId !== undefined;
+  const excluding = args.pinballmapExcluded === true;
+
+  // The resolver treats "neither linked nor excluded" as a valid selection that
+  // CLEARS every PBM column — correct for the edit form, where a human emptied
+  // the picker on purpose. Reached from a tool call it would mean an argument
+  // was forgotten, and a forgotten argument must not wipe a link (CORE-ARCH-012).
+  if (!linking && !excluding) {
+    throw new McpToolError(
+      "invalid",
+      "Pass pinballmapMachineId to link this machine to a Pinball Map title, or pinballmapExcluded: true to record that it is not on Pinball Map. This tool cannot clear a link back to 'nothing recorded' — use the machine's edit page for that."
+    );
+  }
+  if (linking && excluding) {
+    throw new McpToolError(
+      "invalid",
+      "A machine can't be both linked to a Pinball Map title and marked as not on Pinball Map. Pass one or the other."
+    );
+  }
+
+  const updated = await updateMachinePbmLink({
+    machineId: machine.id,
+    actorUserId: ctx.userId,
+    // Model metadata (manufacturer/year/OPDB/IPDB) is NOT passed and cannot be:
+    // the service derives it from the catalog mirror for whichever id lands
+    // here, so a caller cannot write a year the catalog disagrees with.
+    selection: {
+      pinballmapMachineId: args.pinballmapMachineId,
+      pinballmapExcluded: args.pinballmapExcluded,
+      pinballmapExcludedReason: args.pinballmapExcludedReason,
+    },
+    current: {
+      pinballmapMachineId: machine.pinballmapMachineId,
+      pinballmapListed: machine.pinballmapListed,
+      pinballmapLmxId: machine.pinballmapLmxId,
+      presenceStatus: machine.presenceStatus,
+    },
+  });
+
+  if (!updated.ok) {
+    throw new McpToolError("invalid", updated.message);
+  }
+
+  // Same block `get_machine` returns, built from the STORED columns — a read
+  // and the write that followed it never describe one machine differently.
+  const [previous, pinballmap] = await Promise.all([
+    buildMachinePinballmap(machine),
+    buildMachinePinballmap(updated.columns),
+  ]);
+
+  return {
+    result: {
+      initials: machine.initials,
+      name: machine.name,
+      pinballmap,
+      previousPinballmap: previous,
+      url: machineUrl(machine.initials),
+    },
+    machineId: machine.id,
+  };
+}
+
+export function registerSetMachinePinballmap(server: McpServer): void {
+  server.registerTool(
+    "set_machine_pinballmap",
+    {
+      title: "Set a machine's Pinball Map title",
+      description:
+        "Record WHICH Pinball Map catalog title a machine is — or that it isn't on Pinball Map at all. Two steps, always in this order: (1) call search_pinballmap_catalog to find the title and get its `pinballmapMachineId`, (2) call this tool with that id. Do not guess an id; ids are not derivable from a title's name. THE ID MUST BE A `pinballmapMachineId`, NOT A `machineGroupId` — the catalog search returns both as adjacent bare integers, and they are separate id spaces that overlap numerically, so passing a group id links the machine to a real but unrelated title and nothing about the number itself will tell you. Group ids come back from families; machine ids come back from editions and from single-edition families. Alternatively pass `pinballmapExcluded: true` with a `pinballmapExcludedReason` for a machine that genuinely isn't a catalog title (homebrew, a one-off). Pass one or the other, never both, and never neither: this tool cannot clear a link back to 'nothing recorded'. Manufacturer, year, OPDB id and IPDB id are re-derived from the catalog for the id you pass — you cannot set them, and passing a wrong id rewrites all four. Re-targeting a machine that is LISTED on the public map to a different title clears its listing (the old public entry no longer describes it; PinPoint records it as an entry to remove by hand), while re-sending the SAME id it already has leaves the listing untouched. Nothing here lists or unlists a machine on pinballmap.com. Returns the machine's new Pinball Map state in the same shape get_machine reports, plus `previousPinballmap` so you can see exactly what changed. Use get_machine or list_machines(pinballmap: 'unlinked') first to find machines still needing a title.",
+      inputSchema: setMachinePinballmapSchema.shape,
+    },
+    (args, extra) =>
+      runTool("set_machine_pinballmap", extra, (ctx) =>
+        runSetMachinePinballmap(args, ctx)
+      )
+  );
+}

--- a/src/lib/mcp/tools/shared.ts
+++ b/src/lib/mcp/tools/shared.ts
@@ -38,7 +38,12 @@ import {
  */
 export class McpToolError extends Error {
   constructor(
-    readonly reason: "denied" | "not_found" | "invalid",
+    // `conflict` is its own reason, not a flavour of `invalid`: it means the row
+    // moved under a compare-and-set and nothing was written, which is a fact
+    // about concurrency, not about the arguments. Collapsing it into `invalid`
+    // would tell `mcp_tool_calls` — the only server-side record of MCP
+    // mutations — to blame the caller for a burst of failures it did not cause.
+    readonly reason: "denied" | "not_found" | "invalid" | "conflict",
     message: string
   ) {
     super(message);

--- a/src/services/machines.ts
+++ b/src/services/machines.ts
@@ -713,12 +713,44 @@ export interface UpdateMachinePbmLinkParams {
   actorUserId: string;
   /** The requested link selection. Listing state is never part of it. */
   selection: PbmLinkSelection;
-  /** The machine's STORED PBM + presence state, read from the row. */
-  current: StoredPbmLinkState & { presenceStatus: MachinePresenceStatus };
 }
 
 export type UpdateMachinePbmLinkResult =
-  { ok: true; columns: MachinePbmColumns } | { ok: false; message: string };
+  | { ok: true; columns: MachinePbmColumns; previous: MachinePbmColumns }
+  | {
+      ok: false;
+      reason: "invalid" | "not_found" | "conflict";
+      message: string;
+    };
+
+/** The PBM + presence state a plan was decided against, for the CAS check. */
+type PbmLinkBasis = StoredPbmLinkState & {
+  presenceStatus: MachinePresenceStatus;
+};
+
+const PBM_LINK_COLUMNS = {
+  pinballmapMachineId: true,
+  pinballmapExcluded: true,
+  pinballmapExcludedReason: true,
+  pinballmapListed: true,
+  pinballmapLmxId: true,
+  manufacturer: true,
+  year: true,
+  opdbId: true,
+  ipdbId: true,
+} as const;
+
+/** How many times a losing CAS attempt re-plans before giving up. */
+const PBM_LINK_MAX_ATTEMPTS = 3;
+
+function pbmLinkBasisUnchanged(a: PbmLinkBasis, b: PbmLinkBasis): boolean {
+  return (
+    a.pinballmapMachineId === b.pinballmapMachineId &&
+    a.pinballmapListed === b.pinballmapListed &&
+    a.pinballmapLmxId === b.pinballmapLmxId &&
+    a.presenceStatus === b.presenceStatus
+  );
+}
 
 /**
  * Change a machine's PinballMap link and nothing else — the focused slice of
@@ -728,63 +760,142 @@ export type UpdateMachinePbmLinkResult =
  * seam: plan, apply in a transaction, then capture any auto-link post-commit.
  * Authorization stays in the caller (`machines.pinballmap.link`).
  *
+ * **Reads its own basis, and writes it back under compare-and-set.** The plan
+ * has to be decided before the transaction opens — it reads the catalog mirror
+ * and ranks auto-link candidates, and neither belongs inside a held row lock —
+ * so the snapshot it planned against can go stale in between. The hourly
+ * reconcile pass is the writer that does it: it sets `pinballmapListed` true and
+ * captures an lmx, and because {@link applyMachinePbmLink} writes the whole
+ * column set, a plan made from the pre-reconcile snapshot would put `listed:
+ * false, lmxId: null` back and — having seen no listing — record no abandonment,
+ * leaving a live pinballmap.com entry nobody tracks. That is the PP-l81u defect
+ * exactly. The fleet linking pass (PP-h059) drives this tool across ~100
+ * machines in one session, so the window is wide open in practice, not
+ * theoretically.
+ *
+ * The `FOR UPDATE` re-read inside the transaction closes it: whoever holds the
+ * lock sees the other writer's committed state, and a basis that moved means the
+ * plan is void, so it is thrown away and re-planned rather than written. Same
+ * read-modify-write serialization `editStoredSnapshot` uses in
+ * `m/pinballmap-actions.ts`, for the same reason.
+ *
+ * A missing row is reported as `not_found` rather than a success payload
+ * describing a link that was never stored (CORE-ARCH-012).
+ *
  * Returns the machine's PBM columns AS STORED after everything settled, not as
  * planned: an auto-link that lands sets `pinballmapListed`/`pinballmapLmxId`
  * outside the plan, and reporting the planned values would tell the caller the
- * machine is unlisted while the row says otherwise (CORE-ARCH-012).
+ * machine is unlisted while the row says otherwise (CORE-ARCH-012). `previous`
+ * comes from the locked read, so it describes the state this change actually
+ * replaced — not whatever the caller happened to read earlier.
  */
 export async function updateMachinePbmLink({
   machineId,
   actorUserId,
   selection,
-  current,
 }: UpdateMachinePbmLinkParams): Promise<UpdateMachinePbmLinkResult> {
-  const planned = await planMachinePbmLink({
-    machineId,
-    selection,
-    stored: {
-      pinballmapMachineId: current.pinballmapMachineId,
-      pinballmapListed: current.pinballmapListed,
-      pinballmapLmxId: current.pinballmapLmxId,
-    },
-    presenceStatus: current.presenceStatus,
-  });
-  if (!planned.ok) {
-    return { ok: false, message: planned.message };
+  for (let attempt = 1; ; attempt++) {
+    const basisRow = await db.query.machines.findFirst({
+      where: eq(machines.id, machineId),
+      columns: { ...PBM_LINK_COLUMNS, presenceStatus: true },
+    });
+    if (!basisRow) {
+      return { ok: false, reason: "not_found", message: MACHINE_GONE_MESSAGE };
+    }
+
+    const planned = await planMachinePbmLink({
+      machineId,
+      selection,
+      stored: {
+        pinballmapMachineId: basisRow.pinballmapMachineId,
+        pinballmapListed: basisRow.pinballmapListed,
+        pinballmapLmxId: basisRow.pinballmapLmxId,
+      },
+      presenceStatus: basisRow.presenceStatus,
+    });
+    if (!planned.ok) {
+      return { ok: false, reason: "invalid", message: planned.message };
+    }
+
+    const outcome = await db.transaction(async (tx) => {
+      const [locked] = await tx
+        .select({
+          pinballmapMachineId: machines.pinballmapMachineId,
+          pinballmapExcluded: machines.pinballmapExcluded,
+          pinballmapExcludedReason: machines.pinballmapExcludedReason,
+          pinballmapListed: machines.pinballmapListed,
+          pinballmapLmxId: machines.pinballmapLmxId,
+          manufacturer: machines.manufacturer,
+          year: machines.year,
+          opdbId: machines.opdbId,
+          ipdbId: machines.ipdbId,
+          presenceStatus: machines.presenceStatus,
+        })
+        .from(machines)
+        .where(eq(machines.id, machineId))
+        .for("update");
+      if (!locked) return { state: "gone" } as const;
+      if (!pbmLinkBasisUnchanged(locked, basisRow)) {
+        return { state: "stale" } as const;
+      }
+
+      await applyMachinePbmLink(tx, machineId, planned.plan, actorUserId);
+      const { presenceStatus: _presence, ...previous } = locked;
+      return { state: "applied", previous } as const;
+    });
+
+    if (outcome.state === "gone") {
+      return { ok: false, reason: "not_found", message: MACHINE_GONE_MESSAGE };
+    }
+    if (outcome.state === "stale") {
+      if (attempt >= PBM_LINK_MAX_ATTEMPTS) {
+        return {
+          ok: false,
+          reason: "conflict",
+          message:
+            "This machine's Pinball Map state kept changing while the update was being applied. Nothing was written — read it back and try again.",
+        };
+      }
+      continue;
+    }
+
+    return finishMachinePbmLink(
+      machineId,
+      actorUserId,
+      planned.plan,
+      outcome.previous
+    );
+  }
+}
+
+const MACHINE_GONE_MESSAGE =
+  "That machine no longer exists — it was deleted while the update was being applied. Nothing was written.";
+
+/**
+ * The post-commit half: capture any auto-link, then report the columns AS
+ * STORED. Split out only so {@link updateMachinePbmLink}'s retry loop has a
+ * single exit.
+ */
+async function finishMachinePbmLink(
+  machineId: string,
+  actorUserId: string,
+  plan: MachinePbmLinkPlan,
+  previous: MachinePbmColumns
+): Promise<UpdateMachinePbmLinkResult> {
+  if (plan.autoLink === null) {
+    return { ok: true, columns: plan.columns, previous };
   }
 
-  await db.transaction(async (tx) => {
-    await applyMachinePbmLink(tx, machineId, planned.plan, actorUserId);
-  });
-
-  if (planned.plan.autoLink === null) {
-    return { ok: true, columns: planned.plan.columns };
-  }
-
-  await captureMachineAutoLink(
-    machineId,
-    planned.plan.autoLink.lmxId,
-    actorUserId
-  );
+  await captureMachineAutoLink(machineId, plan.autoLink.lmxId, actorUserId);
 
   const row = await db.query.machines.findFirst({
     where: eq(machines.id, machineId),
-    columns: {
-      pinballmapMachineId: true,
-      pinballmapExcluded: true,
-      pinballmapExcludedReason: true,
-      pinballmapListed: true,
-      pinballmapLmxId: true,
-      manufacturer: true,
-      year: true,
-      opdbId: true,
-      ipdbId: true,
-    },
+    columns: PBM_LINK_COLUMNS,
   });
   // The row was updated moments ago in a committed transaction, so a miss means
   // it was deleted concurrently. Fall back to the planned columns rather than
   // throwing away a change that did commit.
-  return { ok: true, columns: row ?? planned.plan.columns };
+  return { ok: true, columns: row ?? plan.columns, previous };
 }
 
 export interface UpdateMachineNameParams {

--- a/src/services/machines.ts
+++ b/src/services/machines.ts
@@ -1,5 +1,5 @@
 import { eq, and, type InferSelectModel } from "drizzle-orm";
-import { db } from "~/server/db";
+import { db, type DbTransaction } from "~/server/db";
 import {
   machines,
   machineWatchers,
@@ -24,6 +24,17 @@ import {
 } from "~/lib/notifications";
 import { type MachinePresenceStatus } from "~/lib/machines/presence";
 import { type ProseMirrorDoc } from "~/lib/tiptap/types";
+import { recordAbandonedListing } from "~/lib/pinballmap/abandoned-listings";
+import {
+  resolvePbmLinkColumnsForUpdate,
+  type AbandonedListing,
+  type PbmLinkSelection,
+  type StoredPbmLinkState,
+} from "~/lib/pinballmap/link-columns";
+import {
+  captureAutoLink,
+  resolveAutoLinkForMachine,
+} from "~/lib/pinballmap/sync";
 
 export type Machine = InferSelectModel<typeof machines>;
 
@@ -543,6 +554,237 @@ export async function updateMachinePresence({
   });
 
   return { changed: true };
+}
+
+// --- PinballMap link seam (PP-u4ab.12) --------------------------------------
+//
+// One seam, three steps, shared by `updateMachineAction` (the machine edit
+// page) and the MCP `set_machine_pinballmap` tool:
+//
+//   1. {@link planMachinePbmLink}  — decide, before any transaction opens.
+//   2. {@link applyMachinePbmLink} — write, inside the caller's transaction.
+//   3. {@link captureMachineAutoLink} — best-effort listing capture, after it
+//      commits.
+//
+// Split into three rather than one function because the two callers have
+// genuinely different transaction shapes: the edit form saves the link
+// alongside name/owner/presence/description and must keep all of that atomic,
+// while the MCP tool changes the link and nothing else. Collapsing them into
+// one `db.transaction` would either fork the seam or make a machine save
+// two transactions — and a half-saved edit is the regression this bead was
+// warned about. What is NOT split is every decision that carries a rule: the
+// carry-over, the abandonment record, and the auto-link choice each exist once.
+
+/** Everything a PBM link change decided, before anything is written. */
+export interface MachinePbmLinkPlan {
+  /** The full column set to write — catalog-derived, never caller-supplied. */
+  columns: MachinePbmColumns;
+  /** A live PBM entry this change walks away from (PP-l81u), or null. */
+  abandoned: AbandonedListing | null;
+  /**
+   * The listing this change decided to capture (PP-o355.20), or null.
+   *
+   * Decided here and applied AFTER the caller's transaction commits — the
+   * one-lister index makes the listing write the only statement that can
+   * collide, and derived bookkeeping must never discard the edit a human (or an
+   * MCP caller) actually asked for.
+   */
+  autoLink: { lmxId: number } | null;
+}
+
+export type PlanMachinePbmLinkResult =
+  { ok: true; plan: MachinePbmLinkPlan } | { ok: false; message: string };
+
+export interface PlanMachinePbmLinkParams {
+  machineId: string;
+  /** The requested link selection. Listing state is never part of it. */
+  selection: PbmLinkSelection;
+  /** The machine's STORED PBM state, read from the row — never from a request. */
+  stored: StoredPbmLinkState;
+  /**
+   * The machine's presence as it will be AFTER this change — the tie guard
+   * ranks on it, and an edit form can change availability in the same submit.
+   */
+  presenceStatus: MachinePresenceStatus;
+}
+
+/**
+ * Decide a machine's new PinballMap columns, plus the two follow-ups that ride
+ * with them. Pure decision-making: reads the catalog mirror and the stored PBM
+ * snapshot, writes nothing, and opens no transaction (so it is also the right
+ * side of CORE-ARCH-011 for the auto-link lookup).
+ *
+ * `pinballmapListed` is never an input. `resolvePbmLinkColumnsForUpdate` takes
+ * the STORED row and owns the carry-over decision, so no caller can unlist a
+ * machine by leaving an argument out (PP-l81u), and no caller can list one by
+ * putting it in a request body (PP-o355.29).
+ */
+export async function planMachinePbmLink({
+  machineId,
+  selection,
+  stored,
+  presenceStatus,
+}: PlanMachinePbmLinkParams): Promise<PlanMachinePbmLinkResult> {
+  const resolved = await resolvePbmLinkColumnsForUpdate(selection, stored);
+  if (!resolved.ok) {
+    return { ok: false, message: resolved.message };
+  }
+
+  // Only from unlinked/re-targeted → not-yet-listed. A row the carry-over kept
+  // listed is skipped entirely, which is also why this can never produce a heal:
+  // lmx drift belongs to the hourly reconcile pass, not to whoever hit Save.
+  const autoLink =
+    resolved.columns.pinballmapMachineId !== null &&
+    !resolved.columns.pinballmapListed
+      ? await resolveAutoLinkForMachine({
+          machineId,
+          pinballmapMachineId: resolved.columns.pinballmapMachineId,
+          presenceStatus,
+        })
+      : null;
+
+  return {
+    ok: true,
+    plan: {
+      columns: resolved.columns,
+      abandoned: resolved.abandoned,
+      autoLink,
+    },
+  };
+}
+
+/**
+ * Write a planned link change in the CALLER's transaction: the columns, and the
+ * record of any listing the change walks away from.
+ *
+ * Both must commit together — a retitle that lands without its abandonment
+ * record leaves a public PinballMap entry nobody can find (PP-l81u), which is
+ * exactly the defect this pairing closes. Both writes are local, so nothing here
+ * violates CORE-ARCH-011.
+ *
+ * The columns go out as their own UPDATE rather than being spread into a
+ * caller's statement, so the pairing cannot be half-adopted by a new caller.
+ * `machines_owner_not_guest` is the only trigger on this table and it fires only
+ * `OF owner_id, invited_owner_id`, so a second UPDATE in the same transaction
+ * costs a round trip and nothing else.
+ */
+export async function applyMachinePbmLink(
+  tx: DbTransaction,
+  machineId: string,
+  plan: MachinePbmLinkPlan,
+  actorUserId: string
+): Promise<void> {
+  await tx.update(machines).set(plan.columns).where(eq(machines.id, machineId));
+
+  if (plan.abandoned) {
+    await recordAbandonedListing(tx, machineId, plan.abandoned, actorUserId);
+  }
+}
+
+/**
+ * Apply a plan's auto-link, best-effort, AFTER the caller's transaction has
+ * committed. Swallows everything.
+ *
+ * `captureAutoLink` already stands down on the one collision that is expected
+ * (another cabinet of this title took the listing first), but a deadlock, a
+ * dropped connection, or a failure writing the receipt would otherwise surface
+ * as "failed to save" for a change that is already saved — sending the caller to
+ * redo work that landed. Auto-link is derived bookkeeping: it is allowed to not
+ * happen, and the hourly reconcile pass picks it up next time round.
+ */
+export async function captureMachineAutoLink(
+  machineId: string,
+  lmxId: number,
+  actorUserId: string
+): Promise<void> {
+  try {
+    await captureAutoLink({ machineId, lmxId, action: "linked" }, actorUserId);
+  } catch (error) {
+    reportError(error, {
+      action: "captureMachineAutoLink",
+      bestEffort: true,
+      machineId,
+    });
+  }
+}
+
+export interface UpdateMachinePbmLinkParams {
+  machineId: string;
+  actorUserId: string;
+  /** The requested link selection. Listing state is never part of it. */
+  selection: PbmLinkSelection;
+  /** The machine's STORED PBM + presence state, read from the row. */
+  current: StoredPbmLinkState & { presenceStatus: MachinePresenceStatus };
+}
+
+export type UpdateMachinePbmLinkResult =
+  { ok: true; columns: MachinePbmColumns } | { ok: false; message: string };
+
+/**
+ * Change a machine's PinballMap link and nothing else — the focused slice of
+ * `updateMachineAction`'s PBM logic, for the MCP `set_machine_pinballmap` tool.
+ *
+ * Runs the same three steps the edit page runs, in the same order, over the same
+ * seam: plan, apply in a transaction, then capture any auto-link post-commit.
+ * Authorization stays in the caller (`machines.pinballmap.link`).
+ *
+ * Returns the machine's PBM columns AS STORED after everything settled, not as
+ * planned: an auto-link that lands sets `pinballmapListed`/`pinballmapLmxId`
+ * outside the plan, and reporting the planned values would tell the caller the
+ * machine is unlisted while the row says otherwise (CORE-ARCH-012).
+ */
+export async function updateMachinePbmLink({
+  machineId,
+  actorUserId,
+  selection,
+  current,
+}: UpdateMachinePbmLinkParams): Promise<UpdateMachinePbmLinkResult> {
+  const planned = await planMachinePbmLink({
+    machineId,
+    selection,
+    stored: {
+      pinballmapMachineId: current.pinballmapMachineId,
+      pinballmapListed: current.pinballmapListed,
+      pinballmapLmxId: current.pinballmapLmxId,
+    },
+    presenceStatus: current.presenceStatus,
+  });
+  if (!planned.ok) {
+    return { ok: false, message: planned.message };
+  }
+
+  await db.transaction(async (tx) => {
+    await applyMachinePbmLink(tx, machineId, planned.plan, actorUserId);
+  });
+
+  if (planned.plan.autoLink === null) {
+    return { ok: true, columns: planned.plan.columns };
+  }
+
+  await captureMachineAutoLink(
+    machineId,
+    planned.plan.autoLink.lmxId,
+    actorUserId
+  );
+
+  const row = await db.query.machines.findFirst({
+    where: eq(machines.id, machineId),
+    columns: {
+      pinballmapMachineId: true,
+      pinballmapExcluded: true,
+      pinballmapExcludedReason: true,
+      pinballmapListed: true,
+      pinballmapLmxId: true,
+      manufacturer: true,
+      year: true,
+      opdbId: true,
+      ipdbId: true,
+    },
+  });
+  // The row was updated moments ago in a committed transaction, so a miss means
+  // it was deleted concurrently. Fall back to the planned columns rather than
+  // throwing away a change that did commit.
+  return { ok: true, columns: row ?? planned.plan.columns };
 }
 
 export interface UpdateMachineNameParams {

--- a/src/services/machines.ts
+++ b/src/services/machines.ts
@@ -726,6 +726,8 @@ export type UpdateMachinePbmLinkResult =
 /** The PBM + presence state a plan was decided against, for the CAS check. */
 type PbmLinkBasis = StoredPbmLinkState & {
   presenceStatus: MachinePresenceStatus;
+  pinballmapExcluded: boolean;
+  pinballmapExcludedReason: string | null;
 };
 
 const PBM_LINK_COLUMNS = {
@@ -748,8 +750,46 @@ function pbmLinkBasisUnchanged(a: PbmLinkBasis, b: PbmLinkBasis): boolean {
     a.pinballmapMachineId === b.pinballmapMachineId &&
     a.pinballmapListed === b.pinballmapListed &&
     a.pinballmapLmxId === b.pinballmapLmxId &&
-    a.presenceStatus === b.presenceStatus
+    a.presenceStatus === b.presenceStatus &&
+    // The exclusion pair is in the basis because {@link carryExcludedReason}
+    // reads it. Anything the plan is derived from has to be compared, or the
+    // CAS would wave through a write built on a value that has since moved.
+    a.pinballmapExcluded === b.pinballmapExcluded &&
+    a.pinballmapExcludedReason === b.pinballmapExcludedReason
   );
+}
+
+/**
+ * Keep a stored exclusion reason when the caller re-states the exclusion without
+ * one.
+ *
+ * `resolvePbmLinkColumnsForUpdate` writes `reason ?? null`, which is right for
+ * the edit form — that form always posts the field, so an absent one means a
+ * human emptied the box. An MCP caller re-confirming an exclusion it did not
+ * author has no such intent, and the fleet pass (PP-h059) does exactly that
+ * across the whole floor: `{ machine: "UM", pinballmapExcluded: true }` would
+ * have nulled "homebrew — one-off cabinet" on every machine it touched. Same
+ * shape as the listing carry-over, and the same rule behind it — a forgotten
+ * argument must not destroy stored state (CORE-ARCH-012).
+ *
+ * An explicit empty string is still a clear: it is a value the caller sent.
+ */
+function carryExcludedReason(
+  selection: PbmLinkSelection,
+  stored: Pick<PbmLinkBasis, "pinballmapExcluded" | "pinballmapExcludedReason">
+): PbmLinkSelection {
+  if (
+    selection.pinballmapExcluded !== true ||
+    selection.pinballmapExcludedReason !== undefined ||
+    !stored.pinballmapExcluded ||
+    stored.pinballmapExcludedReason === null
+  ) {
+    return selection;
+  }
+  return {
+    ...selection,
+    pinballmapExcludedReason: stored.pinballmapExcludedReason,
+  };
 }
 
 /**
@@ -780,7 +820,8 @@ function pbmLinkBasisUnchanged(a: PbmLinkBasis, b: PbmLinkBasis): boolean {
  * `m/pinballmap-actions.ts`, for the same reason.
  *
  * A missing row is reported as `not_found` rather than a success payload
- * describing a link that was never stored (CORE-ARCH-012).
+ * describing a link that was never stored (CORE-ARCH-012). An exclusion
+ * re-stated without a reason keeps the stored one ({@link carryExcludedReason}).
  *
  * Returns the machine's PBM columns AS STORED after everything settled, not as
  * planned: an auto-link that lands sets `pinballmapListed`/`pinballmapLmxId`
@@ -805,7 +846,7 @@ export async function updateMachinePbmLink({
 
     const planned = await planMachinePbmLink({
       machineId,
-      selection,
+      selection: carryExcludedReason(selection, basisRow),
       stored: {
         pinballmapMachineId: basisRow.pinballmapMachineId,
         pinballmapListed: basisRow.pinballmapListed,

--- a/src/test/integration/mcp-tools.test.ts
+++ b/src/test/integration/mcp-tools.test.ts
@@ -21,7 +21,9 @@ import {
   issueComments,
   issues,
   machines,
+  pinballmapAbandonedListings,
   pinballmapCatalog,
+  pinballmapState,
   timelineEvents,
   userProfiles,
 } from "~/server/db/schema";
@@ -67,6 +69,7 @@ import type { McpMachinePinballmap } from "~/lib/mcp/tools/pinballmap-block";
 import { runSetMachineAvailability } from "~/lib/mcp/tools/set-machine-availability";
 import { runSetMachineName } from "~/lib/mcp/tools/set-machine-name";
 import { runSetMachineOwner } from "~/lib/mcp/tools/set-machine-owner";
+import { runSetMachinePinballmap } from "~/lib/mcp/tools/set-machine-pinballmap";
 import { runUpdateIssue } from "~/lib/mcp/tools/update-issue";
 import {
   McpToolError,
@@ -1265,6 +1268,387 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
     });
   });
 
+  describe("set_machine_pinballmap (PP-u4ab.12)", () => {
+    /**
+     * A lineup the local snapshot already holds. Auto-link reads this table and
+     * never pinballmap.com (CORE-PBM-001, CORE-TEST-006); `enabled` is
+     * load-bearing, since save-time auto-link stands down while the integration
+     * is off.
+     */
+    async function seedLineup(
+      rows: { id: number; machineId: number }[]
+    ): Promise<void> {
+      const db = await getTestDb();
+      await db.insert(pinballmapState).values({
+        id: "singleton",
+        locationId: 26454,
+        enabled: true,
+        lastSyncStatus: "ok",
+        snapshotJson: {
+          locationId: 26454,
+          name: "APC",
+          dateLastUpdated: null,
+          lastUpdatedByUsername: null,
+          machineCount: rows.length,
+          lmxes: rows.map((r) => ({
+            ...r,
+            icEnabled: null,
+            lastUpdatedByUsername: null,
+            conditions: [],
+          })),
+          fetchedAtIso: "2026-08-02T00:00:00Z",
+          raw: {},
+        },
+      });
+    }
+
+    async function pbmRow(machineId: string): Promise<{
+      pinballmapMachineId: number | null;
+      pinballmapExcluded: boolean;
+      pinballmapExcludedReason: string | null;
+      pinballmapListed: boolean;
+      pinballmapLmxId: number | null;
+      manufacturer: string | null;
+      year: number | null;
+      opdbId: string | null;
+      ipdbId: number | null;
+    }> {
+      const db = await getTestDb();
+      const row = await db.query.machines.findFirst({
+        where: eq(machines.id, machineId),
+        columns: {
+          pinballmapMachineId: true,
+          pinballmapExcluded: true,
+          pinballmapExcludedReason: true,
+          pinballmapListed: true,
+          pinballmapLmxId: true,
+          manufacturer: true,
+          year: true,
+          opdbId: true,
+          ipdbId: true,
+        },
+      });
+      if (!row) throw new Error("machine vanished");
+      return row;
+    }
+
+    it("links an unlinked machine and derives the metadata from the catalog", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({ name: "Elvira" });
+
+      const outcome = await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+        ctx("admin", admin)
+      );
+
+      // The echo is the same shape `get_machine` returns — one description of a
+      // machine's PBM state, never a second one invented by the write path.
+      expect(outcome.result).toMatchObject({
+        initials: machine.initials,
+        previousPinballmap: null,
+        pinballmap: {
+          status: "linked",
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          catalogLookup: "found",
+          title: "Elvira's House of Horrors (Premium)",
+          manufacturer: "Stern",
+          year: 2019,
+          opdbId: "GRBN4-MQGE5",
+          ipdbId: 6587,
+          listed: false,
+          lmxId: null,
+        },
+      });
+
+      // Model metadata is copied from the mirror, not accepted from the caller —
+      // there is no argument that can write these four columns.
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: ELVIRA_PREMIUM_ID,
+        manufacturer: "Stern",
+        year: 2019,
+        opdbId: "GRBN4-MQGE5",
+        ipdbId: 6587,
+      });
+    });
+
+    it("clears listing state when a LISTED machine is re-targeted, and records the abandoned entry", async () => {
+      const db = await getTestDb();
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({
+        name: "Elvira",
+        pbm: {
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          pinballmapListed: true,
+          pinballmapLmxId: 44_710,
+          manufacturer: "Stern",
+          year: 2019,
+        },
+      });
+
+      const outcome = await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: 70_013 },
+        ctx("admin", admin)
+      );
+
+      // The old public entry describes the OLD title, so it cannot follow the
+      // machine to the new one (PP-l81u / PP-o355.19).
+      expect(outcome.result).toMatchObject({
+        pinballmap: {
+          status: "linked",
+          pinballmapMachineId: 70_013,
+          title: "Elvira's House of Horrors (LE)",
+          listed: false,
+          lmxId: null,
+        },
+      });
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: 70_013,
+        pinballmapListed: false,
+        pinballmapLmxId: null,
+      });
+
+      // Dropping the listing without writing down the live entry is what leaves
+      // an orphan on pinballmap.com that nobody can find.
+      const abandoned = await db
+        .select()
+        .from(pinballmapAbandonedListings)
+        .where(eq(pinballmapAbandonedListings.machineId, machine.id));
+      expect(abandoned).toHaveLength(1);
+      expect(abandoned[0]).toMatchObject({
+        lmxId: 44_710,
+        pinballmapMachineId: ELVIRA_PREMIUM_ID,
+      });
+    });
+
+    it("keeps listing state when the SAME title is re-sent", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({
+        pbm: {
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          pinballmapListed: true,
+          pinballmapLmxId: 44_710,
+        },
+      });
+
+      await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+        ctx("admin", admin)
+      );
+
+      // The carry-over is the whole reason listing state is read from the row
+      // rather than taken as an argument: a re-save that silently unlisted a
+      // listed machine is PP-o355.19.
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: ELVIRA_PREMIUM_ID,
+        pinballmapListed: true,
+        pinballmapLmxId: 44_710,
+      });
+    });
+
+    it("marks a machine excluded, clearing any existing link and its metadata", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({
+        pbm: {
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          manufacturer: "Stern",
+          year: 2019,
+        },
+      });
+
+      const outcome = await runSetMachinePinballmap(
+        {
+          machine: machine.initials,
+          pinballmapExcluded: true,
+          pinballmapExcludedReason: "Homebrew, not a catalog title",
+        },
+        ctx("admin", admin)
+      );
+
+      expect(outcome.result).toMatchObject({
+        pinballmap: {
+          status: "excluded",
+          reason: "Homebrew, not a catalog title",
+        },
+      });
+      // `machines_pinballmap_link_exclusive` forbids linked AND excluded, so the
+      // link has to come off in the same write — the row landing at all is the
+      // proof the CHECK held.
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: null,
+        pinballmapExcluded: true,
+        pinballmapExcludedReason: "Homebrew, not a catalog title",
+        manufacturer: null,
+        year: null,
+      });
+    });
+
+    it("captures the listing when the title is already on the synced lineup", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      await seedLineup([{ id: 88_001, machineId: ELVIRA_PREMIUM_ID }]);
+      const machine = await seedMachine({ name: "Elvira" });
+
+      const outcome = await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+        ctx("admin", admin)
+      );
+
+      // Auto-link (PP-o355.20) lands AFTER the link transaction commits, so the
+      // echoed block is read back from the row rather than from the plan —
+      // reporting `listed: false` here while the row says otherwise is the
+      // confident wrong answer CORE-ARCH-012 forbids.
+      expect(outcome.result).toMatchObject({
+        pinballmap: { status: "linked", listed: true, lmxId: 88_001 },
+      });
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapListed: true,
+        pinballmapLmxId: 88_001,
+      });
+    });
+
+    it("links a duplicate cabinet without disturbing the title's incumbent lister", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      await seedLineup([{ id: 88_001, machineId: ELVIRA_PREMIUM_ID }]);
+      const incumbent = await seedMachine({
+        name: "Elvira (by the door)",
+        pbm: {
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          pinballmapListed: true,
+          pinballmapLmxId: 88_001,
+        },
+      });
+      const duplicate = await seedMachine({ name: "Elvira (back row)" });
+
+      // Two cabinets of one title is ordinary in a 100+ machine collection.
+      // `machines_pinballmap_listed_unique` allows only one LISTER, not one
+      // linked machine — so this must succeed quietly, not 23505 into a 500.
+      const outcome = await runSetMachinePinballmap(
+        { machine: duplicate.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+        ctx("admin", admin)
+      );
+
+      expect(outcome.result).toMatchObject({
+        pinballmap: {
+          status: "linked",
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          listed: false,
+          lmxId: null,
+        },
+      });
+      // The incumbent keeps the listing: an edit to one cabinet must never
+      // silently move another cabinet's public entry.
+      expect(await pbmRow(incumbent.id)).toMatchObject({
+        pinballmapListed: true,
+        pinballmapLmxId: 88_001,
+      });
+    });
+
+    it("denies a member who does not own the machine", async () => {
+      const member = await makeUser("member", "Not", "Owner");
+      await seedElviraCatalog();
+      const machine = await seedMachine({ name: "Elvira" });
+
+      await expect(
+        runSetMachinePinballmap(
+          { machine: machine.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+          ctx("member", member)
+        )
+      ).rejects.toMatchObject({ reason: "denied" });
+
+      // Denied means nothing was written, not "written and reported as denied".
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: null,
+      });
+    });
+
+    it("lets the machine's owner set its title", async () => {
+      const owner = await makeUser("member", "Pat", "Owner");
+      await seedElviraCatalog();
+      const machine = await seedMachine({ name: "Elvira", ownerId: owner });
+
+      await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+        ctx("member", owner)
+      );
+
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: ELVIRA_PREMIUM_ID,
+      });
+    });
+
+    it("refuses a call that states neither a title nor exclusion, instead of unlinking", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({
+        pbm: { pinballmapMachineId: ELVIRA_PREMIUM_ID, manufacturer: "Stern" },
+      });
+
+      await expect(
+        runSetMachinePinballmap(
+          { machine: machine.initials },
+          ctx("admin", admin)
+        )
+      ).rejects.toMatchObject({ reason: "invalid" });
+
+      // The resolver reads "neither" as "clear everything", which is right for a
+      // human emptying the picker and catastrophic for a forgotten argument.
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: ELVIRA_PREMIUM_ID,
+      });
+    });
+
+    it("refuses a call that is both linked and excluded", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine();
+
+      await expect(
+        runSetMachinePinballmap(
+          {
+            machine: machine.initials,
+            pinballmapMachineId: ELVIRA_PREMIUM_ID,
+            pinballmapExcluded: true,
+          },
+          ctx("admin", admin)
+        )
+      ).rejects.toMatchObject({ reason: "invalid" });
+    });
+
+    it("rejects a catalog id the mirror does not have", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine();
+
+      // The predictable mistake is passing a `machineGroupId` where a
+      // `pinballmapMachineId` belongs. A group id that matches no catalog row
+      // must fail rather than store a link to a title we cannot name.
+      await expect(
+        runSetMachinePinballmap(
+          { machine: machine.initials, pinballmapMachineId: ELVIRA_GROUP_ID },
+          ctx("admin", admin)
+        )
+      ).rejects.toMatchObject({ reason: "invalid" });
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapMachineId: null,
+      });
+    });
+
+    it("throws not_found when the machine is unknown", async () => {
+      const admin = await makeUser("admin");
+      await expect(
+        runSetMachinePinballmap(
+          { machine: "NOPE", pinballmapMachineId: 1 },
+          ctx("admin", admin)
+        )
+      ).rejects.toMatchObject({ reason: "not_found" });
+    });
+  });
+
   describe("resolveIssue / resolveAssignee (PP-u4ab.14)", () => {
     it("resolves an issue by machine initials and number", async () => {
       const admin = await makeUser("admin");
@@ -1523,6 +1907,7 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
       "set_machine_availability",
       "set_machine_name",
       "set_machine_owner",
+      "set_machine_pinballmap",
       "update_issue",
     ]);
   });

--- a/src/test/integration/mcp-tools.test.ts
+++ b/src/test/integration/mcp-tools.test.ts
@@ -1700,6 +1700,103 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
       expect(result).toMatchObject({ ok: false, reason: "not_found" });
     });
 
+    it("keeps a stored exclusion reason when the exclusion is re-confirmed without one", async () => {
+      // The fleet pass (PP-h059) re-confirms exclusions it did not author, and
+      // the natural call carries no reason. Writing `reason ?? null` there would
+      // erase someone else's note on every machine it walked past — the same
+      // "a forgotten argument must not destroy stored state" rule that stops a
+      // missing id from wiping a link (CORE-ARCH-012).
+      const admin = await makeUser("admin");
+      const machine = await seedMachine({
+        name: "Unicorn Magic",
+        pbm: {
+          pinballmapExcluded: true,
+          pinballmapExcludedReason: "homebrew — one-off cabinet",
+        },
+      });
+
+      await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapExcluded: true },
+        ctx("admin", admin)
+      );
+
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapExcluded: true,
+        pinballmapExcludedReason: "homebrew — one-off cabinet",
+      });
+    });
+
+    it("replaces a stored exclusion reason when the caller sends a new one", async () => {
+      // The carry-over is a floor, not a lock: a caller that states a reason
+      // still overwrites whatever was there.
+      const admin = await makeUser("admin");
+      const machine = await seedMachine({
+        name: "Border Town",
+        pbm: {
+          pinballmapExcluded: true,
+          pinballmapExcludedReason: "homebrew — one-off cabinet",
+        },
+      });
+
+      await runSetMachinePinballmap(
+        {
+          machine: machine.initials,
+          pinballmapExcluded: true,
+          pinballmapExcludedReason: "1940 pre-flipper, not a catalog title",
+        },
+        ctx("admin", admin)
+      );
+
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapExcluded: true,
+        pinballmapExcludedReason: "1940 pre-flipper, not a catalog title",
+      });
+    });
+
+    it("does not carry a reason onto a machine that was not already excluded", async () => {
+      // The carry-over reads the STORED exclusion, so a machine being excluded
+      // for the first time gets no reason invented for it — and a machine
+      // moving from excluded to LINKED keeps none either (the resolver clears
+      // the whole column set on that branch).
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({
+        name: "Hyperball",
+        pbm: {
+          pinballmapExcluded: true,
+          pinballmapExcludedReason: "rapid-fire hybrid, not a pinball title",
+        },
+      });
+
+      await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: ELVIRA_PREMIUM_ID },
+        ctx("admin", admin)
+      );
+
+      expect(await pbmRow(machine.id)).toMatchObject({
+        pinballmapExcluded: false,
+        pinballmapExcludedReason: null,
+        pinballmapMachineId: ELVIRA_PREMIUM_ID,
+      });
+    });
+
+    it("rejects an empty exclusion reason, which the edit form must accept", () => {
+      // Deliberate divergence, not drift: an emptied input is how a human
+      // clears a reason, but from a tool call "" is a field filled with
+      // nothing — and accepting it would make the carry-over hinge on whether
+      // the caller sent "" or nothing at all.
+      expect(
+        setMachinePinballmapSchema
+          .pick({ pinballmapExcludedReason: true })
+          .safeParse({ pinballmapExcludedReason: "   " }).success
+      ).toBe(false);
+      expect(
+        updateMachineSchema
+          .pick({ pinballmapExcludedReason: true })
+          .safeParse({ pinballmapExcludedReason: "" }).success
+      ).toBe(true);
+    });
+
     it("caps an exclusion reason exactly where the edit form caps it", () => {
       // Both schemas write `pinballmap_excluded_reason`, and the edit form
       // PREFILLS it. A reason accepted here but rejected there would render into

--- a/src/test/integration/mcp-tools.test.ts
+++ b/src/test/integration/mcp-tools.test.ts
@@ -69,7 +69,12 @@ import type { McpMachinePinballmap } from "~/lib/mcp/tools/pinballmap-block";
 import { runSetMachineAvailability } from "~/lib/mcp/tools/set-machine-availability";
 import { runSetMachineName } from "~/lib/mcp/tools/set-machine-name";
 import { runSetMachineOwner } from "~/lib/mcp/tools/set-machine-owner";
-import { runSetMachinePinballmap } from "~/lib/mcp/tools/set-machine-pinballmap";
+import {
+  runSetMachinePinballmap,
+  setMachinePinballmapSchema,
+} from "~/lib/mcp/tools/set-machine-pinballmap";
+import { updateMachineSchema } from "~/app/(app)/m/schemas";
+import { updateMachinePbmLink } from "~/services/machines";
 import { runUpdateIssue } from "~/lib/mcp/tools/update-issue";
 import {
   McpToolError,
@@ -1646,6 +1651,85 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
           ctx("admin", admin)
         )
       ).rejects.toMatchObject({ reason: "not_found" });
+    });
+
+    it("reports the state it actually replaced, read under the write's own lock", async () => {
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+      const machine = await seedMachine({
+        name: "Elvira",
+        pbm: {
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+          manufacturer: "Stern",
+          year: 2019,
+        },
+      });
+
+      const outcome = await runSetMachinePinballmap(
+        { machine: machine.initials, pinballmapMachineId: 70_013 },
+        ctx("admin", admin)
+      );
+
+      // `previousPinballmap` comes from the FOR UPDATE read inside the write,
+      // not from the resolve that ran before the permission check — so it names
+      // the state this call displaced even if something moved in between.
+      expect(outcome.result).toMatchObject({
+        previousPinballmap: {
+          status: "linked",
+          pinballmapMachineId: ELVIRA_PREMIUM_ID,
+        },
+        pinballmap: { status: "linked", pinballmapMachineId: 70_013 },
+      });
+    });
+
+    it("reports not_found, not a success payload, when the row is gone", async () => {
+      // Straight at the service: the tool's own `resolveMachine` would reject an
+      // unknown ref long before this guard, so the only way to exercise it is to
+      // hand the write a machineId that resolves to nothing. Without the guard
+      // this returned `ok` with the columns it MEANT to write — a confident
+      // wrong answer about a row that does not exist (CORE-ARCH-012).
+      const admin = await makeUser("admin");
+      await seedElviraCatalog();
+
+      const result = await updateMachinePbmLink({
+        machineId: randomUUID(),
+        actorUserId: admin,
+        selection: { pinballmapMachineId: ELVIRA_PREMIUM_ID },
+      });
+
+      expect(result).toMatchObject({ ok: false, reason: "not_found" });
+    });
+
+    it("caps an exclusion reason exactly where the edit form caps it", () => {
+      // Both schemas write `pinballmap_excluded_reason`, and the edit form
+      // PREFILLS it. A reason accepted here but rejected there would render into
+      // an input that fails validation on every later save from that page,
+      // wedging the picker behind text the user never typed. Asserted against
+      // the form's own schema so the two cannot drift apart silently.
+      const tooLong = { pinballmapExcludedReason: "x".repeat(201) };
+      const atLimit = { pinballmapExcludedReason: "x".repeat(200) };
+
+      expect(
+        setMachinePinballmapSchema
+          .pick({ pinballmapExcludedReason: true })
+          .safeParse(tooLong).success
+      ).toBe(false);
+      expect(
+        updateMachineSchema
+          .pick({ pinballmapExcludedReason: true })
+          .safeParse(tooLong).success
+      ).toBe(false);
+
+      expect(
+        setMachinePinballmapSchema
+          .pick({ pinballmapExcludedReason: true })
+          .safeParse(atLimit).success
+      ).toBe(true);
+      expect(
+        updateMachineSchema
+          .pick({ pinballmapExcludedReason: true })
+          .safeParse(atLimit).success
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
Closes PP-u4ab.12 — the write half of the walk-the-floor flow, and the last thing blocking the 110-machine fleet linking pass (PP-h059).

## What this adds

**`set_machine_pinballmap(machine, pinballmapMachineId | pinballmapExcluded + pinballmapExcludedReason)`** — resolve a machine by initials or UUID, gate on `machines.pinballmap.link`, record which Pinball Map catalog title it is (or that it isn't one). Manufacturer, year, OPDB id and IPDB id are re-derived from the catalog mirror for whichever id lands; there is no argument that can write them. The response echoes `McpMachinePinballmap` — the same block `get_machine` returns — plus `previousPinballmap`, so a fleet pass can see exactly what each call changed.

Argument names match `add_machine` (`pinballmapExcluded` / `pinballmapExcludedReason`) rather than the bead's shorter `excluded` / `reason`: one model drives both tools in a linking session, and two spellings of one concept is a trap.

## What was extracted

The PinballMap half of `updateMachineAction` now lives in `~/services/machines.ts` as one seam both callers use:

- `planMachinePbmLink` — the listing carry-over, the abandoned-listing detection, and the auto-link decision. No transaction, no writes.
- `applyMachinePbmLink` — the columns UPDATE plus the abandonment record, in the **caller's** transaction, so the pairing cannot be half-adopted.
- `captureMachineAutoLink` — post-commit, best-effort (moved out of the action verbatim).
- `updateMachinePbmLink` — composes all three for the MCP tool, and reads the row back so an auto-link that lands is reported as `listed: true` rather than as the plan's `false`.

Three functions rather than one because the two callers have genuinely different transaction shapes — the edit form saves the link alongside name/owner/presence/description and must keep that atomic, the tool changes the link and nothing else. Collapsing them into one `db.transaction` would either fork the seam or make a machine save two transactions, and a half-saved edit is the regression this bead was warned about.

## Regression surface: the machine edit page

The edit page keeps its single transaction. The one behaviour change is that the link columns now travel as their own UPDATE inside that transaction instead of being spread into the details statement. `machines_owner_not_guest` is the only trigger on the table and it fires only `OF owner_id, invited_owner_id`, and `machines.updatedAt` has no `$onUpdate`, so the extra statement is inert.

That change did surface one real bug, caught by the existing `pinballmap-retitle-abandonment` integration tests: a save that carries **only** PBM fields (the picker's own submit posts no `name`) left the details statement with an empty `.set()`, which Drizzle rejects. The details UPDATE is now skipped when nothing outside the PBM block changed, and the row is read instead so the `NOT_FOUND` check still runs. Net statement count for a PBM-only save is unchanged from before.

## Tests

12 new integration cases in `src/test/integration/mcp-tools.test.ts` (PGlite, CORE-TEST-001; catalog and lineup seeded locally, nothing reaches pinballmap.com):

- links an unlinked machine, metadata derived from the catalog
- re-targeting a LISTED machine clears `pinballmapListed`/`pinballmapLmxId` and records the abandoned entry
- re-sending the SAME id preserves both
- excluded branch clears the link and its metadata without tripping `machines_pinballmap_link_exclusive`
- auto-link captures a listing already on the synced lineup, and the echo reports it
- a duplicate cabinet links without disturbing the title's incumbent lister
- permission denial (non-owner member) writes nothing; the owner is allowed
- a call naming neither a title nor exclusion is refused instead of unlinking
- both-at-once is refused; an id the mirror doesn't have is refused; unknown machine is `not_found`

## Where the bead's design was stale

- **The 23505 "one lister per title" catch is gone and should stay gone.** `@Claude-PbmListUnlist` flagged this on #1810 and it holds: the listing write moved behind `captureAutoLink`, which matches by constraint name and stands down. The carry-over re-writes a value the row already holds, so it cannot collide with itself. Re-absorbing a collision branch here would be dead code.
- **The acceptance criterion "linking to a title another cabinet already lists returns a readable 'already listed by X' error" describes behaviour that would now be wrong.** Duplicate cabinets of one title are ordinary; only one *lister* is forbidden. The new machine links quietly and stays unlisted. The test asserts that instead.
- **Auto-link is included on the MCP path** — not called out either way in the bead. Excluding it would fork the seam (UI links capture the listing, MCP links don't) for no gain: it reads the stored PBM snapshot, never a caller's claim, so it does not reopen PP-o355.29.

## Follow-up worth considering

The tool cannot clear a link back to "nothing recorded", so an accidental `pinballmapExcluded: true` can only be undone from the web edit form. Deliberate — the resolver's "neither" branch is right for a human emptying the picker and dangerous for a forgotten argument — but a future `clear: true` opt-in would close it honestly.

## Verification

- `pnpm run check` — green
- `pnpm run test` — 2107 unit tests green
- `pnpm run test:integration` (crabbox) — 647 green, 57 files
- `pnpm run build` (crabbox) — green

No migrations, no new env vars, no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByHxCmTMweKpw9WphUnp3N
