### PR TITLE
feat(mcp): let list_machines filter on a set of presence values (PP-u4ab.13)

### DIFF
--- a/src/lib/mcp/tools/list-machines.ts
+++ b/src/lib/mcp/tools/list-machines.ts
@@ -6,6 +6,7 @@ import {
   count,
   eq,
   ilike,
+  inArray,
   isNotNull,
   isNull,
   or,
@@ -14,7 +15,10 @@ import {
 import { z } from "zod";
 
 import { checkPermission } from "~/lib/permissions/helpers";
-import { VALID_MACHINE_PRESENCE_STATUSES } from "~/lib/machines/presence";
+import {
+  VALID_MACHINE_PRESENCE_STATUSES,
+  type MachinePresenceStatus,
+} from "~/lib/machines/presence";
 import { db } from "~/server/db";
 import { machines } from "~/server/db/schema";
 
@@ -74,7 +78,39 @@ const PINBALLMAP_FILTER_CONDITIONS: Record<PinballmapFilter, [SQL, ...SQL[]]> =
     excluded: [eq(machines.pinballmapExcluded, true)],
   };
 
-const listMachinesSchema = z.object({
+/**
+ * `presence` takes a SET, not a single value (PP-u4ab.13).
+ *
+ * A single value cannot express the question the fleet linking pass (PP-h059)
+ * actually runs on: "unlinked AND still plausibly in the collection". Without
+ * it, `pinballmap: "unlinked"` also returns the cabinets that are `removed` or
+ * `pending_arrival` — rows nobody will ever link, which therefore sit in every
+ * page of that filter forever and hold `total` above zero permanently. The
+ * model was left to notice and skip them by hand on each page.
+ *
+ * The single-value form is kept, not deprecated: it is what every existing
+ * caller sends, and `presence: "off_the_floor"` stays the natural way to ask a
+ * one-state question.
+ *
+ * `.min(1)` on the array is deliberate. An empty set would type-check, produce
+ * `inArray(col, [])` — a predicate matching nothing — and hand back
+ * `total: 0` for the whole collection, which reads as an authoritative "there
+ * are none" rather than as the malformed filter it is (CORE-ARCH-012). Zod
+ * rejects it instead.
+ */
+const presenceFilterSchema = z.union([
+  z.enum(VALID_MACHINE_PRESENCE_STATUSES),
+  z.array(z.enum(VALID_MACHINE_PRESENCE_STATUSES)).min(1),
+]);
+
+type PresenceFilter = z.infer<typeof presenceFilterSchema>;
+
+function resolvePresence(filter: PresenceFilter): MachinePresenceStatus[] {
+  return Array.isArray(filter) ? filter : [filter];
+}
+
+/** Exported for the schema-level tests; the tool registers this same object. */
+export const listMachinesSchema = z.object({
   search: z
     .string()
     .trim()
@@ -83,10 +119,11 @@ const listMachinesSchema = z.object({
     .describe(
       "Filter by machine name or initials (case-insensitive substring)."
     ),
-  presence: z
-    .enum(VALID_MACHINE_PRESENCE_STATUSES)
+  presence: presenceFilterSchema
     .optional()
-    .describe("Only machines with this availability status."),
+    .describe(
+      "Which availability statuses to include: one status, or an array of them. The statuses are on_the_floor, off_the_floor, on_loan, pending_arrival, removed. A cabinet in any of the first three is still plausibly in the collection; removed is gone and pending_arrival has not arrived yet."
+    ),
   pinballmap: z
     .enum(PINBALLMAP_FILTERS)
     .optional()
@@ -123,8 +160,13 @@ export async function runListMachines(
   }
 
   const conditions = [];
-  if (args.presence) {
-    conditions.push(eq(machines.presenceStatus, args.presence));
+  if (args.presence !== undefined) {
+    // `inArray` for both forms — the single value is normalised to a one-element
+    // set rather than kept on a separate `eq` path, so there is one condition to
+    // keep in step with the count query instead of two (PP-u4ab.13).
+    conditions.push(
+      inArray(machines.presenceStatus, resolvePresence(args.presence))
+    );
   }
   if (args.search) {
     const like = `%${args.search}%`;
@@ -232,7 +274,7 @@ export function registerListMachines(server: McpServer): void {
     {
       title: "List machines",
       description:
-        "List machines with their initials, name, availability, owner name, and open-issue count. Use this to find a machine's initials before acting on it (e.g. disambiguate 'the Medieval Madness by the door'). Supports a name/initials search, a presence filter, and a PinballMap link-state filter (pinballmap: 'unlinked' | 'linked' | 'excluded') — use pinballmap: 'unlinked' to get the machines still needing a PinballMap catalog match. Returns 'count' (this page), 'total' (every match), 'offset', and 'hasMore'. Answer counting questions from 'total', never from 'count' or the array length. To enumerate a collection larger than one page, keep requesting with offset += limit until hasMore is false — raising limit alone caps at 100 and will not reach the rest. That works only while the matching set holds still, and your own calls can move it: set_machine_availability changes presence, set_machine_name changes name (the search target and the sort key), add_machine adds rows. So if you are ACTING on the machines as you page them — 'put every off-the-floor machine back on the floor' — do NOT advance the offset. Each machine you fix leaves the filter and the rest shift up, so offset += limit steps over exactly as many machines as you just fixed, and the sweep ends on hasMore:false having never shown them. Re-request offset 0 and let the list drain instead. Raise offset only past machines you deliberately left unchanged, so they don't keep coming back. You are done when a request returns EMPTY (count 0), NOT when total reaches 0 — machines you left unchanged hold total above 0 forever.",
+        "List machines with their initials, name, availability, owner name, and open-issue count. Use this to find a machine's initials before acting on it (e.g. disambiguate 'the Medieval Madness by the door'). Supports a name/initials search, a presence filter (one status, or an array of them to accept several at once), and a PinballMap link-state filter (pinballmap: 'unlinked' | 'linked' | 'excluded') — use pinballmap: 'unlinked' to get the machines still needing a PinballMap catalog match. For that linking pass, ask for pinballmap: 'unlinked' TOGETHER WITH presence: ['on_the_floor', 'on_loan', 'off_the_floor'], which is the actionable worklist. 'unlinked' on its own also returns cabinets that are 'removed' (no longer in the collection) or 'pending_arrival' (not here yet) — nobody will ever link those, so they come back on every page of every sweep and you would have to recognise and skip them by hand each time. Narrowing presence drops them from 'total' as well as from the page, so 'total' is the size of the work actually left. Returns 'count' (this page), 'total' (every match), 'offset', and 'hasMore'. Answer counting questions from 'total', never from 'count' or the array length. To enumerate a collection larger than one page, keep requesting with offset += limit until hasMore is false — raising limit alone caps at 100 and will not reach the rest. That works only while the matching set holds still, and your own calls can move it: set_machine_availability changes presence, set_machine_name changes name (the search target and the sort key), add_machine adds rows. So if you are ACTING on the machines as you page them — 'put every off-the-floor machine back on the floor' — do NOT advance the offset. Each machine you fix leaves the filter and the rest shift up, so offset += limit steps over exactly as many machines as you just fixed, and the sweep ends on hasMore:false having never shown them. Re-request offset 0 and let the list drain instead. Raise offset only past machines you deliberately left unchanged, so they don't keep coming back. You are done when a request returns EMPTY (count 0), NOT when total reaches 0 — machines you left unchanged hold total above 0 forever. Narrowing the filter so it matches only rows you can actually act on, as the presence set above does, is what lets total fall to 0 at all.",
       inputSchema: listMachinesSchema.shape,
     },
     (args, extra) =>

--- a/src/test/integration/mcp-tools.test.ts
+++ b/src/test/integration/mcp-tools.test.ts
@@ -26,6 +26,10 @@ import {
   userProfiles,
 } from "~/server/db/schema";
 import { docToPlainText } from "~/lib/tiptap/types";
+import {
+  VALID_MACHINE_PRESENCE_STATUSES,
+  type MachinePresenceStatus,
+} from "~/lib/machines/presence";
 import { getTestDb, setupTestDb } from "~/test/setup/pglite";
 import type * as NotificationsModule from "~/lib/notifications";
 import type { McpAuthContext } from "~/lib/mcp/verify-token";
@@ -57,7 +61,10 @@ import { runGetIssue } from "~/lib/mcp/tools/get-issue";
 import { runGetMachine } from "~/lib/mcp/tools/get-machine";
 import { registerPinpointTools } from "~/lib/mcp/tools";
 import { runListIssues } from "~/lib/mcp/tools/list-issues";
-import { runListMachines } from "~/lib/mcp/tools/list-machines";
+import {
+  listMachinesSchema,
+  runListMachines,
+} from "~/lib/mcp/tools/list-machines";
 import { runSearchPinballmapCatalog } from "~/lib/mcp/tools/search-pinballmap-catalog";
 import type {
   McpCatalogEditionResult,
@@ -125,7 +132,7 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
   async function seedMachine(overrides?: {
     name?: string;
     ownerId?: string | null;
-    presenceStatus?: "on_the_floor" | "off_the_floor";
+    presenceStatus?: MachinePresenceStatus;
     pbm?: SeedPbm;
   }): Promise<{ id: string; initials: string }> {
     const db = await getTestDb();
@@ -517,6 +524,198 @@ describe("MCP tool handlers (PP-u4ab.2)", () => {
         // only stable within a single query — not across the separate queries
         // paging actually issues — shows up here as a duplicate plus a miss.
         expect(seen).toEqual(expected);
+      });
+    });
+
+    describe("presence set filter (PP-u4ab.13)", () => {
+      interface PresencePage {
+        count: number;
+        total: number;
+        hasMore: boolean;
+        machines: { initials: string; presence: string }[];
+      }
+
+      async function list(
+        args: Parameters<typeof runListMachines>[0],
+        admin: string
+      ): Promise<PresencePage> {
+        const outcome = await runListMachines(args, ctx("admin", admin));
+        return outcome.result as PresencePage;
+      }
+
+      /**
+       * One cabinet in each presence state, all sharing a name so `search`
+       * isolates them from the rest of the worker-scoped database.
+       *
+       * The `Record<MachinePresenceStatus, …>` return annotation is what keeps
+       * this exhaustive: adding a sixth presence state fails to compile here
+       * rather than quietly leaving it unseeded and untested.
+       */
+      async function seedOnePerState(
+        name: string
+      ): Promise<Record<MachinePresenceStatus, string>> {
+        const seed = async (
+          presenceStatus: MachinePresenceStatus
+        ): Promise<string> =>
+          (await seedMachine({ name, presenceStatus })).initials;
+        return {
+          on_the_floor: await seed("on_the_floor"),
+          off_the_floor: await seed("off_the_floor"),
+          on_loan: await seed("on_loan"),
+          pending_arrival: await seed("pending_arrival"),
+          removed: await seed("removed"),
+        };
+      }
+
+      it("still accepts a single presence value", async () => {
+        const admin = await makeUser("admin");
+        const byState = await seedOnePerState("Single Presence");
+
+        const result = await list(
+          { search: "Single Presence", presence: "off_the_floor" },
+          admin
+        );
+
+        // The pre-PP-u4ab.13 call shape. Every existing caller sends this, so
+        // widening the parameter must not change what it means.
+        expect(result.machines.map((m) => m.initials)).toEqual([
+          byState.off_the_floor,
+        ]);
+        expect(result.total).toBe(1);
+      });
+
+      it("accepts a set and returns exactly the listed states", async () => {
+        const admin = await makeUser("admin");
+        const byState = await seedOnePerState("Set Presence");
+
+        const result = await list(
+          {
+            search: "Set Presence",
+            presence: ["on_the_floor", "on_loan", "off_the_floor"],
+          },
+          admin
+        );
+
+        // Set equality on the states, not just the row count: an OR that leaked
+        // an unlisted state in while dropping a listed one returns the same
+        // number of rows and would pass a length assertion.
+        expect(new Set(result.machines.map((m) => m.presence))).toEqual(
+          new Set(["on_the_floor", "on_loan", "off_the_floor"])
+        );
+        expect(result.machines.map((m) => m.initials).sort()).toEqual(
+          [byState.on_the_floor, byState.on_loan, byState.off_the_floor].sort()
+        );
+        expect(result.total).toBe(3);
+        expect(result.hasMore).toBe(false);
+      });
+
+      it("narrows the unlinked worklist to cabinets that are still around", async () => {
+        const admin = await makeUser("admin");
+        const db = await getTestDb();
+        const byState = await seedOnePerState("Worklist");
+        // A linked cabinet on the floor: in the presence set, out of the
+        // worklist. Without it the presence filter alone would produce the same
+        // answer as the two filters together.
+        const linked = await seedMachine({
+          name: "Worklist",
+          presenceStatus: "on_the_floor",
+        });
+        await db
+          .update(machines)
+          .set({ pinballmapMachineId: 910_001 })
+          .where(eq(machines.id, linked.id));
+
+        const wide = await list(
+          { search: "Worklist", pinballmap: "unlinked" },
+          admin
+        );
+        const narrowed = await list(
+          {
+            search: "Worklist",
+            pinballmap: "unlinked",
+            presence: ["on_the_floor", "on_loan", "off_the_floor"],
+          },
+          admin
+        );
+
+        // This is the bead: 'unlinked' alone keeps handing back the cabinets
+        // nobody will ever link, so they sit in every page of every sweep and
+        // hold `total` above zero permanently.
+        expect(wide.total).toBe(VALID_MACHINE_PRESENCE_STATUSES.length);
+        expect(wide.machines.map((m) => m.presence)).toContain("removed");
+        expect(wide.machines.map((m) => m.presence)).toContain(
+          "pending_arrival"
+        );
+
+        expect(narrowed.machines.map((m) => m.initials).sort()).toEqual(
+          [byState.on_the_floor, byState.on_loan, byState.off_the_floor].sort()
+        );
+        expect(narrowed.total).toBe(3);
+      });
+
+      it("counts the same set the page returns while paging a set filter", async () => {
+        const admin = await makeUser("admin");
+        const db = await getTestDb();
+
+        const rows: (typeof machines.$inferInsert)[] = [];
+        const expected: string[] = [];
+        const wanted: MachinePresenceStatus[] = [
+          "on_the_floor",
+          "on_loan",
+          "off_the_floor",
+        ];
+        for (let i = 0; i < 60; i += 1) {
+          const initials = nextInitials();
+          const presenceStatus =
+            VALID_MACHINE_PRESENCE_STATUSES[
+              i % VALID_MACHINE_PRESENCE_STATUSES.length
+            ];
+          if (presenceStatus === undefined) throw new Error("no state");
+          // Four cabinets per title, so page boundaries land inside tie groups.
+          const name = `Presence Fleet ${String(Math.floor(i / 4)).padStart(2, "0")}`;
+          rows.push({ name, initials, presenceStatus });
+          if (wanted.includes(presenceStatus)) expected.push(initials);
+        }
+        await db.insert(machines).values([...rows].reverse());
+
+        const seen: string[] = [];
+        const limit = 7;
+        let offset = 0;
+        let total = -1;
+        // Bounded: a `hasMore` that never clears is one of the failures this
+        // guards, and an unbounded loop would hang the suite instead.
+        for (let page = 0; page < 12; page += 1) {
+          const result = await list(
+            { search: "Presence Fleet", presence: wanted, limit, offset },
+            admin
+          );
+          total = result.total;
+          seen.push(...result.machines.map((m) => m.initials));
+          if (!result.hasMore) break;
+          offset += limit;
+        }
+
+        // The condition is pushed onto the shared array, so the count query and
+        // the page query see the same WHERE. A `total` the page can never reach
+        // is a sweep that never terminates (CORE-ARCH-012).
+        expect(total).toBe(expected.length);
+        expect(new Set(seen).size).toBe(seen.length);
+        expect([...seen].sort()).toEqual([...expected].sort());
+      });
+
+      it("rejects an empty presence set rather than matching nothing", () => {
+        // An empty array would type-check and produce `inArray(col, [])` — a
+        // predicate matching no row — so the tool would answer `total: 0` for
+        // the whole collection as if that were the truth (CORE-ARCH-012).
+        expect(listMachinesSchema.safeParse({ presence: [] }).success).toBe(
+          false
+        );
+        expect(
+          listMachinesSchema.safeParse({ presence: ["removed"] }).success
+        ).toBe(true);
+        expect(
+          listMachinesSchema.safeParse({ presence: "removed" }).success
+        ).toBe(true);
       });
     });
   });


### PR DESCRIPTION
## What

`list_machines` took `presence` as a **single** value. That made one question unaskable — the exact question the PinballMap fleet linking pass (PP-h059) runs on:

> which machines still have no catalog match **and** are still plausibly in the collection?

`pinballmap: "unlinked"` on its own also returns the cabinets that are `removed` or `pending_arrival`. Nobody will ever link those, so they come back on every page of every sweep and hold `total` above zero permanently. On prod today that is **14 of the 110 unlinked machines** (10 `removed`, 4 other non-floor states) — 13% of the worklist is rows the model has to recognise and skip by hand, every page, every time.

`presence` now accepts **one status or an array of them**:

```jsonc
{ "presence": "off_the_floor" }                                     // unchanged
{ "presence": ["on_the_floor", "on_loan", "off_the_floor"] }        // new
```

## The parameter shape

A `z.union([z.enum(...), z.array(z.enum(...)).min(1)])`, mirroring the `statusFilterSchema` that `list_issues` already ships — which cites this bead by name as its reason for shipping the set form first rather than second.

Both forms normalise through `resolvePresence()` to a single `inArray(...)` condition. Not an `eq` path plus an `inArray` path: one condition is one thing to keep in step with the count query.

`.min(1)` rejects an empty array. An empty set would type-check, produce `inArray(col, [])` — a predicate matching no row — and hand back `total: 0` for the whole collection, which reads as an authoritative "there are none" rather than as the malformed filter it is (CORE-ARCH-012).

## Page and count share the condition

The `inArray` joins the **same** `conditions` array the tool already builds. `const where = and(...conditions)` is computed once and passed to both `db.query.machines.findMany` and the `count()` select, so they cannot diverge. That matters because the tool's own description tells the model to answer counting questions from `total`, never from `count`.

Verified by mutation in both directions, against the new tests:

| Mutation | Result |
| --- | --- |
| Count query drops the presence condition (`conditions.slice(1)`) | 4 tests fail — `expected 5 to be 1`, `expected 60 to be 36` |
| Page query drops it instead | the same 4 fail, on the row sets |

Both reverted; the diff contains neither.

## Description text

The tool description now recommends the narrowed worklist directly rather than relying on the model to notice un-actionable rows itself: ask for `pinballmap: "unlinked"` **together with** `presence: ["on_the_floor", "on_loan", "off_the_floor"]`, because narrowing presence drops those cabinets from `total` as well as from the page.

The existing paging/drain guidance is unchanged and now closes the loop — "you are done when a request returns EMPTY, not when total reaches 0" gains a sentence saying that narrowing the filter to rows you can actually act on is what lets `total` fall to 0 at all.

## Tests

Five cases added to `src/test/integration/mcp-tools.test.ts` (class I — DB query correctness — so integration/PGlite, alongside the PP-u4ab.9 link-state cases):

- the single-value form still means what it meant
- the array form returns exactly the listed states (set equality on the states, not a row count — an OR that leaked one state in while dropping another returns the same number of rows)
- `unlinked` alone vs `unlinked` + the presence set, with a linked on-the-floor cabinet present so the two filters can't produce the same answer by accident
- a 60-machine fleet paged at `limit: 7` with the set filter: `total` equals the matching set, no repeats, no gaps
- an empty presence array is rejected by the schema

The per-state seed helper is annotated `Record<MachinePresenceStatus, string>`, so adding a sixth presence state fails to compile here rather than quietly going unseeded.

## Scope

**MCP only.** `src/components/machines/MachineFilters.tsx` already has a multi-select presence filter defaulting to `["on_the_floor"]`; this is the tool catching up to the UI. No migration, no registration change, no service change. Read-only query change, so `pnpm run check` + `pnpm run test` per AGENTS.md §5, plus the full integration suite on the remote runner (640 passed).

Closes PP-u4ab.13.
