### PR TITLE
fix(hooks): stop normalize-workspace-paths corrupting remote /var/home paths (PP-xbfn)

### DIFF
--- a/.claude/hooks/normalize-workspace-paths.cjs
+++ b/.claude/hooks/normalize-workspace-paths.cjs
@@ -12,34 +12,88 @@
  * match, causing unnecessary permission prompts. This hook auto-fixes the
  * command and tells the agent to use relative paths next time.
  *
- * The prefixes it matches are derived from THIS machine's repo root, not
- * hardcoded. Three rules keep the rewrite from changing what a command means
- * (all three learned from PP-xbfn):
+ * ---------------------------------------------------------------------------
+ * What makes this hook dangerous, and the four guards that hold it back
+ * ---------------------------------------------------------------------------
  *
- * 1. **Only this machine's repo root.** The matcher used to hardcode
- *    `/home/froeht/Code/PinPoint`, which on the Mac names no local directory at
- *    all — it is Bazzite's path. So the hook rewrote paths that were meant for
- *    the *remote* box. A crabbox invocation carrying
- *    `CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/...`
- *    is a remote path; relativizing it is wrong however it is spelled. Matching
- *    only the local root leaves it alone.
+ * An absolute path and a root-relative one only mean the same thing when the
+ * command runs from the root, on this machine. Every guard below exists because
+ * some case broke that assumption, and a broken rewrite is invisible: the
+ * transcript records what the agent wrote, not what ran (PP-xbfn).
  *
- * 2. **Match at a path boundary.** Bazzite's home is `/var/home/froeht` and
+ * 1. **Only prefixes that name THIS machine's repo root.** The matcher used to
+ *    hardcode `/home/froeht/Code/PinPoint`, which on the Mac names no local
+ *    directory at all — it is Bazzite's path. So the hook rewrote paths meant
+ *    for the *remote* box, e.g. a crabbox invocation carrying
+ *    `CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/...`.
+ *
+ * 2. **Only at a path boundary.** Bazzite's home is `/var/home/froeht` and
  *    `/home` is a symlink to it, so an unanchored matcher found
  *    `/home/froeht/Code/PinPoint/` in the MIDDLE of a `/var/home/...` path and
- *    stripped it, leaving the orphaned `/var` glued to the tail:
- *    `/var.claude/worktrees`. crabbox then died on
- *    `mkdir: cannot create directory '/var.claude'`. The transcript records the
- *    command the agent wrote — the rewrite happens after — so the corruption is
- *    invisible until something downstream fails.
+ *    stripped it, leaving `/var` glued to the tail: `/var.claude/worktrees`.
+ *    crabbox died on `mkdir: cannot create directory '/var.claude'`.
  *
- * 3. **Only when cwd IS the repo root.** A root-relative path is only equivalent
- *    to the absolute one when the command runs from the root. From a
- *    subdirectory the rewrite would silently retarget the file.
+ * 3. **Only when cwd IS the repo root**, and only for commands that keep it
+ *    that way. `cd /tmp && bash <root>/scripts/x.sh` would otherwise become
+ *    `cd /tmp && bash scripts/x.sh`, i.e. `/tmp/scripts/x.sh`.
+ *
+ * 4. **Never for a command that hands the text to another machine or
+ *    namespace.** `ssh bazzite 'ls <root>/scripts'` names the *remote* root,
+ *    which on Bazzite is spelled exactly like the local one — guard 1 cannot
+ *    tell them apart, so the whole command is skipped instead.
+ *
+ * Guards 3 and 4 are deliberately blunt: skipping a rewrite that would have been
+ * fine costs one permission prompt, while making a wrong one costs a silently
+ * mis-targeted command. Bias every judgement call toward skipping.
  */
 
 const fs = require("fs");
 const path = require("path");
+
+/**
+ * Command words that make a rewrite unsafe, because after them the path is no
+ * longer interpreted from this cwd on this machine.
+ *
+ * - directory changes: the relative path would resolve somewhere else
+ * - remote/namespace execution: the path names a filesystem we are not on
+ */
+const CONTEXT_SHIFTING_WORDS = [
+  // changes cwd
+  "cd",
+  "pushd",
+  "popd",
+  "chdir",
+  // hands the command to another host or namespace
+  "ssh",
+  "scp",
+  "sftp",
+  "rsync",
+  "crabbox",
+  "docker",
+  "podman",
+  "kubectl",
+  "nsenter",
+  "chroot",
+];
+
+// A context-shifting word in command position: start of string, or after a
+// separator (`;`, `&&`, `||`, `|`, a subshell paren, or a newline).
+const CONTEXT_SHIFT_REGEX = new RegExp(
+  String.raw`(?:^|[\n;&|(])\s*(?:${CONTEXT_SHIFTING_WORDS.join("|")})\b`
+);
+
+// `-C <dir>` — git, make and tar all use it to run somewhere else.
+const CHDIR_FLAG_REGEX = /(?:^|\s)-C(?:\s|=)/;
+
+/**
+ * True when the command changes where a relative path would resolve.
+ *
+ * @param {string} command
+ * @returns {boolean}
+ */
+function shiftsContext(command) {
+  return CONTEXT_SHIFT_REGEX.test(command) || CHDIR_FLAG_REGEX.test(command);
+}
 
 /** Escape a literal string for embedding in a RegExp. */
 function escapeRegExp(literal) {
@@ -47,16 +101,41 @@ function escapeRegExp(literal) {
 }
 
 /**
+ * True when two paths name the same directory on this machine.
+ *
+ * Compares resolved symlinks, not just lexical form: on Bazzite the repo root
+ * has two spellings (`/home/...` and `/var/home/...`), and on macOS `/tmp` and
+ * `/private/tmp` are the same place.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @param {(p: string) => string} [realpath]
+ */
+function samePath(a, b, realpath = fs.realpathSync) {
+  if (path.resolve(a) === path.resolve(b)) return true;
+  try {
+    return realpath(a) === realpath(b);
+  } catch {
+    // One of them does not exist — they are not the same directory.
+    return false;
+  }
+}
+
+/**
  * The absolute prefixes that name `repoRoot` on this machine.
  *
- * Includes the symlinked spelling, so a Bazzite agent that types the
- * `/home/froeht/...` form still gets the rewrite even though git reports the
- * canonical `/var/home/froeht/...`.
+ * The `/home` <-> `/var/home` sibling is offered only when both spellings
+ * actually resolve to the same directory. On Bazzite (Fedora Atomic) they do,
+ * so an agent that types either form gets the rewrite. On any other Linux with
+ * the repo at `/home/...`, `/var/home/...` is a different — usually
+ * nonexistent — directory, and synthesizing it unchecked would reintroduce the
+ * original bug in mirror image.
  *
  * @param {string} repoRoot
+ * @param {(p: string) => string} [realpath]
  * @returns {string[]} deduped, longest first
  */
-function workspacePrefixes(repoRoot) {
+function workspacePrefixes(repoRoot, realpath = fs.realpathSync) {
   const roots = new Set();
 
   const add = (p) => {
@@ -66,15 +145,17 @@ function workspacePrefixes(repoRoot) {
 
   add(repoRoot);
   try {
-    add(fs.realpathSync(repoRoot));
+    add(realpath(repoRoot));
   } catch {
     // Root does not resolve — the literal spelling is all we have.
   }
 
-  // /home <-> /var/home are the same directory on Bazzite (Fedora Atomic).
   for (const root of [...roots]) {
-    if (root.startsWith("/var/home/")) add(root.slice("/var".length));
-    else if (root.startsWith("/home/")) add(`/var${root}`);
+    let sibling = null;
+    if (root.startsWith("/var/home/")) sibling = root.slice("/var".length);
+    else if (root.startsWith("/home/")) sibling = `/var${root}`;
+
+    if (sibling && samePath(sibling, root, realpath)) add(sibling);
   }
 
   return [...roots].sort((a, b) => b.length - a.length);
@@ -85,7 +166,7 @@ function workspacePrefixes(repoRoot) {
  *
  * `(?<![\w./@{}~-])` requires the match to START a path: the character before
  * it must not be one that could continue a path. That is what stops a prefix
- * from matching inside a longer, unrelated path.
+ * from matching inside a longer, unrelated path (guard 2).
  */
 function buildRegex(prefixes) {
   const alternation = prefixes.map(escapeRegExp).join("|");
@@ -97,17 +178,26 @@ function buildRegex(prefixes) {
 
 /**
  * Rewrite absolute workspace paths in `command` to paths relative to
- * `repoRoot`, but only where the target actually exists under `repoRoot`.
+ * `repoRoot`, but only where the target exists under `repoRoot` and the
+ * command does not move the ground out from under a relative path.
  *
- * Pure apart from the injected `exists` probe, so it is unit-testable.
+ * Pure apart from the injected probes, so it is unit-testable.
  *
  * @param {string} command
  * @param {string} repoRoot
- * @param {(p: string) => boolean} [exists]
+ * @param {{ exists?: (p: string) => boolean, realpath?: (p: string) => string }} [probes]
  * @returns {{ modified: string, rewrites: string[] }}
  */
-function normalizeCommand(command, repoRoot, exists = fs.existsSync) {
-  const prefixes = workspacePrefixes(repoRoot);
+function normalizeCommand(command, repoRoot, probes = {}) {
+  const { exists = fs.existsSync, realpath = fs.realpathSync } = probes;
+
+  // Guards 3 and 4: after a `cd` or an `ssh`, a relative path means something
+  // else. Leave the whole command alone rather than guess at its scope.
+  if (shiftsContext(command)) {
+    return { modified: command, rewrites: [] };
+  }
+
+  const prefixes = workspacePrefixes(repoRoot, realpath);
   if (prefixes.length === 0) {
     return { modified: command, rewrites: [] };
   }
@@ -166,9 +256,11 @@ async function main() {
     // Not in a git repo — fall back to cwd
   }
 
-  // A root-relative path only means the same thing as the absolute one when the
-  // command runs from the root. From a subdirectory, stay out of the way.
-  if (path.resolve(agentCwd) !== path.resolve(repoRoot)) {
+  // Guard 3: a root-relative path only means the same thing as the absolute one
+  // when the command starts at the root. From a subdirectory, stay out of the
+  // way. Compared through symlinks, since git and the agent can spell the same
+  // directory differently.
+  if (!samePath(agentCwd, repoRoot)) {
     process.exit(0);
   }
 
@@ -196,7 +288,12 @@ async function main() {
   process.exit(0);
 }
 
-module.exports = { normalizeCommand, workspacePrefixes };
+module.exports = {
+  normalizeCommand,
+  workspacePrefixes,
+  shiftsContext,
+  samePath,
+};
 
 if (require.main === module) {
   main().catch((err) => {

--- a/.claude/hooks/normalize-workspace-paths.cjs
+++ b/.claude/hooks/normalize-workspace-paths.cjs
@@ -42,6 +42,11 @@
  *    which on Bazzite is spelled exactly like the local one — guard 1 cannot
  *    tell them apart, so the whole command is skipped instead.
  *
+ * 5. **Never auto-allow.** The hook rewrites and then gets out of the way; the
+ *    rewritten command still goes through normal permission evaluation. Sending
+ *    `permissionDecision: "allow"` turned `rm -rf <root>/src/app` into an
+ *    auto-approved `rm -rf src/app`, skipping the `permissions.ask` prompt.
+ *
  * Guards 3 and 4 are deliberately blunt: skipping a rewrite that would have been
  * fine costs one permission prompt, while making a wrong one costs a silently
  * mis-targeted command. Bias every judgement call toward skipping.
@@ -76,10 +81,18 @@ const CONTEXT_SHIFTING_WORDS = [
   "chroot",
 ];
 
-// A context-shifting word in command position: start of string, or after a
-// separator (`;`, `&&`, `||`, `|`, a subshell paren, or a newline).
+// Matched as a whole word ANYWHERE in the command, not just in command
+// position. Command position is not detectable by regex: a leading
+// `VAR=value`, a wrapper (`sudo`, `env`, `time`, `xargs`, `nohup`), a quoted
+// `-c` payload, or a `do`/`then` keyword all put the word somewhere an
+// anchored pattern cannot see — and the first of those is the PR's own
+// motivating command, `CRABBOX_STATIC_WORK_ROOT=… crabbox …`.
+//
+// The cost is false positives: `cat docker-compose.yml` and `echo "cd there"`
+// both suppress the rewrite. That is one permission prompt, which is the
+// cheaper error — see the header.
 const CONTEXT_SHIFT_REGEX = new RegExp(
-  String.raw`(?:^|[\n;&|(])\s*(?:${CONTEXT_SHIFTING_WORDS.join("|")})\b`
+  String.raw`\b(?:${CONTEXT_SHIFTING_WORDS.join("|")})\b`
 );
 
 // `-C <dir>` — git, make and tar all use it to run somewhere else.
@@ -272,10 +285,23 @@ async function main() {
       rewrites.join("\n") +
       "\nUse relative paths from the start — they match the settings.json allowlist.";
 
+    // No `permissionDecision`. The hook rewrites the command and then gets out
+    // of the way, so the rewritten command goes through normal permission
+    // evaluation.
+    //
+    // It used to send `"allow"`, which short-circuits that evaluation. Harmless
+    // while the matcher hardcoded a path that names nothing on the Mac — the
+    // hook never fired here — but fixing the matcher made it reachable, and
+    // `rm -rf <root>/src/app` came back as an auto-allowed `rm -rf src/app`
+    // even though `Bash(rm -rf:*)` is on `permissions.ask`. Same for
+    // `git reset --hard`, `git clean`, `git branch -D`, `docker volume rm`.
+    //
+    // Auto-allow was never needed for the hook's purpose: the point is that the
+    // REWRITTEN path matches the allowlist, and the allowlist grants that by
+    // itself.
     const decision = {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        permissionDecision: "allow",
         permissionDecisionReason: reason,
         updatedInput: { ...input.tool_input, command: modified },
       },

--- a/.claude/hooks/normalize-workspace-paths.cjs
+++ b/.claude/hooks/normalize-workspace-paths.cjs
@@ -3,7 +3,7 @@
  * PreToolUse hook: Rewrites unnecessary absolute workspace paths to relative.
  *
  * When an agent in a worktree runs a command with an absolute path like:
- *   bash /home/.../PinPoint/scripts/workflow/merge-pr.sh 1039 ...
+ *   bash /var/home/froeht/Code/PinPoint/scripts/workflow/merge-pr.sh 1039 ...
  *
  * This hook rewrites it to:
  *   bash scripts/workflow/merge-pr.sh 1039 ...
@@ -11,10 +11,122 @@
  * Why: The settings.json allowlist uses relative paths. Absolute paths don't
  * match, causing unnecessary permission prompts. This hook auto-fixes the
  * command and tells the agent to use relative paths next time.
+ *
+ * The prefixes it matches are derived from THIS machine's repo root, not
+ * hardcoded. Three rules keep the rewrite from changing what a command means
+ * (all three learned from PP-xbfn):
+ *
+ * 1. **Only this machine's repo root.** The matcher used to hardcode
+ *    `/home/froeht/Code/PinPoint`, which on the Mac names no local directory at
+ *    all — it is Bazzite's path. So the hook rewrote paths that were meant for
+ *    the *remote* box. A crabbox invocation carrying
+ *    `CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/...`
+ *    is a remote path; relativizing it is wrong however it is spelled. Matching
+ *    only the local root leaves it alone.
+ *
+ * 2. **Match at a path boundary.** Bazzite's home is `/var/home/froeht` and
+ *    `/home` is a symlink to it, so an unanchored matcher found
+ *    `/home/froeht/Code/PinPoint/` in the MIDDLE of a `/var/home/...` path and
+ *    stripped it, leaving the orphaned `/var` glued to the tail:
+ *    `/var.claude/worktrees`. crabbox then died on
+ *    `mkdir: cannot create directory '/var.claude'`. The transcript records the
+ *    command the agent wrote — the rewrite happens after — so the corruption is
+ *    invisible until something downstream fails.
+ *
+ * 3. **Only when cwd IS the repo root.** A root-relative path is only equivalent
+ *    to the absolute one when the command runs from the root. From a
+ *    subdirectory the rewrite would silently retarget the file.
  */
 
 const fs = require("fs");
 const path = require("path");
+
+/** Escape a literal string for embedding in a RegExp. */
+function escapeRegExp(literal) {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The absolute prefixes that name `repoRoot` on this machine.
+ *
+ * Includes the symlinked spelling, so a Bazzite agent that types the
+ * `/home/froeht/...` form still gets the rewrite even though git reports the
+ * canonical `/var/home/froeht/...`.
+ *
+ * @param {string} repoRoot
+ * @returns {string[]} deduped, longest first
+ */
+function workspacePrefixes(repoRoot) {
+  const roots = new Set();
+
+  const add = (p) => {
+    if (!p || p === "/") return;
+    roots.add(p.replace(/\/+$/, ""));
+  };
+
+  add(repoRoot);
+  try {
+    add(fs.realpathSync(repoRoot));
+  } catch {
+    // Root does not resolve — the literal spelling is all we have.
+  }
+
+  // /home <-> /var/home are the same directory on Bazzite (Fedora Atomic).
+  for (const root of [...roots]) {
+    if (root.startsWith("/var/home/")) add(root.slice("/var".length));
+    else if (root.startsWith("/home/")) add(`/var${root}`);
+  }
+
+  return [...roots].sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Build the matcher for a set of workspace prefixes.
+ *
+ * `(?<![\w./@{}~-])` requires the match to START a path: the character before
+ * it must not be one that could continue a path. That is what stops a prefix
+ * from matching inside a longer, unrelated path.
+ */
+function buildRegex(prefixes) {
+  const alternation = prefixes.map(escapeRegExp).join("|");
+  return new RegExp(
+    `(?<![\\w./@{}~-])(?:${alternation})/([\\w./@{}-][^\\s"']*)`,
+    "g"
+  );
+}
+
+/**
+ * Rewrite absolute workspace paths in `command` to paths relative to
+ * `repoRoot`, but only where the target actually exists under `repoRoot`.
+ *
+ * Pure apart from the injected `exists` probe, so it is unit-testable.
+ *
+ * @param {string} command
+ * @param {string} repoRoot
+ * @param {(p: string) => boolean} [exists]
+ * @returns {{ modified: string, rewrites: string[] }}
+ */
+function normalizeCommand(command, repoRoot, exists = fs.existsSync) {
+  const prefixes = workspacePrefixes(repoRoot);
+  if (prefixes.length === 0) {
+    return { modified: command, rewrites: [] };
+  }
+
+  const rewrites = [];
+  const modified = command.replace(
+    buildRegex(prefixes),
+    (fullAbsPath, relativePart) => {
+      // Only rewrite if the file exists relative to the repo/worktree root.
+      if (!exists(path.join(repoRoot, relativePart))) {
+        return fullAbsPath;
+      }
+      rewrites.push(`  ${fullAbsPath} -> ${relativePart}`);
+      return relativePart;
+    }
+  );
+
+  return { modified, rewrites };
+}
 
 async function main() {
   let inputData = "";
@@ -40,7 +152,7 @@ async function main() {
 
   const agentCwd = input.cwd || process.cwd();
 
-  // Resolve worktree/repo root for path existence checks (handles subdirectory cwd)
+  // Resolve the worktree/repo root.
   let repoRoot = agentCwd;
   try {
     const { execSync } = require("child_process");
@@ -54,26 +166,13 @@ async function main() {
     // Not in a git repo — fall back to cwd
   }
 
-  let modified = command;
-  const rewrites = [];
-
-  // Match absolute paths starting with known workspace roots.
-  // Handles /home/.../PinPoint/foo and /home/.../pinpoint-worktrees/branch-name/foo
-  const absPathRegex =
-    /\/home\/froeht\/Code\/(?:PinPoint|pinpoint-worktrees\/[^\s/"']+)\/([\w./@{}-][^\s"']*)/g;
-
-  let match;
-  while ((match = absPathRegex.exec(command)) !== null) {
-    const fullAbsPath = match[0];
-    const relativePart = match[1];
-
-    // Only rewrite if the file exists relative to the repo/worktree root
-    const localPath = path.join(repoRoot, relativePart);
-    if (fs.existsSync(localPath)) {
-      modified = modified.replace(fullAbsPath, relativePart);
-      rewrites.push(`  ${fullAbsPath} -> ${relativePart}`);
-    }
+  // A root-relative path only means the same thing as the absolute one when the
+  // command runs from the root. From a subdirectory, stay out of the way.
+  if (path.resolve(agentCwd) !== path.resolve(repoRoot)) {
+    process.exit(0);
   }
+
+  const { modified, rewrites } = normalizeCommand(command, repoRoot);
 
   if (rewrites.length > 0) {
     const reason =
@@ -97,9 +196,13 @@ async function main() {
   process.exit(0);
 }
 
-main().catch((err) => {
-  process.stderr.write(
-    `[normalize-workspace-paths] Hook error: ${err?.message ?? err}\n`
-  );
-  process.exit(0);
-});
+module.exports = { normalizeCommand, workspacePrefixes };
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(
+      `[normalize-workspace-paths] Hook error: ${err?.message ?? err}\n`
+    );
+    process.exit(0);
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5129,8 +5129,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.18:
-    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11036,7 +11036,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.18: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -11327,7 +11327,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.18
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5129,8 +5129,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11036,7 +11036,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -11327,7 +11327,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/src/test/unit/hooks/normalize-workspace-paths.test.ts
+++ b/src/test/unit/hooks/normalize-workspace-paths.test.ts
@@ -1,19 +1,15 @@
-// Unit tests for `normalizeCommand` / `workspacePrefixes`, exported from
+// Unit tests for the pieces exported from
 // .claude/hooks/normalize-workspace-paths.cjs.
 //
-// The `exists` probe is injected, so these run without touching the filesystem.
+// Both filesystem probes (`exists`, `realpath`) are injected, so these run
+// without touching the disk and can model Bazzite from a Mac.
 //
-// The regression under test (PP-xbfn) had two halves, both visible from a Mac
-// session driving crabbox:
-//
-//   - The matcher hardcoded `/home/froeht/Code/PinPoint`, which on the Mac names
-//     no local directory — it is Bazzite's path. So it rewrote paths meant for
-//     the REMOTE box.
-//   - It was unanchored, so it matched in the MIDDLE of `/var/home/froeht/...`
-//     (Bazzite's canonical home; `/home` is a symlink to it) and stripped the
-//     inner span, leaving `/var` glued to the tail. A crabbox run carrying
-//     `CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/...`
-//     died on `mkdir: cannot create directory '/var.claude'`.
+// The hook rewrites absolute workspace paths to relative so they match the
+// settings.json allowlist. Every test here covers one of the four guards that
+// keep a rewrite from changing what a command means — see the hook's header.
+// The original regression (PP-xbfn) was guards 1 and 2 missing: a crabbox run
+// carrying `/var/home/froeht/Code/PinPoint/.claude/worktrees/...` came out as
+// `/var.claude/worktrees/...` and died on `mkdir`.
 
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -24,40 +20,78 @@ const hookPath = path.resolve(
   process.cwd(),
   ".claude/hooks/normalize-workspace-paths.cjs"
 );
-const { normalizeCommand, workspacePrefixes } = require(hookPath) as {
-  normalizeCommand: (
-    command: string,
-    repoRoot: string,
-    exists?: (p: string) => boolean
-  ) => { modified: string; rewrites: string[] };
-  workspacePrefixes: (repoRoot: string) => string[];
-};
+
+interface Probes {
+  exists?: (p: string) => boolean;
+  realpath?: (p: string) => string;
+}
+
+const { normalizeCommand, workspacePrefixes, shiftsContext, samePath } =
+  require(hookPath) as {
+    normalizeCommand: (
+      command: string,
+      repoRoot: string,
+      probes?: Probes
+    ) => { modified: string; rewrites: string[] };
+    workspacePrefixes: (
+      repoRoot: string,
+      realpath?: (p: string) => string
+    ) => string[];
+    shiftsContext: (command: string) => boolean;
+    samePath: (
+      a: string,
+      b: string,
+      realpath?: (p: string) => string
+    ) => boolean;
+  };
 
 /** A Mac session — the machine that drives crabbox. */
 const MAC_ROOT = "/Users/froeht/Code/PinPoint";
 /** A Bazzite session, where the repo really does live under /var/home. */
 const BAZZITE_ROOT = "/var/home/froeht/Code/PinPoint";
 
+const ENOENT = (p: string): never => {
+  throw new Error(`ENOENT: no such file or directory, '${p}'`);
+};
+
+/** macOS: /Users resolves to itself, nothing else exists. */
+const macRealpath = (p: string) => (p.startsWith("/Users/") ? p : ENOENT(p));
+
+/** Bazzite (Fedora Atomic): /home is a symlink to /var/home. */
+const bazziteRealpath = (p: string) => {
+  if (p.startsWith("/var/home/")) return p;
+  if (p.startsWith("/home/")) return `/var${p}`;
+  return ENOENT(p);
+};
+
+/** A plain Linux box with a real /home and no /var/home. */
+const plainLinuxRealpath = (p: string) =>
+  p.startsWith("/home/") ? p : ENOENT(p);
+
 /** Every candidate tail exists — the permissive case. */
 const allExist = () => true;
-/** Nothing exists — the guard should suppress every rewrite. */
-const noneExist = () => false;
 
 function run(
   command: string,
   repoRoot = MAC_ROOT,
-  exists: (p: string) => boolean = allExist
+  probes: Probes = {}
 ): string {
-  return normalizeCommand(command, repoRoot, exists).modified;
+  const realpath =
+    probes.realpath ??
+    (repoRoot.startsWith("/Users/") ? macRealpath : bazziteRealpath);
+  return normalizeCommand(command, repoRoot, {
+    exists: probes.exists ?? allExist,
+    realpath,
+  }).modified;
 }
 
 // ---------------------------------------------------------------------------
-// The regression: a Mac session must not touch Bazzite paths at all
+// Guard 1 — only prefixes that name THIS machine's repo root
 // ---------------------------------------------------------------------------
-describe("remote (Bazzite) paths seen from a Mac session", () => {
+describe("guard 1: remote paths seen from a Mac session", () => {
   it("leaves a crabbox work root untouched", () => {
     const cmd =
-      "CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/crabbox-runner crabbox job run smoke";
+      "CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/crabbox-runner env";
     expect(run(cmd)).toBe(cmd);
   });
 
@@ -66,40 +100,12 @@ describe("remote (Bazzite) paths seen from a Mac session", () => {
       run("ls /var/home/froeht/Code/PinPoint/.claude/worktrees")
     ).not.toContain("/var.claude");
   });
-
-  it("leaves an ssh command's remote path untouched", () => {
-    const cmd = "ssh bazzite 'ls /home/froeht/Code/PinPoint/scripts'";
-    expect(run(cmd)).toBe(cmd);
-  });
 });
 
 // ---------------------------------------------------------------------------
-// On Bazzite itself, both spellings of the local root still rewrite
+// Guard 2 — the match must start a path, not continue one
 // ---------------------------------------------------------------------------
-describe("a Bazzite session's own repo root", () => {
-  it("rewrites the canonical /var/home spelling in full", () => {
-    expect(
-      run("bash /var/home/froeht/Code/PinPoint/scripts/x.sh", BAZZITE_ROOT)
-    ).toBe("bash scripts/x.sh");
-  });
-
-  it("rewrites the symlinked /home spelling too", () => {
-    expect(
-      run("bash /home/froeht/Code/PinPoint/scripts/x.sh", BAZZITE_ROOT)
-    ).toBe("bash scripts/x.sh");
-  });
-
-  it("offers both spellings as prefixes", () => {
-    expect(workspacePrefixes(BAZZITE_ROOT)).toEqual(
-      expect.arrayContaining([BAZZITE_ROOT, "/home/froeht/Code/PinPoint"])
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Boundary: the match must start a path, not continue one
-// ---------------------------------------------------------------------------
-describe("path boundaries", () => {
+describe("guard 2: path boundaries", () => {
   it("ignores an unrelated prefix that merely contains the root", () => {
     const cmd = "ls /aaa/Users/froeht/Code/PinPoint/scripts/x.sh";
     expect(run(cmd)).toBe(cmd);
@@ -116,6 +122,127 @@ describe("path boundaries", () => {
 
   it("still matches after an = in an assignment", () => {
     expect(run(`P=${MAC_ROOT}/scripts/x.sh`)).toBe("P=scripts/x.sh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 3 — commands that move cwd out from under a relative path
+// ---------------------------------------------------------------------------
+describe("guard 3: commands that change directory", () => {
+  it("skips a command with a leading cd", () => {
+    const cmd = `cd /tmp && bash ${MAC_ROOT}/scripts/x.sh`;
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("skips a cd that appears after the first command", () => {
+    const cmd = `echo hi; cd /tmp; bash ${MAC_ROOT}/scripts/x.sh`;
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("skips a cd inside a subshell", () => {
+    const cmd = `(cd sub && bash ${MAC_ROOT}/scripts/x.sh)`;
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("skips pushd", () => {
+    const cmd = `pushd /tmp && bash ${MAC_ROOT}/scripts/x.sh`;
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("skips a -C flag (git, make, tar)", () => {
+    const cmd = `git -C /tmp apply ${MAC_ROOT}/patch.diff`;
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("does not mistake a word merely containing cd for the command", () => {
+    expect(shiftsContext("bash scripts/cdrom-check.sh")).toBe(false);
+    expect(shiftsContext("echo abcd")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 4 — commands that hand the text to another machine
+// ---------------------------------------------------------------------------
+describe("guard 4: remote execution", () => {
+  // This is the case guard 1 CANNOT catch: on Bazzite the remote root is
+  // spelled exactly like the local one, so only the ssh verb distinguishes it.
+  it("leaves an ssh payload alone even when the spelling is local", () => {
+    const cmd = `ssh bazzite 'ls ${BAZZITE_ROOT}/scripts/x.sh'`;
+    expect(run(cmd, BAZZITE_ROOT)).toBe(cmd);
+  });
+
+  it("leaves an ssh payload alone on the Mac too", () => {
+    const cmd = "ssh bazzite 'ls /home/froeht/Code/PinPoint/scripts/x.sh'";
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it.each(["scp", "rsync", "crabbox", "docker", "podman", "kubectl"])(
+    "skips %s",
+    (verb) => {
+      const cmd = `${verb} run ${MAC_ROOT}/scripts/x.sh`;
+      expect(run(cmd)).toBe(cmd);
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Prefix derivation, including the /home <-> /var/home sibling
+// ---------------------------------------------------------------------------
+describe("workspacePrefixes", () => {
+  it("offers both spellings on Bazzite, where they resolve to one directory", () => {
+    expect(workspacePrefixes(BAZZITE_ROOT, bazziteRealpath)).toEqual(
+      expect.arrayContaining([BAZZITE_ROOT, "/home/froeht/Code/PinPoint"])
+    );
+  });
+
+  it("does NOT synthesize /var/home on a plain Linux box", () => {
+    const prefixes = workspacePrefixes(
+      "/home/froeht/Code/PinPoint",
+      plainLinuxRealpath
+    );
+    expect(prefixes).toEqual(["/home/froeht/Code/PinPoint"]);
+  });
+
+  it("offers only the literal root on the Mac", () => {
+    expect(workspacePrefixes(MAC_ROOT, macRealpath)).toEqual([MAC_ROOT]);
+  });
+
+  it("orders longest first, so a worktree beats its parent", () => {
+    const prefixes = workspacePrefixes(BAZZITE_ROOT, bazziteRealpath);
+    expect(prefixes).toEqual([...prefixes].sort((a, b) => b.length - a.length));
+  });
+});
+
+describe("both spellings rewrite on Bazzite", () => {
+  it("rewrites the canonical /var/home spelling", () => {
+    expect(run(`bash ${BAZZITE_ROOT}/scripts/x.sh`, BAZZITE_ROOT)).toBe(
+      "bash scripts/x.sh"
+    );
+  });
+
+  it("rewrites the symlinked /home spelling", () => {
+    expect(
+      run("bash /home/froeht/Code/PinPoint/scripts/x.sh", BAZZITE_ROOT)
+    ).toBe("bash scripts/x.sh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// samePath — the cwd guard's comparison
+// ---------------------------------------------------------------------------
+describe("samePath", () => {
+  it("matches two spellings of one directory through symlinks", () => {
+    expect(
+      samePath("/home/froeht/Code/PinPoint", BAZZITE_ROOT, bazziteRealpath)
+    ).toBe(true);
+  });
+
+  it("does not match genuinely different directories", () => {
+    expect(samePath(`${MAC_ROOT}/a`, `${MAC_ROOT}/b`, macRealpath)).toBe(false);
+  });
+
+  it("is false rather than throwing when a path does not resolve", () => {
+    expect(samePath("/nope/a", "/nope/b", macRealpath)).toBe(false);
   });
 });
 
@@ -137,14 +264,14 @@ describe("the allowlist rewrite it exists for", () => {
 
   it("leaves the path alone when the tail does not exist locally", () => {
     const cmd = `ls ${MAC_ROOT}/nope/missing`;
-    expect(run(cmd, MAC_ROOT, noneExist)).toBe(cmd);
+    expect(run(cmd, MAC_ROOT, { exists: () => false })).toBe(cmd);
   });
 
   it("reports what it rewrote", () => {
     const { rewrites } = normalizeCommand(
       `bash ${MAC_ROOT}/scripts/x.sh`,
       MAC_ROOT,
-      allExist
+      { exists: allExist, realpath: macRealpath }
     );
     expect(rewrites).toHaveLength(1);
     expect(rewrites[0]).toContain("-> scripts/x.sh");
@@ -153,7 +280,6 @@ describe("the allowlist rewrite it exists for", () => {
   it("leaves a command with no workspace path untouched", () => {
     const cmd = "pnpm run check";
     expect(run(cmd)).toBe(cmd);
-    expect(normalizeCommand(cmd, MAC_ROOT, allExist).rewrites).toHaveLength(0);
   });
 });
 

--- a/src/test/unit/hooks/normalize-workspace-paths.test.ts
+++ b/src/test/unit/hooks/normalize-workspace-paths.test.ts
@@ -11,6 +11,7 @@
 // carrying `/var/home/froeht/Code/PinPoint/.claude/worktrees/...` came out as
 // `/var.claude/worktrees/...` and died on `mkdir`.
 
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { describe, it, expect } from "vitest";
@@ -158,6 +159,18 @@ describe("guard 3: commands that change directory", () => {
     expect(shiftsContext("bash scripts/cdrom-check.sh")).toBe(false);
     expect(shiftsContext("echo abcd")).toBe(false);
   });
+
+  // The word is matched anywhere, because command position is not detectable
+  // by regex — these all hide it somewhere an anchored pattern cannot see.
+  it("catches a cd inside a quoted -c payload", () => {
+    const cmd = `bash -c 'cd /tmp && bash ${MAC_ROOT}/scripts/x.sh'`;
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("catches a cd inside a loop body", () => {
+    const cmd = `for f in a b; do cd /tmp; bash ${MAC_ROOT}/scripts/x.sh; done`;
+    expect(run(cmd)).toBe(cmd);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -181,6 +194,21 @@ describe("guard 4: remote execution", () => {
     (verb) => {
       const cmd = `${verb} run ${MAC_ROOT}/scripts/x.sh`;
       expect(run(cmd)).toBe(cmd);
+    }
+  );
+
+  // A leading assignment or wrapper word pushes the verb out of command
+  // position. The first of these is the command that motivated the whole PR.
+  it("catches a verb behind a leading env-var assignment", () => {
+    const cmd = `CRABBOX_STATIC_WORK_ROOT=${BAZZITE_ROOT}/.claude/wt crabbox run ${BAZZITE_ROOT}/scripts/x.sh`;
+    expect(run(cmd, BAZZITE_ROOT)).toBe(cmd);
+  });
+
+  it.each(["sudo", "env FOO=1", "time", "nohup"])(
+    "catches ssh behind the %s wrapper",
+    (wrapper) => {
+      const cmd = `${wrapper} ssh bazzite ls ${BAZZITE_ROOT}/scripts/x.sh`;
+      expect(run(cmd, BAZZITE_ROOT)).toBe(cmd);
     }
   );
 });
@@ -280,6 +308,32 @@ describe("the allowlist rewrite it exists for", () => {
   it("leaves a command with no workspace path untouched", () => {
     const cmd = "pnpm run check";
     expect(run(cmd)).toBe(cmd);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 5 — the hook must never approve the command it rewrote
+// ---------------------------------------------------------------------------
+describe("guard 5: the decision payload", () => {
+  // Runs the real hook end to end, because the decision is built in main().
+  function runHook(command: string, cwd = process.cwd()) {
+    const out = execFileSync(process.execPath, [hookPath], {
+      input: JSON.stringify({ cwd, tool_input: { command } }),
+      encoding: "utf8",
+    });
+    return out.trim() ? JSON.parse(out).hookSpecificOutput : null;
+  }
+
+  it("rewrites without approving, so permissions.ask still applies", () => {
+    // `Bash(rm -rf:*)` is on permissions.ask. Returning "allow" here would skip
+    // that prompt for anyone who happened to spell the path absolutely.
+    const out = runHook(`rm -rf ${process.cwd()}/src/app`);
+    expect(out?.updatedInput?.command).toBe("rm -rf src/app");
+    expect(out).not.toHaveProperty("permissionDecision");
+  });
+
+  it("stays silent when there is nothing to rewrite", () => {
+    expect(runHook("pnpm run check")).toBeNull();
   });
 });
 

--- a/src/test/unit/hooks/normalize-workspace-paths.test.ts
+++ b/src/test/unit/hooks/normalize-workspace-paths.test.ts
@@ -1,0 +1,176 @@
+// Unit tests for `normalizeCommand` / `workspacePrefixes`, exported from
+// .claude/hooks/normalize-workspace-paths.cjs.
+//
+// The `exists` probe is injected, so these run without touching the filesystem.
+//
+// The regression under test (PP-xbfn) had two halves, both visible from a Mac
+// session driving crabbox:
+//
+//   - The matcher hardcoded `/home/froeht/Code/PinPoint`, which on the Mac names
+//     no local directory — it is Bazzite's path. So it rewrote paths meant for
+//     the REMOTE box.
+//   - It was unanchored, so it matched in the MIDDLE of `/var/home/froeht/...`
+//     (Bazzite's canonical home; `/home` is a symlink to it) and stripped the
+//     inner span, leaving `/var` glued to the tail. A crabbox run carrying
+//     `CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/...`
+//     died on `mkdir: cannot create directory '/var.claude'`.
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+const require = createRequire(import.meta.url);
+const hookPath = path.resolve(
+  process.cwd(),
+  ".claude/hooks/normalize-workspace-paths.cjs"
+);
+const { normalizeCommand, workspacePrefixes } = require(hookPath) as {
+  normalizeCommand: (
+    command: string,
+    repoRoot: string,
+    exists?: (p: string) => boolean
+  ) => { modified: string; rewrites: string[] };
+  workspacePrefixes: (repoRoot: string) => string[];
+};
+
+/** A Mac session — the machine that drives crabbox. */
+const MAC_ROOT = "/Users/froeht/Code/PinPoint";
+/** A Bazzite session, where the repo really does live under /var/home. */
+const BAZZITE_ROOT = "/var/home/froeht/Code/PinPoint";
+
+/** Every candidate tail exists — the permissive case. */
+const allExist = () => true;
+/** Nothing exists — the guard should suppress every rewrite. */
+const noneExist = () => false;
+
+function run(
+  command: string,
+  repoRoot = MAC_ROOT,
+  exists: (p: string) => boolean = allExist
+): string {
+  return normalizeCommand(command, repoRoot, exists).modified;
+}
+
+// ---------------------------------------------------------------------------
+// The regression: a Mac session must not touch Bazzite paths at all
+// ---------------------------------------------------------------------------
+describe("remote (Bazzite) paths seen from a Mac session", () => {
+  it("leaves a crabbox work root untouched", () => {
+    const cmd =
+      "CRABBOX_STATIC_WORK_ROOT=/var/home/froeht/Code/PinPoint/.claude/worktrees/crabbox-runner crabbox job run smoke";
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("never produces the orphaned /var prefix", () => {
+    expect(
+      run("ls /var/home/froeht/Code/PinPoint/.claude/worktrees")
+    ).not.toContain("/var.claude");
+  });
+
+  it("leaves an ssh command's remote path untouched", () => {
+    const cmd = "ssh bazzite 'ls /home/froeht/Code/PinPoint/scripts'";
+    expect(run(cmd)).toBe(cmd);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On Bazzite itself, both spellings of the local root still rewrite
+// ---------------------------------------------------------------------------
+describe("a Bazzite session's own repo root", () => {
+  it("rewrites the canonical /var/home spelling in full", () => {
+    expect(
+      run("bash /var/home/froeht/Code/PinPoint/scripts/x.sh", BAZZITE_ROOT)
+    ).toBe("bash scripts/x.sh");
+  });
+
+  it("rewrites the symlinked /home spelling too", () => {
+    expect(
+      run("bash /home/froeht/Code/PinPoint/scripts/x.sh", BAZZITE_ROOT)
+    ).toBe("bash scripts/x.sh");
+  });
+
+  it("offers both spellings as prefixes", () => {
+    expect(workspacePrefixes(BAZZITE_ROOT)).toEqual(
+      expect.arrayContaining([BAZZITE_ROOT, "/home/froeht/Code/PinPoint"])
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boundary: the match must start a path, not continue one
+// ---------------------------------------------------------------------------
+describe("path boundaries", () => {
+  it("ignores an unrelated prefix that merely contains the root", () => {
+    const cmd = "ls /aaa/Users/froeht/Code/PinPoint/scripts/x.sh";
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("ignores a root embedded after a word character", () => {
+    const cmd = "ls fooUsers/froeht/Code/PinPoint/scripts/x.sh";
+    expect(run(cmd)).toBe(cmd);
+  });
+
+  it("still matches after a quote", () => {
+    expect(run(`bash "${MAC_ROOT}/scripts/x.sh"`)).toBe(`bash "scripts/x.sh"`);
+  });
+
+  it("still matches after an = in an assignment", () => {
+    expect(run(`P=${MAC_ROOT}/scripts/x.sh`)).toBe("P=scripts/x.sh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The allowlist rewrite it exists for
+// ---------------------------------------------------------------------------
+describe("the allowlist rewrite it exists for", () => {
+  it("rewrites a script path to relative", () => {
+    expect(run(`bash ${MAC_ROOT}/scripts/workflow/merge-pr.sh 1039`)).toBe(
+      "bash scripts/workflow/merge-pr.sh 1039"
+    );
+  });
+
+  it("rewrites every occurrence in one command", () => {
+    expect(run(`diff ${MAC_ROOT}/a.txt ${MAC_ROOT}/b.txt`)).toBe(
+      "diff a.txt b.txt"
+    );
+  });
+
+  it("leaves the path alone when the tail does not exist locally", () => {
+    const cmd = `ls ${MAC_ROOT}/nope/missing`;
+    expect(run(cmd, MAC_ROOT, noneExist)).toBe(cmd);
+  });
+
+  it("reports what it rewrote", () => {
+    const { rewrites } = normalizeCommand(
+      `bash ${MAC_ROOT}/scripts/x.sh`,
+      MAC_ROOT,
+      allExist
+    );
+    expect(rewrites).toHaveLength(1);
+    expect(rewrites[0]).toContain("-> scripts/x.sh");
+  });
+
+  it("leaves a command with no workspace path untouched", () => {
+    const cmd = "pnpm run check";
+    expect(run(cmd)).toBe(cmd);
+    expect(normalizeCommand(cmd, MAC_ROOT, allExist).rewrites).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worktrees: a worktree root is its own root, and does not match the main one
+// ---------------------------------------------------------------------------
+describe("worktrees", () => {
+  const WORKTREE = `${MAC_ROOT}/.claude/worktrees/feat-x`;
+
+  it("rewrites paths under the worktree it is running in", () => {
+    expect(run(`bash ${WORKTREE}/scripts/x.sh`, WORKTREE)).toBe(
+      "bash scripts/x.sh"
+    );
+  });
+
+  it("does not relativize a main-repo path from inside a worktree", () => {
+    const cmd = `bash ${MAC_ROOT}/scripts/x.sh`;
+    expect(run(cmd, WORKTREE)).toBe(cmd);
+  });
+});


### PR DESCRIPTION
## What

`.claude/hooks/normalize-workspace-paths.cjs` rewrites absolute workspace paths to relative so they match the `settings.json` allowlist. Its matcher hardcoded `/home/froeht/Code/PinPoint` and was unanchored. That broke crabbox from the Mac.

Bazzite's home is `/var/home/froeht` and `/home` is a symlink to it, so `/home/froeht/Code/PinPoint/` appears as a **substring in the middle** of any `/var/home/...` path. The hook stripped that span and left the orphaned `/var` glued to the tail:

```
CRABBOX_STATIC_WORK_ROOT=/var/home/.../PinPoint/.claude/worktrees/crabbox-runner
                      -> /var.claude/worktrees/crabbox-runner
```

crabbox then died on `mkdir: cannot create directory '/var.claude': Read-only file system`.

## Why it was hard to see

- The transcript records the command the **agent wrote** — the rewrite happens after — so the corruption was invisible until the remote `mkdir` failed. It read as a crabbox bug.
- An `existsSync` guard on the tail made it look intermittent: `.claude/worktrees` and `.git/config` triggered it, made-up tails did not.
- It fired twice during PP-cuf1 before being traced here.

## The fix

Anchoring the regex alone would not have been enough — a `/var/home/...` string on the Mac is a **remote** path, so relativizing it is wrong however it is spelled. The prefixes are now derived from this machine's own repo root, with three rules that keep a rewrite from changing what a command means:

- **only paths under the local repo root** — a Mac session no longer touches Bazzite paths at all, and the stale `pinpoint-worktrees/` layout drops out (a worktree is its own root)
- **only at a path boundary** — negative lookbehind, so a prefix can't match mid-path
- **only when cwd IS the repo root** — a root-relative path is equivalent to the absolute one nowhere else

A Bazzite session still gets the rewrite for both spellings of its own root; `workspacePrefixes` adds the `/home` ↔ `/var/home` sibling.

**Side effect worth naming:** the hook now does something on the Mac, where every path it could match was previously foreign.

## Testing

- 17 new unit tests (`src/test/unit/hooks/normalize-workspace-paths.test.ts`) covering both halves of the regression, the boundary cases, and worktree/main-repo separation
- End-to-end hook check on real stdin: the crabbox command passes through untouched; a local absolute script path is rewritten
- `pnpm run check` green, `pnpm run test` green (2147 passed)

Closes PP-xbfn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCqraD9WEZMFCp5y5VPBhc

---

_Note: this branch briefly carried a nanoid lockfile bump to get past the red `pnpm audit` gate. Reverted — #1881 (PP-5m4t) fixes it properly by bumping the override floor in `pnpm-workspace.yaml`, which the lockfile-only change did not touch. This branch needs main merged in once #1881 lands._
