### PR TITLE
fix(deps): bump the nanoid override floor to 3.3.18 (PP-5m4t)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
   postcss: '>=8.5.23'
-  nanoid: '>=3.3.17 <4'
+  nanoid: '>=3.3.18 <4'
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'
@@ -5129,8 +5129,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11036,7 +11036,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -11327,7 +11327,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ overrides:
   yaml: '>=2.8.3'
   uuid: '>=14.0.0'
   postcss: '>=8.5.23'
-  nanoid: '>=3.3.17 <4'
+  nanoid: '>=3.3.18 <4'
   shell-quote: '>=1.8.4'
   ws: '>=8.21.0'
   vite: '>=8.0.16'


### PR DESCRIPTION
Unblocks the audit gate, which is currently red on **every open PR** (#1875–#1880) — none of which touched dependencies.

## The advisory

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high), published 2026-08-13: nanoid custom generators can loop indefinitely when size is zero. Patched in 3.3.18.

We reach nanoid transitively and dev-only, through `webpack` → `postcss` → `nanoid` (21 paths).

## The fix

We already pin nanoid in `pnpm-workspace.yaml` overrides, so the floor just moves:

```diff
-  nanoid: '>=3.3.17 <4'
+  nanoid: '>=3.3.18 <4'
```

The lockfile delta is nanoid and nothing else — 6 lines, all `3.3.17` → `3.3.18`.

## Why not `/audit-override`

That hatch exists for an advisory with no available patch, where the alternative is an admin merge. This one has a patch, and we already own the pin — waving it through would leave a fixable high advisory in the tree and mask the next one behind the same override.

## Verification

- `pnpm audit --audit-level=high` — **no known vulnerabilities found** (was: 1 high)
- `pnpm run check` — pass
