### PR TITLE
fix(ci): stop main merges from cancelling each other's CI runs (PP-tbhv)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,31 @@ on:
 
 permissions: read-all  # zizmor: ignore[excessive-permissions]
 
-# Cancel in-progress runs when a new run is triggered
+# Cancel superseded PR runs; never cancel a push to main.
+#
+# A PR push supersedes the one before it — same branch, same question, and the
+# older answer is worthless — so cancelling saves runners with nothing lost.
+# A push to main is the opposite: each one is a distinct commit whose result is
+# the thing we want, and `test-e2e-comprehensive` takes ~30 minutes to produce
+# it. Under a shared `${{ github.ref }}` group every merge cancelled the
+# previous merge's run, so on any evening with more than one merge per half
+# hour that job was cancelled far more often than it finished — leaving the
+# same silent non-verdict PP-jxhy set out to remove, reached by a different
+# route. (Observed on run 31755670441: Smoke evaluated clean, then the Full
+# step was cancelled 30 minutes in by two later merges, and both the Full
+# evaluate and the gating step skipped.)
+#
+# Appending the SHA on `push` gives every main commit its own group, so main
+# runs neither cancel nor queue behind each other. Pull-request runs keep the
+# ref-based group and the old behaviour exactly.
+#
+# Not job-level `concurrency` on that job: job-level groups govern queueing
+# between jobs, they do not exempt a job from the workflow-level cancel. Not
+# `cancel-in-progress: false` either — main runs would then serialize, so one
+# 30-minute comprehensive job delays the next main run by up to 30 minutes and
+# they pile up. (PP-tbhv.)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/tests/test_evaluate_e2e_results.py
+++ b/scripts/tests/test_evaluate_e2e_results.py
@@ -443,10 +443,14 @@ def test_a_push_to_main_is_not_cancelled_by_the_next_push() -> None:
     reached without ever hitting the timeout PP-jxhy fixed. (PP-tbhv.)
     """
     ci = _ci_yml()
-    group = next(line for line in ci.splitlines() if line.strip().startswith("group:"))
-    assert "github.event_name == 'push' && github.sha" in group, group
+    # Scope to the workflow-level block. Both assertions are satisfiable by a
+    # job-level `concurrency:` somewhere else in the file, which would govern
+    # only that one job — so a whole-file substring check would keep passing
+    # while the setting it claims to pin had moved or been flipped.
+    block = ci.split("\nconcurrency:\n", 1)[1].split("\njobs:", 1)[0]
+    assert "github.event_name == 'push' && github.sha" in block, block
     # PR runs must keep cancelling — that is the whole point of the setting.
-    assert "cancel-in-progress: true" in ci
+    assert "cancel-in-progress: true" in block
 
 
 def test_a_dedicated_step_gates_on_both_verdicts() -> None:

--- a/scripts/tests/test_evaluate_e2e_results.py
+++ b/scripts/tests/test_evaluate_e2e_results.py
@@ -433,6 +433,22 @@ def test_both_evaluate_steps_are_continue_on_error() -> None:
         assert "continue-on-error: true" in block, step_id
 
 
+def test_a_push_to_main_is_not_cancelled_by_the_next_push() -> None:
+    """Every main commit needs its own concurrency group.
+
+    Under a group keyed only on `github.ref`, each merge cancelled the previous
+    merge's in-flight run. `test-e2e-comprehensive` takes ~30 minutes, so on any
+    evening with more than one merge per half hour it was cancelled more often
+    than it finished — a missing verdict, the class this gate exists to remove,
+    reached without ever hitting the timeout PP-jxhy fixed. (PP-tbhv.)
+    """
+    ci = _ci_yml()
+    group = next(line for line in ci.splitlines() if line.strip().startswith("group:"))
+    assert "github.event_name == 'push' && github.sha" in group, group
+    # PR runs must keep cancelling — that is the whole point of the setting.
+    assert "cancel-in-progress: true" in ci
+
+
 def test_a_dedicated_step_gates_on_both_verdicts() -> None:
     """Something still has to fail the job once both suites have reported."""
     ci = _ci_yml()


### PR DESCRIPTION
The third way the post-merge comprehensive E2E job could report nothing — and the one that fires most often. Found by watching the first post-merge run after #1861 landed.

## What happens

`ci.yml` keys its concurrency group on `github.ref` alone with `cancel-in-progress: true`. On `refs/heads/main` every merge shares one group, so **each merge cancels the previous merge's in-flight run**.

`test-e2e-comprehensive` takes ~30 minutes. Main routinely gets several merges inside that window, so the job was cancelled far more often than it finished.

## The evidence

Run [31755670441](https://github.com/timothyfroehlich/PinPoint/actions/runs/31755670441), the merge of #1873:

| | |
| :--- | :--- |
| job started | 00:01:42 |
| `Run Comprehensive Smoke Tests` | success |
| `Evaluate gating browser results (Smoke)` | **success** — the #1861 gate working |
| `Run Comprehensive Full Tests` | **cancelled** at 00:31:31 |
| `Evaluate gating browser results (Full)` | skipped |
| `Gate on E2E verdicts` | skipped |

Two further merges landed at 00:30:55 and 00:31:35 — the pbm docs PR and the nanoid bump. Those cancelled it. The job cap is now 90 minutes, so this was nowhere near the timeout #1861 fixed.

Net result: no verdict, which is exactly the class PP-jxhy set out to remove, reached by a different route.

## The fix

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
```

Every main commit gets its own group, so main runs neither cancel nor queue behind each other. Pull-request runs keep the ref-based group and cancel on force-push exactly as before — which is the only case the setting was ever for. A PR push supersedes the one before it; a merge to main does not.

## Alternatives rejected

- **Job-level `concurrency` on `test-e2e-comprehensive`.** Job-level groups govern queueing between jobs; they do not exempt a job from a workflow-level cancel.
- **`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.** Main runs would then serialize, so one 30-minute comprehensive job delays the next main run by up to 30 minutes and they pile up.
- **Splitting the job into its own workflow.** It `needs:` nine upstream jobs; a separate workflow would have to re-derive all of that or chain on `workflow_run`.

Both rejections are recorded in the comment above the block, so the next person to look at it doesn't re-derive them.

## Verification

Regression pin added beside the other `ci.yml` assertions in `test_evaluate_e2e_results.py` — it asserts both halves, that pushes are SHA-scoped and that PR runs still cancel. `pnpm run check` and all 575 python tests pass.

The real proof is behavioral and arrives after merge: two merges to main inside 30 minutes should both reach a real conclusion.

Bead: PP-tbhv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TZGgLY8eiTJy72XeESpQX