### PR TITLE
chore(hooks): disable normalize-workspace-paths and see who misses it (PP-yv19)

### DIFF
--- a/.claude/hooks/normalize-workspace-paths.cjs
+++ b/.claude/hooks/normalize-workspace-paths.cjs
@@ -1,5 +1,29 @@
 #!/usr/bin/env node
 /**
+ * DISABLED — not registered in .claude/settings.json since 2026-08-14 (PP-yv19).
+ *
+ * Kept on disk, with its tests, because re-enabling is one settings entry plus
+ * three expected-hook list entries (verify-guard-stack.cjs, its unit test,
+ * scripts/tests/test_node_hook_paths.py). Delete all of it if nothing misses it.
+ *
+ * Why it was turned off: what it buys is fewer permission prompts when an agent
+ * spells a repo path absolutely. What it cost, over three review rounds on
+ * PR #1880, was a silent path corruption that broke crabbox twice, two
+ * command mis-targeting bugs, and a `permissionDecision: "allow"` that skipped
+ * the `permissions.ask` prompt on `rm -rf` and `git reset --hard`. Rewriting
+ * arbitrary shell text is a poor trade for that.
+ *
+ * The prompt it dodged is also solvable without rewriting anything: Bash
+ * permission rules match the literal command string with `*` wildcards, so an
+ * absolute-path allow rule covers the case directly. The machine-local settings
+ * already carry one, of the shape `Bash(bash <abs repo root>WILDCARD/scripts/
+ * workflow/...)`, where the wildcard right after the repo root makes it cover
+ * worktrees too. (Written that way here because a literal `*` followed by a
+ * slash would end this comment block — which is exactly how this note first
+ * broke the file.)
+ *
+ * ---------------------------------------------------------------------------
+ *
  * PreToolUse hook: Rewrites unnecessary absolute workspace paths to relative.
  *
  * When an agent in a worktree runs a command with an absolute path like:

--- a/.claude/hooks/verify-guard-stack.cjs
+++ b/.claude/hooks/verify-guard-stack.cjs
@@ -43,7 +43,6 @@ const fs = require("node:fs");
 
 // Keep in sync when adding/removing a PreToolUse guard hook.
 const EXPECTED_GUARD_HOOKS = [
-  "normalize-workspace-paths.cjs",
   "inject-beads-actor.cjs",
   "block-direct-merge.cjs",
   "block-main-worktree-branch-switch.cjs",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,11 +66,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/normalize-workspace-paths.cjs",
-            "timeout": 5000
-          },
-          {
-            "type": "command",
             "command": "node \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/hooks/inject-beads-actor.cjs",
             "timeout": 5000
           }

--- a/scripts/tests/test_node_hook_paths.py
+++ b/scripts/tests/test_node_hook_paths.py
@@ -79,7 +79,6 @@ NODE_HOOK_COMMANDS = _node_hook_commands()
 # settings.json edit that silently drops one is caught rather than the
 # parametrized tests just running over a shorter list.
 EXPECTED_NODE_HOOK_BASENAMES = [
-    "normalize-workspace-paths.cjs",
     "inject-beads-actor.cjs",
     "block-direct-merge.cjs",
     "block-main-worktree-branch-switch.cjs",

--- a/src/test/unit/hooks/verify-guard-stack.test.ts
+++ b/src/test/unit/hooks/verify-guard-stack.test.ts
@@ -57,7 +57,6 @@ const {
 // Fixture builders
 // ---------------------------------------------------------------------------
 const ALL_EXPECTED_HOOKS = [
-  "normalize-workspace-paths.cjs",
   "inject-beads-actor.cjs",
   "block-direct-merge.cjs",
   "block-main-worktree-branch-switch.cjs",
@@ -139,12 +138,12 @@ describe("evaluateGuardStack — missing hooks", () => {
   it("lists multiple missing hooks in one problem string", () => {
     const remaining = ALL_EXPECTED_HOOKS.filter(
       (b) =>
-        b !== "normalize-workspace-paths.cjs" &&
+        b !== "inject-beads-actor.cjs" &&
         b !== "block-main-worktree-branch-switch.cjs"
     );
     const problems = evaluateGuardStack(settingsWithHooks(remaining));
     expect(problems).toEqual([
-      "missing PreToolUse hooks: normalize-workspace-paths.cjs, block-main-worktree-branch-switch.cjs",
+      "missing PreToolUse hooks: inject-beads-actor.cjs, block-main-worktree-branch-switch.cjs",
     ]);
   });
 


### PR DESCRIPTION
## What

Unregisters `.claude/hooks/normalize-workspace-paths.cjs` from `.claude/settings.json`. The file and its 45 tests stay on disk.

## What the hook did

Rewrote absolute paths pointing inside the current repo into relative ones, **in the command text**, before the command ran:

```
bash /Users/froeht/Code/PinPoint/scripts/workflow/merge-handoff.sh 1880
                      ↓
bash scripts/workflow/merge-handoff.sh 1880
```

The point was that the allowlist is written in relative paths, so the absolute spelling matched no entry and produced a permission prompt for an already-approved command.

## Why turn it off

That benefit — fewer prompts when an agent spells a repo path absolutely — cost the following across three review rounds on #1880:

| | |
|---|---|
| Silent path corruption | `/var/home/…/PinPoint/.claude/worktrees` → `/var.claude/worktrees`; broke crabbox twice before it was traced |
| Command mis-targeting | `cd /tmp && bash <root>/x.sh` → `cd /tmp && bash scripts/x.sh`, i.e. `/tmp/scripts/x.sh` |
| Command mis-targeting | `ssh bazzite 'ls <root>/scripts'` relativized on Bazzite, where local and remote roots are spelled alike |
| Permission bypass | `permissionDecision: "allow"` skipped the `permissions.ask` prompt on `rm -rf`, `git reset --hard`, `git clean` |

Each was fixed, and each was found only because someone went looking. Rewriting arbitrary shell text to save a prompt is the wrong trade.

## The prompt doesn't need a hook

Bash permission rules match the **literal command string** with `*` wildcards and no path resolution ([permissions docs](https://code.claude.com/docs/en/permissions)). So an absolute-path allow rule covers the case directly, with no rewriting. The machine-local settings already carry one for `scripts/workflow/`, with a wildcard right after the repo root so it covers worktrees too — which is why the hook's benefit was already largely redundant on this machine.

If a prompt does start showing up, the fix is one allowlist line for the case that actually came up.

## Disabled, not deleted

Re-enabling is one settings entry plus the three expected-hook list entries removed here (`verify-guard-stack.cjs`, its unit test, `test_node_hook_paths.py`). Those lists had to lose it either way — a hook listed as expected but not registered makes the guard-stack canary warn every session. Delete the lot if nothing misses it.

The file header now states that it is disabled and why, so nobody reads it as live.

## Testing

`pnpm run check`, `pnpm run check:python` (573 passed), and `src/test/unit/hooks/` (286 passed) all green.

Closes PP-yv19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCqraD9WEZMFCp5y5VPBhc