### PR TITLE
chore(gitignore): ignore bd's root-level .beads.gate.lock (PP-42vn)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ logs/
 # Beads issue tracker (Dolt DB — not tracked in git)
 .beads/
 .dolt/
+# bd's workspace gate lock lands *beside* the guarded root, i.e. at the repo
+# root as `.beads.gate.lock`, so `.beads/` above does not cover it. bd bundles
+# this same `*.gate.lock*` pattern, but only into `.beads/.gitignore`, which is
+# itself inside an ignored directory and therefore never consulted.
+*.gate.lock*
 
 # Environment variable files
 # Strategy: Ignore every .env* variant by default, then explicitly allow safe templates.


### PR DESCRIPTION
## What

Adds `*.gate.lock*` to the root `.gitignore`.

## Why

bd 1.2.1 writes its workspace gate lock **beside** the guarded root rather than inside it, so on this repo it lands at the repo root as `.beads.gate.lock`. The existing `.beads/` rule doesn't cover a sibling, so the file has been sitting untracked on `main`.

bd bundles the matching `*.gate.lock*` pattern itself — but only into `.beads/.gitignore`, which lives inside an already-ignored directory and is therefore never consulted. Hence the same pattern at the root.

## Verification

```
$ git check-ignore -v .beads.gate.lock
.gitignore:52:*.gate.lock*	.beads.gate.lock
```

`pnpm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L57BsaAVyEShauV7EnJMgR