### PR TITLE
feat(scripts): read-only Postgres role and query tool for prod investigations (PP-xdvw)

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -185,6 +185,7 @@ the degradation is a known, documented choice — not an oversight.
 | `MOCK_BLOB_STORAGE`                                                             | 🟢            | Dev/test | `src/lib/blob/client.ts`                   | feature flag                                                                   |
 | `DRIZZLE_FORCE_PRODUCTION`                                                      | 🟢            | Ops      | `drizzle.config.ts`                        | explicit opt-in guard for prod DDL — see the `*_FORCE_PRODUCTION` note below   |
 | `LOG_LEVEL` / `PINPOINT_LOG_DIR`                                                | 🟢            | All      | `src/lib/logger.ts`                        | defaults: `info` / `<cwd>/logs`                                                |
+| `POSTGRES_URL_READONLY`                                                         | 🔴            | Ops      | `scripts/query-readonly.mjs`               | `pinpoint_readonly` role; **never** in Vercel — the app never reads it         |
 | `SKIP_SUPABASE_RESET`, `E2E_DOCKER_READY_ATTEMPTS`, `E2E_DOCKER_READY_DELAY_MS` | 🟢            | CI/test  | `e2e/global-setup.ts`                      | E2E harness tuning                                                             |
 
 > **`*_FORCE_PRODUCTION` accepts `1` or `true`, and nothing else.**

--- a/scripts/query-readonly.mjs
+++ b/scripts/query-readonly.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Run a query against a database with writes made impossible.
+ *
+ * Two independent layers, either of which is sufficient on its own:
+ *
+ *  1. **A read-only transaction.** Every statement runs inside
+ *     `BEGIN TRANSACTION READ ONLY`, which Postgres enforces server-side: any
+ *     INSERT/UPDATE/DELETE/DDL fails with 25006 no matter what the connecting
+ *     role is permitted to do. This works even against the ordinary
+ *     POSTGRES_URL, which is why the script is useful before anyone has set up
+ *     the role.
+ *  2. **A SELECT-only role.** `POSTGRES_URL_READONLY` should point at
+ *     `pinpoint_readonly` (see scripts/sql/readonly-role.sql), which holds no
+ *     write grants anywhere.
+ *
+ * The transaction is always rolled back, so even a read that acquires locks
+ * leaves nothing behind.
+ *
+ * This exists because investigating a production bug means reading production,
+ * and doing that over a service-role connection makes every read one typo away
+ * from a mutation. Removing the capability beats asking for restraint.
+ *
+ * Usage:
+ *   node scripts/query-readonly.mjs "select count(*) from user_profiles"
+ *   node scripts/query-readonly.mjs --file query.sql
+ *   node scripts/query-readonly.mjs --json "select ..."
+ *   node scripts/query-readonly.mjs --env other.env "select ..."
+ *
+ * Reading auth data: the role cannot select from `auth.users` directly — query
+ * `readonly_auth.users` / `readonly_auth.identities` instead. The reason is a
+ * Supabase platform constraint, spelled out in scripts/sql/readonly-role.sql.
+ *
+ * The env-file flag is `--env`, NOT `--env-file`: Node itself owns `--env-file`
+ * (v20+) and consumes it even when it appears after the script path, so a script
+ * flag by that name is unreachable. Worse, Node's version loads EVERY key in the
+ * file into the environment, which is the opposite of the whitelist below.
+ */
+
+import { readFileSync } from "node:fs";
+
+import postgres from "postgres";
+
+import {
+  describeTarget,
+  isPinPointProductionTarget,
+} from "./lib/db-target.mjs";
+
+function parseArgs(argv) {
+  const args = { json: false, file: null, sql: null, envFile: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") args.json = true;
+    else if (arg === "--file") args.file = argv[++i] ?? null;
+    // `--env`, not `--env-file` — see the header. Node would eat the latter.
+    else if (arg === "--env") args.envFile = argv[++i] ?? null;
+    else if (!arg.startsWith("--")) args.sql = arg;
+  }
+  return args;
+}
+
+/**
+ * Read POSTGRES_URL* out of a dotenv file into the environment.
+ *
+ * Exists so a connection string never has to be pasted onto a command line,
+ * where it lands in shell history and in this tool's own logs. Only the two
+ * keys this script uses are read; everything else in the file is ignored.
+ */
+function loadEnvFile(path, { required = true } = {}) {
+  let contents;
+  try {
+    contents = readFileSync(path, "utf8");
+  } catch (error) {
+    // A missing default file is not an error — the caller may have exported the
+    // variables instead. An explicitly named one that cannot be read is.
+    if (!required) return;
+    console.error(`❌ Cannot read env file ${path}: ${error.message}`);
+    process.exit(1);
+  }
+  for (const line of contents.split("\n")) {
+    const match = /^\s*(POSTGRES_URL(?:_READONLY)?)\s*=\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const value = match[2].trim().replace(/^["']|["']$/g, "");
+    if (value) process.env[match[1]] = value;
+  }
+}
+
+function resolveUrl() {
+  const readonly = process.env.POSTGRES_URL_READONLY;
+  if (readonly) return { url: readonly, dedicated: true };
+
+  const fallback = process.env.POSTGRES_URL;
+  if (!fallback) {
+    console.error(
+      "❌ Neither POSTGRES_URL_READONLY nor POSTGRES_URL is defined.\n" +
+        "   Set up the read-only role: scripts/sql/readonly-role.sql"
+    );
+    process.exit(1);
+  }
+  return { url: fallback, dedicated: false };
+}
+
+const args = parseArgs(process.argv.slice(2));
+// `.env.local` by default, so the documented invocations work in a checkout
+// without anyone having to remember `--env`; absent, it is skipped rather
+// than fatal. Values in the file override exported ones, which fails in the safe
+// direction — `.env.local` is the local stack, so the accident it can cause is
+// querying local while you meant prod, never the reverse.
+loadEnvFile(args.envFile ?? ".env.local", { required: args.envFile !== null });
+const sql = args.file ? readFileSync(args.file, "utf8") : args.sql;
+
+if (!sql?.trim()) {
+  console.error(
+    "❌ No query given.\n" +
+      '   node scripts/query-readonly.mjs "select 1"\n' +
+      "   node scripts/query-readonly.mjs --file query.sql"
+  );
+  process.exit(1);
+}
+
+const { url, dedicated } = resolveUrl();
+
+// Say plainly which database this is and how it is protected. A read against
+// prod is legitimate; a read against prod that the operator THOUGHT was local
+// is how bad assumptions get made, so the target is never implicit.
+const target = isPinPointProductionTarget(url)
+  ? "PRODUCTION"
+  : "non-production";
+console.error(`→ ${target}: ${describeTarget(url)}`);
+console.error(
+  dedicated
+    ? "→ read-only role + read-only transaction"
+    : "→ read-only transaction only (POSTGRES_URL_READONLY not set — the " +
+        "connecting role CAN write; the transaction is what is stopping it)"
+);
+
+// `prepare: false` — the transaction pooler on :6543 does not support prepared
+// statements (AGENTS.md §7; PP-d8l8 traced silent prod commit loss to this).
+// `max: 1` so the BEGIN and the query provably share one connection.
+const client = postgres(url, { prepare: false, max: 1 });
+
+let exitCode = 0;
+try {
+  // `.begin()` would COMMIT on success. This has to roll back unconditionally,
+  // so the transaction is driven by hand on a reserved connection.
+  const connection = await client.reserve();
+  try {
+    await connection.unsafe("BEGIN TRANSACTION READ ONLY");
+    const rows = await connection.unsafe(sql);
+    // Roll back before printing: if rendering throws, the transaction is
+    // already closed rather than left open on the pooler.
+    await connection.unsafe("ROLLBACK");
+
+    if (args.json) {
+      console.log(JSON.stringify(rows, null, 2));
+    } else if (rows.length === 0) {
+      console.log("(0 rows)");
+    } else {
+      console.table(rows);
+      console.log(`(${rows.length} row${rows.length === 1 ? "" : "s"})`);
+    }
+  } catch (error) {
+    await connection.unsafe("ROLLBACK").catch(() => {});
+    throw error;
+  } finally {
+    connection.release();
+  }
+} catch (error) {
+  // 25006 is "cannot execute X in a read-only transaction" — the guard doing
+  // its job, so name it rather than letting it read as a broken script.
+  if (error?.code === "25006") {
+    console.error(
+      "❌ Refused: that statement writes, and this tool only reads.\n" +
+        "   Blocked by the server, not by this script."
+    );
+  } else {
+    console.error(`❌ ${error?.message ?? String(error)}`);
+  }
+  exitCode = 1;
+} finally {
+  await client.end({ timeout: 5 });
+}
+
+process.exit(exitCode);

--- a/scripts/query-readonly.mjs
+++ b/scripts/query-readonly.mjs
@@ -15,12 +15,16 @@
  *    write fails with 25006 and the session leaves nothing behind.
  *  - BUT a multi-statement query can defeat the transaction: `ROLLBACK; <write>`
  *    ends the block, and the write then runs in autocommit. The session-level
- *    read-only default still catches it — unless the same query also does
- *    `SET default_transaction_read_only = off` first, which any session may do.
+ *    read-only default is only a BEST-EFFORT catch for that, and over the
+ *    Supavisor transaction pooler (`:6543`) not even reliable: the pooler can
+ *    route the escaped autocommit statement to a different backend than the one
+ *    the `SET` ran on. Any query can also `SET … = off` first regardless.
  *
  * So on the FALLBACK path (`POSTGRES_URL`, a role that CAN write), a determined
  * multi-statement query can still write. That path is a convenience for before
- * the role exists, not a safe place to run untrusted SQL. Set up the role.
+ * the role exists, not a safe place to run untrusted SQL. Set up the role — its
+ * write-refusal depends on none of the above, because the privilege to write is
+ * simply absent.
  *
  * This exists because investigating a production bug means reading production,
  * and doing that over a service-role connection makes every read one typo away
@@ -92,6 +96,16 @@ function parseArgs(argv) {
       );
     }
   }
+
+  // `--file` plus an inline query is the same ambiguity a second positional is:
+  // `--file` would win and the positional would be dropped without a word. The
+  // parser is loud about which statement runs everywhere else, so be loud here.
+  if (args.file !== null && args.sql !== null) {
+    throw new UsageError(
+      "give a query OR --file, not both — --file would win and the inline query would be silently ignored"
+    );
+  }
+
   return args;
 }
 
@@ -116,7 +130,13 @@ function loadEnvFile(path, { required = true } = {}) {
     const match = /^\s*(POSTGRES_URL(?:_READONLY)?)\s*=\s*(.*)$/.exec(line);
     if (!match) continue;
     const value = match[2].trim().replace(/^["']|["']$/g, "");
-    if (value) process.env[match[1]] = value;
+    // Standard dotenv precedence: an already-exported variable wins over the
+    // file, so an explicit `export POSTGRES_URL_READONLY=<prod>` is never
+    // silently swapped out for a worktree's local `.env.local`. Getting which
+    // database this points at wrong is the one failure this tool cannot have.
+    if (value && process.env[match[1]] === undefined) {
+      process.env[match[1]] = value;
+    }
   }
 }
 
@@ -155,9 +175,9 @@ async function main() {
 
   // `.env.local` by default, so the documented invocations work in a checkout
   // without anyone having to remember `--env`; absent, it is skipped rather than
-  // fatal. Values in the file override exported ones, which fails in the safe
-  // direction — `.env.local` is the local stack, so the accident it can cause is
-  // querying local while you meant prod, never the reverse.
+  // fatal. An exported variable wins over the file (dotenv precedence, see
+  // loadEnvFile), so an operator who exported a prod URL and happens to run from
+  // a worktree gets prod, not the worktree's local stack silently swapped in.
   loadEnvFile(args.envFile ?? ".env.local", {
     required: args.envFile !== null,
   });
@@ -207,10 +227,11 @@ async function main() {
   try {
     const connection = await client.reserve();
     try {
-      // Session-level read-only extends the transaction's protection across a
-      // `ROLLBACK; …` escape (see the header): autocommit statements after such
-      // a break still inherit it. Not a wall — `SET … = off` defeats it — but it
-      // closes the accidental case on the fallback path.
+      // Session-level read-only is a best-effort catch for a `ROLLBACK; …`
+      // escape (see the header) on the fallback path — and only best-effort:
+      // over the :6543 transaction pooler the escaped autocommit statement may
+      // land on a different backend than this SET, and any query can SET it off.
+      // The dedicated role does not rely on it; its write-refusal is the grant.
       await connection.unsafe("SET SESSION default_transaction_read_only = on");
       // `.begin()` would COMMIT on success. This has to roll back
       // unconditionally, so the transaction is driven by hand.

--- a/scripts/query-readonly.mjs
+++ b/scripts/query-readonly.mjs
@@ -1,25 +1,30 @@
 #!/usr/bin/env node
 /**
- * Run a query against a database with writes made impossible.
+ * Run a query against a database, biased hard toward reading only.
  *
- * Two independent layers, either of which is sufficient on its own:
+ * **The real boundary is the role, not this script.** `POSTGRES_URL_READONLY`
+ * should point at `pinpoint_readonly` (see scripts/sql/readonly-role.sql), which
+ * holds no write grant anywhere. With that role, no query this script sends can
+ * write, because the privilege to write does not exist — that is the guarantee.
  *
- *  1. **A read-only transaction.** Every statement runs inside
- *     `BEGIN TRANSACTION READ ONLY`, which Postgres enforces server-side: any
- *     INSERT/UPDATE/DELETE/DDL fails with 25006 no matter what the connecting
- *     role is permitted to do. This works even against the ordinary
- *     POSTGRES_URL, which is why the script is useful before anyone has set up
- *     the role.
- *  2. **A SELECT-only role.** `POSTGRES_URL_READONLY` should point at
- *     `pinpoint_readonly` (see scripts/sql/readonly-role.sql), which holds no
- *     write grants anywhere.
+ * Everything this script adds is accident-prevention on top of that, and is NOT
+ * a security boundary against a hostile query string:
  *
- * The transaction is always rolled back, so even a read that acquires locks
- * leaves nothing behind.
+ *  - `SET SESSION default_transaction_read_only = on`, then every query inside a
+ *    `BEGIN TRANSACTION READ ONLY` that is always rolled back. A single-statement
+ *    write fails with 25006 and the session leaves nothing behind.
+ *  - BUT a multi-statement query can defeat the transaction: `ROLLBACK; <write>`
+ *    ends the block, and the write then runs in autocommit. The session-level
+ *    read-only default still catches it — unless the same query also does
+ *    `SET default_transaction_read_only = off` first, which any session may do.
+ *
+ * So on the FALLBACK path (`POSTGRES_URL`, a role that CAN write), a determined
+ * multi-statement query can still write. That path is a convenience for before
+ * the role exists, not a safe place to run untrusted SQL. Set up the role.
  *
  * This exists because investigating a production bug means reading production,
  * and doing that over a service-role connection makes every read one typo away
- * from a mutation. Removing the capability beats asking for restraint.
+ * from a mutation.
  *
  * Usage:
  *   node scripts/query-readonly.mjs "select count(*) from user_profiles"
@@ -31,30 +36,61 @@
  * `readonly_auth.users` / `readonly_auth.identities` instead. The reason is a
  * Supabase platform constraint, spelled out in scripts/sql/readonly-role.sql.
  *
- * The env-file flag is `--env`, NOT `--env-file`: Node itself owns `--env-file`
- * (v20+) and consumes it even when it appears after the script path, so a script
- * flag by that name is unreachable. Worse, Node's version loads EVERY key in the
- * file into the environment, which is the opposite of the whitelist below.
+ * The env-file flag is `--env`, NOT `--env-file`. Node (v20+) implements
+ * `--env-file` itself: when the named file EXISTS, Node loads EVERY key in it
+ * into the environment — the opposite of the two-key whitelist below — and when
+ * it does not exist, Node aborts before this script runs. The flag still reaches
+ * argv, so a script flag by that name would be shadowed by Node's own handling.
+ * `--env` sidesteps both.
  */
 
 import { readFileSync } from "node:fs";
 
-import postgres from "postgres";
-
+import { createScriptClient } from "./lib/pg-client.mjs";
 import {
   describeTarget,
   isPinPointProductionTarget,
 } from "./lib/db-target.mjs";
 
+class UsageError extends Error {}
+
+/**
+ * Parse argv, rejecting anything it does not recognise.
+ *
+ * A silent-drop parser is a footgun here: a misspelled `--env` would be dropped
+ * and its filename reinterpreted as the query, and a stray extra word would
+ * overwrite the query with the last positional winning — both silently running
+ * against a different database or a different statement than the operator typed.
+ * So an unknown `--flag`, a second positional, and a flag that swallows the next
+ * flag as its value are all hard errors.
+ */
 function parseArgs(argv) {
   const args = { json: false, file: null, sql: null, envFile: null };
+
+  const takeValue = (flag, next) => {
+    if (next === undefined || next.startsWith("--")) {
+      throw new UsageError(`${flag} needs a value`);
+    }
+    return next;
+  };
+
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === "--json") args.json = true;
-    else if (arg === "--file") args.file = argv[++i] ?? null;
-    // `--env`, not `--env-file` — see the header. Node would eat the latter.
-    else if (arg === "--env") args.envFile = argv[++i] ?? null;
-    else if (!arg.startsWith("--")) args.sql = arg;
+    if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--file") {
+      args.file = takeValue(arg, argv[++i]);
+    } else if (arg === "--env") {
+      args.envFile = takeValue(arg, argv[++i]);
+    } else if (arg.startsWith("--")) {
+      throw new UsageError(`unknown flag ${arg}`);
+    } else if (args.sql === null) {
+      args.sql = arg;
+    } else {
+      throw new UsageError(
+        `unexpected extra argument ${JSON.stringify(arg)} — quote the whole query as one argument`
+      );
+    }
   }
   return args;
 }
@@ -74,8 +110,7 @@ function loadEnvFile(path, { required = true } = {}) {
     // A missing default file is not an error — the caller may have exported the
     // variables instead. An explicitly named one that cannot be read is.
     if (!required) return;
-    console.error(`❌ Cannot read env file ${path}: ${error.message}`);
-    process.exit(1);
+    throw new UsageError(`Cannot read env file ${path}: ${error.message}`);
   }
   for (const line of contents.split("\n")) {
     const match = /^\s*(POSTGRES_URL(?:_READONLY)?)\s*=\s*(.*)$/.exec(line);
@@ -91,94 +126,142 @@ function resolveUrl() {
 
   const fallback = process.env.POSTGRES_URL;
   if (!fallback) {
-    console.error(
-      "❌ Neither POSTGRES_URL_READONLY nor POSTGRES_URL is defined.\n" +
+    throw new UsageError(
+      "Neither POSTGRES_URL_READONLY nor POSTGRES_URL is defined.\n" +
         "   Set up the read-only role: scripts/sql/readonly-role.sql"
     );
-    process.exit(1);
   }
   return { url: fallback, dedicated: false };
 }
 
-const args = parseArgs(process.argv.slice(2));
-// `.env.local` by default, so the documented invocations work in a checkout
-// without anyone having to remember `--env`; absent, it is skipped rather
-// than fatal. Values in the file override exported ones, which fails in the safe
-// direction — `.env.local` is the local stack, so the accident it can cause is
-// querying local while you meant prod, never the reverse.
-loadEnvFile(args.envFile ?? ".env.local", { required: args.envFile !== null });
-const sql = args.file ? readFileSync(args.file, "utf8") : args.sql;
-
-if (!sql?.trim()) {
-  console.error(
-    "❌ No query given.\n" +
-      '   node scripts/query-readonly.mjs "select 1"\n' +
-      "   node scripts/query-readonly.mjs --file query.sql"
-  );
-  process.exit(1);
+/**
+ * Read the query text for `--file`, turning a bad path into a friendly error
+ * rather than a raw ENOENT stack trace (every other input error here exits 1
+ * with a `❌` line, and `--file` should match).
+ */
+function readQuery(args) {
+  if (!args.file) return args.sql;
+  try {
+    return readFileSync(args.file, "utf8");
+  } catch (error) {
+    throw new UsageError(
+      `Cannot read query file ${args.file}: ${error.message}`
+    );
+  }
 }
 
-const { url, dedicated } = resolveUrl();
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
 
-// Say plainly which database this is and how it is protected. A read against
-// prod is legitimate; a read against prod that the operator THOUGHT was local
-// is how bad assumptions get made, so the target is never implicit.
-const target = isPinPointProductionTarget(url)
-  ? "PRODUCTION"
-  : "non-production";
-console.error(`→ ${target}: ${describeTarget(url)}`);
-console.error(
-  dedicated
-    ? "→ read-only role + read-only transaction"
-    : "→ read-only transaction only (POSTGRES_URL_READONLY not set — the " +
-        "connecting role CAN write; the transaction is what is stopping it)"
-);
+  // `.env.local` by default, so the documented invocations work in a checkout
+  // without anyone having to remember `--env`; absent, it is skipped rather than
+  // fatal. Values in the file override exported ones, which fails in the safe
+  // direction — `.env.local` is the local stack, so the accident it can cause is
+  // querying local while you meant prod, never the reverse.
+  loadEnvFile(args.envFile ?? ".env.local", {
+    required: args.envFile !== null,
+  });
 
-// `prepare: false` — the transaction pooler on :6543 does not support prepared
-// statements (AGENTS.md §7; PP-d8l8 traced silent prod commit loss to this).
-// `max: 1` so the BEGIN and the query provably share one connection.
-const client = postgres(url, { prepare: false, max: 1 });
+  const sql = readQuery(args);
+  if (!sql?.trim()) {
+    throw new UsageError(
+      "No query given.\n" +
+        '   node scripts/query-readonly.mjs "select 1"\n' +
+        "   node scripts/query-readonly.mjs --file query.sql"
+    );
+  }
 
-let exitCode = 0;
-try {
-  // `.begin()` would COMMIT on success. This has to roll back unconditionally,
-  // so the transaction is driven by hand on a reserved connection.
-  const connection = await client.reserve();
+  const { url, dedicated } = resolveUrl();
+
+  // Say plainly which database this is and how it is protected. A read against
+  // prod is legitimate; a read against prod that the operator THOUGHT was local
+  // is how bad assumptions get made, so the target is never implicit.
+  const target = isPinPointProductionTarget(url)
+    ? "PRODUCTION"
+    : "non-production";
+  console.error(`→ ${target}: ${describeTarget(url)}`);
+  console.error(
+    dedicated
+      ? "→ read-only role: writes have no privilege to run (the real guarantee)"
+      : "→ NO read-only role (POSTGRES_URL_READONLY unset): the connecting role " +
+          "CAN write. A single-statement write is refused, but a multi-statement " +
+          "query is NOT safely contained here — set up the role."
+  );
+
+  // Delegate the pooler-safe client construction (prepare:false applied last, so
+  // these options cannot re-enable prepared statements). `max: 1` so BEGIN and
+  // the query provably share one connection. `onnotice` to stderr so a NOTICE
+  // cannot corrupt `--json` on stdout. The two timeouts bound an accidental
+  // runaway query against prod rather than letting it hold a pooler connection
+  // and an MVCC snapshot open indefinitely.
+  const client = createScriptClient(url, {
+    max: 1,
+    onnotice: (notice) => console.error(`NOTICE: ${notice.message ?? notice}`),
+    connection: {
+      statement_timeout: "30s",
+      idle_in_transaction_session_timeout: "60s",
+    },
+  });
+
+  let exitCode = 0;
   try {
-    await connection.unsafe("BEGIN TRANSACTION READ ONLY");
-    const rows = await connection.unsafe(sql);
-    // Roll back before printing: if rendering throws, the transaction is
-    // already closed rather than left open on the pooler.
-    await connection.unsafe("ROLLBACK");
+    const connection = await client.reserve();
+    try {
+      // Session-level read-only extends the transaction's protection across a
+      // `ROLLBACK; …` escape (see the header): autocommit statements after such
+      // a break still inherit it. Not a wall — `SET … = off` defeats it — but it
+      // closes the accidental case on the fallback path.
+      await connection.unsafe("SET SESSION default_transaction_read_only = on");
+      // `.begin()` would COMMIT on success. This has to roll back
+      // unconditionally, so the transaction is driven by hand.
+      await connection.unsafe("BEGIN TRANSACTION READ ONLY");
+      const rows = await connection.unsafe(sql);
+      // Roll back before printing: if rendering throws, the transaction is
+      // already closed rather than left open on the pooler.
+      await connection.unsafe("ROLLBACK");
 
-    if (args.json) {
-      console.log(JSON.stringify(rows, null, 2));
-    } else if (rows.length === 0) {
-      console.log("(0 rows)");
-    } else {
-      console.table(rows);
-      console.log(`(${rows.length} row${rows.length === 1 ? "" : "s"})`);
+      if (args.json) {
+        console.log(JSON.stringify(rows, null, 2));
+      } else if (rows.length === 0) {
+        console.log("(0 rows)");
+      } else {
+        console.table(rows);
+        console.log(`(${rows.length} row${rows.length === 1 ? "" : "s"})`);
+      }
+    } catch (error) {
+      await connection.unsafe("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      connection.release();
     }
   } catch (error) {
-    await connection.unsafe("ROLLBACK").catch(() => {});
-    throw error;
+    // 25006 is "cannot execute X in a read-only transaction" — the guard doing
+    // its job, so name it rather than letting it read as a broken script.
+    if (error?.code === "25006") {
+      console.error(
+        "❌ Refused: that statement writes, and this tool only reads.\n" +
+          "   Blocked by the server, not by this script."
+      );
+    } else {
+      console.error(`❌ ${error?.message ?? String(error)}`);
+    }
+    exitCode = 1;
   } finally {
-    connection.release();
+    await client.end({ timeout: 5 });
   }
-} catch (error) {
-  // 25006 is "cannot execute X in a read-only transaction" — the guard doing
-  // its job, so name it rather than letting it read as a broken script.
-  if (error?.code === "25006") {
-    console.error(
-      "❌ Refused: that statement writes, and this tool only reads.\n" +
-        "   Blocked by the server, not by this script."
-    );
-  } else {
-    console.error(`❌ ${error?.message ?? String(error)}`);
-  }
-  exitCode = 1;
-} finally {
-  await client.end({ timeout: 5 });
+
+  // `process.exitCode`, not `process.exit()`: the latter tears the process down
+  // before a piped stdout has flushed, silently truncating a large `--json`
+  // result with a success code. `client.end()` released the only handle, so the
+  // event loop drains and the process exits on its own with this code.
+  process.exitCode = exitCode;
 }
 
-process.exit(exitCode);
+main().catch((error) => {
+  if (error instanceof UsageError) {
+    console.error(`❌ ${error.message}`);
+  } else {
+    console.error(`❌ ${error?.stack ?? error?.message ?? String(error)}`);
+  }
+  process.exitCode = 1;
+});

--- a/scripts/sql/readonly-role.sql
+++ b/scripts/sql/readonly-role.sql
@@ -1,0 +1,155 @@
+-- A SELECT-only role for investigative queries against production.
+--
+-- Run ONCE per database, by a human, with the service-role connection string.
+-- Re-running it is safe: every step is idempotent, and the auth views are
+-- dropped and recreated so an edited column list actually takes effect.
+--
+-- This is deliberately NOT a drizzle migration: a login role is an operator
+-- concern, not app schema. Preview branches and local stacks have nothing worth
+-- protecting and would only accumulate a useless role, and putting `CREATE ROLE`
+-- into the migration history means every future `db:reset` re-runs it.
+--
+--   psql "$POSTGRES_URL_ADMIN" -v pw="$(openssl rand -base64 24)" \
+--        -f scripts/sql/readonly-role.sql
+--
+-- Then build the connection string for scripts/query-readonly.mjs:
+--   postgres://pinpoint_readonly.<project-ref>:<pw>@<same-host>:6543/postgres
+-- The `.<project-ref>` suffix on the USERNAME is not optional: port 6543 is
+-- Supavisor, which routes by tenant and reads it from there, so the bare role
+-- name fails authentication rather than failing to route. Put it in .env.local
+-- as POSTGRES_URL_READONLY. It does NOT belong in the Vercel env registry — the
+-- app never reads it, and the registry's membership test is "PinPoint is broken
+-- without this".
+--
+-- Why this exists: agents investigating a bug need to read production, including
+-- `auth.users`. Handing them the service-role string means every read carries
+-- write authority, and the only thing standing between a typo and a mutation is
+-- the agent's own judgement. This role removes the capability instead of asking
+-- for restraint.
+--
+-- Reading auth data: query `readonly_auth.users` / `readonly_auth.identities`,
+-- NOT `auth.users`. The reason is in the "auth" section below — it is a Supabase
+-- platform constraint, not a stylistic choice.
+
+\if :{?pw}
+\else
+  \echo 'ERROR: pass a password with  -v pw=...'
+  \quit 1
+\endif
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pinpoint_readonly') THEN
+    CREATE ROLE pinpoint_readonly LOGIN;
+  END IF;
+END
+$$;
+
+-- Set/rotate the password. Kept out of the DO block so the value is never
+-- interpolated into a string that could end up in pg_stat_statements.
+ALTER ROLE pinpoint_readonly WITH LOGIN PASSWORD :'pw';
+
+-- BYPASSRLS is what makes the role useful: without it, RLS policies written for
+-- end users hide most rows, and an investigation returns a confidently wrong
+-- "no rows" rather than an error. It grants visibility, never mutation — the
+-- role holds no INSERT/UPDATE/DELETE anywhere, and Supabase forbids SUPERUSER.
+ALTER ROLE pinpoint_readonly WITH BYPASSRLS NOCREATEDB NOCREATEROLE NOINHERIT;
+
+-- Every statement this role runs is read-only, belt to the braces of the
+-- read-only transaction scripts/query-readonly.mjs opens. This is the load-
+-- bearing write defense: unlike a REVOKE, it cannot be widened later by someone
+-- granting a privilege to PUBLIC.
+ALTER ROLE pinpoint_readonly SET default_transaction_read_only = on;
+
+-- The app schema in full: it holds no credentials, and an investigation that
+-- has to guess which table it may read is an investigation that reaches for the
+-- service-role string instead.
+GRANT USAGE ON SCHEMA public TO pinpoint_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO pinpoint_readonly;
+
+-- Tables added by future migrations, so the role does not silently go stale and
+-- start returning permission errors mid-investigation.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO pinpoint_readonly;
+
+--------------------------------------------------------------------------------
+-- auth: reached through views, because it cannot be granted directly
+--------------------------------------------------------------------------------
+--
+-- `GRANT ... ON auth.users TO pinpoint_readonly` does not work on Supabase, and
+-- fails in the worst way: schema `auth` is owned by `supabase_admin`, and the
+-- `postgres` role you run this as holds USAGE on it *without grant option*
+-- (`postgres=U/supabase_admin` in `pg_namespace.nspacl`). So
+-- `GRANT USAGE ON SCHEMA auth` emits `WARNING: no privileges were granted` —
+-- a warning, not an error, so a script that only checks exit codes reports
+-- success — and every column grant beneath it is then unreachable. Supabase does
+-- not give `postgres` superuser (docs: "Roles, superuser access and unsupported
+-- operations"), and `supabase_admin` is not connectable on a hosted project, so
+-- there is no way to grant it. Verified against a local stack: the role got
+-- `permission denied for schema auth` on every auth table.
+--
+-- A view owned by `postgres` is the way through. Views run with their OWNER's
+-- privileges unless created `security_invoker=true`, and `postgres` does hold
+-- USAGE on `auth` — so the view can read what its caller cannot. Deliberately
+-- NOT `security_invoker` here; that is the mechanism, not an oversight.
+--
+-- This is also a tighter allowlist than column grants were. The columns below
+-- are the whole surface: a future GoTrue migration adding another secret column
+-- cannot widen it, because the view names its columns and nothing re-derives
+-- them. What is being kept out:
+--
+--   auth.flow_state             provider_access_token, provider_refresh_token —
+--                               live Discord OAuth tokens, plaintext
+--   auth.custom_oauth_providers client_secret, also plaintext
+--   auth.users                  encrypted_password, recovery_token,
+--                               confirmation_token, reauthentication_token
+--   auth.sessions               refresh_token_hmac_key
+--   auth.refresh_tokens         token
+--   auth.mfa_factors            secret (TOTP seeds)
+--
+-- Combined with BYPASSRLS, a schema-wide grant on `auth` would have been an
+-- account-takeover path needing no write at all, over a connection string that
+-- is meant to be handed to agents.
+--
+-- The schema is not `public`, so PostgREST does not expose these views over the
+-- REST API — `db-schemas` lists `public, graphql_public` and nothing here adds
+-- to it. The REVOKEs below are what keep that true if it ever changes.
+
+CREATE SCHEMA IF NOT EXISTS readonly_auth;
+
+-- DROP rather than CREATE OR REPLACE: replacing a view cannot change its column
+-- list, so editing the allowlist above would otherwise fail on a re-run.
+DROP VIEW IF EXISTS readonly_auth.users;
+DROP VIEW IF EXISTS readonly_auth.identities;
+
+CREATE VIEW readonly_auth.users AS
+  SELECT
+    id, aud, role, email, email_confirmed_at, confirmed_at, invited_at,
+    last_sign_in_at, raw_app_meta_data, raw_user_meta_data, created_at,
+    updated_at, phone, phone_confirmed_at, banned_until, deleted_at,
+    is_sso_user, is_anonymous
+  FROM auth.users;
+
+CREATE VIEW readonly_auth.identities AS
+  SELECT
+    id, user_id, provider, provider_id, identity_data, email,
+    last_sign_in_at, created_at, updated_at
+  FROM auth.identities;
+
+-- Nobody but this role reads these. `anon` and `authenticated` are the two that
+-- would matter if the schema were ever added to PostgREST's exposed list.
+REVOKE ALL ON SCHEMA readonly_auth FROM PUBLIC;
+REVOKE ALL ON ALL TABLES IN SCHEMA readonly_auth FROM PUBLIC;
+REVOKE ALL ON SCHEMA readonly_auth FROM anon, authenticated;
+REVOKE ALL ON ALL TABLES IN SCHEMA readonly_auth FROM anon, authenticated;
+
+GRANT USAGE ON SCHEMA readonly_auth TO pinpoint_readonly;
+GRANT SELECT ON readonly_auth.users, readonly_auth.identities TO pinpoint_readonly;
+
+-- Vault holds the PinballMap operator credentials; a read-only investigation
+-- role has no business decrypting them. Already absent by default — stated so
+-- the intent survives someone reading only this file.
+REVOKE ALL ON SCHEMA vault FROM pinpoint_readonly;
+
+\echo ''
+\echo 'pinpoint_readonly configured. Verify with:'
+\echo '  \\i scripts/sql/verify-readonly-role.sql'

--- a/scripts/sql/readonly-role.sql
+++ b/scripts/sql/readonly-role.sql
@@ -71,6 +71,13 @@ ALTER ROLE pinpoint_readonly WITH LOGIN PASSWORD :'pw';
 -- end users hide most rows, and an investigation returns a confidently wrong
 -- "no rows" rather than an error. It grants visibility, never mutation — the
 -- role holds no INSERT/UPDATE/DELETE anywhere, and Supabase forbids SUPERUSER.
+--
+-- Granting BYPASSRLS requires the granting role to hold it too. On PG<=15 that
+-- meant SUPERUSER (which Supabase's `postgres` is not), so this statement would
+-- have aborted the whole run under ON_ERROR_STOP; on PG16+ a role with
+-- CREATEROLE + BYPASSRLS may grant it, and that is exactly what Supabase gives
+-- `postgres`. pinpoint-prod runs PG17, so this succeeds. A pre-16 project would
+-- fail here loudly rather than leave a half-built role behind.
 ALTER ROLE pinpoint_readonly WITH BYPASSRLS NOCREATEDB NOCREATEROLE NOINHERIT;
 
 -- Belt to the braces of the read-only transaction query-readonly.mjs opens.

--- a/scripts/sql/readonly-role.sql
+++ b/scripts/sql/readonly-role.sql
@@ -9,8 +9,13 @@
 -- protecting and would only accumulate a useless role, and putting `CREATE ROLE`
 -- into the migration history means every future `db:reset` re-runs it.
 --
---   psql "$POSTGRES_URL_ADMIN" -v pw="$(openssl rand -base64 24)" \
+--   psql "$POSTGRES_URL_ADMIN" -v pw="$(openssl rand -hex 24)" \
 --        -f scripts/sql/readonly-role.sql
+--
+-- Use `rand -hex`, NOT `-base64`: a base64 password can contain `/` or `+`, and
+-- a `/` in the password terminates the authority of the connection string below,
+-- so `new URL(...)` (what postgres.js parses it with) throws `ERR_INVALID_URL`
+-- with no hint that the password is the cause. Hex is URL-safe.
 --
 -- Then build the connection string for scripts/query-readonly.mjs:
 --   postgres://pinpoint_readonly.<project-ref>:<pw>@<same-host>:6543/postgres
@@ -30,11 +35,24 @@
 -- Reading auth data: query `readonly_auth.users` / `readonly_auth.identities`,
 -- NOT `auth.users`. The reason is in the "auth" section below — it is a Supabase
 -- platform constraint, not a stylistic choice.
+--
+-- Verify afterwards with scripts/sql/verify-readonly-role.sql, which asserts the
+-- resulting privileges from the catalog. Do not skip it: several statements here
+-- fail as WARNINGS rather than errors (see the auth section), and psql exits 0
+-- on a warning.
+
+-- Exit non-zero on the first SQL error. Without this, psql's exit status is 0
+-- even when a statement errors, so a failed CREATE VIEW or a missing password
+-- would leave a broken (or absent) role behind a "success" exit. This is also
+-- what makes the missing-password guard below actually stop the run.
+\set ON_ERROR_STOP on
 
 \if :{?pw}
 \else
   \echo 'ERROR: pass a password with  -v pw=...'
-  \quit 1
+  -- `\quit 1` does NOT exit non-zero — psql ignores the argument and exits 0.
+  -- A server error under ON_ERROR_STOP does exit non-zero, so raise one.
+  DO $$ BEGIN RAISE EXCEPTION 'missing required -v pw=...'; END $$;
 \endif
 
 DO $$
@@ -55,21 +73,56 @@ ALTER ROLE pinpoint_readonly WITH LOGIN PASSWORD :'pw';
 -- role holds no INSERT/UPDATE/DELETE anywhere, and Supabase forbids SUPERUSER.
 ALTER ROLE pinpoint_readonly WITH BYPASSRLS NOCREATEDB NOCREATEROLE NOINHERIT;
 
--- Every statement this role runs is read-only, belt to the braces of the
--- read-only transaction scripts/query-readonly.mjs opens. This is the load-
--- bearing write defense: unlike a REVOKE, it cannot be widened later by someone
--- granting a privilege to PUBLIC.
+-- Belt to the braces of the read-only transaction query-readonly.mjs opens.
+-- NOTE this is the WEAKEST layer, not the load-bearing one: it is a USERSET GUC,
+-- so any session can `SET default_transaction_read_only = off`. The durable
+-- write defense is the total absence of write grants below — that is what makes
+-- a write impossible, and it is what a future edit must not quietly relax.
 ALTER ROLE pinpoint_readonly SET default_transaction_read_only = on;
 
--- The app schema in full: it holds no credentials, and an investigation that
--- has to guess which table it may read is an investigation that reaches for the
--- service-role string instead.
+-- The app schema: readable, MINUS the columns that are themselves credentials.
 GRANT USAGE ON SCHEMA public TO pinpoint_readonly;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO pinpoint_readonly;
 
 -- Tables added by future migrations, so the role does not silently go stale and
 -- start returning permission errors mid-investigation.
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO pinpoint_readonly;
+
+-- `public` is NOT credential-free, so the blanket grant above is too wide as-is.
+-- `collections.view_token` is a base64url share token whose possession grants
+-- anonymous read access to an otherwise-private collection — a capability, not a
+-- reference. A connection string built to be handed to agents must not expose
+-- every member's share token. So: drop the table-level grant on `collections`
+-- and re-grant every column of it EXCEPT view_token. Done dynamically, so a
+-- column added to `collections` later is still readable; a NEW credential column
+-- would be re-exposed, which is why verify-readonly-role.sql scans public for
+-- credential-shaped column names the role can read.
+--
+-- (`bot_token_vault_id` / `outbound_token_vault_id` elsewhere in public are UUID
+-- pointers into `vault`, not secrets — the secret is only decryptable with vault
+-- access, which this role does not have. They stay readable.)
+REVOKE SELECT ON public.collections FROM pinpoint_readonly;
+DO $$
+DECLARE
+  col_list text;
+BEGIN
+  SELECT string_agg(quote_ident(column_name), ', ' ORDER BY ordinal_position)
+    INTO col_list
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+     AND table_name = 'collections'
+     AND column_name <> 'view_token';
+
+  IF col_list IS NULL THEN
+    RAISE EXCEPTION 'public.collections not found — cannot scope the view_token exclusion';
+  END IF;
+
+  EXECUTE format(
+    'GRANT SELECT (%s) ON public.collections TO pinpoint_readonly',
+    col_list
+  );
+END
+$$;
 
 --------------------------------------------------------------------------------
 -- auth: reached through views, because it cannot be granted directly
@@ -80,12 +133,13 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO pinpoint_rea
 -- `postgres` role you run this as holds USAGE on it *without grant option*
 -- (`postgres=U/supabase_admin` in `pg_namespace.nspacl`). So
 -- `GRANT USAGE ON SCHEMA auth` emits `WARNING: no privileges were granted` —
--- a warning, not an error, so a script that only checks exit codes reports
--- success — and every column grant beneath it is then unreachable. Supabase does
--- not give `postgres` superuser (docs: "Roles, superuser access and unsupported
--- operations"), and `supabase_admin` is not connectable on a hosted project, so
--- there is no way to grant it. Verified against a local stack: the role got
--- `permission denied for schema auth` on every auth table.
+-- a warning, not an error (which is why this file sets ON_ERROR_STOP but that
+-- alone would not catch it, and why verify-readonly-role.sql exists) — and every
+-- column grant beneath it is then unreachable. Supabase does not give `postgres`
+-- superuser (docs: "Roles, superuser access and unsupported operations"), and
+-- `supabase_admin` is not connectable on a hosted project, so there is no way to
+-- grant it. Verified against a local stack: the role got `permission denied for
+-- schema auth` on every auth table.
 --
 -- A view owned by `postgres` is the way through. Views run with their OWNER's
 -- privileges unless created `security_invoker=true`, and `postgres` does hold
@@ -146,10 +200,18 @@ GRANT USAGE ON SCHEMA readonly_auth TO pinpoint_readonly;
 GRANT SELECT ON readonly_auth.users, readonly_auth.identities TO pinpoint_readonly;
 
 -- Vault holds the PinballMap operator credentials; a read-only investigation
--- role has no business decrypting them. Already absent by default — stated so
--- the intent survives someone reading only this file.
-REVOKE ALL ON SCHEMA vault FROM pinpoint_readonly;
+-- role has no business decrypting them. Guarded on the schema existing: a plain
+-- Postgres or a project without supabase_vault has no `vault` schema, and a
+-- REVOKE against a missing schema is a hard error that would (under
+-- ON_ERROR_STOP) abort the run on its last statement.
+DO $$
+BEGIN
+  IF to_regnamespace('vault') IS NOT NULL THEN
+    EXECUTE 'REVOKE ALL ON SCHEMA vault FROM pinpoint_readonly';
+  END IF;
+END
+$$;
 
 \echo ''
 \echo 'pinpoint_readonly configured. Verify with:'
-\echo '  \\i scripts/sql/verify-readonly-role.sql'
+\echo '  psql "$POSTGRES_URL_ADMIN" -f scripts/sql/verify-readonly-role.sql'

--- a/scripts/sql/verify-readonly-role.sql
+++ b/scripts/sql/verify-readonly-role.sql
@@ -1,7 +1,8 @@
 -- Does `pinpoint_readonly` actually have the shape readonly-role.sql intends?
 --
 -- Run as the admin/service role, against any database where the role has been
--- set up. Raises on the first failing batch, so a plain `psql -f` exits non-zero:
+-- set up. Raises on the first failing batch, so a plain `psql -f` exits non-zero
+-- BECAUSE of the \set below:
 --
 --   psql "$POSTGRES_URL_ADMIN" -f scripts/sql/verify-readonly-role.sql
 --
@@ -14,6 +15,11 @@
 -- the one thing it was built for. Only asserting the resulting privileges
 -- catches that class of failure. Every check below is a fact about the catalog,
 -- never a restatement of a statement that was issued.
+
+-- Make a RAISE EXCEPTION below actually exit non-zero. Without ON_ERROR_STOP,
+-- psql exits 0 even on an error — the exact false-success this script exists to
+-- prevent, so it must not fall into it itself.
+\set ON_ERROR_STOP on
 
 DO $verify$
 DECLARE
@@ -28,9 +34,7 @@ DECLARE
   v_config     text[];
   v_public_tbl text;
   v_leaky_cols text;
-
-  -- Records one assertion: bumps the counters and names the failure.
-  -- (PL/pgSQL has no local procedures, so this is spelled out at each site.)
+  v_defacl     int;
 BEGIN
   SELECT rolcanlogin, rolbypassrls, rolsuper, rolcreaterole, rolcreatedb, rolconfig
     INTO v_canlogin, v_bypassrls, v_super, v_createrole, v_createdb, v_config
@@ -64,8 +68,8 @@ BEGIN
       v_super, v_createrole, v_createdb;
   END IF;
 
-  -- The load-bearing write defense. A REVOKE can be undone by a later GRANT;
-  -- this cannot.
+  -- The weakest write layer, but it should still be pinned. The durable defense
+  -- is the absence of write grants, checked further down.
   checked := checked + 1;
   IF v_config IS NULL OR NOT ('default_transaction_read_only=on' = ANY(v_config)) THEN
     failures := failures + 1;
@@ -82,14 +86,15 @@ BEGIN
   END IF;
 
   -- Sample a real table rather than trusting the grant statement: what matters
-  -- is what the role ended up holding.
+  -- is what the role ended up holding. Exclude `collections`, which is
+  -- deliberately column-scoped (see below) and so fails a table-level check.
   SELECT c.relname INTO v_public_tbl
     FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-   WHERE n.nspname = 'public' AND c.relkind = 'r'
+   WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname <> 'collections'
    ORDER BY c.relname LIMIT 1;
 
   IF v_public_tbl IS NULL THEN
-    RAISE WARNING 'no tables in public — public grants not verified (unmigrated database?)';
+    RAISE WARNING 'no sampleable public table — public grants not verified (unmigrated database?)';
   ELSE
     checked := checked + 1;
     IF NOT has_table_privilege('pinpoint_readonly', 'public.' || quote_ident(v_public_tbl), 'SELECT') THEN
@@ -104,6 +109,57 @@ BEGIN
       failures := failures + 1;
       RAISE WARNING 'holds a WRITE privilege on public.%', v_public_tbl;
     END IF;
+  END IF;
+
+  -- Future tables must be auto-readable. Asserting ALTER DEFAULT PRIVILEGES from
+  -- the catalog, because it is the one statement in the setup script whose effect
+  -- is invisible until a later migration trips over its absence.
+  checked := checked + 1;
+  SELECT count(*) INTO v_defacl
+    FROM pg_default_acl d
+    JOIN pg_namespace n ON n.oid = d.defaclnamespace
+   WHERE n.nspname = 'public'
+     AND d.defaclobjtype = 'r'
+     AND array_to_string(d.defaclacl, ',') LIKE '%pinpoint_readonly=r%';
+  IF v_defacl = 0 THEN
+    failures := failures + 1;
+    RAISE WARNING 'no default SELECT privilege for pinpoint_readonly on future public tables (ALTER DEFAULT PRIVILEGES did not land, or was run by a different role)';
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- public credentials: view_token excluded, nothing else credential-shaped
+  ----------------------------------------------------------------------------
+  -- The capability token must NOT be readable.
+  checked := checked + 1;
+  IF to_regclass('public.collections') IS NOT NULL THEN
+    IF has_column_privilege('pinpoint_readonly', 'public.collections', 'view_token', 'SELECT') THEN
+      failures := failures + 1;
+      RAISE WARNING 'can read public.collections.view_token — that is a share capability token';
+    END IF;
+    -- …but the rest of the table must be, or the exclusion broke the whole table.
+    checked := checked + 1;
+    IF NOT has_column_privilege('pinpoint_readonly', 'public.collections', 'id', 'SELECT') THEN
+      failures := failures + 1;
+      RAISE WARNING 'cannot read public.collections.id — the column re-grant did not land';
+    END IF;
+  END IF;
+
+  -- Name-based sweep for any OTHER credential-shaped column the role can read in
+  -- public — a future token/secret column that the blanket grant would expose.
+  -- `*_vault_id` is deliberately allowed: it is a pointer, decryptable only with
+  -- vault access this role lacks.
+  checked := checked + 1;
+  SELECT string_agg(format('%I.%I', table_name, column_name), ', ')
+    INTO v_leaky_cols
+    FROM information_schema.columns c
+   WHERE table_schema = 'public'
+     AND column_name ~* '(token|secret|password|hmac)'
+     AND column_name !~* 'vault_id$'
+     AND has_column_privilege('pinpoint_readonly',
+           format('public.%I', table_name), column_name, 'SELECT');
+  IF v_leaky_cols IS NOT NULL THEN
+    failures := failures + 1;
+    RAISE WARNING 'role can read credential-shaped public column(s): %', v_leaky_cols;
   END IF;
 
   ----------------------------------------------------------------------------
@@ -150,7 +206,7 @@ BEGIN
   END IF;
 
   ----------------------------------------------------------------------------
-  -- No credential ever reaches the views
+  -- No credential ever reaches the auth views, and the raw tables stay hidden
   ----------------------------------------------------------------------------
   -- Name-based on purpose: it catches a column a future GoTrue release adds that
   -- someone then copies into the view without thinking about what it holds.
@@ -166,15 +222,20 @@ BEGIN
     RAISE WARNING 'readonly_auth exposes credential-shaped column(s): %', v_leaky_cols;
   END IF;
 
-  -- And the tables those columns live on stay unreachable directly.
+  -- And the tables those columns live on stay unreachable directly. Guarded on
+  -- the table existing: a non-Supabase Postgres has no auth.flow_state, and a
+  -- has_table_privilege on a missing relation errors and would abort every check
+  -- above it in this block.
   checked := checked + 1;
-  IF has_table_privilege('pinpoint_readonly', 'auth.flow_state', 'SELECT') THEN
+  IF to_regclass('auth.flow_state') IS NOT NULL
+     AND has_table_privilege('pinpoint_readonly', 'auth.flow_state', 'SELECT') THEN
     failures := failures + 1;
     RAISE WARNING 'can SELECT auth.flow_state — that is plaintext OAuth tokens';
   END IF;
 
   checked := checked + 1;
-  IF has_schema_privilege('pinpoint_readonly', 'vault', 'USAGE') THEN
+  IF to_regnamespace('vault') IS NOT NULL
+     AND has_schema_privilege('pinpoint_readonly', 'vault', 'USAGE') THEN
     failures := failures + 1;
     RAISE WARNING 'has USAGE on schema vault';
   END IF;

--- a/scripts/sql/verify-readonly-role.sql
+++ b/scripts/sql/verify-readonly-role.sql
@@ -1,0 +1,190 @@
+-- Does `pinpoint_readonly` actually have the shape readonly-role.sql intends?
+--
+-- Run as the admin/service role, against any database where the role has been
+-- set up. Raises on the first failing batch, so a plain `psql -f` exits non-zero:
+--
+--   psql "$POSTGRES_URL_ADMIN" -f scripts/sql/verify-readonly-role.sql
+--
+-- Reads catalogs and writes nothing, so it is safe against production.
+--
+-- Why this exists rather than "just read the setup script": that script's most
+-- important statement used to be one that SILENTLY DID NOTHING.
+-- `GRANT USAGE ON SCHEMA auth` emits a WARNING rather than an error when the
+-- grantor lacks grant option, so psql exits 0 and the role ships unable to read
+-- the one thing it was built for. Only asserting the resulting privileges
+-- catches that class of failure. Every check below is a fact about the catalog,
+-- never a restatement of a statement that was issued.
+
+DO $verify$
+DECLARE
+  failures     int := 0;
+  checked      int := 0;
+
+  v_canlogin   boolean;
+  v_bypassrls  boolean;
+  v_super      boolean;
+  v_createrole boolean;
+  v_createdb   boolean;
+  v_config     text[];
+  v_public_tbl text;
+  v_leaky_cols text;
+
+  -- Records one assertion: bumps the counters and names the failure.
+  -- (PL/pgSQL has no local procedures, so this is spelled out at each site.)
+BEGIN
+  SELECT rolcanlogin, rolbypassrls, rolsuper, rolcreaterole, rolcreatedb, rolconfig
+    INTO v_canlogin, v_bypassrls, v_super, v_createrole, v_createdb, v_config
+    FROM pg_roles WHERE rolname = 'pinpoint_readonly';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'pinpoint_readonly does not exist — run scripts/sql/readonly-role.sql first';
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- Role attributes
+  ----------------------------------------------------------------------------
+  checked := checked + 1;
+  IF NOT v_canlogin THEN
+    failures := failures + 1;
+    RAISE WARNING 'role cannot LOGIN — the connection string would fail';
+  END IF;
+
+  -- Without BYPASSRLS an investigation gets a confidently wrong "no rows"
+  -- rather than an error, which is worse than being denied outright.
+  checked := checked + 1;
+  IF NOT v_bypassrls THEN
+    failures := failures + 1;
+    RAISE WARNING 'role lacks BYPASSRLS — reads will silently return too few rows';
+  END IF;
+
+  checked := checked + 1;
+  IF v_super OR v_createrole OR v_createdb THEN
+    failures := failures + 1;
+    RAISE WARNING 'role has an elevated attribute: super=% createrole=% createdb=%',
+      v_super, v_createrole, v_createdb;
+  END IF;
+
+  -- The load-bearing write defense. A REVOKE can be undone by a later GRANT;
+  -- this cannot.
+  checked := checked + 1;
+  IF v_config IS NULL OR NOT ('default_transaction_read_only=on' = ANY(v_config)) THEN
+    failures := failures + 1;
+    RAISE WARNING 'default_transaction_read_only is not pinned on (rolconfig=%)', v_config;
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- public: readable, never writable
+  ----------------------------------------------------------------------------
+  checked := checked + 1;
+  IF NOT has_schema_privilege('pinpoint_readonly', 'public', 'USAGE') THEN
+    failures := failures + 1;
+    RAISE WARNING 'no USAGE on schema public';
+  END IF;
+
+  -- Sample a real table rather than trusting the grant statement: what matters
+  -- is what the role ended up holding.
+  SELECT c.relname INTO v_public_tbl
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relkind = 'r'
+   ORDER BY c.relname LIMIT 1;
+
+  IF v_public_tbl IS NULL THEN
+    RAISE WARNING 'no tables in public — public grants not verified (unmigrated database?)';
+  ELSE
+    checked := checked + 1;
+    IF NOT has_table_privilege('pinpoint_readonly', 'public.' || quote_ident(v_public_tbl), 'SELECT') THEN
+      failures := failures + 1;
+      RAISE WARNING 'cannot SELECT public.% — the public grant did not land', v_public_tbl;
+    END IF;
+
+    checked := checked + 1;
+    IF has_table_privilege('pinpoint_readonly', 'public.' || quote_ident(v_public_tbl), 'INSERT')
+       OR has_table_privilege('pinpoint_readonly', 'public.' || quote_ident(v_public_tbl), 'UPDATE')
+       OR has_table_privilege('pinpoint_readonly', 'public.' || quote_ident(v_public_tbl), 'DELETE') THEN
+      failures := failures + 1;
+      RAISE WARNING 'holds a WRITE privilege on public.%', v_public_tbl;
+    END IF;
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- auth: reachable ONLY through the views
+  ----------------------------------------------------------------------------
+  -- The check that would have caught the original bug. Direct USAGE on `auth` is
+  -- expected to be absent — not because it was revoked, but because Supabase
+  -- cannot grant it from the `postgres` role at all.
+  checked := checked + 1;
+  IF has_schema_privilege('pinpoint_readonly', 'auth', 'USAGE') THEN
+    failures := failures + 1;
+    RAISE WARNING 'has direct USAGE on schema auth — the view indirection is being bypassed';
+  END IF;
+
+  checked := checked + 1;
+  IF NOT has_schema_privilege('pinpoint_readonly', 'readonly_auth', 'USAGE') THEN
+    failures := failures + 1;
+    RAISE WARNING 'no USAGE on readonly_auth — auth data is unreachable, which is the point of the role';
+  END IF;
+
+  checked := checked + 1;
+  IF NOT has_table_privilege('pinpoint_readonly', 'readonly_auth.users', 'SELECT') THEN
+    failures := failures + 1;
+    RAISE WARNING 'cannot SELECT readonly_auth.users';
+  END IF;
+
+  checked := checked + 1;
+  IF NOT has_table_privilege('pinpoint_readonly', 'readonly_auth.identities', 'SELECT') THEN
+    failures := failures + 1;
+    RAISE WARNING 'cannot SELECT readonly_auth.identities';
+  END IF;
+
+  -- The views must NOT be security_invoker: the caller has no USAGE on auth, so
+  -- an invoker-rights view resolves to permission denied. Asserted because
+  -- "harden the view" is a plausible-looking edit that silently breaks it.
+  checked := checked + 1;
+  IF EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'readonly_auth'
+       AND 'security_invoker=true' = ANY(COALESCE(c.reloptions, '{}'))
+  ) THEN
+    failures := failures + 1;
+    RAISE WARNING 'a readonly_auth view is security_invoker — it will resolve to permission denied';
+  END IF;
+
+  ----------------------------------------------------------------------------
+  -- No credential ever reaches the views
+  ----------------------------------------------------------------------------
+  -- Name-based on purpose: it catches a column a future GoTrue release adds that
+  -- someone then copies into the view without thinking about what it holds.
+  checked := checked + 1;
+  SELECT string_agg(table_name || '.' || column_name, ', ')
+    INTO v_leaky_cols
+    FROM information_schema.columns
+   WHERE table_schema = 'readonly_auth'
+     AND column_name ~* '(token|secret|password|hmac|nonce|challenge)';
+
+  IF v_leaky_cols IS NOT NULL THEN
+    failures := failures + 1;
+    RAISE WARNING 'readonly_auth exposes credential-shaped column(s): %', v_leaky_cols;
+  END IF;
+
+  -- And the tables those columns live on stay unreachable directly.
+  checked := checked + 1;
+  IF has_table_privilege('pinpoint_readonly', 'auth.flow_state', 'SELECT') THEN
+    failures := failures + 1;
+    RAISE WARNING 'can SELECT auth.flow_state — that is plaintext OAuth tokens';
+  END IF;
+
+  checked := checked + 1;
+  IF has_schema_privilege('pinpoint_readonly', 'vault', 'USAGE') THEN
+    failures := failures + 1;
+    RAISE WARNING 'has USAGE on schema vault';
+  END IF;
+
+  ----------------------------------------------------------------------------
+  IF failures > 0 THEN
+    RAISE EXCEPTION 'pinpoint_readonly: % of % checks failed — see the warnings above',
+      failures, checked;
+  END IF;
+
+  RAISE NOTICE 'pinpoint_readonly: all % checks pass', checked;
+END
+$verify$;

--- a/src/test/unit/scripts/query-readonly.test.ts
+++ b/src/test/unit/scripts/query-readonly.test.ts
@@ -23,9 +23,10 @@
 // caps each subprocess with a timeout so a misconfigured host cannot wedge CI.
 
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 
 const repoRoot = process.cwd();
 const SCRIPT = "scripts/query-readonly.mjs";
@@ -65,6 +66,12 @@ function run(env: Record<string, string>, argv: string[] = []): RunResult {
 // "nothing configured" cases have to opt out of it explicitly or they pick up
 // the local stack's URL and assert nothing.
 const NO_ENV_FILE = ["--env", "/dev/null"];
+
+// Temp dirs holding throwaway env fixtures; removed after the suite.
+const tmpDirs: string[] = [];
+afterAll(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+});
 
 describe("query-readonly.mjs — refuses to run without a query", () => {
   it("exits 1 and shows both invocations", () => {
@@ -160,6 +167,25 @@ describe("query-readonly.mjs — env resolution", () => {
     expect(status).toBe(1);
     expect(stderr).toContain("Cannot read env file");
   });
+
+  it("lets an exported variable win over the env file (dotenv precedence)", () => {
+    // The which-DB footgun: an operator exports a prod URL, then runs from a
+    // worktree whose .env.local also defines one. The export must win, or the
+    // tool reads local while reporting prod. Here the file says local and the
+    // export says prod-like — prod must be what the banner names.
+    const dir = mkdtempSync(path.join(tmpdir(), "query-readonly-env-"));
+    tmpDirs.push(dir);
+    const envPath = path.join(dir, "local.env");
+    writeFileSync(envPath, `POSTGRES_URL_READONLY=${LOCAL_URL}\n`);
+
+    const { stderr } = run({ POSTGRES_URL_READONLY: PROD_LIKE_URL }, [
+      "--env",
+      envPath,
+      "select 1",
+    ]);
+    expect(stderr).toContain("PRODUCTION");
+    expect(stderr).not.toContain("non-production");
+  });
 });
 
 describe("query-readonly.mjs — --file input", () => {
@@ -181,6 +207,19 @@ describe("query-readonly.mjs — --file input", () => {
     ]);
     expect(status).toBe(1);
     expect(stderr).toContain("--file needs a value");
+  });
+
+  it("rejects --file together with an inline query rather than silently dropping one", () => {
+    // --file would win and the positional would vanish — the same "which
+    // statement ran?" ambiguity the parser is loud about everywhere else.
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "--file",
+      "query.sql",
+      "select 1",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("not both");
   });
 });
 

--- a/src/test/unit/scripts/query-readonly.test.ts
+++ b/src/test/unit/scripts/query-readonly.test.ts
@@ -1,0 +1,279 @@
+// The read-only query tool and the role it pairs with (PP-xdvw).
+//
+// Two layers, matching db-target-guards.test.ts:
+//   1. Real subprocess runs of scripts/query-readonly.mjs — argument handling,
+//      env resolution, and what it tells the operator about the target. A tool
+//      whose whole value is "you cannot write with this" has to be legible about
+//      which database it is pointed at and which layer is protecting it.
+//   2. Source assertions on scripts/sql/readonly-role.sql, pinning the one
+//      mistake that already shipped once: granting on `auth` directly.
+//
+// What is deliberately NOT here: whether a write actually gets SQLSTATE 25006.
+// That is a property of the server, not of this script, and asserting it needs a
+// live database — see scripts/sql/verify-readonly-role.sql, which is run against
+// the target database itself.
+//
+// Every case points at localhost:1 or supplies no URL at all, so nothing here
+// opens a connection or waits on a timeout.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const SCRIPT = "scripts/query-readonly.mjs";
+const ROLE_SQL = "scripts/sql/readonly-role.sql";
+const VERIFY_SQL = "scripts/sql/verify-readonly-role.sql";
+
+const PROD_POOLER_URL =
+  "postgres://pinpoint_readonly.udhesuizjsgxfeotqybn:sup3rs3cret@aws-0-us-east-2.pooler.supabase.com:6543/postgres";
+const LOCAL_URL = "postgres://postgres:pw@localhost:1/postgres";
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(env: Record<string, string>, argv: string[] = []): RunResult {
+  const result = spawnSync("node", [path.join(repoRoot, SCRIPT), ...argv], {
+    encoding: "utf8",
+    cwd: repoRoot,
+    // Clean slate: an ambient POSTGRES_URL must not decide these outcomes.
+    env: { NODE_ENV: "test", PATH: process.env.PATH ?? "", ...env },
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+// `.env.local` is the default env file and exists in every worktree, so the
+// "nothing configured" cases have to opt out of it explicitly or they pick up
+// the local stack's URL and assert nothing.
+const NO_ENV_FILE = ["--env", "/dev/null"];
+
+describe("query-readonly.mjs — refuses to run without a query", () => {
+  it("exits 1 and shows both invocations", () => {
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("No query given");
+    expect(stderr).toContain("--file");
+  });
+
+  it("treats a whitespace-only query as no query", () => {
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "   ",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("No query given");
+  });
+});
+
+describe("query-readonly.mjs — env resolution", () => {
+  it("exits 1 with no connection string, and names the setup script", () => {
+    // The operator's next action has to be in the error, or they are stuck.
+    const { status, stderr } = run({}, [...NO_ENV_FILE, "select 1"]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("POSTGRES_URL_READONLY");
+    expect(stderr).toContain("readonly-role.sql");
+  });
+
+  it("fails on an explicitly named env file it cannot read", () => {
+    // A missing DEFAULT file is fine (the caller may have exported the vars);
+    // a file the caller named and misspelled is not, or the run silently
+    // targets something other than what they asked for.
+    const { status, stderr } = run({}, [
+      "--env",
+      "does/not/exist.env",
+      "select 1",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("Cannot read env file");
+  });
+
+  it("uses --env rather than --env-file, which Node claims for itself", () => {
+    // Node v20+ implements `--env-file` and consumes it even after the script
+    // path, so the script never sees it: a bad path dies with Node's own
+    // "not found" and exit 9 instead of the message above, and a good path has
+    // Node load EVERY key in the file into the environment — the opposite of
+    // the two-key whitelist loadEnvFile applies. Renaming the flag is what
+    // keeps both properties.
+    //
+    // A tripwire, not a spec for Node: if a future runtime stops claiming the
+    // flag this goes red, and the right response is to read this comment and
+    // decide — not to widen the assertion. Only the absence of OUR message is
+    // checked, so it does not pin Node's wording.
+    const { stderr } = run({}, [
+      "--env-file",
+      "does/not/exist.env",
+      "select 1",
+    ]);
+    expect(stderr).not.toContain("Cannot read env file");
+  });
+});
+
+describe("query-readonly.mjs — says which database and which protection", () => {
+  it("names PRODUCTION when the target is the production project", () => {
+    // A prod read is legitimate. A prod read the operator thought was local is
+    // how bad assumptions get made, so the target is never implicit.
+    const { stderr } = run({ POSTGRES_URL_READONLY: PROD_POOLER_URL }, [
+      ...NO_ENV_FILE,
+      "select 1",
+    ]);
+    expect(stderr).toContain("PRODUCTION");
+  });
+
+  it("does not print the password when it names the target", () => {
+    const { stdout, stderr } = run({ POSTGRES_URL_READONLY: PROD_POOLER_URL }, [
+      ...NO_ENV_FILE,
+      "select 1",
+    ]);
+    expect(stderr).not.toContain("sup3rs3cret");
+    expect(stdout).not.toContain("sup3rs3cret");
+  });
+
+  it("labels a non-production target as such", () => {
+    const { stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "select 1",
+    ]);
+    expect(stderr).toContain("non-production");
+  });
+
+  it("warns when falling back to POSTGRES_URL that the role CAN write", () => {
+    // This is the honest-reporting case: without the dedicated role the only
+    // thing stopping a write is the transaction, and the operator should know
+    // they are running on one layer rather than two.
+    const { stderr } = run({ POSTGRES_URL: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "select 1",
+    ]);
+    expect(stderr).toContain("read-only transaction only");
+    expect(stderr).toContain("CAN write");
+  });
+
+  it("reports both layers when the dedicated role is configured", () => {
+    const { stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "select 1",
+    ]);
+    expect(stderr).toContain("read-only role + read-only transaction");
+    expect(stderr).not.toContain("CAN write");
+  });
+
+  it("prefers POSTGRES_URL_READONLY when both are set", () => {
+    const { stderr } = run(
+      { POSTGRES_URL_READONLY: LOCAL_URL, POSTGRES_URL: PROD_POOLER_URL },
+      [...NO_ENV_FILE, "select 1"]
+    );
+    expect(stderr).toContain("non-production");
+    expect(stderr).not.toContain("PRODUCTION");
+  });
+});
+
+/**
+ * Strip `--` comments before asserting on a SQL file.
+ *
+ * These files explain at length what they deliberately do NOT do — the auth
+ * grant, `security_invoker` — so a naive source match hits the prose that warns
+ * against the thing and fails on a correct file. Only executable text counts.
+ */
+function statementsOf(relPath: string): string {
+  return readFileSync(path.join(repoRoot, relPath), "utf8")
+    .split("\n")
+    .filter((line) => !/^\s*--/.test(line))
+    .join("\n");
+}
+
+describe("readonly-role.sql — never grants on auth directly", () => {
+  const sql = statementsOf(ROLE_SQL);
+
+  it("does not GRANT on schema auth — Postgres only WARNS when that fails", () => {
+    // The original version shipped `GRANT USAGE ON SCHEMA auth`. Schema `auth`
+    // is owned by `supabase_admin` and `postgres` holds USAGE on it WITHOUT
+    // grant option, so the statement emits `WARNING: no privileges were
+    // granted` and psql still exits 0 — a role that cannot read the one thing
+    // it exists to read, with a setup script that reported success.
+    expect(sql).not.toMatch(/GRANT\s+USAGE\s+ON\s+SCHEMA\s+auth/i);
+    expect(sql).not.toMatch(/GRANT\s+SELECT[\s\S]{0,200}?ON\s+auth\./i);
+  });
+
+  it("reaches auth through owner-rights views instead", () => {
+    expect(sql).toMatch(/CREATE\s+VIEW\s+readonly_auth\.users/i);
+    expect(sql).toMatch(/CREATE\s+VIEW\s+readonly_auth\.identities/i);
+    expect(sql).toMatch(/GRANT\s+USAGE\s+ON\s+SCHEMA\s+readonly_auth/i);
+  });
+
+  it("does NOT make those views security_invoker", () => {
+    // The caller has no USAGE on auth, so invoker rights would resolve to
+    // permission denied. This is the mechanism, not an oversight.
+    expect(sql).not.toMatch(/security_invoker/i);
+  });
+
+  it("keeps the credential-bearing auth tables out entirely", () => {
+    for (const table of [
+      "flow_state",
+      "refresh_tokens",
+      "mfa_factors",
+      "sessions",
+      "custom_oauth_providers",
+    ]) {
+      expect(sql).not.toMatch(new RegExp(`FROM\\s+auth\\.${table}\\b`, "i"));
+    }
+  });
+
+  it("selects no credential-shaped column into the views", () => {
+    // Mirrors the catalog check in verify-readonly-role.sql, from the source
+    // side: the view bodies are the allowlist.
+    const viewBodies = sql.match(/CREATE\s+VIEW[\s\S]*?;/gi) ?? [];
+    expect(viewBodies.length).toBe(2);
+    for (const body of viewBodies) {
+      expect(body).not.toMatch(
+        /\b\w*(token|secret|password|hmac|nonce|challenge)\w*\b/i
+      );
+    }
+  });
+
+  it("pins the role read-only at the role level, not only per-transaction", () => {
+    expect(sql).toMatch(/default_transaction_read_only\s*=\s*on/i);
+    expect(sql).toMatch(/BYPASSRLS/);
+    expect(sql).toMatch(/NOCREATEDB/);
+    expect(sql).toMatch(/NOCREATEROLE/);
+  });
+
+  it("documents the Supavisor tenant suffix the connection string needs", () => {
+    // Without `.<project-ref>` on the username, port 6543 fails authentication
+    // rather than failing to route — an error that reads like a wrong password.
+    // Asserted against the RAW file: this one lives in the header prose, which
+    // is the only place it can live, since the script cannot know the ref.
+    const raw = readFileSync(path.join(repoRoot, ROLE_SQL), "utf8");
+    expect(raw).toContain("pinpoint_readonly.<project-ref>");
+  });
+});
+
+describe("verify-readonly-role.sql — asserts privileges, not statements", () => {
+  const sql = statementsOf(VERIFY_SQL);
+
+  it("checks the catalog rather than re-running grants", () => {
+    expect(sql).toMatch(/has_schema_privilege\(/);
+    expect(sql).toMatch(/has_table_privilege\(/);
+    expect(sql).not.toMatch(/^\s*GRANT\s/im);
+  });
+
+  it("asserts that direct auth USAGE is ABSENT", () => {
+    // The check that would have caught the original bug.
+    expect(sql).toMatch(
+      /has_schema_privilege\('pinpoint_readonly',\s*'auth',\s*'USAGE'\)/
+    );
+  });
+
+  it("raises rather than merely warning, so psql -f exits non-zero", () => {
+    expect(sql).toMatch(/RAISE\s+EXCEPTION/i);
+  });
+});

--- a/src/test/unit/scripts/query-readonly.test.ts
+++ b/src/test/unit/scripts/query-readonly.test.ts
@@ -5,16 +5,22 @@
 //      env resolution, and what it tells the operator about the target. A tool
 //      whose whole value is "you cannot write with this" has to be legible about
 //      which database it is pointed at and which layer is protecting it.
-//   2. Source assertions on scripts/sql/readonly-role.sql, pinning the one
-//      mistake that already shipped once: granting on `auth` directly.
+//   2. Source assertions on scripts/sql/readonly-role.sql and its verify script,
+//      pinning the mistakes that already shipped once: granting on `auth`
+//      directly, and exposing the collections share token.
 //
-// What is deliberately NOT here: whether a write actually gets SQLSTATE 25006.
-// That is a property of the server, not of this script, and asserting it needs a
-// live database — see scripts/sql/verify-readonly-role.sql, which is run against
-// the target database itself.
+// What is deliberately NOT here: whether a write actually gets SQLSTATE 25006,
+// or whether the view_token exclusion actually denies at the privilege level.
+// Those are properties of the server — see scripts/sql/verify-readonly-role.sql,
+// which is run against the target database itself.
 //
-// Every case points at localhost:1 or supplies no URL at all, so nothing here
-// opens a connection or waits on a timeout.
+// Every URL fixture points at `localhost:1` (connection refused instantly), so a
+// case that reaches the connect step fails fast rather than hanging — and the
+// "production" fixture keeps the prod project ref in the USERNAME while pointing
+// the host at localhost, so `isPinPointProductionTarget` still fires but nothing
+// ever dials the real production endpoint (that would be a CORE-TEST-006
+// violation — a production hostname reachable from a unit run). `run()` also
+// caps each subprocess with a timeout so a misconfigured host cannot wedge CI.
 
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -26,8 +32,10 @@ const SCRIPT = "scripts/query-readonly.mjs";
 const ROLE_SQL = "scripts/sql/readonly-role.sql";
 const VERIFY_SQL = "scripts/sql/verify-readonly-role.sql";
 
-const PROD_POOLER_URL =
-  "postgres://pinpoint_readonly.udhesuizjsgxfeotqybn:sup3rs3cret@aws-0-us-east-2.pooler.supabase.com:6543/postgres";
+// Production project ref in the username, host pinned to localhost:1 — reads as
+// production to isPinPointProductionTarget, connects to nothing reachable.
+const PROD_LIKE_URL =
+  "postgres://pinpoint_readonly.udhesuizjsgxfeotqybn:sup3rs3cret@localhost:1/postgres";
 const LOCAL_URL = "postgres://postgres:pw@localhost:1/postgres";
 
 interface RunResult {
@@ -40,6 +48,9 @@ function run(env: Record<string, string>, argv: string[] = []): RunResult {
   const result = spawnSync("node", [path.join(repoRoot, SCRIPT), ...argv], {
     encoding: "utf8",
     cwd: repoRoot,
+    // A blackholed host must not wedge the worker: localhost:1 refuses in
+    // microseconds, but the timeout is the backstop if a fixture is ever wrong.
+    timeout: 20_000,
     // Clean slate: an ambient POSTGRES_URL must not decide these outcomes.
     env: { NODE_ENV: "test", PATH: process.env.PATH ?? "", ...env },
   });
@@ -75,6 +86,59 @@ describe("query-readonly.mjs — refuses to run without a query", () => {
   });
 });
 
+describe("query-readonly.mjs — argument parsing is strict", () => {
+  // A silent-drop parser would let a misspelled flag or a stray word change
+  // which database or which statement runs, without a word to the operator.
+
+  it("rejects an unknown flag instead of dropping it", () => {
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "--frobnicate",
+      "select 1",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("unknown flag --frobnicate");
+  });
+
+  it("rejects a second positional rather than letting the last one win", () => {
+    // The classic footgun: an unquoted query splits into words and the last one
+    // silently becomes THE query. Loud instead.
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "select 1",
+      "select 2",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("extra argument");
+  });
+
+  it("rejects a value-flag that would swallow the next flag as its value", () => {
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      "--env",
+      "--json",
+      "select 1",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("--env needs a value");
+  });
+
+  it("rejects --env-file as unknown rather than silently mis-running", () => {
+    // Node (v20+) owns `--env-file`: a missing file makes Node abort before this
+    // script runs, and an existing file has Node load EVERY key in it. Either
+    // way the operator meant `--env`; the old silent-drop parser turned the
+    // typo's filename into a positional and ran the default `.env.local`. Now it
+    // is a hard error. (This asserts OUR rejection, so it is robust to a file
+    // that exists vs. not — Node's own abort path never reaches us.)
+    const { stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      "--env-file",
+      "/dev/null",
+      "select 1",
+    ]);
+    expect(stderr).toContain("unknown flag --env-file");
+    expect(stderr).not.toContain("(0 rows)");
+  });
+});
+
 describe("query-readonly.mjs — env resolution", () => {
   it("exits 1 with no connection string, and names the setup script", () => {
     // The operator's next action has to be in the error, or they are stuck.
@@ -96,25 +160,27 @@ describe("query-readonly.mjs — env resolution", () => {
     expect(status).toBe(1);
     expect(stderr).toContain("Cannot read env file");
   });
+});
 
-  it("uses --env rather than --env-file, which Node claims for itself", () => {
-    // Node v20+ implements `--env-file` and consumes it even after the script
-    // path, so the script never sees it: a bad path dies with Node's own
-    // "not found" and exit 9 instead of the message above, and a good path has
-    // Node load EVERY key in the file into the environment — the opposite of
-    // the two-key whitelist loadEnvFile applies. Renaming the flag is what
-    // keeps both properties.
-    //
-    // A tripwire, not a spec for Node: if a future runtime stops claiming the
-    // flag this goes red, and the right response is to read this comment and
-    // decide — not to widen the assertion. Only the absence of OUR message is
-    // checked, so it does not pin Node's wording.
-    const { stderr } = run({}, [
-      "--env-file",
-      "does/not/exist.env",
-      "select 1",
+describe("query-readonly.mjs — --file input", () => {
+  it("turns a missing query file into a friendly error, not a stack trace", () => {
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      ...NO_ENV_FILE,
+      "--file",
+      "does/not/exist.sql",
     ]);
-    expect(stderr).not.toContain("Cannot read env file");
+    expect(status).toBe(1);
+    expect(stderr).toContain("Cannot read query file");
+    expect(stderr).not.toContain("at readFileSync");
+  });
+
+  it("does not treat a following flag as the filename", () => {
+    const { status, stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
+      "--file",
+      "--json",
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toContain("--file needs a value");
   });
 });
 
@@ -122,7 +188,7 @@ describe("query-readonly.mjs — says which database and which protection", () =
   it("names PRODUCTION when the target is the production project", () => {
     // A prod read is legitimate. A prod read the operator thought was local is
     // how bad assumptions get made, so the target is never implicit.
-    const { stderr } = run({ POSTGRES_URL_READONLY: PROD_POOLER_URL }, [
+    const { stderr } = run({ POSTGRES_URL_READONLY: PROD_LIKE_URL }, [
       ...NO_ENV_FILE,
       "select 1",
     ]);
@@ -130,7 +196,7 @@ describe("query-readonly.mjs — says which database and which protection", () =
   });
 
   it("does not print the password when it names the target", () => {
-    const { stdout, stderr } = run({ POSTGRES_URL_READONLY: PROD_POOLER_URL }, [
+    const { stdout, stderr } = run({ POSTGRES_URL_READONLY: PROD_LIKE_URL }, [
       ...NO_ENV_FILE,
       "select 1",
     ]);
@@ -146,30 +212,30 @@ describe("query-readonly.mjs — says which database and which protection", () =
     expect(stderr).toContain("non-production");
   });
 
-  it("warns when falling back to POSTGRES_URL that the role CAN write", () => {
-    // This is the honest-reporting case: without the dedicated role the only
-    // thing stopping a write is the transaction, and the operator should know
-    // they are running on one layer rather than two.
+  it("warns loudly on the fallback path that the role CAN write", () => {
+    // Without the dedicated role the write privilege exists, and a multi-
+    // statement query is NOT contained. The operator must be told this is not a
+    // safe place to run untrusted SQL — the honest framing, not "protected".
     const { stderr } = run({ POSTGRES_URL: LOCAL_URL }, [
       ...NO_ENV_FILE,
       "select 1",
     ]);
-    expect(stderr).toContain("read-only transaction only");
+    expect(stderr).toContain("NO read-only role");
     expect(stderr).toContain("CAN write");
   });
 
-  it("reports both layers when the dedicated role is configured", () => {
+  it("states the real guarantee when the dedicated role is configured", () => {
     const { stderr } = run({ POSTGRES_URL_READONLY: LOCAL_URL }, [
       ...NO_ENV_FILE,
       "select 1",
     ]);
-    expect(stderr).toContain("read-only role + read-only transaction");
+    expect(stderr).toContain("read-only role");
     expect(stderr).not.toContain("CAN write");
   });
 
   it("prefers POSTGRES_URL_READONLY when both are set", () => {
     const { stderr } = run(
-      { POSTGRES_URL_READONLY: LOCAL_URL, POSTGRES_URL: PROD_POOLER_URL },
+      { POSTGRES_URL_READONLY: LOCAL_URL, POSTGRES_URL: PROD_LIKE_URL },
       [...NO_ENV_FILE, "select 1"]
     );
     expect(stderr).toContain("non-production");
@@ -228,9 +294,9 @@ describe("readonly-role.sql — never grants on auth directly", () => {
     }
   });
 
-  it("selects no credential-shaped column into the views", () => {
-    // Mirrors the catalog check in verify-readonly-role.sql, from the source
-    // side: the view bodies are the allowlist.
+  it("selects no credential-shaped column into the auth views", () => {
+    // The view bodies are the allowlist. Mirrors the catalog check in the verify
+    // script from the source side.
     const viewBodies = sql.match(/CREATE\s+VIEW[\s\S]*?;/gi) ?? [];
     expect(viewBodies.length).toBe(2);
     for (const body of viewBodies) {
@@ -240,6 +306,27 @@ describe("readonly-role.sql — never grants on auth directly", () => {
     }
   });
 
+  it("excludes collections.view_token from the public grant", () => {
+    // public is NOT credential-free: collections.view_token is a share
+    // capability token. The blanket grant is narrowed by revoking the table
+    // grant on collections and re-granting every column except view_token.
+    expect(sql).toMatch(/REVOKE\s+SELECT\s+ON\s+public\.collections/i);
+    expect(sql).toMatch(/column_name\s*<>\s*'view_token'/i);
+    // …and it must not simply grant the whole table back.
+    expect(sql).not.toMatch(/GRANT\s+SELECT\s+ON\s+public\.collections\s+TO/i);
+  });
+
+  it("sets ON_ERROR_STOP so a failed statement exits non-zero", () => {
+    // Without it, psql exits 0 on error and a broken setup reports success.
+    expect(sql).toMatch(/ON_ERROR_STOP\s+on/i);
+  });
+
+  it("raises on a missing password rather than \\quit 1 (which exits 0)", () => {
+    // `\quit 1` ignores its argument and exits 0; a RAISE under ON_ERROR_STOP
+    // exits non-zero, which is the only thing that actually stops the run.
+    expect(sql).toMatch(/RAISE\s+EXCEPTION\s+'missing required/i);
+  });
+
   it("pins the role read-only at the role level, not only per-transaction", () => {
     expect(sql).toMatch(/default_transaction_read_only\s*=\s*on/i);
     expect(sql).toMatch(/BYPASSRLS/);
@@ -247,13 +334,14 @@ describe("readonly-role.sql — never grants on auth directly", () => {
     expect(sql).toMatch(/NOCREATEROLE/);
   });
 
-  it("documents the Supavisor tenant suffix the connection string needs", () => {
-    // Without `.<project-ref>` on the username, port 6543 fails authentication
-    // rather than failing to route — an error that reads like a wrong password.
-    // Asserted against the RAW file: this one lives in the header prose, which
-    // is the only place it can live, since the script cannot know the ref.
+  it("documents a URL-safe password and the Supavisor tenant suffix", () => {
+    // A base64 password can contain `/`, which terminates the URL authority and
+    // makes new URL() throw; and without `.<project-ref>` on the username, port
+    // 6543 fails authentication. Both live in the header prose (the script
+    // cannot know the ref), so assert against the raw file.
     const raw = readFileSync(path.join(repoRoot, ROLE_SQL), "utf8");
     expect(raw).toContain("pinpoint_readonly.<project-ref>");
+    expect(raw).toMatch(/rand -hex/);
   });
 });
 
@@ -273,7 +361,22 @@ describe("verify-readonly-role.sql — asserts privileges, not statements", () =
     );
   });
 
-  it("raises rather than merely warning, so psql -f exits non-zero", () => {
+  it("asserts view_token is NOT readable and the rest of collections is", () => {
+    expect(sql).toMatch(
+      /has_column_privilege\('pinpoint_readonly',\s*'public\.collections',\s*'view_token'/
+    );
+  });
+
+  it("sets ON_ERROR_STOP and raises, so psql -f exits non-zero on failure", () => {
+    // Both are required: RAISE EXCEPTION alone still exits 0 without the \set.
+    expect(sql).toMatch(/ON_ERROR_STOP\s+on/i);
     expect(sql).toMatch(/RAISE\s+EXCEPTION/i);
+  });
+
+  it("guards checks on optional schemas so a missing one does not abort", () => {
+    // has_*_privilege on a missing relation/schema errors and would discard
+    // every check before it in the DO block. Guarded on existence.
+    expect(sql).toMatch(/to_regnamespace\('vault'\)/i);
+    expect(sql).toMatch(/to_regclass\('auth\.flow_state'\)/i);
   });
 });


### PR DESCRIPTION
Agents investigating a production bug need to read production, including `auth.users`. Over the service-role string, every one of those reads carries write authority, and the only thing between a typo and a mutation is the agent's own judgement. You asked for a mechanism instead of restraint (mid-PP-if48). This is it.

Built and reviewed during #1883, then pulled out of it so that PR stayed the user-name fix. Restored from `a946675a` — and **running it turned up two bugs that the review could not have caught, one of which made the whole thing inert.**

## The auth grant silently did nothing

The version reviewed in #1883 had:

```sql
GRANT USAGE ON SCHEMA auth TO pinpoint_readonly;
GRANT SELECT (id, email, raw_user_meta_data, …) ON auth.users TO pinpoint_readonly;
```

Schema `auth` is owned by `supabase_admin`, and the `postgres` role you run this as holds USAGE on it **without grant option** — `postgres=U/supabase_admin` in `pg_namespace.nspacl`. Postgres answers that with a **WARNING, not an error**:

```
WARNING:  no privileges were granted for "auth"
```

`psql` exits 0. The column grants beneath it land in the catalog and are unreachable. The result is a role that reports successful setup and then gets `permission denied for schema auth` on every auth table — unable to read the one thing it exists to read.

There is no version of that statement that works: Supabase does not give `postgres` superuser ([docs](https://supabase.com/docs/guides/database/postgres/roles-superuser)), and `supabase_admin` is not connectable on a hosted project.

**Auth is now reached through owner-rights views** in a `readonly_auth` schema. A view runs with its owner's privileges unless created `security_invoker`, and `postgres` does hold USAGE on `auth` — so the view reads what its caller cannot. Not `security_invoker` here is the mechanism, not an oversight, and there is a check asserting it stays that way.

This is also a **tighter** allowlist than the 27 column grants it replaces: the view names its columns and nothing re-derives them, so a future GoTrue migration adding another secret column cannot widen it. `auth.flow_state` (plaintext Discord OAuth access + refresh tokens), `auth.custom_oauth_providers.client_secret`, `auth.refresh_tokens`, `auth.mfa_factors` and `auth.sessions` are absent entirely.

## `--env-file` was unreachable

Node v20+ implements `--env-file` itself and consumes it **even after the script path**. A bad path died with Node's own error and exit 9 rather than the script's message; a good path had Node load *every* key in the file into the environment, which is the opposite of the two-key whitelist the script applies. Renamed to `--env`, with a tripwire test.

## Verified against a live stack, not read

| | |
|---|---|
| apply → verify → probe → re-apply | clean, idempotent, zero warnings |
| reads | `public.*`, `readonly_auth.users`, `readonly_auth.identities` |
| denied | `auth.users`, `auth.flow_state`, `auth.refresh_tokens`, `vault` |
| writes with `SET TRANSACTION READ WRITE` | `permission denied for table user_profiles` |
| a write through the tool | SQLSTATE 25006 refusal, exit 1 |

That fourth row is the one worth noting: the write fails on **privilege** even with the read-only default explicitly overridden, so the two layers are genuinely independent rather than one of them wearing a disguise.

`pnpm run check` clean; 2223/2223 unit tests.

## `verify-readonly-role.sql` is new

15 assertions read from the catalog — `has_schema_privilege` / `has_table_privilege` — rather than trusting that a GRANT was issued. That distinction is the entire reason the first bug survived a review, so the check that matters most is the one asserting direct `auth` USAGE is **absent**. It also fails on any credential-shaped column name reaching the views, which is a guard against a future GoTrue column being copied in without thought.

## What you still have to do

The role does not exist on prod. One-time, human-run, deliberately not a migration (a login role is an operator concern, and `CREATE ROLE` in migration history re-runs on every `db:reset`):

```
psql "$POSTGRES_URL_ADMIN" -v pw="$(openssl rand -base64 24)" -f scripts/sql/readonly-role.sql
psql "$POSTGRES_URL_ADMIN" -f scripts/sql/verify-readonly-role.sql
```

Then put this in `.env.local` as `POSTGRES_URL_READONLY` — **not** in the Vercel registry, the app never reads it:

```
postgres://pinpoint_readonly.<project-ref>:<pw>@<host>:6543/postgres
```

The `.<project-ref>` suffix on the username is not optional; Supavisor routes by tenant and reads it there, so the bare role name fails authentication rather than failing to route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7NuN3hQycxcRfKDmCXJHh
