### PR TITLE
chore(beads): checked-in cloud-init script + exact bd version pin (PP-4p1k)

### DIFF
--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -58,6 +58,7 @@ Then work the checklist. For each item, note findings as a comment on the bead (
        ```
 
      - If it's newer than the current pin (mind major bumps — read the pnpm release notes/migration guide first), bump via `corepack use pnpm@<version>`, then verify no lockfile churn (`pnpm install --frozen-lockfile` → only `package.json` should change), `pnpm audit --audit-level=high` still resolves, and `pnpm run check` is green. PR it through the normal workflow; file a bead if a major bump needs real migration work.
+   - **bd cloud version pin** (from the 2026-08-16 shared-DB schema incident). Cloud beads routines pin `bd` to an exact version in two coupled sites: `BD_PINNED_VERSION` in `scripts/beads-cloud-init.sh` (the enforced guard) and `BD_VER` in the setup script embedded in `docs/runbooks/cloud-routines-beads-access.md` (whose live copy lives in the claude.ai environment UI — not diffable). When Tim's local/Bazzite `bd` moves past the pin, bump **all three** — the two repo sites **and** the UI copy — together, or every cloud routine refuses to run. Exact-pin is deliberate: an accidental _newer_ release migrated the shared DB and locked every client out for two days, so a loud refusal is the safe failure. Compare the pin against the installed `bd version`; bump only once the newer version is running clean locally.
 
 2. **TypeScript-7 rollout status**
    - Read `docs/plans/2026-06-27-typescript-7-upgrade-plan.md` for the current phase. Phases 1–3 are done (PP-xu96, PP-8mv1, PP-4zcj); the GA-pin bead PP-rl1l is closed.

--- a/docs/runbooks/cloud-routines-beads-access.md
+++ b/docs/runbooks/cloud-routines-beads-access.md
@@ -53,8 +53,9 @@ If a push 403s, DoltHub may be using region-scoped upload hosts — widen to
 see Reproducing / debugging). Avoid the broad `*.amazonaws.com`.
 
 Do **not** rely on `api.github.com` — it is rate-limited on shared cloud egress
-IPs (returns 403) and may not be allowlisted. Resolve the latest version off the
-`github.com` `/releases/latest` redirect instead (see setup script).
+IPs (returns 403) and may not be allowlisted. The setup script pins the `bd`
+version and downloads the release asset from `github.com` directly (no API call,
+no redirect resolution needed — see setup script).
 
 ### Environment variables
 
@@ -91,11 +92,9 @@ curl -fsSL -o /tmp/dolt.tgz \
 tar xzf /tmp/dolt.tgz -C /tmp
 install /tmp/dolt-linux-amd64/bin/dolt "$BIN/dolt"
 
-echo "=== RESOLVE BEADS LATEST TAG (via github.com redirect) ==="
-BD_TAG=$(curl -fsSL -o /dev/null -w '%{url_effective}\n' \
-  https://github.com/steveyegge/beads/releases/latest | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
-BD_VER="${BD_TAG#v}"
-echo "=== INSTALL BEADS ${BD_TAG} ==="
+echo "=== INSTALL BEADS (PINNED — keep in sync with the init-script guard) ==="
+BD_VER=1.2.2            # MUST match BD_PINNED_VERSION in scripts/beads-cloud-init.sh
+BD_TAG="v${BD_VER}"
 curl -fsSL -o /tmp/bd.tgz \
   "https://github.com/steveyegge/beads/releases/download/${BD_TAG}/beads_${BD_VER}_linux_amd64.tar.gz"
 tar xzf /tmp/bd.tgz -C /tmp
@@ -110,10 +109,21 @@ if ! bd version; then
 fi
 ```
 
-`bd` is intentionally **unpinned** (both cloud and local track latest stable).
-The drift risk — cloud `bd` schema-ahead of the DB — is handled by beads'
-remote-migrate gate, which refuses to auto-migrate a remote-backed DB and prints
-the fix rather than corrupting anything.
+`bd` is **pinned** to an explicit version (`BD_VER` above), which MUST match
+`BD_PINNED_VERSION` in `scripts/beads-cloud-init.sh`. This reverses the earlier
+"track latest stable" policy: on 2026-08-16 an accidental newer release (1.2.1)
+migrated the shared DB to a schema no supported binary could read and locked
+every client out for two days. An exact pin fails loud (a drifted version makes
+the init script refuse to run) rather than silent (a newer release migrating the
+shared DB before anyone notices). Bumping the pin is a weekly-chores item —
+update this setup script (in the claude.ai UI) **and** the init-script constant
+together.
+
+Caveat, stated plainly: this setup script lives in the claude.ai environment UI,
+**not** in git, so it cannot be reviewed or diffed, and this embedded copy can
+drift from what actually runs. The reviewable, enforced backstop is the version
+guard in `scripts/beads-cloud-init.sh`, which refuses to touch the DB unless the
+installed `bd` equals its pin.
 
 ## Credential setup (one-time)
 
@@ -140,23 +150,30 @@ named `<handle>.jwk` and `user.creds` matches it.
 
 ## Agent preamble (prepend to each beads-writing routine prompt)
 
-```bash
-mkdir -p ~/.dolt/creds
-printf '%s' "$DOLT_CREDS_JWK" > ~/.dolt/creds/"$DOLT_CREDS_PUB".jwk
-chmod 600 ~/.dolt/creds/"$DOLT_CREDS_PUB".jwk
-printf '{"user.creds":"%s","user.email":"<dolthub-account-email>","user.name":"advacar"}' \
-  "$DOLT_CREDS_PUB" > ~/.dolt/config_global.json
+The credential-materialization, version guard, and clone all live in a
+checked-in script — `scripts/beads-cloud-init.sh`, present in the cloud
+checkout — so a routine's preamble is one line:
 
-# Clone + persist sync.remote in one step (no hand-seeded .beads/config.yaml):
-mkdir -p ~/beads && cd ~/beads
-bd init --remote "$BEADS_SYNC_REMOTE" --prefix PP --non-interactive
+```bash
+bash scripts/beads-cloud-init.sh && cd ~/beads
 
 # ... do work: bd ready / bd create / bd update ...
 bd dolt push
 ```
 
-`user.email` is Dolt commit metadata only (not used for authentication — the JWK
-handles that); use your DoltHub account email or any non-personal address.
+The script reads `DOLT_CREDS_JWK`, `DOLT_CREDS_PUB`, and `BEADS_SYNC_REMOTE` from
+the environment (agent-runtime only — see #55440 above), writes the DoltHub
+credential and `~/.dolt/config_global.json`, checks `bd version` against its pin,
+then clones into `~/beads`. It exits non-zero — refusing to touch the DB — on a
+version mismatch or any missing env var, so a routine fails fast instead of
+running against a wrong binary. The generated `user.name`/`user.email` are Dolt
+commit metadata only (not authentication — the JWK handles that); override with
+`DOLT_USER_NAME` / `DOLT_USER_EMAIL` for a specific address.
+
+Why a script and not inline preamble prose: a prompt instruction ("stop if `bd`
+isn't 1.2.2") is the weakest enforcement — a model can reason past it. A script
+that exits non-zero cannot. Keeping the logic in git also makes it reviewable,
+unlike the setup script in the claude.ai UI.
 
 ## Guardrails
 

--- a/scripts/beads-cloud-init.sh
+++ b/scripts/beads-cloud-init.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# beads-cloud-init.sh — one-shot beads (DoltHub) setup for Claude cloud routines.
+#
+# Claude cloud routines run in ephemeral sandboxes with a fresh PinPoint checkout
+# but no .beads data (.beads/ is gitignored). This script — run by the AGENT at
+# routine start, because the claude.ai environment variables are visible only at
+# agent runtime and NEVER to the environment's setup script
+# (anthropics/claude-code#55440, closed not_planned) — materializes the dedicated
+# DoltHub credential, guards the bd version, then clones the shared beads DB.
+#
+# It replaces the multi-line agent preamble that used to be pasted into every
+# beads-writing routine prompt. A routine now runs, in one line:
+#
+#     bash scripts/beads-cloud-init.sh && cd ~/beads
+#
+# THE VERSION PIN (loud, exact, deliberate). This refuses to proceed unless bd is
+# EXACTLY BD_PINNED_VERSION — newer or older. Rationale: an accidental *newer*
+# beads release (1.2.1, 2026-08-16) migrated the shared DB to a schema no
+# supported binary could read and locked every client out for two days. A stale
+# exact pin fails LOUD ("routine refuses to run") — the safe direction; a version
+# floor would fail SILENT (a newer release migrates the shared DB before anyone
+# notices). The binary is already installed by the environment's setup script
+# (from releases/latest) before this runs, so this guard's job is to stop a wrong
+# binary from TOUCHING THE DB, not to control the download. The real download pin
+# belongs in that setup script — which lives in the claude.ai UI, not this repo,
+# and so cannot be reviewed or diffed. This in-repo guard is the reviewable
+# backstop.
+#
+# When Tim upgrades his machines past the pin, bump BD_PINNED_VERSION below. It is
+# a weekly-chores checklist item so the bump is a known recurring task, not a
+# surprise Saturday outage.
+#
+# Required env (materialized by claude.ai environment config; agent-runtime only):
+#   DOLT_CREDS_JWK     — the dedicated cloud DoltHub credential's private JWK
+#                        (one-line JSON)
+#   DOLT_CREDS_PUB     — the local file-stem handle for that credential
+#   BEADS_SYNC_REMOTE  — https://doltremoteapi.dolthub.com/advacar/pinpoint-beads
+# Optional env:
+#   BEADS_DIR          — where to clone (default: ~/beads)
+#   DOLT_USER_NAME     — Dolt commit author name (default: advacar)
+#   DOLT_USER_EMAIL    — Dolt commit author email; metadata only, NOT auth
+#                        (default: beads-cloud@pinpoint.invalid)
+
+set -euo pipefail
+
+# --- The pin. Bump when Tim's machines move past it (weekly chores item). ------
+BD_PINNED_VERSION="1.2.2"
+# ------------------------------------------------------------------------------
+
+BEADS_DIR="${BEADS_DIR:-$HOME/beads}"
+DOLT_USER_NAME="${DOLT_USER_NAME:-advacar}"
+DOLT_USER_EMAIL="${DOLT_USER_EMAIL:-beads-cloud@pinpoint.invalid}"
+
+log() { printf '[beads-cloud-init] %s\n' "$*" >&2; }
+die() { printf '[beads-cloud-init] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# 1. bd must be installed and actually RUN. A version that will not print usually
+#    means the tarball binary is missing libicu (the setup script installs it on
+#    that failure).
+command -v bd >/dev/null 2>&1 \
+  || die "bd not found on PATH — the environment setup script should install it"
+bd_ver="$(bd version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" \
+  || die "bd is installed but will not run (missing libicu?) — check the setup script"
+[[ -n "$bd_ver" ]] || die "could not parse 'bd version' output"
+
+# 2. THE GUARD. Exact-pin — refuse anything else, newer OR older.
+if [[ "$bd_ver" != "$BD_PINNED_VERSION" ]]; then
+  die "bd $bd_ver != pinned $BD_PINNED_VERSION — refusing to touch the shared beads DB.
+       If this is a deliberate upgrade, bump BD_PINNED_VERSION in scripts/beads-cloud-init.sh.
+       Do NOT install, build, or 'upgrade' bd inside a cloud routine to get past this."
+fi
+log "bd $bd_ver matches pin — proceeding"
+
+# 3. Required env for credential materialization.
+[[ -n "${DOLT_CREDS_JWK:-}" ]]    || die "DOLT_CREDS_JWK not set (claude.ai env var, agent-runtime only)"
+[[ -n "${DOLT_CREDS_PUB:-}" ]]    || die "DOLT_CREDS_PUB not set"
+[[ -n "${BEADS_SYNC_REMOTE:-}" ]] || die "BEADS_SYNC_REMOTE not set"
+
+# 4. Materialize the dedicated DoltHub credential. The private key stays off git —
+#    it comes from the env var each run. user.creds binds the private JWK to the
+#    registered public key (that is the access grant); user.name/email are Dolt
+#    commit metadata only, not authentication.
+log "materializing DoltHub credential"
+mkdir -p "$HOME/.dolt/creds"
+printf '%s' "$DOLT_CREDS_JWK" > "$HOME/.dolt/creds/$DOLT_CREDS_PUB.jwk"
+chmod 600 "$HOME/.dolt/creds/$DOLT_CREDS_PUB.jwk"
+printf '{"user.creds":"%s","user.name":"%s","user.email":"%s"}' \
+  "$DOLT_CREDS_PUB" "$DOLT_USER_NAME" "$DOLT_USER_EMAIL" \
+  > "$HOME/.dolt/config_global.json"
+
+# 5. Clone the shared beads DB (persists sync.remote; no hand-seeded config.yaml).
+if [[ -d "$BEADS_DIR/.beads" ]]; then
+  log "beads workspace already present in $BEADS_DIR — leaving it as-is"
+else
+  log "cloning shared beads DB into $BEADS_DIR"
+  mkdir -p "$BEADS_DIR"
+  cd "$BEADS_DIR"
+  bd init --remote "$BEADS_SYNC_REMOTE" --prefix PP --non-interactive
+fi
+
+log "beads ready in $BEADS_DIR (bd $bd_ver) — cd there to use bd"

--- a/scripts/beads-cloud-init.sh
+++ b/scripts/beads-cloud-init.sh
@@ -35,7 +35,6 @@
 #   DOLT_CREDS_PUB     — the local file-stem handle for that credential
 #   BEADS_SYNC_REMOTE  — https://doltremoteapi.dolthub.com/advacar/pinpoint-beads
 # Optional env:
-#   BEADS_DIR          — where to clone (default: ~/beads)
 #   DOLT_USER_NAME     — Dolt commit author name (default: advacar)
 #   DOLT_USER_EMAIL    — Dolt commit author email; metadata only, NOT auth
 #                        (default: beads-cloud@pinpoint.invalid)
@@ -46,7 +45,10 @@ set -euo pipefail
 BD_PINNED_VERSION="1.2.2"
 # ------------------------------------------------------------------------------
 
-BEADS_DIR="${BEADS_DIR:-$HOME/beads}"
+# Fixed, not overridable: the runbook preamble cd's into ~/beads, so a
+# configurable clone target would let the two drift (clone one place, cd to an
+# empty other). Edit here if you ever need a different path.
+BEADS_DIR="$HOME/beads"
 DOLT_USER_NAME="${DOLT_USER_NAME:-advacar}"
 DOLT_USER_EMAIL="${DOLT_USER_EMAIL:-beads-cloud@pinpoint.invalid}"
 
@@ -63,9 +65,13 @@ die() { printf '[beads-cloud-init] ERROR: %s\n' "$*" >&2; exit 1; }
 command -v bd >/dev/null 2>&1 \
   || die "bd not found on PATH — the environment setup script should install it"
 bd_raw="$(bd version 2>&1 || true)"
-bd_ver="$(printf '%s\n' "$bd_raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+# Anchor on bd's own "bd version X.Y.Z ..." line rather than the first semver-
+# shaped token anywhere in the output — a future banner that also prints a Go
+# runtime or build id in semver shape must not be able to feed the pin guard the
+# wrong number. If the prefix ever changes, this parses empty and dies loud.
+bd_ver="$(printf '%s\n' "$bd_raw" | sed -nE 's/^bd version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n1 || true)"
 [[ -n "$bd_ver" ]] \
-  || die "bd is installed but 'bd version' produced no parseable version (missing libicu, or a broken binary): $bd_raw"
+  || die "could not parse a version from 'bd version' (missing libicu, a broken binary, or a changed output format): $bd_raw"
 
 # 2. THE GUARD. Exact-pin — refuse anything else, newer OR older.
 if [[ "$bd_ver" != "$BD_PINNED_VERSION" ]]; then
@@ -79,6 +85,17 @@ log "bd $bd_ver matches pin — proceeding"
 [[ -n "${DOLT_CREDS_JWK:-}" ]]    || die "DOLT_CREDS_JWK not set (claude.ai env var, agent-runtime only)"
 [[ -n "${DOLT_CREDS_PUB:-}" ]]    || die "DOLT_CREDS_PUB not set"
 [[ -n "${BEADS_SYNC_REMOTE:-}" ]] || die "BEADS_SYNC_REMOTE not set"
+
+# DOLT_CREDS_PUB becomes a file path; DOLT_USER_NAME/EMAIL are interpolated into
+# JSON. Defaults are safe, but a malformed override could traverse out of the
+# creds dir or produce invalid JSON — reject both. (if/then, not `&& die`, so a
+# false test does not trip `set -e`.)
+if [[ "$DOLT_CREDS_PUB" == *[/\\]* ]]; then
+  die "DOLT_CREDS_PUB must be a bare file stem with no path separators: $DOLT_CREDS_PUB"
+fi
+if [[ "$DOLT_USER_NAME$DOLT_USER_EMAIL" == *[\"\\]* ]]; then
+  die "DOLT_USER_NAME / DOLT_USER_EMAIL must not contain a double-quote or backslash — they would break config_global.json"
+fi
 
 # 4. Materialize the dedicated DoltHub credential. The private key stays off git —
 #    it comes from the env var each run. user.creds binds the private JWK to the
@@ -94,7 +111,12 @@ printf '{"user.creds":"%s","user.name":"%s","user.email":"%s"}' \
 
 # 5. Clone the shared beads DB (persists sync.remote; no hand-seeded config.yaml).
 if [[ -d "$BEADS_DIR/.beads" ]]; then
-  log "beads workspace already present in $BEADS_DIR — leaving it as-is"
+  # A surviving/reused workspace must be re-synced, not trusted — operating on a
+  # stale local snapshot of the shared DB (then pushing work computed against it)
+  # is the exact failure that motivated this script. Pull fails loud if it can't.
+  log "beads workspace already present in $BEADS_DIR — syncing from remote"
+  cd "$BEADS_DIR"
+  bd dolt pull
 else
   log "cloning shared beads DB into $BEADS_DIR"
   mkdir -p "$BEADS_DIR"

--- a/scripts/beads-cloud-init.sh
+++ b/scripts/beads-cloud-init.sh
@@ -20,11 +20,10 @@
 # exact pin fails LOUD ("routine refuses to run") — the safe direction; a version
 # floor would fail SILENT (a newer release migrates the shared DB before anyone
 # notices). The binary is already installed by the environment's setup script
-# (from releases/latest) before this runs, so this guard's job is to stop a wrong
-# binary from TOUCHING THE DB, not to control the download. The real download pin
-# belongs in that setup script — which lives in the claude.ai UI, not this repo,
-# and so cannot be reviewed or diffed. This in-repo guard is the reviewable
-# backstop.
+# before this runs — that script pins the same version (BD_VER), but its live
+# copy lives in the claude.ai UI, not this repo, and so cannot be reviewed or
+# diffed and can drift. This guard's job is to stop a wrong binary from TOUCHING
+# THE DB if that happens: it is the reviewable, enforced backstop to the UI pin.
 #
 # When Tim upgrades his machines past the pin, bump BD_PINNED_VERSION below. It is
 # a weekly-chores checklist item so the bump is a known recurring task, not a
@@ -56,12 +55,17 @@ die() { printf '[beads-cloud-init] ERROR: %s\n' "$*" >&2; exit 1; }
 
 # 1. bd must be installed and actually RUN. A version that will not print usually
 #    means the tarball binary is missing libicu (the setup script installs it on
-#    that failure).
+#    that failure). Capture stdout AND stderr (some CLIs print the banner to
+#    stderr), and keep the grep|head pipeline off the die path — under `set -o
+#    pipefail`, head closing the pipe early makes grep exit 141 (SIGPIPE), which
+#    would otherwise fire a false "will not run" abort on a healthy bd. The real
+#    gate is whether a version parsed at all.
 command -v bd >/dev/null 2>&1 \
   || die "bd not found on PATH — the environment setup script should install it"
-bd_ver="$(bd version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" \
-  || die "bd is installed but will not run (missing libicu?) — check the setup script"
-[[ -n "$bd_ver" ]] || die "could not parse 'bd version' output"
+bd_raw="$(bd version 2>&1 || true)"
+bd_ver="$(printf '%s\n' "$bd_raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+[[ -n "$bd_ver" ]] \
+  || die "bd is installed but 'bd version' produced no parseable version (missing libicu, or a broken binary): $bd_raw"
 
 # 2. THE GUARD. Exact-pin — refuse anything else, newer OR older.
 if [[ "$bd_ver" != "$BD_PINNED_VERSION" ]]; then


### PR DESCRIPTION
## Why

Follow-up to the **2026-08-16 shared-beads-DB schema incident**: an accidental bd **1.2.1** release migrated the shared `PP` DB to schema **v65**, and every supported **1.2.2** client refused it for ~2 days (recovered by rolling the schema cursor back to v53). Root vector: cloud beads routines installed bd from `releases/latest`, **unpinned**.

## What

- **New `scripts/beads-cloud-init.sh`** — the credential-materialization, version guard, and clone that used to be a multi-line agent preamble pasted into every beads-writing routine prompt. It:
  - reads DoltHub creds from env at **agent runtime** (env vars are never visible to the environment setup script — [anthropics/claude-code#55440](https://github.com/anthropics/claude-code/issues/55440), closed `not_planned`, so this split is permanent);
  - **exact-pins** bd and refuses to touch the DB on a mismatch — a loud fail beats a version floor's *silent* DB migration — with an error naming the file+constant to bump;
  - then clones. A routine's preamble collapses to `bash scripts/beads-cloud-init.sh && cd ~/beads`.
- **Runbook** (`docs/runbooks/cloud-routines-beads-access.md`) — pin `BD_VER` in the embedded setup script; replace the multi-line preamble with the one-liner; **delete** the "intentionally unpinned / remote-migrate gate is the backstop" rationale outright so it can't be cited to restore the old behavior.
- **Weekly chores** — add a `bd cloud version pin` bump item (three coupled sites incl. the non-diffable claude.ai UI copy) so the exact pin doesn't rot silently; mirrored onto the Weekly Chores bead.

## Notes

- The setup script that *downloads* bd lives in the claude.ai environment UI (not diffable); this in-repo guard is the reviewable, enforced backstop. Bumping the pin means updating **all three** sites together.
- Coordinated with the session drafting the nightly-triage routine — its inline "refuse if not 1.2.2" prose guard folds into this script.
- Verified: `shellcheck` clean, `pnpm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)