### PR TITLE
refactor(agents): cite AGENTS.md sections by title, not number (PP-z9m1)

### DIFF
--- a/.agents/rules/antigravity.md
+++ b/.agents/rules/antigravity.md
@@ -10,7 +10,7 @@ Antigravity is Google's CLI agent harness (currently Gemini-based) with full loc
 
 ## Core Mandates
 
-- **Read AGENTS.md**: Immediately read @AGENTS.md before following any user instructions. It carries the process rules, environment, and workflow. The implementation non-negotiables are **not** in it — `docs/NON_NEGOTIABLES.md` is the catalog, and §2.1 is now only a pointer to it (PP-22e4.4 moved the per-rule summaries into `.claude/rules/`, which only Claude Code loads). Read the catalog directly.
+- **Read AGENTS.md**: Immediately read @AGENTS.md before following any user instructions. It carries the process rules, environment, and workflow. The implementation non-negotiables are **not** in it — `docs/NON_NEGOTIABLES.md` is the catalog, and "Implementation" is now only a pointer to it (PP-22e4.4 moved the per-rule summaries into `.claude/rules/`, which only Claude Code loads). Read the catalog directly.
 - **Read the review brief**: @REVIEW.md is the canonical code-review rubric, shared with Claude Code — read it before reviewing any PR.
 - **You review when Tim asks — never on your own.** Nothing on this repo reviews on PR-open or on push; the bot reviewer that used to was retired on 2026-08-02 (PP-4ric).
 - **Your review does not satisfy the merge gate.** `merge-pr.sh`'s `reviewed` gate only recognises the SHA-pinned marker `mark-claude-review.sh` posts, which attests Tim's `/code-review` pass. Post your findings as review comments; don't treat having reviewed as clearing the gate. Note that unresolved review threads DO block the merge now, whoever opened them — so resolve or get resolution on what you raise.

--- a/.agents/skills/pinpoint-briefing/SKILL.md
+++ b/.agents/skills/pinpoint-briefing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-briefing
-description: Run a full project health review at session start or on demand — answers "what should I work on?" before the orchestrator answers "how do I work on it?". Sweeps five surfaces in parallel: open PRs / worktrees / ready beads / Dependabot alerts, `pnpm audit`, the last CI runs on main, GitHub issues filed in the last five days, and open security-review beads. Carries the two audit-reading decisions a wrong reading turns into a phantom finding: why a stale local main makes `pnpm audit` report already-patched CVEs as regressions, and why `pnpm outdated` is deliberately never run (Dependabot's soak time is the supply-chain protection). Use when starting a new session, when the user asks for a briefing, when main's CI or a new issue needs triage, or before deciding what to pick up next. The weekly maintenance pass is `pinpoint-chores`, not this.
+description: Run a full project health review at session start or on demand — answers "what should I work on?" before the orchestrator answers "how do I work on it?". Sweeps six surfaces in parallel: open PRs / worktrees / ready beads / Dependabot alerts, `pnpm audit`, the last CI runs on main, GitHub issues filed in the last five days, open security-review beads, and what the unattended nightly routine did overnight (`nightly-report` beads plus the `human` decision queue it built). Carries the two audit-reading decisions a wrong reading turns into a phantom finding: why a stale local main makes `pnpm audit` report already-patched CVEs as regressions, and why `pnpm outdated` is deliberately never run (Dependabot's soak time is the supply-chain protection). Use when starting a new session, when the user asks for a briefing, when main's CI or a new issue needs triage, or before deciding what to pick up next. The weekly maintenance pass is `pinpoint-chores`, not this.
 ---
 
 # PinPoint Session Briefing
@@ -43,7 +43,7 @@ fi
 
 ## Step 1 — Parallel Data Gathering
 
-Launch these five groups simultaneously:
+Launch these six groups simultaneously:
 
 ### Group A: Orchestration Baseline
 
@@ -94,6 +94,27 @@ bd list --status=open --label=security
 
 Read the severity and one-line summary of each open `security` bead. These beads stay **OPEN until the finding is addressed**, so open security beads are normal — surface them; don't treat their open state as an alarm by itself.
 
+### Group F: Overnight Work
+
+The nightly bead routine runs unattended, triages a batch of the backlog, and takes one bead as far as it can. It reports **on the bead itself**, flagged with the `nightly-report` label:
+
+```bash
+bd list --status=open --label=nightly-report --json
+bd list --status=open --label=human
+```
+
+Two separate queues, and they answer different questions:
+
+- **`nightly-report`** — what the nightly actually did since you last looked. Each bead's `notes` carry the PR number, what it changed, what it deliberately didn't, and anything it found that changes the bead's premise. Read the notes, not just the title.
+- **`human`** — beads the nightly could not decide on alone: a taste call, a scope question, a recommended close it isn't allowed to perform, or simply something it wasn't sure how to classify. This is Tim's decision queue. `bd human list` is the same set in a friendlier format; `bd human respond` / `bd human dismiss` clear it.
+
+Neither label clears itself. `nightly-report` is dropped once the work has been picked up or merged; `human` is dropped when Tim answers. So a growing count in either is the signal — surface both counts even when nothing else is notable.
+
+**Each `nightly-report` bead records the session that produced it**, in its notes:
+
+- `session_id:` — a durable handle. `claude --resume <id>` reopens that exact conversation with its full context, which is how you ask the nightly _why_ it did something rather than inferring it from the diff. Reach for this before re-deriving a half-finished bead's reasoning.
+- `session_name:` — `nightly-<YYYY-MM-DD>`, for identifying which night's run it was.
+
 ---
 
 ## Step 2 — Structured Briefing Output
@@ -106,6 +127,12 @@ Synthesize all gathered data into the format in [references/briefing-output.md](
 
 After the briefing, propose one specific bead to pick up (from `bd ready`, prioritized by P-level and
 relation to open PRs). Reference bead ID and title. Wait for user confirmation before claiming.
+
+**Don't propose a bead the nightly already claimed.** `bd ready` excludes in-progress work, so a
+claimed bead won't surface there — but a `nightly-report` bead with an open PR is work in flight, not
+work available, even though nobody is actively sitting on it. Reading the `nightly-report` queue first
+is what tells you which is which. If the most useful next move is finishing or reviewing what the
+nightly started, say that instead of proposing something new.
 
 ---
 

--- a/.agents/skills/pinpoint-briefing/references/briefing-output.md
+++ b/.agents/skills/pinpoint-briefing/references/briefing-output.md
@@ -26,6 +26,12 @@ Highlight: any with failing CI or stale > 7 days
 ## 🐛 New GitHub Issues (last 5 days)
 [List: #NNN Title (created X days ago) — [in beads / NOT TRACKED]]
 
+## 🌙 Overnight
+Nightly ran:  [which night(s) since the last briefing, or "no run since <date>"]
+Reported:     [each `nightly-report` bead: ID, what it did, PR # if it opened one]
+Needs you:    [count from `bd list --status=open --label=human`, and the newest few]
+[Say plainly if the nightly did not run — a silent gap is a failed run, not an idle one.]
+
 ## 📦 Beads State
 Ready to pick up: [top 5 from `bd ready`]
 In progress:     [from `bd list --status=in_progress`]

--- a/.agents/skills/pinpoint-chores/SKILL.md
+++ b/.agents/skills/pinpoint-chores/SKILL.md
@@ -92,7 +92,7 @@ Then work the checklist. For each item, note findings as a comment on the bead (
 9. **Prod backup validation**
    - Run `pnpm run chores:backups`. It calls `supabase backups list` against PinPoint-Prod and asserts the daily physical backups are still happening: newest COMPLETED backup < 48h old, at least 7 retained, `walg_enabled` true. It warns on a 24–48h-old newest backup, any non-`COMPLETED` entry, and a >36h gap inside the window; it reports `pitr_enabled` so a posture change is visible.
    - **What this proves and doesn't.** It attests that backups **exist** and are being **retained**. It does **not** prove they restore — a real restore drill means restoring a physical backup into a throwaway project, which isn't a weekly-cadence activity. Don't let a green run read as "DR is verified."
-   - On **FAIL**: check the Supabase dashboard and `status.supabase.com` before assuming the script is wrong, then file a **P1** bead. This is the only signal we have that the DR posture in `AGENTS.md` §7 is still true.
+   - On **FAIL**: check the Supabase dashboard and `status.supabase.com` before assuming the script is wrong, then file a **P1** bead. This is the only signal we have that the DR posture in `AGENTS.md` "Deployment" is still true.
    - On **WARN**: note it as a comment on the chores bead; a single skipped day isn't an incident, a pattern across weeks is.
    - Requires the Supabase CLI to be logged in (`supabase login`) — auth comes from its stored token, not an env var. `pnpm run db:backup` is unrelated: that's a data-only `public`-schema dev-seeding dump with no schema and no `auth.users`, not a DR artifact.
 

--- a/.agents/skills/pinpoint-deployment/SKILL.md
+++ b/.agents/skills/pinpoint-deployment/SKILL.md
@@ -9,7 +9,7 @@ Merged reference covering PinPoint's deployment-adjacent operational surfaces: D
 
 ## DB Connections
 
-Full pooler/endpoint reference for PinPoint's Supabase Postgres setup. The one-line operational rules live in `AGENTS.md` §7 Supabase — this skill is the deep reference behind them.
+Full pooler/endpoint reference for PinPoint's Supabase Postgres setup. The one-line operational rules live in `AGENTS.md` "Supabase" — this skill is the deep reference behind them.
 
 ### Connection string format
 
@@ -63,7 +63,7 @@ PinPoint uses **Drizzle ORM** for schema definition and migrations, plus a **sep
 - **Migrations only, never `drizzle-kit push`** (CORE-ARCH-009). Generate and apply; the Supabase migration config is deliberately disabled.
 - **Descriptive names** — `add-notifications-table`, not `changes2`.
 - **Commit everything together**: `schema.ts`, the new `drizzle/` files (`.sql` **and** `_snapshot.json`), and the updated `src/test/setup/schema.sql`.
-- **Production and preview are `db:migrate` only.** Never `db:reset`, never `drizzle-kit push` against them. (AGENTS.md §7.)
+- **Production and preview are `db:migrate` only.** Never `db:reset`, never `drizzle-kit push` against them. (AGENTS.md "Deployment".)
 
 ## Local stack won't start on an SELinux host (resolved, PP-9mg0)
 

--- a/.agents/skills/pinpoint-e2e/SKILL.md
+++ b/.agents/skills/pinpoint-e2e/SKILL.md
@@ -27,7 +27,7 @@ If all five say "E2E is the right layer", write it. Otherwise, the cheapest laye
 
 ## Which Tests to Run (Decision Tree)
 
-See AGENTS.md §5 "Which tests to run" — canonical, don't duplicate here.
+See AGENTS.md "Which tests to run" — canonical, don't duplicate here.
 
 ## The Golden Rule: Worker Isolation
 

--- a/.agents/skills/pinpoint-orchestrator/SKILL.md
+++ b/.agents/skills/pinpoint-orchestrator/SKILL.md
@@ -75,7 +75,7 @@ Present options to the user. Before proceeding, verify tasks are independent:
 
 1. The bead ID + "First run `bd show <id>` && `bd update <id> --claim`, then work from the bead." The bead carries scope, files, line numbers, and acceptance criteria — do NOT restate them in the prompt (two places to drift).
 2. Only context that ISN'T already in the bead — cross-bead conflicts, a reference PR, sequencing constraints. Omit when there's nothing to add.
-3. Quality gate: point the agent at **AGENTS.md §5 "Which tests to run"** and tell it to run the tiers matching what it touched. Do **not** write "run `pnpm run check`" and stop — `check` is a static gate that runs no unit tests and no pytest (PP-4zcj), so that instruction cannot fail on a broken test and CI becomes the first thing that notices (PP-lql4).
+3. Quality gate: point the agent at **AGENTS.md "Which tests to run"** and tell it to run the tiers matching what it touched. Do **not** write "run `pnpm run check`" and stop — `check` is a static gate that runs no unit tests and no pytest (PP-4zcj), so that instruction cannot fail on a broken test and CI becomes the first thing that notices (PP-lql4).
 4. Full PR lifecycle: "Create PR, verify CI green."
 5. Structured return format: branch, PR#, CI status, blockers
 

--- a/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
+++ b/.agents/skills/pinpoint-orchestrator/references/agent-prompt-template.md
@@ -13,7 +13,7 @@ Work bead {beads_id}. First run `bd show {beads_id}` && `bd update {beads_id} --
 
 ### Quality Gates
 
-Before returning, run the gates **AGENTS.md §5 "Which tests to run"** names for the layers you touched — that tiered list is the source of truth, so read it rather than assuming. Note in particular that `pnpm run check` is a **static** gate: it runs no unit tests and no pytest, so on its own it cannot fail on a broken test.
+Before returning, run the gates **AGENTS.md "Which tests to run"** names for the layers you touched — that tiered list is the source of truth, so read it rather than assuming. Note in particular that `pnpm run check` is a **static** gate: it runs no unit tests and no pytest, so on its own it cannot fail on a broken test.
 
 Then self-review **by hand**: read your own diff (`git diff origin/main...HEAD`) against `REVIEW.md` — the canonical rubric — plus the bead's acceptance criteria and out-of-scope list, and fix what you find. Don't reach for `/code-review` or `ultra`: both are user-triggered harness surfaces (`ultra` is also billed) and an agent cannot launch either.
 
@@ -64,7 +64,7 @@ If tests fail with `POSTGRES_URL is not set`:
 
 1. `isolation: "worktree"` sets CWD automatically — no absolute paths needed
 2. The bead is the source of truth — point the agent at `bd show`; don't restate scope/files in the prompt (two places to drift)
-3. Quality is self-enforced — hooks don't fire for subagents, so the prompt IS the enforcement. Point at AGENTS.md §5's tiered list, never at `pnpm run check` alone: `check` is static and cannot fail on a broken test (PP-lql4)
+3. Quality is self-enforced — hooks don't fire for subagents, so the prompt IS the enforcement. Point at AGENTS.md "Which tests to run"'s tiered list, never at `pnpm run check` alone: `check` is static and cannot fail on a broken test (PP-lql4)
 4. Structured return format enables quick lead assessment
 5. Nothing reviews automatically and there is nothing for the agent to request — its terminal state is a PR reported as needing Tim's `/code-review`. The return format asks for exactly that, and at handoff the lead checks the marker's pinned SHA against head (SKILL.md → "Ensure every PR is reviewed")
 

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -20,8 +20,8 @@ End-to-end pipeline from "I have changes" to "merged in main".
 ## Phase 1: Commit
 
 Branch rules (never on `main`, never rebase, verify `git branch -vv` tracks your branch) are
-AGENTS.md §5 "Branches". Which gate to run before committing is AGENTS.md §2.2 "Process rules"
-and the §5 key-commands table; which tests to run is AGENTS.md §5 "Which tests to run" —
+AGENTS.md "Branches". Which gate to run before committing is AGENTS.md "Process rules"
+and the §5 key-commands table; which tests to run is AGENTS.md "Which tests to run" —
 canonical, don't duplicate here.
 
 ### Commit message
@@ -38,7 +38,7 @@ PinPoint scopes: `issues`, `machines`, `auth`, `ui`, `db`, `e2e`, `agents`, `wor
 ## Phase 2: PR
 
 Prefer MCP `create_pull_request` for typed argument handling, or `gh pr create` if you're
-already in a shell. Open **ready-for-review, not draft** (AGENTS.md §6).
+already in a shell. Open **ready-for-review, not draft** (AGENTS.md "Working style").
 
 ### PR description template
 
@@ -73,7 +73,7 @@ Read threads via `mcp__github__pull_request_read(method: "get_review_comments", 
 
 ### 3.3 Address review comments
 
-Fixing, declining with a one-sentence signed reply, and resolving the thread is AGENTS.md §5 "Review comments"; the rubric is `REVIEW.md`.
+Fixing, declining with a one-sentence signed reply, and resolving the thread is AGENTS.md "Review comments"; the rubric is `REVIEW.md`.
 
 Every unresolved thread counts, whoever opened it — the `threads` gate is author-agnostic. Resolve or decline each one before moving on.
 

--- a/.agents/skills/pinpoint-pr-workflow/SKILL.md
+++ b/.agents/skills/pinpoint-pr-workflow/SKILL.md
@@ -21,7 +21,7 @@ End-to-end pipeline from "I have changes" to "merged in main".
 
 Branch rules (never on `main`, never rebase, verify `git branch -vv` tracks your branch) are
 AGENTS.md "Branches". Which gate to run before committing is AGENTS.md "Process rules"
-and the §5 key-commands table; which tests to run is AGENTS.md "Which tests to run" —
+and the "Key commands" table; which tests to run is AGENTS.md "Which tests to run" —
 canonical, don't duplicate here.
 
 ### Commit message

--- a/.agents/skills/pinpoint-prototype-mode/SKILL.md
+++ b/.agents/skills/pinpoint-prototype-mode/SKILL.md
@@ -34,7 +34,7 @@ than quietly relaxing rigor on logic that matters.
 Enter **only** when the user explicitly asks: "prototype mode", "rapid
 iteration", "let's just explore", "vibe on this UI", "don't worry about tests
 for now", or similar — and the work is **UI/UX**. **Never self-elect into this
-mode.** Full rigor (AGENTS.md §2) is always the default.
+mode.** Full rigor (AGENTS.md "Critical Non-Negotiables") is always the default.
 
 ## Entering the mode
 
@@ -95,7 +95,7 @@ land it", or starts asking for tests/PR/commit.
    green, DRY cleanup.
 2. Delete the marker file.
 3. Announce: "✅ Exited prototype mode. Repaying debt:" followed by the
-   checklist. Then resume full AGENTS.md §2 rigor.
+   checklist. Then resume full AGENTS.md "Critical Non-Negotiables" rigor.
 
 Do not silently drop the ledger. If the user wants to abandon the prototype
 entirely, confirm before deleting the marker without repaying.

--- a/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
+++ b/.agents/skills/pinpoint-superpowers-bridge/SKILL.md
@@ -15,7 +15,7 @@ The superpowers plugin (`brainstorming → writing-plans → subagent-driven-dev
 
 ## 1. Field conventions — plans live in git, beads carry pointers
 
-Specs and plans stay as **files in git** (the superpowers default locations, kept as dated records — AGENTS.md §8). Beads do **not** duplicate their content; they carry **pointers** so any session can recover context:
+Specs and plans stay as **files in git** (the superpowers default locations, kept as dated records — AGENTS.md "Documentation"). Beads do **not** duplicate their content; they carry **pointers** so any session can recover context:
 
 | Bead field     | Holds                                                   | Example                                                             |
 | :------------- | :------------------------------------------------------ | :------------------------------------------------------------------ |
@@ -38,7 +38,7 @@ Specs and plans stay as **files in git** (the superpowers default locations, kep
 2. **After each plan is written** (`writing-plans`): update the child bead's `--design` with the plan path + branch name.
 3. **Epics vs single-PR work:** a multi-PR epic may decompose into child beads (and MAY use a beads formula for the workflow). **Single-PR work must NOT** spawn per-task child beads — that creates sliver-beads. One bead, plan-file checkboxes for the steps.
 
-Everything above happens **in a worktree** — the root checkout is read-only (AGENTS.md §2.2.5). `brainstorming`/`writing-plans` commit spec/plan files to git, so enter a worktree first (`EnterWorktree`, or dispatch an `Agent(isolation:"worktree")`).
+Everything above happens **in a worktree** — the root checkout is read-only (AGENTS.md "Process rules"). `brainstorming`/`writing-plans` commit spec/plan files to git, so enter a worktree first (`EnterWorktree`, or dispatch an `Agent(isolation:"worktree")`).
 
 ---
 
@@ -46,7 +46,7 @@ Everything above happens **in a worktree** — the root checkout is read-only (A
 
 ### `using-git-worktrees`
 
-- PinPoint has native worktree tooling — **prefer `EnterWorktree`** (or `Agent(isolation:"worktree")`) over raw `git worktree add`. Either way the `post-checkout` hook wires ports/env/config, so when you do need a manual worktree, `git worktree add /path -b branch origin/main` (AGENTS.md §4) is the supported fallback. 6.1.x already prefers native tools; this just names ours.
+- PinPoint has native worktree tooling — **prefer `EnterWorktree`** (or `Agent(isolation:"worktree")`) over raw `git worktree add`. Either way the `post-checkout` hook wires ports/env/config, so when you do need a manual worktree, `git worktree add /path -b branch origin/main` (AGENTS.md "Environment") is the supported fallback. 6.1.x already prefers native tools; this just names ours.
 - **Dispatch `Agent(isolation:"worktree")` only from the main worktree** (upstream bug #47548). See CLAUDE.md "Worktree Dispatch Safety".
 
 ### `writing-plans`
@@ -64,14 +64,14 @@ Everything above happens **in a worktree** — the root checkout is read-only (A
 
 - Superpowers' reviewer-subagent is fine as an **optional local self-check**. The **authoritative** review gate is **CI Gate + the head-commit review requirement** in `pinpoint-pr-workflow` (Tim runs `/code-review`; you attest with `mark-claude-review.sh`), not a plugin subagent. Running the plugin's review does **not** satisfy that requirement.
 - **`requesting-code-review` does not satisfy the merge gate.** No bot reviews this repo, and a review still gates the merge. Stop iterating, then ask Tim to run `/code-review` — an agent cannot launch it — and attest the head he reviewed with `mark-claude-review.sh`. Full rules: `pinpoint-pr-workflow` Phase 3.4.
-- **Reply to review comments via MCP** (`add_reply_to_pull_request_comment` + resolve the thread with `pull_request_review_write method:"resolve_thread"`), **signed with your agent name** (`—Claude` / `—Gemini` / `—Codex` / `—Antigravity`, per AGENTS.md §5 "Review comments"). Declined comments still get a one-sentence reply — no silent ignores. Do not use the plugin's own reply flow.
+- **Reply to review comments via MCP** (`add_reply_to_pull_request_comment` + resolve the thread with `pull_request_review_write method:"resolve_thread"`), **signed with your agent name** (`—Claude` / `—Gemini` / `—Codex` / `—Antigravity`, per AGENTS.md "Review comments"). Declined comments still get a one-sentence reply — no silent ignores. Do not use the plugin's own reply flow.
 
 ### `finishing-a-development-branch` — the biggest override
 
 Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally". **In PinPoint that menu does not apply.** There is exactly one finish path:
 
 - **Never merge locally, never push/merge to `main`, and never merge the PR yourself by any path.** Ship through a PR: push the branch, open it **ready-for-review**, let **CI** run the full suite, post UI screenshots if UI-touching, then hand Tim the exact command to run himself: `! scripts/workflow/merge-pr.sh <PR> --human` (never `gh pr merge` / MCP merge / running `merge-pr.sh` yourself — all three are blocked for agents, PP-wi85). Full pipeline: `pinpoint-pr-workflow` (Phases 4-5, "landing the plane").
-- **Tests:** use PinPoint's tiered commands, listed in **AGENTS.md §5 "Which tests to run"** (`pnpm run check` is the **static** floor and runs no tests; `pnpm run test` is the unit suite; `pnpm run check:python` covers `scripts/` and `.claude/hooks/`; `pnpm run preflight` for migrations/auth/server-actions/middleware/schema; `pnpm run smoke` for UI) — **not** `npm test` / `pytest`. The full E2E suite (`e2e:full` / `e2e:all`) is CI's job by default; it peaks at several GB, so run it locally only when the host has the headroom.
+- **Tests:** use PinPoint's tiered commands, listed in **AGENTS.md "Which tests to run"** (`pnpm run check` is the **static** floor and runs no tests; `pnpm run test` is the unit suite; `pnpm run check:python` covers `scripts/` and `.claude/hooks/`; `pnpm run preflight` for migrations/auth/server-actions/middleware/schema; `pnpm run smoke` for UI) — **not** `npm test` / `pytest`. The full E2E suite (`e2e:full` / `e2e:all`) is CI's job by default; it peaks at several GB, so run it locally only when the host has the headroom.
 - **Worktree cleanup is destructive → wait for explicit confirmation** (`pinpoint-pr-workflow` Phase 5.2 "Cleanup"). When confirmed, cleanup goes through the `WorktreeRemove` hook / `scripts/worktree_cleanup.py` (dealloc slot + Docker volumes) — **never raw `git worktree remove`/`rm -rf`**, which leaks the slot manifest and volumes.
 - **"Discard" is not a routine option.** Abandoning work is a deliberate, confirmed action, not a menu pick.
 - **Close the bead only after merge** (landing-the-plane) — not at push, not at PR-open.
@@ -88,7 +88,7 @@ Superpowers presents a 4-option menu led by "1. Merge back to `<base>` locally".
 | SDD dispatch             | clear the scale gate (count + cost, Tim's yes) first                                              |
 | Code review              | CI Gate + `pinpoint-pr-workflow` head-commit review; replies via MCP, signed with your agent name |
 | Finish: "merge locally"  | ❌ prohibited → PR + human-only `merge-pr.sh --human` handoff + landing-the-plane                 |
-| Finish: tests            | AGENTS.md §5's tiered `check`/`test`/`preflight`/`smoke`, not `npm test`                          |
+| Finish: tests            | AGENTS.md "Which tests to run"'s tiered `check`/`test`/`preflight`/`smoke`, not `npm test`        |
 | Finish: worktree cleanup | `WorktreeRemove` hook / `worktree_cleanup.py`, on confirmation                                    |
 | Close bead               | only after merge                                                                                  |
 

--- a/.agents/skills/pinpoint-testing/SKILL.md
+++ b/.agents/skills/pinpoint-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pinpoint-testing
-description: Which layer catches which class of bug, and where the coverage for each class already lives — the bug-class table AGENTS.md routes to, the canonical file per class so new tests extend rather than duplicate, and the "Test What We Own" boundary with its casework. Also the one mocking pattern worth knowing — forwarding `~/server/db` to the worker-scoped PGlite instance rather than handing a test canned rows. Use when deciding what layer a new test belongs at, before creating a new test file, when reaching for a mock of the database or an ORM, when tempted to synthesize a third party's internal state in a test, or when reviewing whether a PR picked the right layer. Playwright technique lives in `pinpoint-e2e`; the rules themselves are `CORE-TEST-*` in `docs/NON_NEGOTIABLES.md`; which commands to run is AGENTS.md §5.
+description: Which layer catches which class of bug, and where the coverage for each class already lives — the bug-class table AGENTS.md routes to, the canonical file per class so new tests extend rather than duplicate, and the "Test What We Own" boundary with its casework. Also the one mocking pattern worth knowing — forwarding `~/server/db` to the worker-scoped PGlite instance rather than handing a test canned rows. Use when deciding what layer a new test belongs at, before creating a new test file, when reaching for a mock of the database or an ORM, when tempted to synthesize a third party's internal state in a test, or when reviewing whether a PR picked the right layer. Playwright technique lives in `pinpoint-e2e`; the rules themselves are `CORE-TEST-*` in `docs/NON_NEGOTIABLES.md`; which commands to run is AGENTS.md "Which tests to run".
 ---
 
 # PinPoint Testing
@@ -103,6 +103,6 @@ The house pattern instead forwards the `db` singleton to worker-scoped PGlite, s
 
 - `pinpoint-e2e` — Playwright technique, selector strategy, worker isolation, environment defaults.
 - [src/test/README.md](../../../src/test/README.md) — the mechanics: `setupTestDb()` / `getTestDb()` call contract, factories, and which command runs which project.
-- AGENTS.md §5 "Which tests to run" — the decision tree and the commands.
+- AGENTS.md "Which tests to run" — the decision tree and the commands.
 - [NON_NEGOTIABLES.md](../../../docs/NON_NEGOTIABLES.md#testing) — the `CORE-TEST-*` rules themselves.
 - [e2e-audit-2026-05.md](../../../docs/testing/e2e-audit-2026-05.md) — per-spec verdicts and the bug-class framework's history.

--- a/.claude/hooks/block-main-worktree-branch-switch.cjs
+++ b/.claude/hooks/block-main-worktree-branch-switch.cjs
@@ -2,7 +2,7 @@
 // .claude/hooks/block-main-worktree-branch-switch.cjs
 // PreToolUse hook: hard-blocks git branch switches in the MAIN worktree unless
 // the target branch is `main`. The root checkout is read-only and stays on main
-// (AGENTS.md §2.2.5). Branch work belongs in a dedicated worktree.
+// (AGENTS.md "Process rules"). Branch work belongs in a dedicated worktree.
 //
 // Incident (2026-05-31): a `git checkout <feature-branch>` ran in the MAIN
 // worktree, switching it off `main`; a later `git merge --ff-only origin/main`
@@ -230,7 +230,7 @@ if (require.main === module) {
     // 5. Block.
     console.error(
       `Branch switch blocked in the MAIN worktree: ${detail}. ` +
-        `The root checkout is read-only and stays on \`main\` (AGENTS.md §2.2.5) — ` +
+        `The root checkout is read-only and stays on \`main\` (AGENTS.md "Process rules") — ` +
         `switching it off main lets a later \`git merge\` advance the wrong branch and clobber another session's state. ` +
         `Do branch work in a dedicated worktree: \`git worktree add <path> -b <branch> origin/main\`, ` +
         `or dispatch an Agent(isolation:"worktree"). ` +

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -21,7 +21,7 @@ Two things this rule does not say, both of which bite here:
   regenerate-don't-edit protocol is in the `pinpoint-deployment` skill.
 - **Local `db:reset` is fine; production `db:reset` never is.** Production has
   real user data, daily backups with 7-day retention and no PITR, so the
-  recovery floor is the previous nightly snapshot (`AGENTS.md` §7).
+  recovery floor is the previous nightly snapshot (`AGENTS.md` "Deployment").
 
 Pooler and connection-string reference, and the PP-d8l8 silent-commit-loss
 incident behind `prepare:false` on every `:6543` client: `pinpoint-deployment`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -23,6 +23,6 @@ Full statements, severity, and do/don't: `docs/NON_NEGOTIABLES.md`.
   hostname reachable from an E2E run is a class-J violation — delete the spec
   and add an SDK-boundary mock.
 
-Which command to run for which change is `AGENTS.md` §5; Playwright technique
+Which command to run for which change is `AGENTS.md` "Which tests to run"; Playwright technique
 is the `pinpoint-e2e` skill; where the coverage for each bug class already
 lives is `pinpoint-testing`.

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -16,7 +16,7 @@ BRANCH_CHECKOUT=$3
 # We check the post-checkout state, not the pre-checkout state. This catches all
 # cases: switching from main to a feature branch, switching between two feature
 # branches, or landing on a detached HEAD — all forbidden in the root checkout
-# (AGENTS.md §2.2 "Root Checkout Is Read-Only").
+# (AGENTS.md "Process rules").
 
 if [ "$BRANCH_CHECKOUT" = "1" ] && [ -d ".git" ]; then
   # Detached HEAD returns empty from `symbolic-ref --short` — treat that as an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,10 @@ That tier is Claude Code-specific. In any other tool, read the catalog directly.
 
 1. **Escape parentheses in paths**: `src/app/\(app\)/page.tsx`.
 2. **Run `pnpm run check` before committing** (~9s — the default floor). It is a **static** gate: types, lint, format, and the shell/YAML/Python linters. **It does not run unit tests, and does not run pytest** (PP-4zcj) — unit tests are a required CI job (`test-unit`), part of `preflight`, and available via `pnpm run test`; the Python hook/script tests are a required CI job (`linters`) and available via `pnpm run check:python`. Reserve `pnpm run preflight` (the slower check + build + unit + integration) for **non-trivial changes**: migrations, security/auth, server actions, middleware, DB schema. Preflight is the exception, not the per-commit rule.
-3. **Don't kill processes you didn't start** — see §4 Process safety.
-4. **Sync with merge, never rebase** — see §5 Branches.
+3. **Don't kill processes you didn't start** — see "Process safety".
+4. **Sync with merge, never rebase** — see "Branches".
 5. **Root checkout is read-only.** It stays on `main`. All work — including planning docs — happens in a worktree. Dispatch a subagent or switch into an existing worktree. Tool-specific dispatch mechanics live in `CLAUDE.md`. (PP-46z, PP-bg45.)
-6. **Never `--no-verify`**, never wildcard tool permissions — without explicit user approval each time. **Merging is human-only, via ANY path** — never `gh pr merge`, never MCP `merge_pull_request`, and never `scripts/workflow/merge-pr.sh` (even though it enforces the merge gates, running it is still an agent merge). An agent's terminal state on a PR is: ready-for-review, CI green, a review covering the head commit (see §5 "Getting a PR reviewed"), threads resolved, screenshots posted if UI-touching, then hand over with `bash scripts/workflow/merge-handoff.sh <PR>` — it prints the state Tim needs plus the command for him to run himself, `! scripts/workflow/merge-pr.sh <PR> --human`. (PP-wi85.)
+6. **Never `--no-verify`**, never wildcard tool permissions — without explicit user approval each time. **Merging is human-only, via ANY path** — never `gh pr merge`, never MCP `merge_pull_request`, and never `scripts/workflow/merge-pr.sh` (even though it enforces the merge gates, running it is still an agent merge). An agent's terminal state on a PR is: ready-for-review, CI green, a review covering the head commit (see "Getting a PR reviewed"), threads resolved, screenshots posted if UI-touching, then hand over with `bash scripts/workflow/merge-handoff.sh <PR>` — it prints the state Tim needs plus the command for him to run himself, `! scripts/workflow/merge-pr.sh <PR> --human`. (PP-wi85.)
 7. **Beads: `team-maintainer` policy** (not the conservative default).
 
 ## 3. Agent Skills
@@ -115,7 +115,7 @@ The general rule this illustrates: when the mirror is stricter than authoritativ
 
 ### Prototype mode (rapid iteration)
 
-When the user explicitly asks for "prototype mode" / "rapid iteration" / "just explore" **for UI/UX work**, load the `pinpoint-prototype-mode` skill and enter it. It's scoped to **presentation only** — layout, components, styling, page structure, interaction/flow — and explicitly **not** for backend/internal work (data layer, server-action logic, auth, permissions, migrations), which keep full rigor; stub data rather than building it. Within that scope it relaxes the §2 rigor (skip preflight/tests before showing work, defer lint/type fixes, defer coverage and DRY) while logging every skipped item to a `.prototype-mode` debt ledger. It changes **agent behavior only** — pre-commit and `preflight` hooks still run on any real commit, which is fine because prototype work stays local and uncommitted. Never self-elect into it; full rigor is the default. A `UserPromptSubmit`/`SessionStart` hook reminds the agent while the marker exists, so the mode survives compaction. Exit on "exit prototype mode" / "make this real" — then repay the ledger.
+When the user explicitly asks for "prototype mode" / "rapid iteration" / "just explore" **for UI/UX work**, load the `pinpoint-prototype-mode` skill and enter it. It's scoped to **presentation only** — layout, components, styling, page structure, interaction/flow — and explicitly **not** for backend/internal work (data layer, server-action logic, auth, permissions, migrations), which keep full rigor; stub data rather than building it. Within that scope it relaxes the "Critical Non-Negotiables" rigor (skip preflight/tests before showing work, defer lint/type fixes, defer coverage and DRY) while logging every skipped item to a `.prototype-mode` debt ledger. It changes **agent behavior only** — pre-commit and `preflight` hooks still run on any real commit, which is fine because prototype work stays local and uncommitted. Never self-elect into it; full rigor is the default. A `UserPromptSubmit`/`SessionStart` hook reminds the agent while the marker exists, so the mode survives compaction. Exit on "exit prototype mode" / "make this real" — then repay the ledger.
 
 ### Which tests to run
 
@@ -142,7 +142,7 @@ Always try local first — seconds vs minutes, full devtools. If a single-test r
 
 - **Check for conflicts first**: `gh pr view <PR> --json mergeable,mergeStateStatus`. `DIRTY`/`CONFLICTING` means GitHub silently skips workflow runs until you resolve. `pnpm run check` includes a `check:behind-main` warning.
 - **Required check**: only `CI Gate` (ruleset `6326455`). Vercel is not required. `BLOCKED` while E2E is still running is normal.
-- **Vercel preview migrations**: preview deployments skip `migrate:production` (branch DB user lacks `CREATE SCHEMA`). The on-demand `Preview Controller` workflow migrates + seeds the branch DB before building the preview (see §7 "Preview deployments"). Production deploys still migrate.
+- **Vercel preview migrations**: preview deployments skip `migrate:production` (branch DB user lacks `CREATE SCHEMA`). The on-demand `Preview Controller` workflow migrates + seeds the branch DB before building the preview (see "Preview deployments"). Production deploys still migrate.
 
 ### Migration conflicts
 
@@ -180,7 +180,7 @@ Use worktree-isolated subagents for independent tasks. Tool-specific dispatch, h
 
 ### Superpowers lifecycle → beads
 
-When you run the superpowers plugin lifecycle (`brainstorming → writing-plans → subagent-driven-development → finishing-a-development-branch`), load `pinpoint-superpowers-bridge` — several superpowers steps conflict with PinPoint rules (local merge, raw `git worktree remove`, generic test commands, uncapped subagent dispatch, the plugin's own review-reply flow) and the skill spells out the overrides. Specs and plans stay as **files in git** (their superpowers default locations, kept as records — §8); beads carry **pointers**, not copies:
+When you run the superpowers plugin lifecycle (`brainstorming → writing-plans → subagent-driven-development → finishing-a-development-branch`), load `pinpoint-superpowers-bridge` — several superpowers steps conflict with PinPoint rules (local merge, raw `git worktree remove`, generic test commands, uncapped subagent dispatch, the plugin's own review-reply flow) and the skill spells out the overrides. Specs and plans stay as **files in git** (their superpowers default locations, kept as records — "Documentation"); beads carry **pointers**, not copies:
 
 - `--spec-id` = spec file path
 - `--design` = plan file path(s) **+ branch name** while unmerged (recover with `git show origin/<branch>:<path>`)
@@ -195,7 +195,7 @@ When a decision is **visual or hard to convey in prose** — color/contrast, spa
 
 ## 6. Working style
 
-How Tim wants agents to behave. (§1 has the one-line version; this is the detail.)
+How Tim wants agents to behave. ("User & Mission" has the one-line version; this is the detail.)
 
 ### Collaboration & decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ See `pinpoint-orchestrator` skill Phase 2 for the full technical record.
 - **Dispatch**: `isolation: "worktree"` works out of the box — Claude Code creates the worktree, the `post-checkout` hook configures it (slot allocation, ports, `.env.local`, `.claude/launch.json`).
 - **Cleanup**: Claude Code's `WorktreeRemove` hook runs `scripts/worktree_cleanup.py` (stops Supabase, removes Docker volumes, deallocates slot) **when something removes a worktree** — it does not remove finished worktrees itself, and it never fires for a background agent that just commits, pushes and ends. Manual `git worktree remove /path` or `rm -rf` skips the hook entirely — slot manifest entry and Docker volumes leak. `scripts/worktree_orphan_sweep.py` reconciles the slot manifest, active worktrees, and Supabase Docker resources.
 - **Reaping**: `scripts/worktree_reap.py` is what actually removes worktrees whose work has landed (it delegates teardown to `worktree_cleanup.py`). The sweep cannot see them — a worktree still on disk is "active" by its definition. Reaps only on positive proof (merged PR with `HEAD == headRefOid` + clean tree, or zero commits ahead of `origin/main` with no PR); dry-run by default, `--apply` to reclaim. `merge-pr.sh` reaps the merged branch's worktree on merge. The SessionStart hook runs the sweep **and** the reap in dry-run mode every 6h and surfaces a one-line nudge when either finds something.
-- **Branch creation**: `Agent(isolation:"worktree")` handles branch creation automatically. AGENTS.md §5 "Branches" rules still apply if you create a branch manually inside an existing worktree.
+- **Branch creation**: `Agent(isolation:"worktree")` handles branch creation automatically. AGENTS.md "Branches" rules still apply if you create a branch manually inside an existing worktree.
 
 ### Parallel Subagent Workflow
 
@@ -63,7 +63,7 @@ For multiple independent tasks, use worktree-isolated subagents.
 
 **Primary**: Standalone subagents with `isolation: "worktree"` + `run_in_background: true`. Use `SendMessage` (by agent ID or `name`) for follow-up (review comments, CI fixes). The `post-checkout` hook automatically allocates ports and generates configs.
 
-**Quality Enforcement**: Hooks don't fire for subagents, so the dispatch prompt is the enforcement. Point the agent at AGENTS.md §5 "Which tests to run" — the tiered list — not at `pnpm run check` alone, which is a static gate that runs no tests.
+**Quality Enforcement**: Hooks don't fire for subagents, so the dispatch prompt is the enforcement. Point the agent at AGENTS.md "Which tests to run" — the tiered list — not at `pnpm run check` alone, which is a static gate that runs no tests.
 
 **Anti-patterns**:
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ pnpm run smoke        # Playwright smoke E2E tests
 pnpm run preflight    # full local CI gate before pushing
 ```
 
-For the command reference and the rules behind it, see `AGENTS.md` §5; for which
+For the command reference and the rules behind it, see `AGENTS.md` "Key commands"; for which
 tests to write where, the `pinpoint-testing` skill at
 `.agents/skills/pinpoint-testing/SKILL.md`.
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -220,7 +220,7 @@ naming) — not coupling. The registry treats each pair as "any one satisfies":
 - `UPSTASH_REDIS_REST_TOKEN` ⇄ `KV_REST_API_TOKEN`
 - `MAILPIT_PORT` ⇄ `INBUCKET_PORT`, `MAILPIT_SMTP_PORT` ⇄ `INBUCKET_SMTP_PORT`
 - `POSTGRES_URL_NON_POOLING` is a **distinct** value (session pooler), not an
-  alias of `POSTGRES_URL` (transaction pooler) — see AGENTS.md §7.
+  alias of `POSTGRES_URL` (transaction pooler) — see AGENTS.md "Deployment".
 
 **Audit result:** no _dangerous_ couplings remain. The historical
 `UNSUBSCRIBE_SIGNING_SECRET` ↔ `SUPABASE_SERVICE_ROLE_KEY` reuse is fixed; all

--- a/docs/NON_NEGOTIABLES.md
+++ b/docs/NON_NEGOTIABLES.md
@@ -363,7 +363,7 @@
 
 - **Severity:** Critical
 - **Why:** Production has real user data. `push` bypasses migration history, can drop columns silently, and corrupts the schema's relationship to `drizzle/meta` snapshots. Supabase migrations are disabled (`db.migrations.enabled = false`) — Drizzle is the single source of truth.
-- **Do:** Use `pnpm run db:generate` to author migrations, then `pnpm run db:migrate` to apply. Treat `drizzle/meta` snapshots as authoritative; never edit them by hand (see also `AGENTS.md` §5 Migration conflicts).
+- **Do:** Use `pnpm run db:generate` to author migrations, then `pnpm run db:migrate` to apply. Treat `drizzle/meta` snapshots as authoritative; never edit them by hand (see also `AGENTS.md` "Migration conflicts").
 - **Don't:** Run `drizzle-kit push` against any database (local, preview, prod). Don't use Supabase CLI migrations. Don't hand-edit `drizzle/meta/*.json`.
 - **Enforced by:** `drizzle.config.ts` calls `assertNotDrizzlePush()` (`scripts/lib/drizzle-push-guard.ts`) before any credential is resolved, so drizzle-kit refuses `push` no matter how it was invoked. `package.json`'s `db:_push` tripwire is a second, independent line of defense.
 

--- a/docs/pbm-listing-redesign-refresher.md
+++ b/docs/pbm-listing-redesign-refresher.md
@@ -1,6 +1,6 @@
 # Pinball Map listing + machine edit page — settled design spec
 
-_Canonical spec, not session scratch._ Settled across three design sessions ending 2026-07-22, amended 2026-07-23 (§6a) and 2026-07-25 (§7). **PP-o355.7 / .15 / .19 / .20 / .21 / .22 cite this file by path**, so amend it in place rather than superseding it elsewhere (AGENTS.md §8). Current build state is §11.
+_Canonical spec, not session scratch._ Settled across three design sessions ending 2026-07-22, amended 2026-07-23 (§6a) and 2026-07-25 (§7). **PP-o355.7 / .15 / .19 / .20 / .21 / .22 cite this file by path**, so amend it in place rather than superseding it elsewhere (AGENTS.md "Documentation"). Current build state is §11.
 
 ---
 

--- a/scripts/check-prod-backups.mjs
+++ b/scripts/check-prod-backups.mjs
@@ -4,7 +4,7 @@
  * backups still exist and that retention is intact.
  *
  * Background: our disaster-recovery posture is "Supabase Pro takes daily
- * backups with 7-day retention" (AGENTS.md §7, bead PinPoint-dka). Nothing
+ * backups with 7-day retention" (AGENTS.md "Deployment", bead PinPoint-dka). Nothing
  * ever verified that claim, so a silently-failing backup job or a retention
  * change would only surface during a restore. This script is that verification.
  *
@@ -27,7 +27,7 @@ import { pathToFileURL } from "node:url";
 /** PinPoint-Prod. Same hardcoded ref as scripts/backup-production.sh. */
 const PROD_REF = "udhesuizjsgxfeotqybn";
 
-/** Documented retention (AGENTS.md §7): 7 daily backups. */
+/** Documented retention (AGENTS.md "Deployment"): 7 daily backups. */
 const EXPECTED_RETENTION = 7;
 
 /** Newest backup older than this warns (a day was likely skipped). */

--- a/scripts/check_rule_ids.py
+++ b/scripts/check_rule_ids.py
@@ -19,13 +19,15 @@ Three checks:
   ERROR  A cited CORE-* ID that does not exist in the catalog. Always a bug:
          either a typo or a rule that was renamed/removed without updating its
          citations. This is the check that runs in `pnpm run check`.
-  ERROR  A fragile "rule N" / "commandment N" / "AGENTS.md §2.1" citation
-         (PP-22e4). AGENTS.md §2.1 used to be the numbered non-negotiables
-         list; PP-22e4.4 moved the rules to .claude/rules/, so every citation
-         by rule number or to "§2.1" itself now points at nothing. Unlike a
-         CORE-* ID, neither form is machine-checkable against the catalog, so
-         the only sound gate is banning the pattern outright and requiring
-         the CORE-* ID instead.
+  ERROR  A fragile "rule N" / "commandment N" / "AGENTS.md §N" citation
+         (PP-22e4, PP-z9m1). Rule numbers stopped resolving when PP-22e4.4
+         moved the rules to .claude/rules/. Section numbers are the same
+         hazard on a slower clock: they shift whenever AGENTS.md gains or
+         loses a section, and nothing tells the citation -- PP-z9m1 found
+         three sites citing "§2.2.5", which is not a section at all. Neither
+         form is machine-checkable the way a CORE-* ID is, so the gate bans
+         the pattern. Cite the CORE-* ID for a rule, or the heading title
+         for a section: AGENTS.md "Which tests to run".
   AUDIT  (--orphans) A catalog rule cited nowhere. Opt-in, never fails the
          build: 17 of 67 catalog rules are "orphans" by this definition as of
          2026-08-07 (it was 42 of 62 before the .claude/rules/ tier, which
@@ -36,7 +38,7 @@ Three checks:
          you run deliberately, not a default warning.
 
 Exit codes: 0 clean, 1 unknown IDs found, 2 catalog missing, 3 descending
-range cited, 4 fragile rule-number/§2.1 citation found.
+range cited, 4 fragile rule-number/section-number citation found.
 """
 
 from __future__ import annotations
@@ -93,11 +95,18 @@ WRAPPED_RULE_CITATION = re.compile(
 )
 WRAPPED_CITATION_NUMBER = re.compile(r"^[ \t]*#?\d+\b")
 
-# "AGENTS.md §2.1" itself. That section no longer lists the rules -- PP-22e4.4
-# moved them to .claude/rules/ and left a pointer -- so citing it sends the
-# reader somewhere the rule is not. Tolerates the same optional backtick as
-# NUMBERED_RULE_CITATION.
-SECTION_21_CITATION = re.compile(r"AGENTS\.md`?[ \t]*§[ \t]*2\.1\b")
+# Any "AGENTS.md §N" section citation. This started as §2.1 alone -- that
+# section stopped listing the rules in PP-22e4.4, so citing it sent the reader
+# somewhere the rule is not -- but the whole numbering is the same hazard, just
+# slower: section numbers shift whenever AGENTS.md gains or loses a section, and
+# nothing tells the citation. PP-z9m1 found ~40 such citations across 25 files,
+# three of them pointing at "§2.2.5", which is not a section at all (it is item
+# 5 of a numbered list under §2.2) and never was.
+#
+# The durable form is the heading title: `AGENTS.md "Which tests to run"`.
+# Titles are edited far less often than numbers are renumbered, and a stale one
+# is greppable. Tolerates the same optional backtick as NUMBERED_RULE_CITATION.
+SECTION_CITATION = re.compile(r"AGENTS\.md`?[ \t]*§[ \t]*\d[\d.]*")
 
 CATALOG = "docs/NON_NEGOTIABLES.md"
 
@@ -262,7 +271,7 @@ def find_legacy_citations(text: str) -> list[tuple[int, str]]:
     offending line instead of just the file.
     """
     hits: list[tuple[int, str]] = []
-    for regex in (NUMBERED_RULE_CITATION, SECTION_21_CITATION):
+    for regex in (NUMBERED_RULE_CITATION, SECTION_CITATION):
         for match in regex.finditer(text):
             line_no = text.count("\n", 0, match.start()) + 1
             hits.append((line_no, match.group(0)))
@@ -339,25 +348,28 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 3
 
-    # ERROR: a fragile "rule N" / "commandment N" / "AGENTS.md §2.1" citation
-    # (PP-22e4). §2.1 no longer lists the rules -- PP-22e4.4 moved them to
-    # .claude/rules/ -- so both forms now point at nothing, and neither is
-    # machine-checkable against a catalog the way a CORE-* ID is: ban the
-    # pattern outright.
+    # ERROR: a fragile "rule N" / "commandment N" / "AGENTS.md §N" citation
+    # (PP-22e4, PP-z9m1). Rule numbers stopped resolving when PP-22e4.4 moved
+    # the rules to .claude/rules/; section numbers shift silently whenever
+    # AGENTS.md gains or loses a section. Neither is machine-checkable against
+    # a catalog the way a CORE-* ID is: ban the pattern outright.
     legacy = collect_legacy_citations(root)
     if legacy:
         print(
-            "check:rule-ids: fragile AGENTS.md rule-number/§2.1 citation(s) found\n",
+            "check:rule-ids: fragile AGENTS.md rule-number/section-number "
+            "citation(s) found\n",
             file=sys.stderr,
         )
         for rel in sorted(legacy):
             for line_no, matched_text in legacy[rel]:
                 print(f"  {rel}:{line_no}: {matched_text!r}", file=sys.stderr)
         print(
-            "\nAGENTS.md §2.1 no longer lists the rules (PP-22e4.4) -- they "
-            'moved to .claude/rules/, so a rule number or a "§2.1" citation '
-            "now points at nothing. Cite the CORE-* ID instead; look it up in "
-            f"{CATALOG}, which is the only catalog there is.",
+            "\nNeither form resolves on its own. A rule number points at "
+            "nothing since PP-22e4.4 moved the rules to .claude/rules/ -- "
+            f"cite the CORE-* ID instead, from {CATALOG}, which is the only "
+            "catalog there is. A section number goes stale the next time "
+            "AGENTS.md is restructured, and nothing tells the citation -- "
+            'cite the heading title instead: AGENTS.md "Which tests to run".',
             file=sys.stderr,
         )
         return 4

--- a/scripts/lib/pg-client.mjs
+++ b/scripts/lib/pg-client.mjs
@@ -7,7 +7,7 @@ import postgres from "postgres";
  * (`…pooler.supabase.com:6543`). We deliberately do NOT fall back to
  * POSTGRES_URL_NON_POOLING: in prod/preview that resolves to an IPv6-only host
  * unreachable from CI/preview/Vercel runners (the cause of ENETUNREACH seed
- * failures). See AGENTS.md §7 (Deployment).
+ * failures). See AGENTS.md "Deployment".
  *
  * @returns {string}
  */
@@ -28,7 +28,7 @@ export function resolveScriptDatabaseUrl() {
  * statement caching. Pass `options` to extend (e.g. `{ max: 1 }` for DDL).
  * `prepare: false` is applied last so callers cannot accidentally re-enable
  * prepared statements (which would reintroduce the transaction-pooler hazard).
- * See AGENTS.md §7 (Deployment).
+ * See AGENTS.md "Deployment".
  *
  * @param {string} [databaseUrl]
  * @param {Record<string, unknown>} [options]

--- a/scripts/mark-migration-applied.ts
+++ b/scripts/mark-migration-applied.ts
@@ -62,7 +62,7 @@ if (!migrationNumber) {
 // production, REFUSE to silently fall back to POSTGRES_URL (the :6543
 // TRANSACTION pooler) — it does not support prepared statements (the PP-d8l8
 // silent-COMMIT-loss hazard) and is the wrong endpoint for a migration write.
-// Mirrors scripts/migrate-production.ts. See AGENTS.md §7.
+// Mirrors scripts/migrate-production.ts. See AGENTS.md "Deployment".
 const isVercelProduction = process.env["VERCEL_ENV"] === "production";
 const nonPooling = process.env["POSTGRES_URL_NON_POOLING"];
 
@@ -102,7 +102,7 @@ if (isProductionTarget && !forceProduction) {
       `   Marking a migration applied without running it makes future\n` +
       `   \`migrate:production\` runs SKIP it — prod's schema then diverges from\n` +
       `   the migration history permanently, and nightly backups do not catch it.\n\n` +
-      `   This IS the documented stuck-migration recovery path (AGENTS.md §7).\n` +
+      `   This IS the documented stuck-migration recovery path (AGENTS.md "Deployment").\n` +
       `   To proceed intentionally, re-run with:\n` +
       `     MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<url> tsx scripts/mark-migration-applied.ts ${migrationNumber}`
   );

--- a/scripts/mark-migration-applied.ts
+++ b/scripts/mark-migration-applied.ts
@@ -32,8 +32,8 @@ interface MigrationJournal {
  * Usage (local):
  *   POSTGRES_URL=<url> tsx scripts/mark-migration-applied.ts <migration-number>
  *
- * Usage (production — the documented stuck-migration recovery path, AGENTS.md
- * §7). This script stays prod-capable on purpose, so it takes an explicit
+ * Usage (production — the documented stuck-migration recovery path,
+ * AGENTS.md "Deployment"). This script stays prod-capable on purpose, so it takes an explicit
  * opt-in token rather than a hard refusal:
  *   MARK_MIGRATION_FORCE_PRODUCTION=1 POSTGRES_URL=<prod_url> \
  *     tsx scripts/mark-migration-applied.ts <migration-number>

--- a/scripts/migrate-production.ts
+++ b/scripts/migrate-production.ts
@@ -44,7 +44,7 @@ if (process.env["VERCEL_ENV"] === "preview") {
 // possible over the IPv4 session pooler. We therefore REQUIRE NON_POOLING in
 // production and refuse to silently fall back to POSTGRES_URL, the `:6543`
 // TRANSACTION pooler: it does not support prepared statements (the PP-d8l8
-// hazard class) and is the wrong endpoint for DDL. See AGENTS.md §7.
+// hazard class) and is the wrong endpoint for DDL. See AGENTS.md "Deployment".
 const isVercelProduction = process.env["VERCEL_ENV"] === "production";
 const nonPooling = process.env["POSTGRES_URL_NON_POOLING"];
 

--- a/scripts/reset-preview-db.mjs
+++ b/scripts/reset-preview-db.mjs
@@ -2,7 +2,7 @@ import { assertNotPinPointProduction } from "./lib/db-target.mjs";
 import { createScriptClient } from "./lib/pg-client.mjs";
 
 // Use POSTGRES_URL (transaction pooler, :6543, IPv4) — NOT POSTGRES_URL_NON_POOLING
-// (the IPv6 direct host, unreachable from CI/preview runners). See AGENTS.md §7 (Deployment).
+// (the IPv6 direct host, unreachable from CI/preview runners). See AGENTS.md "Deployment".
 const databaseUrl = process.env.POSTGRES_URL;
 
 if (!databaseUrl) {

--- a/scripts/tests/test_check_rule_ids.py
+++ b/scripts/tests/test_check_rule_ids.py
@@ -133,6 +133,34 @@ class TestFindLegacyCitations:
             (1, "AGENTS.md §2.1")
         ]
 
+    def test_finds_any_top_level_section_citation(self):
+        # PP-z9m1 widened this from §2.1 alone to every section number: the
+        # numbering shifts whenever AGENTS.md gains or loses a section and
+        # nothing tells the citation.
+        assert find_legacy_citations("See AGENTS.md §7 for the pooler table") == [
+            (1, "AGENTS.md §7")
+        ]
+
+    def test_finds_multi_level_section_citation(self):
+        # "§2.2.5" is not a section at all -- it is item 5 of a numbered list
+        # under §2.2. Three sites cited it before PP-z9m1, so the pattern has
+        # to reach arbitrary depth rather than stopping at N.N.
+        assert find_legacy_citations("root checkout (AGENTS.md §2.2.5)") == [
+            (1, "AGENTS.md §2.2.5")
+        ]
+
+    def test_ignores_bare_section_mark_without_agents_md(self):
+        # docs/pbm-listing-redesign-refresher.md numbers its OWN sections and
+        # refers to them as "§7"/"§11". Those are not AGENTS.md citations and
+        # must not trip the gate.
+        assert (
+            find_legacy_citations("amended 2026-07-25 (§7). Build state is §11.") == []
+        )
+
+    def test_accepts_the_durable_heading_title_form(self):
+        # The replacement form this gate is steering people toward.
+        assert find_legacy_citations('per AGENTS.md "Which tests to run"') == []
+
     def test_tolerates_backtick_between_filename_and_keyword(self):
         # `AGENTS.md` §2.1 -- code-fenced filename immediately followed by
         # the section mark broke a naive "AGENTS\.md\s*§2\.1" regex on main

--- a/scripts/tests/test_pr_gates.py
+++ b/scripts/tests/test_pr_gates.py
@@ -323,7 +323,7 @@ def test_no_threads_at_all_passes() -> None:
 
 
 def test_thread_failure_names_the_two_ways_to_clear_it() -> None:
-    """AGENTS.md §5 allows declining, not ignoring. The gate should say so."""
+    """AGENTS.md "Review comments" allows declining, not ignoring. The gate should say so."""
     with gate_env(threads=[thread(resolved=False, author="timothyfroehlich")]) as env:
         result = run_gate("check_unresolved_threads", env)
     assert "decline" in result.stdout.lower(), result.stdout

--- a/scripts/workflow/_pr-gates.sh
+++ b/scripts/workflow/_pr-gates.sh
@@ -239,7 +239,7 @@ check_unresolved_threads() {
   fi
   echo "FAIL: threads: $unresolved unresolved review threads"
   echo "  remedy: fix the code, or decline with a one-sentence reply — then resolve"
-  echo "          the thread. A silent ignore is not a resolution (AGENTS.md §5)."
+  echo "          the thread. A silent ignore is not a resolution (AGENTS.md \"Review comments\")."
   return 1
 }
 

--- a/scripts/workflow/pr-watch.py
+++ b/scripts/workflow/pr-watch.py
@@ -289,7 +289,7 @@ def _unresolved_threads(threads: list[dict]) -> int:
 
     Author-agnostic since PP-4ric: the old Copilot-login filter would match
     nothing now that Copilot is retired, silently turning every thread check
-    into a pass. Threads come from Tim or another agent, and AGENTS.md §5
+    into a pass. Threads come from Tim or another agent, and AGENTS.md "Review comments"
     requires each to be fixed or declined-and-resolved either way.
     """
     return sum(1 for t in threads if not t["isResolved"])

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -28,7 +28,7 @@ const globalForDb = globalThis as unknown as {
 // whole write transactions resolved as committed yet never persisted (PP-d8l8,
 // incident 2026-06-18). This is the canonical Drizzle + postgres-js + Supabase
 // serverless setting; scripts/lib/pg-client.mjs sets it for the same reason.
-// See AGENTS.md §7 (canonical endpoint table).
+// See AGENTS.md "Deployment".
 const conn = globalForDb.conn ?? postgres(databaseUrl, { prepare: false });
 if (process.env.NODE_ENV !== "production") globalForDb.conn = conn;
 

--- a/src/test/integration/supabase/pinballmap-credentials-rpc.test.ts
+++ b/src/test/integration/supabase/pinballmap-credentials-rpc.test.ts
@@ -41,7 +41,7 @@ const anonClient = createClient(supabaseUrl, supabaseAnonKey);
 //
 // `prepare: false` because `databaseUrl` falls back to `POSTGRES_URL`, which in
 // any pooled environment is the Supavisor transaction pooler on `:6543` — no
-// prepared statements there (AGENTS.md §7, PP-d8l8). Without it a pooled run
+// prepared statements there (AGENTS.md "Deployment", PP-d8l8). Without it a pooled run
 // fails on the GRANT rather than on an assertion, which reads as a broken guard
 // test instead of a misconfigured connection.
 const sql = postgres(databaseUrl, { prepare: false });

--- a/src/test/unit/scripts/db-target-guards.test.ts
+++ b/src/test/unit/scripts/db-target-guards.test.ts
@@ -27,7 +27,7 @@ import {
 
 const repoRoot = process.cwd();
 
-// Shapes taken from the real endpoints (AGENTS.md §7 / pinpoint-deployment).
+// Shapes taken from the real endpoints (AGENTS.md "Deployment" / pinpoint-deployment).
 const PROD_POOLER_URL = `postgres://postgres.${PRODUCTION_PROJECT_REF}:pw@aws-0-us-east-2.pooler.supabase.com:6543/postgres`;
 const PROD_DIRECT_URL = `postgres://postgres:pw@db.${PRODUCTION_PROJECT_REF}.supabase.co:5432/postgres`;
 const PROD_API_URL = `https://${PRODUCTION_PROJECT_REF}.supabase.co`;

--- a/supabase/seed-machine-settings.mjs
+++ b/supabase/seed-machine-settings.mjs
@@ -54,7 +54,7 @@ import { assertLocalDatabase } from "../scripts/assert-local-db.mjs";
 
 // Use the pooled POSTGRES_URL (port :6543, IPv4) like seed-users.mjs — NOT
 // POSTGRES_URL_NON_POOLING (:5432), which resolves to IPv6 and is unreachable
-// from CI / the preview pipeline runners (AGENTS.md §7). The preview "Seed
+// from CI / the preview pipeline runners (AGENTS.md "Deployment"). The preview "Seed
 // machine settings demo" step crashed with ENETUNREACH against the :5432 host
 // before this was switched.
 const databaseUrl = process.env.POSTGRES_URL;


### PR DESCRIPTION
Closes PP-z9m1.

## What

AGENTS.md section numbers shift whenever the file gains or loses a section, and nothing tells the citation. Three sites cited `§2.2.5`, which is not a section at all — it is item 5 of a numbered list under `§2.2`, and never had a heading.

This converts ~40 citations across 25 files to the heading title:

```
AGENTS.md §5 "Which tests to run"  ->  AGENTS.md "Which tests to run"
AGENTS.md §7                       ->  AGENTS.md "Deployment"
AGENTS.md §2.2.5                   ->  AGENTS.md "Process rules"
```

and broadens the existing `§2.1`-only gate in `scripts/check_rule_ids.py` to every `AGENTS.md §N`, so the class cannot recur.

**The gate immediately earned it.** It caught five citations in the `` `AGENTS.md` §7 `` form — backtick then space — that my own ripgrep pattern missed. Every quoted title was then verified to resolve against a real heading in AGENTS.md.

Two of my first-pass substitutions were wrong and are fixed here, both worth knowing about as a reviewer:

- A parenthesised gloss (`§7 (canonical endpoint table)`) became a fake title `AGENTS.md "canonical endpoint table"`. A quoted title matching no heading is worse than the number it replaced, because it looks authoritative.
- A blanket `§5 -> "Workflow"` was too coarse — several of those sites mean `"Review comments"` or `"Which tests to run"` specifically, and landing a reader in the wrong subsection is the failure this PR is supposed to prevent.

## Also here

**AGENTS.md's own internal self-references** (`see §4 Process safety`, `see §5 Branches`, …) are converted too. They are the same fragility, and leaving them would make the PR incoherent. The `pinpoint-design-bible` `§5`/`§17` reference on line ~237 is deliberately untouched — those are that spec's sections, not AGENTS.md's. Same for `docs/pbm-listing-redesign-refresher.md`, which numbers its own sections.

**`pinpoint-briefing` gains Group F.** At Tim's request, so the unattended nightly bead routine can hand work off: it reports on the bead it worked, flagged `nightly-report`, and the briefing reads that queue plus the `human` decision queue it builds. Note this producer does not exist yet — it is still a draft prompt outside the repo.

## Sequencing note

PP-z9m1's notes say to do this before "PP-22e4 PR 10 (AGENTS.md → stub)". That PR was superseded and never shipped — PP-22e4's close reason says the stub was deliberately not done. So the deadline is gone; this is durability work, not a race. Recorded on the bead.

## Testing

- `pnpm run check` — green
- `pnpm run check:python` — 442 passed
- New tests cover the multi-level `§2.2.5` case, a bare `§N` with no `AGENTS.md` prefix (must NOT match — the PBM spec's own numbering), and the durable `AGENTS.md "Title"` form being accepted

## Known gap

The gate bans section *numbers* but does not verify that a quoted *title* still resolves to a real heading. Renaming a heading would silently strand its citations. I verified all of them by hand this time; closing it in the gate is a follow-up worth filing if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HshAyr2EZe5ZcSk95GfGek